### PR TITLE
Support retrieving the branch build data via the API

### DIFF
--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -103,6 +103,11 @@ public class BuildData implements Action, Serializable, Cloneable {
         return lastBuild==null?null:lastBuild.revision;
     }
 
+    @Exported
+    public Map<String,Build> getBuildsByBranchName() {
+        return buildsByBranchName;
+    }
+
     @Override
     public BuildData clone() {
         BuildData clone;


### PR DESCRIPTION
I found the branch-to-build mapping available at $HUDSON_URL/job/$JOBNAME/$BUILDNUMBER/git to be really useful, but it wasn't exposed via the API at $HUDSON_URL/job/$JOBNAME/$BUILDNUMBER/git/api/json and I needed programmatic access for a project I'm working on.

This change simply exposes the appropriate mapping to make it visible.
