### PR TITLE
Fix build failure with scp-style URIs when rebuilding existing projects

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -19,6 +19,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -478,6 +479,11 @@ public class GitAPI implements IGitAPI {
             }
 
             origin = new URI( url );
+        } catch (URISyntaxException e) {
+            // Sometimes the URI is of a form that we can't parse; like
+            //   user@git.somehost.com:repository
+            // In these cases, origin is null and it's best to just exit early.
+            return;
         } catch (Exception e) {
             throw new GitException("Could determine remote.origin.url", e);
         }


### PR DESCRIPTION
On the current HEAD builds of the git plugin, there is a regression when running jobs that use an scp-style URI for cloning the repository, such as git@git.mycompany.com:repositoryname. The bug doesn't manifest itself on the initial clone - blowing away the workspace after each build is a workaround - but subsequent builds fail because the code to fixup the submodule support blindly assumes that the remote.origin.url is going to be a format parseable by java.net.URI.

I'm not really convinced this is the best fix for the bug - I'm simply returning early from fixSubmoduleUrls because the rest of the function depends pretty heavily on the origin URI object not being null. I don't use submodules so this works great for me, but I could see another implementation being potentially smarter than this.
