### PR TITLE
Prune before build should prune by name

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -191,7 +191,7 @@ public class GitAPI implements IGitAPI {
 
     public void prune(RemoteConfig repository) throws GitException {
         ArgumentListBuilder args = new ArgumentListBuilder();
-        args.add("remote", "prune", repository.getURIs().get(0).toString());
+        args.add("remote", "prune", repository.getName());
         
         launchCommand(args);
     }


### PR DESCRIPTION
When pruning a remote source, hudson should be pruning via the remote's name, not it's url. I would submit this as a jira ticket, but since it's down right now I'm just sending this pull request.

I've had prune before build enabled on some projects of ours for awhile, and it doesn't seem to be working. I'm not sure if it's a git version issue, but I don't believe git remote prune url actually does anything, at least with a  named remote. Since hudson always names the remote, prune should always use that name.

Here's a somewhat convoluted showing the different behavior between the two:
git clone git@github.com:richievos/git-plugin.git
cd git-plugin
git push origin HEAD:master-to_delete
git remote add alternative git@github.com:richievos/git-plugin.git
git fetch alternative

From github.com:richievos/git-plugin
- [new branch]      git-svn    -> alternative/git-svn
- [new branch]      master     -> alternative/master
- [new branch]      master-to_delete -> alternative/master-to_delete
- [new branch]      release    -> alternative/release
- [new branch]      submodule-combinator -> alternative/submodule-combinator
- [new branch]      svn        -> alternative/svn
#### Now we have 2 remotes setup

git push origin :master-to_delete
git remote prune git@github.com:richievos/git-plugin.git # This does nothing, doesn't prune anything

git remote prune alternative # This actually prunes

Pruning alternative
URL: git@github.com:richievos/git-plugin.git
- [pruned] alternative/master-to_delete

So this pull changes prune to use the RemoteConfig's name instead of the url. This makes the prune before build step work in my setup.
