### PR TITLE
Fixed bug where password is excluded from the URL

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -153,7 +153,7 @@ public class GitAPI implements IGitAPI {
         }
 
         // Assume only 1 URL for this repository
-        final String source = remoteConfig.getURIs().get(0).toString();
+        final String source = remoteConfig.getURIs().get(0).toPrivateString();
 
         try {
             workspace.act(new FileCallable<String>() {
@@ -191,7 +191,7 @@ public class GitAPI implements IGitAPI {
 
     public void prune(RemoteConfig repository) throws GitException {
         ArgumentListBuilder args = new ArgumentListBuilder();
-        args.add("remote", "prune", repository.getURIs().get(0).toString());
+        args.add("remote", "prune", repository.getURIs().get(0).toPrivateString());
         
         launchCommand(args);
     }
@@ -601,7 +601,7 @@ public class GitAPI implements IGitAPI {
 
     public void push(RemoteConfig repository, String refspec) throws GitException {
         ArgumentListBuilder args = new ArgumentListBuilder();
-        args.add("push", repository.getURIs().get(0).toString());
+        args.add("push", repository.getURIs().get(0).toPrivateString());
 
         if (refspec != null)
             args.add(refspec);
@@ -782,7 +782,7 @@ public class GitAPI implements IGitAPI {
 
     public void fetch(RemoteConfig remoteRepository) throws GitException {
         // Assume there is only 1 URL / refspec for simplicity
-        fetch(remoteRepository.getURIs().get(0).toString(), remoteRepository.getFetchRefSpecs().get(0).toString());
+        fetch(remoteRepository.getURIs().get(0).toPrivateString(), remoteRepository.getFetchRefSpecs().get(0).toString());
 
     }
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -362,7 +362,7 @@ public class GitSCM extends SCM implements Serializable {
 
         for (RemoteConfig oldRepo : Util.fixNull(remoteRepositories)) {
             expandedRepos.add(newRemoteConfig(oldRepo.getName(),
-                                              oldRepo.getURIs().get(0).toString(),
+                                              oldRepo.getURIs().get(0).toPrivateString(),
                                               new RefSpec(getRefSpec(oldRepo, build))));
         }
 

--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -22,7 +22,7 @@
            <table width="100%">
            
            <f:entry title="URL of repository">
-            <f:textbox name="git.repo.url" value="${repo.URIs.get(0)}" />
+            <f:textbox name="git.repo.url" value="${repo.URIs.get(0).toPrivateString()}" />
            </f:entry>
            
            <f:advanced>


### PR DESCRIPTION
Fixed bug where password is excluded from the URL. Replace usages of toString() in plugin with toPrivateString() so the password is not elided when issuing git commands.

Original Source: https://github.com/magnayn/Hudson-GIT-plugin/pull/5
