### PR TITLE
JENKINS-7156 Incorrect mail address used for sending email notifications: it uses "Firstname Lastname@defaultDomain.com" instead of the e-mail address from git

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -233,7 +233,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
         User user = User.get(csAuthor, true);
 
         // set email address for user if needed
-        if (fixEmpty(csAuthorEmail) != null && user.getProperty(Mailer.UserProperty.class) == null) {
+        if (fixEmpty(csAuthorEmail) != null) {
             try {
                 user.addProperty(new Mailer.UserProperty(csAuthorEmail));
             } catch (IOException e) {


### PR DESCRIPTION
This bug is really annoying as users that break a build don't get an email notification.

Fixed as proposed in:
  http://issues.jenkins-ci.org/browse/JENKINS-7156?focusedCommentId=145008&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-145008

Full analysis of the problem:
  http://hustoknow.blogspot.com/2011/01/hudson-git-plug-in-issues.html
