### PR TITLE
[JENKINS-9620] added shared option to git clone

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -176,7 +176,7 @@ public class GitAPI implements IGitAPI {
      * @param remoteConfig remote config
      * @throws GitException if deleting or cloning the workspace fails
      */
-    public void clone(final RemoteConfig remoteConfig) throws GitException {
+    public void clone(final RemoteConfig remoteConfig, final boolean shared) throws GitException {
         listener.getLogger().println("Cloning repository " + remoteConfig.getName());
 
         // TODO: Not here!
@@ -200,6 +200,10 @@ public class GitAPI implements IGitAPI {
                         final ArgumentListBuilder args = new ArgumentListBuilder();
                         args.add("clone");
                         args.add("--progress");
+                        if (shared)
+                        {
+                          args.add("--shared");
+                        }
                         args.add("-o", remoteConfig.getName());
                         args.add(source);
                         args.add(workspace.getAbsolutePath());

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -99,6 +99,8 @@ public class GitSCM extends SCM implements Serializable {
     private boolean wipeOutWorkspace;
     
     private boolean pruneBranches;
+
+    private boolean shared;
     
     /**
      * @deprecated
@@ -148,7 +150,7 @@ public class GitSCM extends SCM implements Serializable {
                 Collections.singletonList(new BranchSpec("")),
                 new PreBuildMergeOptions(), false, Collections.<SubmoduleConfig>emptyList(), false, 
                 false, new DefaultBuildChooser(), null, null, false, null,
-                null, null, null, false, false, null, null, false);
+                null, null, null, false, false, null, null, false, false);
     }
 
     @DataBoundConstructor
@@ -171,7 +173,8 @@ public class GitSCM extends SCM implements Serializable {
                   boolean pruneBranches,
                   String gitConfigName,
                   String gitConfigEmail,
-                  boolean skipTag) {
+                  boolean skipTag,
+		  boolean shared) {
 
         // normalization
         this.branches = branches;
@@ -184,7 +187,7 @@ public class GitSCM extends SCM implements Serializable {
 
         this.doGenerateSubmoduleConfigurations = doGenerateSubmoduleConfigurations;
         this.submoduleCfg = submoduleCfg;
-
+	this.shared = shared;
         this.clean = clean;
         this.wipeOutWorkspace = wipeOutWorkspace;
         this.configVersion = 1L;
@@ -340,6 +343,10 @@ public class GitSCM extends SCM implements Serializable {
 
     public boolean getSkipTag() {
         return this.skipTag;
+    }
+
+    public boolean getShared() {
+        return this.shared;
     }
     
     public boolean getPruneBranches() {
@@ -869,7 +876,7 @@ public class GitSCM extends SCM implements Serializable {
                         boolean successfullyCloned = false;
                         for(RemoteConfig rc : paramRepos) {
                             try {
-                                git.clone(rc);
+                                git.clone(rc, getShared());
                                 successfullyCloned = true;
                                 break;
                             }
@@ -1284,7 +1291,8 @@ public class GitSCM extends SCM implements Serializable {
                               req.getParameter("git.pruneBranches") != null,
                               req.getParameter("git.gitConfigName"),
                               req.getParameter("git.gitConfigEmail"),
-                              req.getParameter("git.skipTag") != null);
+                              req.getParameter("git.skipTag") != null,
+			       req.getParameter("git.shared") != null);
         }
         
         /**

--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -54,7 +54,7 @@ public interface IGitAPI {
     void fetch() throws GitException;
     void push(RemoteConfig repository, String revspec) throws GitException;
     void merge(String revSpec) throws GitException;
-    void clone(RemoteConfig source) throws GitException;
+    void clone(RemoteConfig source, boolean shared) throws GitException;
     void clean() throws GitException;
     void prune(RemoteConfig repository) throws GitException;
     

--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -154,6 +154,9 @@
     <f:entry title="Wipe out workspace before build" help="/plugin/git/wipeOutWorkspace.html">
       <f:checkbox name="git.wipeOutWorkspace" checked="${scm.wipeOutWorkspace}"/>
     </f:entry>
+    <f:entry title="Use shared option during clone" help="/plugin/git/shared.html">
+      <f:checkbox name="git.shared" checked="${scm.shared}"/>
+    </f:entry>
     <f:dropdownList name="buildChooser" title="${%Choosing strategy}" help="/plugin/git/choosingStrategy.html">
       <j:scope>
         <j:set var="current" value="${instance.buildChooser}"/>

--- a/src/main/webapp/shared.html
+++ b/src/main/webapp/shared.html
@@ -1,0 +1,1 @@
+Add the "--shared" option during the git clone, usefull when localy cloning large repositories.


### PR DESCRIPTION
this is related this issue : https://issues.jenkins-ci.org/browse/JENKINS-9620

the is, for large repositories, to have a local clone, and all the jobs that use this repository uses it with the shared option to minimize the disk space used.

I've added a share option to the git clone method, is there any better way to do it with a RemoteConfig object ? 
