### PR TITLE
Fix compilation issue by referencing correct exception variable name.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -990,7 +990,7 @@ public class GitSCM extends SCM implements Serializable {
                                     "Problem fetching from " + remoteRepository.getName()
                                     + " / " + remoteRepository.getName()
                                     + " - could be unavailable. Continuing anyway.");
-                            listener.error(" (Underlying report) : " + ex.getMessage());
+                            listener.error(" (Underlying report) : " + e.getMessage());
 
                         }
                     }


### PR DESCRIPTION
Simple change of `ex` to `e` for the exception variable in the catch block. 

The issue was introduced in commit [37810d7](https://github.com/jenkinsci/git-plugin/commit/37810d767d4729c6c7dc4bb46dc7a12e9c40638b#L0R993).
