### PR TITLE
Update deprecated call to MarkupText.toString method.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -301,7 +301,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
         for (ChangeLogAnnotator a : ChangeLogAnnotator.all())
             a.annotate(getParent().build,this,markup);
 
-        return markup.toString();
+        return markup.toString(false);
     }
 
     @ExportedBean(defaultVisibility=999)


### PR DESCRIPTION
Migrate call from deprecated:

``` java
MarkupText.toString()
```

To:

``` java
MarkupText.toString(false)
```
