### PR TITLE
Update plug-in to use JGit 0.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,25 +42,9 @@
 
   <repositories>
     <repository>
-      <id>jgit-snapshot-repository</id>
-      <url>http://egit.googlecode.com/svn/maven/snapshot-repository</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-    
-    <repository>
-      <id>jgit-release-repository</id>
-      <url>http://egit.googlecode.com/svn/maven</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
+      <id>jgit-repository</id>
+      <name>Eclipse JGit Repository</name>
+      <url>http://download.eclipse.org/jgit/maven</url>
     </repository>
     
     <repository>
@@ -72,22 +56,15 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.spearce</groupId>
-      <artifactId>jgit</artifactId>
-      <!-- SEE README! -->
-      <version>0.4-47e4af3</version>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit</artifactId>
+      <version>0.12.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>3.8.1</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jgit</groupId>
-      <artifactId>org.eclipse.jgit</artifactId>
-      <version>0.5.1.51-g96b2e76</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>

--- a/src/main/java/hudson/plugins/git/Branch.java
+++ b/src/main/java/hudson/plugins/git/Branch.java
@@ -1,7 +1,7 @@
 package hudson.plugins.git;
 
-import org.spearce.jgit.lib.ObjectId;
-import org.spearce.jgit.lib.Ref;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
 
 public class Branch extends GitObject {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/plugins/git/GitObject.java
+++ b/src/main/java/hudson/plugins/git/GitObject.java
@@ -3,7 +3,7 @@ import java.io.Serializable;
 
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-import org.spearce.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectId;
 
 @ExportedBean(defaultVisibility = 999)
 public class GitObject implements Serializable {

--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -35,7 +35,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import org.spearce.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.RemoteConfig;
 
 public class GitPublisher extends Recorder implements Serializable, MatrixAggregatable {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -44,10 +44,12 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
-import org.spearce.jgit.lib.ObjectId;
-import org.spearce.jgit.lib.RepositoryConfig;
-import org.spearce.jgit.transport.RefSpec;
-import org.spearce.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.storage.file.FileBasedConfig;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.util.FS;
 
 /**
  * Git SCM.
@@ -775,7 +777,7 @@ public class GitSCM extends SCM implements Serializable {
         File temp = null;
         try {
             temp = File.createTempFile("tmp", "config");
-            RepositoryConfig repoConfig = new RepositoryConfig(null, temp);
+            StoredConfig repoConfig = new FileBasedConfig(null, temp, FS.DETECTED);
             // Make up a repo config from the request parameters
 
 
@@ -1435,7 +1437,7 @@ public class GitSCM extends SCM implements Serializable {
                 String[] refSpecs,
                 File temp) {
             List<RemoteConfig> remoteRepositories;
-            RepositoryConfig repoConfig = new RepositoryConfig(null, temp);
+            StoredConfig repoConfig = new FileBasedConfig(null, temp, FS.DETECTED);
             // Make up a repo config from the request parameters
 
             String[] urls = pUrls;

--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -9,9 +9,9 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Set;
 
-import org.spearce.jgit.lib.ObjectId;
-import org.spearce.jgit.lib.Tag;
-import org.spearce.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.transport.RemoteConfig;
 
 /**
  * Encapsulates Git operations on a particular directory through git(1).
@@ -70,7 +70,7 @@ public interface IGitAPI {
 
     String describe(String commitIsh) throws GitException;
 
-    List<Tag> getTagsOnCommit(String revName) throws GitException, IOException;
+    List<Ref> getTagsOnCommit(String revName) throws GitException, IOException;
 
     void tag(String tagName, String comment) throws GitException;
     boolean tagExists(String tagName) throws GitException;

--- a/src/main/java/hudson/plugins/git/Revision.java
+++ b/src/main/java/hudson/plugins/git/Revision.java
@@ -5,7 +5,7 @@ import java.util.Collection;
 
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-import org.spearce.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectId;
 
 /**
  * A Revision is a SHA1 in the object tree, and the collection of branches

--- a/src/main/java/hudson/plugins/git/RevisionParameterAction.java
+++ b/src/main/java/hudson/plugins/git/RevisionParameterAction.java
@@ -24,7 +24,7 @@
 package hudson.plugins.git;
 
 import hudson.model.InvisibleAction;
-import org.spearce.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectId;
 
 import java.io.Serializable;
 import java.util.Collections;

--- a/src/main/java/hudson/plugins/git/SubmoduleCombinator.java
+++ b/src/main/java/hudson/plugins/git/SubmoduleCombinator.java
@@ -15,7 +15,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.spearce.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectId;
 
 /**
  * A common usecase for git submodules is to have child submodules, and a parent 'configuration' project that ties the

--- a/src/main/java/hudson/plugins/git/Tag.java
+++ b/src/main/java/hudson/plugins/git/Tag.java
@@ -1,6 +1,6 @@
 package hudson.plugins.git;
 
-import org.spearce.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectId;
 
 public class Tag extends GitObject {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/plugins/git/opt/PreBuildMergeOptions.java
+++ b/src/main/java/hudson/plugins/git/opt/PreBuildMergeOptions.java
@@ -1,7 +1,7 @@
 package hudson.plugins.git.opt;
 
 import java.io.Serializable;
-import org.spearce.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.RemoteConfig;
 
 /**
  * Git SCM can optionally perform a merge with another branch (possibly another repository.)

--- a/src/main/java/hudson/plugins/git/util/Build.java
+++ b/src/main/java/hudson/plugins/git/util/Build.java
@@ -7,7 +7,7 @@ import java.io.Serializable;
 
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-import org.spearce.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectId;
 
 @ExportedBean(defaultVisibility = 999)
 public class Build implements Serializable, Cloneable {

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-import org.spearce.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectId;
 
 import static hudson.Util.fixNull;
 

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -9,7 +9,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.IGitAPI;
 import hudson.plugins.git.Revision;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.spearce.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectId;
 
 import java.io.IOException;
 import java.text.MessageFormat;

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import org.spearce.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectId;
 
 public class GitUtils {
     IGitAPI git;

--- a/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
@@ -6,8 +6,7 @@ import hudson.model.TaskListener;
 import hudson.model.User;
 import hudson.util.StreamTaskListener;
 import org.jvnet.hudson.test.HudsonTestCase;
-import org.spearce.jgit.lib.PersonIdent;
-import org.spearce.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.lib.PersonIdent;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -17,8 +17,6 @@ import hudson.plugins.git.util.DefaultBuildChooser;
 import hudson.util.StreamTaskListener;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import org.jvnet.hudson.test.HudsonTestCase;
-import org.spearce.jgit.lib.PersonIdent;
-import org.spearce.jgit.transport.RemoteConfig;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
This removes the use of the custom JGit version and now uses the Eclipse JGit 0.12.1 version.

The following classes now implement `Serializable` that previously were custom patched to:
- `org.eclipse.jgit.lib.ObjectId`
- `org.eclipse.jgit.transport.RemoteConfig`
