### PR TITLE
Fix embedded quotes in verbose logging string

### DIFF
--- a/src/main/java/hudson/plugins/git/Revision.java
+++ b/src/main/java/hudson/plugins/git/Revision.java
@@ -1,5 +1,9 @@
 package hudson.plugins.git;
 
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Iterables;
+
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -8,10 +12,10 @@ import org.kohsuke.stapler.export.ExportedBean;
 import org.eclipse.jgit.lib.ObjectId;
 
 /**
- * A Revision is a SHA1 in the object tree, and the collection of branches
- * that share this ID. Unlike other SCMs, git can have >1 branches point
- * at the _same_ commit.
- *
+ * A Revision is a SHA1 in the object tree, and the collection of branches that
+ * share this ID. Unlike other SCMs, git can have >1 branches point at the
+ * _same_ commit.
+ * 
  * @author magnayn
  */
 @ExportedBean(defaultVisibility = 999)
@@ -63,15 +67,16 @@ public class Revision implements java.io.Serializable, Cloneable {
     }
 
     public String toString() {
-        String s = "Revision " + sha1.name() + " (";
-        for (Branch br : branches) {
-            s += br.getName() + ", ";
-        }
-        if (s.endsWith(", "))
-            s = s.substring(0, s.length() - 2);
-        s += ")";
+        StringBuilder s = new StringBuilder("Revision " + sha1.name() + " (");
+        Joiner.on(", ").appendTo(s,
+                Iterables.transform(branches, new Function<Branch, String>() {
 
-        return s;
+                    public String apply(Branch from) {
+                        return from.getName();
+                    }
+                }));
+        s.append(')');
+        return s.toString();
     }
 
     @Override

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -158,7 +158,7 @@ public class DefaultBuildChooser extends BuildChooser {
         verbose(listener, "After non-tip filtering: {0}", revs);
 
         // 4. Finally, remove any revisions that have already been built.
-        verbose(listener, "Removing what's already been built: {0}", data.getBuildsByBranchName());
+        verbose(listener, "Removing what''s already been built: {0}", data.getBuildsByBranchName());
         for (Iterator<Revision> i = revs.iterator(); i.hasNext();) {
             Revision r = i.next();
 
@@ -166,7 +166,7 @@ public class DefaultBuildChooser extends BuildChooser {
                 i.remove();
             }
         }
-        verbose(listener, "After filtering out what's already been built: {0}", revs);
+        verbose(listener, "After filtering out what''s already been built: {0}", revs);
 
         // if we're trying to run a build (not an SCM poll) and nothing new
         // was found then just run the last build again


### PR DESCRIPTION
Also use StringBuilder in the Revision.toString method.

Single quotes that appears in `String`` passed to`MessageFormat```
must be '' instead of ' in order to output properly.

`Revision.toString` was using `+=` `String` concatenation which is
must less performant than `StringBuilder.append` is.
