### PR TITLE
Add missing single-quote in calls to MessageFormat

### DIFF
--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -140,13 +140,13 @@ public class DefaultBuildChooser extends BuildChooser {
                 }
 
                 if (!keep) {
-                    verbose(listener, "Ignoring {0} because it doesn't match branch specifier", b);
+                    verbose(listener, "Ignoring {0} because it doesn''t match branch specifier", b);
                     j.remove();
                 }
             }
 
             if (r.getBranches().size() == 0) {
-                verbose(listener, "Ignoring {0} because we don't care about any of the branches that point to it", r);
+                verbose(listener, "Ignoring {0} because we don''t care about any of the branches that point to it", r);
                 i.remove();
             }
         }


### PR DESCRIPTION
Follow-up to pull #28 which begun fixing embedded quotes in verbose logging strings.
