### PR TITLE
Prevent parsing duplicates from the change log.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeLogParser.java
+++ b/src/main/java/hudson/plugins/git/GitChangeLogParser.java
@@ -8,7 +8,9 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.xml.sax.SAXException;
 
@@ -27,7 +29,7 @@ public class GitChangeLogParser extends ChangeLogParser {
     public GitChangeSetList parse(AbstractBuild build, File changelogFile)
         throws IOException, SAXException {
         
-        ArrayList<GitChangeSet> r = new ArrayList<GitChangeSet>();
+        Set<GitChangeSet> r = new LinkedHashSet<GitChangeSet>();
         
         // Parse the log file into GitChangeSet items - each one is a commit
         
@@ -55,7 +57,7 @@ public class GitChangeLogParser extends ChangeLogParser {
                 r.add(parseCommit(lines, authorOrCommitter));
             }
             
-            return new GitChangeSetList(build, r);
+            return new GitChangeSetList(build, new ArrayList<GitChangeSet>(r));
         }
         finally {
             rdr.close();

--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -350,4 +350,16 @@ public class GitChangeSet extends ChangeLogSet.Entry {
             }
         }
     }
+    
+    public int hashCode() {
+        return id != null ? id.hashCode() : super.hashCode();
+    }
+
+    public boolean equals(Object obj) {
+        if (obj == this)
+            return true;
+        if (obj instanceof GitChangeSet)
+            return id != null && id.equals(((GitChangeSet) obj).id);
+        return false;
+    }
 }

--- a/src/test/java/hudson/plugins/git/GitChangeLogParserTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeLogParserTest.java
@@ -1,0 +1,36 @@
+package hudson.plugins.git;
+
+import java.io.File;
+import java.io.FileWriter;
+
+import org.jvnet.hudson.test.HudsonTestCase;
+
+/**
+ * Unit tests of {@link GitChangeLogParser}
+ */
+public class GitChangeLogParserTest extends HudsonTestCase {
+
+    /**
+     * Test duplicate changes filtered from parsed change set list.
+     * 
+     * @throws Exception
+     */
+    public void testDuplicatesFiltered() throws Exception {
+        GitChangeLogParser parser = new GitChangeLogParser(true);
+        File log = File.createTempFile(getClass().getName(), ".tmp");
+        FileWriter writer = new FileWriter(log);
+        writer.write("commit 123abc456def\n");
+        writer.write("    first message\n");
+        writer.write("commit 123abc456def\n");
+        writer.write("    second message");
+        writer.close();
+        GitChangeSetList list = parser.parse(null, log);
+        assertNotNull(list);
+        assertNotNull(list.getLogs());
+        assertEquals(1, list.getLogs().size());
+        GitChangeSet first = list.getLogs().get(0);
+        assertNotNull(first);
+        assertEquals("123abc456def", first.getId());
+        assertEquals("first message", first.getMsg());
+    }
+}


### PR DESCRIPTION
Implement hashCode and equals in GitChangeSet such that
GitChangeLogParser can use a linked hash set to build up
the parsed change log strings.

Branches pointing to the same commit will no longer cause
duplicate commits to appear in the change set list.

An example of the issue is show below:
![Duplicate changes](http://img.skitch.com/20110603-fu92a74s4fnqa81nuxpfseawij.png)
