### PR TITLE
Update help for repository browser URLs

### DIFF
--- a/src/main/resources/hudson/plugins/git/browser/GitWeb/help-url.html
+++ b/src/main/resources/hudson/plugins/git/browser/GitWeb/help-url.html
@@ -1,3 +1,3 @@
 <div>
-  Specify the root URL serving this repository (such as <a href="http://repo.or.cz/r/git.git">this</a>.)
+  Specify the root URL serving this repository (such as <a target="_blank" href="http://git.kernel.org/?p=git/git.git">this</a>).
 </div>

--- a/src/main/resources/hudson/plugins/git/browser/GithubWeb/help-url.html
+++ b/src/main/resources/hudson/plugins/git/browser/GithubWeb/help-url.html
@@ -1,3 +1,3 @@
 <div>
-  Specify the root URL serving this repository (such as <a href="http://github.com/USERNAME/REPO/">this</a>.)
+  Specify the HTTP URL for this repository's GitHub page (such as <a target="_blank" href="https://github.com/jquery/jquery">this</a>).
 </div>

--- a/src/main/resources/hudson/plugins/git/browser/RedmineWeb/help-url.html
+++ b/src/main/resources/hudson/plugins/git/browser/RedmineWeb/help-url.html
@@ -1,3 +1,3 @@
 <div>
-  Specify the root URL serving this repository (such as <a href="http://SERVER/PATH/projects/PROJECT/repository">this</a>.)
+  Specify the root URL serving this repository (such as <a href="http://SERVER/PATH/projects/PROJECT/repository">this</a>).
 </div>


### PR DESCRIPTION
-  Fix broken link in GitWeb example URL
-  Link to actual GitHub project
- Specify GitHub URL must be HTTP
-  Set valid links to open in new window
