### PR TITLE
Migrate to using JGit for merge base computation

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -980,7 +980,7 @@ public class GitAPI implements IGitAPI {
         return launchCommand("log", "--all", "--pretty=format:'%H#%ct'", branch);
     }
 
-    private Repository getRepository() throws IOException {
+    public Repository getRepository() throws IOException {
         return new FileRepository(new File(workspace.getRemote(), Constants.DOT_GIT));
     }
 

--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -1,6 +1,7 @@
 package hudson.plugins.git;
 
 import hudson.EnvVars;
+import hudson.FilePath;
 import hudson.model.TaskListener;
 
 import java.io.File;
@@ -11,6 +12,7 @@ import java.util.Set;
 
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.RemoteConfig;
 
 /**
@@ -19,6 +21,7 @@ import org.eclipse.jgit.transport.RemoteConfig;
 public interface IGitAPI {
     String getGitExe();
     EnvVars getEnvironment();
+    Repository getRepository() throws IOException; 
 
     public void init() throws GitException;
 

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -18,20 +18,23 @@ import hudson.plugins.git.IGitAPI;
 import hudson.plugins.git.IndexEntry;
 import hudson.plugins.git.Revision;
 
-
 import java.io.IOException;
 import java.io.OutputStream;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.filter.RevFilter;
+import org.eclipse.jgit.storage.file.FileRepository;
 
 public class GitUtils {
     IGitAPI git;
@@ -92,8 +95,8 @@ public class GitUtils {
     /**
      * Return a list of 'tip' branches (I.E. branches that aren't included entirely within another branch).
      *
-     * @param git
-     * @return
+     * @param revisions
+     * @return filtered tip branches
      */
     public Collection<Revision> filterTipBranches(Collection<Revision> revisions) {
         // If we have 3 branches that we might want to build
@@ -101,31 +104,65 @@ public class GitUtils {
         //        \-----C
 
         // we only want (B) and (C), as (A) is an ancestor (old).
-
         List<Revision> l = new ArrayList<Revision>(revisions);
 
-        OUTER:
-        for (int i=0; i<l.size(); i++) {
-            for (int j=i+1; j<l.size(); j++) {
-                Revision ri = l.get(i);
-                Revision rj = l.get(j);
-                ObjectId commonAncestor = git.mergeBase(ri.getSha1(), rj.getSha1());
-                if (commonAncestor==null)   continue;
+        boolean log = LOGGER.isLoggable(Level.FINE);
+        Revision revI;
+        Revision revJ;
+        ObjectId shaI;
+        ObjectId shaJ;
+        ObjectId commonAncestor;
+        RevWalk walk = null;
+        long start = System.currentTimeMillis();
+        long calls = 0;
+        if (log)
+            LOGGER.fine(MessageFormat.format(
+                    "Computing merge base of {0}  branches", l.size()));
+        try {
+            walk = new RevWalk(git.getRepository());
+            walk.setRetainBody(false);
+            walk.setRevFilter(RevFilter.MERGE_BASE);
+            for (int i = 0; i < l.size(); i++) {
+                for (int j = i + 1; j < l.size(); j++) {
+                    revI = l.get(i);
+                    revJ = l.get(j);
+                    shaI = revI.getSha1();
+                    shaJ = revJ.getSha1();
 
-                if (commonAncestor.equals(ri.getSha1())) {
-                    LOGGER.fine("filterTipBranches: "+rj+" subsumes "+ri);
-                    l.remove(i);
-                    i--;
-                    continue OUTER;
-                }
-                if (commonAncestor.equals(rj.getSha1())) {
-                    LOGGER.fine("filterTipBranches: "+ri+" subsumes "+rj);
-                    l.remove(j);
-                    j--;
+                    walk.reset();
+                    walk.markStart(walk.parseCommit(shaI));
+                    walk.markStart(walk.parseCommit(shaJ));
+                    commonAncestor = walk.next();
+                    calls++;
+                    if (commonAncestor == null)
+                        continue;
+                    if (commonAncestor.equals(shaI)) {
+                        if (log)
+                            LOGGER.fine("filterTipBranches: " + revJ
+                                    + " subsumes " + revI);
+                        l.remove(i);
+                        i--;
+                        break;
+                    }
+                    if (commonAncestor.equals(shaJ)) {
+                        if (log)
+                            LOGGER.fine("filterTipBranches: " + revI
+                                    + " subsumes " + revJ);
+                        l.remove(j);
+                        j--;
+                    }
                 }
             }
+        } catch (IOException e) {
+            throw new GitException("Error computing merge base", e);
+        } finally {
+            if (walk != null)
+                walk.release();
         }
-
+        if (log)
+            LOGGER.fine(MessageFormat.format(
+                    "Computed {0} merge bases in {1} ms", calls,
+                    (System.currentTimeMillis() - start)));
         return l;
     }
 


### PR DESCRIPTION
I tested using a repository with ~90 branches that referenced different commits.  I saw dramatic performance improvements when using JGit to compute the merge base versus the command line.
# Command-line
- ~4000 `git merge-base` command invoked
- ~300 seconds (5 minutes) to complete
# JGit RevWalk
- ~4000 resets of the same `RevWalk` instance
- ~10 seconds to complete
