### PR TITLE
Use XSTREAM2 compatibility helper for jgit package rename

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1284,6 +1284,8 @@ public class GitSCM extends SCM implements Serializable {
 
         public DescriptorImpl() {
             super(GitSCM.class, GitRepositoryBrowser.class);
+            Run.XSTREAM2.addCompatibilityAlias("org.spearce.jgit.lib.ObjectId",
+                    ObjectId.class);
             load();
         }
 


### PR DESCRIPTION
This uses 

``` java
Run.XSTREAM2.addCompatibilityAlias
```

to register `org.spearce.jgit.lib.ObjectId`
