### PR TITLE
Fixed NPE (releated to JENKINS-9843)

### DIFF
--- a/src/main/java/hudson/plugins/git/opt/PreBuildMergeOptions.java
+++ b/src/main/java/hudson/plugins/git/opt/PreBuildMergeOptions.java
@@ -45,7 +45,7 @@ public class PreBuildMergeOptions implements Serializable {
 
     @Exported
     public String getRemoteBranchName() {
-        return mergeRemote.getName() + "/" + mergeTarget;
+        return (mergeRemote == null) ? null : mergeRemote.getName() + "/" + mergeTarget;
     }
 
     public boolean doMerge() {


### PR DESCRIPTION
NPE results into invalid XML when accessing api/xml?depth=1
