### PR TITLE
support for multi-commit pushes (related to [JENKINS-8342])

### DIFF
--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -9,7 +9,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.IGitAPI;
 import hudson.plugins.git.Revision;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.spearce.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectId;
 
 import java.io.IOException;
 import java.text.MessageFormat;


### PR DESCRIPTION
fix that all commits since the last build are taken into account on calculating the revision candidates. Before only the last commit was used. The list of candidates is used to check against the excludedRegions pattern.
