### PR TITLE
JENKINS-10272 Global git config name and email address settings not used.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -423,27 +423,21 @@ public class GitSCM extends SCM implements Serializable {
     }
 
     public String getGitConfigNameToUse() {
-        String confName;
-        String globalConfigName = ((DescriptorImpl) getDescriptor()).getGlobalConfigName();
-        if ((fixEmptyAndTrim(globalConfigName) != null) && (gitConfigName == null)) {
-            confName = globalConfigName;
-        } else {
-            confName = gitConfigName;
+        String confName = fixEmptyAndTrim(gitConfigName);
+        if (confName == null) {
+        	String globalConfigName = ((DescriptorImpl) getDescriptor()).getGlobalConfigName();
+        	confName = fixEmptyAndTrim(globalConfigName);
         }
-
-        return fixEmptyAndTrim(confName);
+        return confName;
     }
 
     public String getGitConfigEmailToUse() {
-        String confEmail;
-        String globalConfigEmail = ((DescriptorImpl) getDescriptor()).getGlobalConfigEmail();
-        if ((fixEmptyAndTrim(globalConfigEmail) != null) && (gitConfigEmail == null)) {
-            confEmail = globalConfigEmail;
-        } else {
-            confEmail = gitConfigEmail;
+        String confEmail = fixEmptyAndTrim(gitConfigEmail);
+        if (confEmail == null) {
+        	String globalConfigEmail = ((DescriptorImpl) getDescriptor()).getGlobalConfigEmail();
+        	confEmail = fixEmptyAndTrim(globalConfigEmail);
         }
-
-        return fixEmptyAndTrim(confEmail);
+        return confEmail;
     }
 
     public boolean getSkipTag() {


### PR DESCRIPTION
JENKINS-10272 Global git config name and email address settings not used.
An empty string for project local settings is treated as a valid setting
and hence there is no fallback to global settings.

Using fixEmptyAndTrim on the project local setting allows fallback to the global settings.

Please pull.

Regards

Richard
