### PR TITLE
Changed firstLine() method in GitAPI to ignore a trailing empty line 

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -264,19 +264,13 @@ public class GitAPI implements IGitAPI {
     }
 
     private String firstLine(String result) {
-        BufferedReader reader = new BufferedReader(new StringReader(result));
-        String line;
-        try {
-            line = reader.readLine();
-            if (line == null)
-                return null;
-            if (reader.readLine() != null)
-                throw new GitException("Result has multiple lines");
-        } catch (IOException e) {
-            throw new GitException("Error parsing result", e);
-        }
-
-        return line;
+       String[] lines = result.split("(\\r?\\n)+");
+       if (lines[0].trim().isEmpty()) {
+          return null;
+       } else if (lines.length > 1) {
+          throw new GitException("Result has multiple lines");
+       }
+       return lines[0];
     }
 
     public void changelog(String revFrom, String revTo, OutputStream outputStream) throws GitException {


### PR DESCRIPTION
Trying to fix a problem in my build server. I suspect that the GitAPI.firstLine() method was overly strict. Here is an example of the console output:

00:01:23 Checkout:development / c:\development - hudson.remoting.LocalChannel@1f6f81b
00:01:23 Workspace has a .git repository, but it appears to be corrupt.
00:01:23 Cloning the remote Git repository
00:01:23 Cloning repository origin
00:01:23 Error trying to determine the git version: Result has multiple lines
00:01:23 Assuming 1.6
00:02:56 ERROR: Error cloning remote repo 'origin' : Could not clone gitolite@code:central-code
00:02:56 ERROR: Cause: Error performing command: C:\Apps\Git\cmd\git.cmd clone -o origin gitolite@code:central-code c:\development
00:02:56 null
00:02:56 Trying next repository
00:02:56 ERROR: Could not clone repository
00:02:56 FATAL: Could not clone
00:02:56 hudson.plugins.git.GitException: Could not clone
00:02:56 at hudson.plugins.git.GitSCM$2.invoke(GitSCM.java:1042)
00:02:56 at hudson.plugins.git.GitSCM$2.invoke(GitSCM.java:968)
00:02:56 at hudson.FilePath.act(FilePath.java:758)
00:02:56 at hudson.FilePath.act(FilePath.java:740)
00:02:56 at hudson.plugins.git.GitSCM.checkout(GitSCM.java:968)
00:02:56 at hudson.model.AbstractProject.checkout(AbstractProject.java:1193)
00:02:56 at hudson.model.AbstractBuild$AbstractRunner.checkout(AbstractBuild.java:555)
00:02:56 at hudson.model.AbstractBuild$AbstractRunner.run(AbstractBuild.java:443)
00:02:56 at hudson.model.Run.run(Run.java:1376)
00:02:56 at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:46)
00:02:56 at hudson.model.ResourceController.execute(ResourceController.java:88)
00:02:56 at hudson.model.Executor.run(Executor.java:175)
