### PR TITLE
option for submodule updating

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -135,6 +135,9 @@
     <f:entry title="Fast remote polling" help="/plugin/git/help-fastremote.html">
       <f:checkbox name="git.remotePoll" checked="${scm.remotePoll}" />
     </f:entry>
+    <f:entry title="Updated submodules" help="/plugin/git/help-updateSubmodules.html">
+      <f:checkbox name="git.updateSubmodules" checked="${scm.updateSubmodules}" default="true" />
+    </f:entry>
     <f:entry title="Recursively update submodules" field="recursiveSubmodules" help="/plugin/git/help-recursiveSubmodules.html">
       <f:checkbox />
     </f:entry>

--- a/src/main/webapp/help-recursiveSubmodules.html
+++ b/src/main/webapp/help-recursiveSubmodules.html
@@ -1,5 +1,5 @@
 <div>
-  Retrieve all submodules recursively 
+  Retrieve all submodules recursively. Requires "Update Submodules" to be enabled.
   
   (uses '--recursive' option which requires git>=1.6.5)  
 </div>

--- a/src/main/webapp/help-updateSubmodules.html
+++ b/src/main/webapp/help-updateSubmodules.html
@@ -1,0 +1,5 @@
+<div>
+  Retrieve all submodules. This is necessary for recursive updates.
+
+  This option should generally be enabled. If your submodules need special processing before being updated, then you may disable this option. e.g. your submodules do not use the refs/heads/ refspec
+</div>


### PR DESCRIPTION
My repository can require special processing on the submodules before
they are updated. This is because Gerrit is used, so the submodules
may not always point to refs/heads/, which is the only place git looks
at by default. This should really be fixed in git, but as a workaround
we have created a script that checks ls-remotes and updates to the
appropriate location.

This shouldn't be used in normal circumstances, so I would consider
this somewhat of a hack; however, the option itself doesn't require any
obtrusive code in the git plugin.
