### PR TITLE
Always set git name and email environment variables

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -936,20 +936,7 @@ public class GitSCM extends SCM implements Serializable {
             listener.getLogger().println("Last Built Revision: " + buildData.lastBuild.revision);
         }
 
-        EnvVars tempEnvironment = build.getEnvironment(listener);
-
-        String confName = getGitConfigNameToUse();
-        if ((confName != null) && (!confName.equals(""))) {
-            tempEnvironment.put("GIT_COMMITTER_NAME", confName);
-            tempEnvironment.put("GIT_AUTHOR_NAME", confName);
-        }
-        String confEmail = getGitConfigEmailToUse();
-        if ((confEmail != null) && (!confEmail.equals(""))) {
-            tempEnvironment.put("GIT_COMMITTER_EMAIL", confEmail);
-            tempEnvironment.put("GIT_AUTHOR_EMAIL", confEmail);
-        }
-
-        final EnvVars environment = tempEnvironment;
+        final EnvVars environment = build.getEnvironment(listener);
 
         final String singleBranch = getSingleBranch(build);
         final String paramLocalBranch = getParamLocalBranch(build);
@@ -1311,6 +1298,17 @@ public class GitSCM extends SCM implements Serializable {
             if (commit != null) {
                 env.put(GIT_COMMIT, commit);
             }
+        }
+
+        String confName = getGitConfigNameToUse();
+        if ((confName != null) && (!confName.equals(""))) {
+            env.put("GIT_COMMITTER_NAME", confName);
+            env.put("GIT_AUTHOR_NAME", confName);
+        }
+        String confEmail = getGitConfigEmailToUse();
+        if ((confEmail != null) && (!confEmail.equals(""))) {
+            env.put("GIT_COMMITTER_EMAIL", confEmail);
+            env.put("GIT_AUTHOR_EMAIL", confEmail);
         }
 
     }


### PR DESCRIPTION
Currently, when e.g. using Jenkins Maven 2 Pelease Plugin to perform
releases of Maven jobs, the commits and tags created by the release
process don't honour configured user.name and user.email values. This
patch fixes the incorrect behaviour by always defining the relevant
environment variables when building the environment for execution of Git
from within the plugin.

See https://issues.jenkins-ci.org/browse/JENKINS-11057
