### PR TITLE
[FIXED JENKINS-11749] Included regions feature for GitSCM plugin

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -66,6 +66,9 @@
   </f:entry>
 
   <f:advanced>
+    <f:entry title="${%Included Regions}" field="includedRegions" help="/plugin/git/help-includedRegions.html">
+        <f:textarea />
+    </f:entry>
     <f:entry title="${%Excluded Regions}" field="excludedRegions" help="/plugin/git/help-excludedRegions.html">
         <f:textarea />
     </f:entry>

--- a/src/main/webapp/help-includedRegions.html
+++ b/src/main/webapp/help-includedRegions.html
@@ -1,0 +1,19 @@
+<div>
+  If set, and Jenkins is set to poll for changes, Jenkins will honor any files and/or
+  folders in this list when determining if a build needs to be triggered.
+  <p/>
+  Each inclusion uses regular expression pattern matching, and must be separated by a new line.
+  An empty list implies that everything is included.
+  <p/>
+  <pre>
+	myapp/src/main/web/.*\.html
+	myapp/src/main/web/.*\.jpeg
+	myapp/src/main/web/.*\.gif
+  </pre>
+  The example above illustrates that a build will only occur, if html/jpeg/gif files
+  have been committed to the SCM. Exclusions take precedence over inclusions, if there is
+  an overlap between included and excluded regions.
+  <p/>
+  More information on regular expressions can be found
+  <a href="http://www.regular-expressions.info/" target="_blank">here</a>.
+</div>


### PR DESCRIPTION
This patch adds support for included regions. The default
behaviour is to include every path/file. Similar to the excluded
regions, regular expressions are used to specify which
paths/files should be included when determining if a build
should be triggered.
