### PR TITLE
Small change to make annotated tags more obvious

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -251,7 +251,7 @@ public class GitAPI implements IGitAPI {
     }
 
     public ObjectId revParse(String revName) throws GitException {
-        String result = launchCommand("rev-parse", revName);
+        String result = launchCommand("rev-parse", revName + "^{commit}");
         return ObjectId.fromString(firstLine(result).trim());
     }
 


### PR DESCRIPTION
Hi all, in our build environment we have noticed that annotated tags are only being dereferenced to the tags own object.

Since we have a fair few things that depend on jenkins git revisions, this causes us confusion as our artefacts get named for the tag object rather than the commit the tag ultimately points to.

This pull changes the rev-parse to be aware that it might be attempting to find the revision for a tag, and, as such tells git to follow that revision until it finds a real commit.
