### PR TITLE
No exceptions stacktrace in GitAPI.validateRevision

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -116,7 +116,7 @@ public class GitAPI implements IGitAPI {
             }
             catch(Exception ex)
             {
-                listener.getLogger().println("Workspace has a .git repository, but it appears to be corrupt.");
+                ex.printStackTrace(listener.error("Workspace has a .git repository, but it appears to be corrupt."));
                 return false;
             }
             return true;


### PR DESCRIPTION
_Problem_: Exception in validateRevision cause permanent build triggering even if there’s nothing changed since last build.  

_Cause_: When there’s a problem with git verifying repository (OOM, no space left on device, or anything), there’s no way to figure out what’s going wrong.

_Solution_: My patch allows you to see original exception stacktrace so it helps figuring out what the problem really is.
