### PR TITLE
Ignore repository on notify commit

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -126,6 +126,7 @@ public class GitSCM extends SCM implements Serializable {
     private boolean wipeOutWorkspace;
     private boolean pruneBranches;
     private boolean remotePoll;
+    private boolean ignoreNotifyCommit;
 
     /**
      * @deprecated
@@ -177,7 +178,7 @@ public class GitSCM extends SCM implements Serializable {
                 false, Collections.<SubmoduleConfig>emptyList(), false,
                 false, new DefaultBuildChooser(), null, null, false, null,
                 null,
-                null, null, null, false, false, false, false, null, null, false, null);
+                null, null, null, false, false, false, false, null, null, false, null, false);
     }
 
     @DataBoundConstructor
@@ -205,7 +206,8 @@ public class GitSCM extends SCM implements Serializable {
             String gitConfigName,
             String gitConfigEmail,
             boolean skipTag,
-            String includedRegions) {
+            String includedRegions,
+            boolean ignoreNotifyCommit) {
 
         this.scmName = scmName;
 
@@ -252,6 +254,7 @@ public class GitSCM extends SCM implements Serializable {
         this.disableSubmodules = disableSubmodules;
         this.recursiveSubmodules = recursiveSubmodules;
         this.pruneBranches = pruneBranches;
+        this.ignoreNotifyCommit = ignoreNotifyCommit;
         if (remotePoll
             && (branches.size() != 1
             || branches.get(0).getName().contains("*")
@@ -513,6 +516,10 @@ public class GitSCM extends SCM implements Serializable {
 
     public boolean getClean() {
         return this.clean;
+    }
+
+    public boolean isIgnoreNotifyCommit() {
+        return ignoreNotifyCommit;
     }
 
     public BuildChooser getBuildChooser() {

--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -83,7 +83,7 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
                         if (uri.equals(remoteURL)) { repositoryMatches = true; break; }
                     }
 
-                    if (!repositoryMatches) continue;
+                    if (!repositoryMatches || git.isIgnoreNotifyCommit()) continue;
 
                     if (branchesArray.length == 1 && branchesArray[0] == "") {
                         branchMatches = true;

--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -1,5 +1,5 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  
+
     <script><![CDATA[
     function encodeAllInputs(sep, form, field) {
         var inputs = Form.getInputs(form, null, field);
@@ -45,24 +45,24 @@
 
       </f:repeatable>
     </f:entry>
-  
+
   <f:entry title="Branches to build" help="/plugin/git/branch.html">
   <f:repeatable var="branch" name="branches" varStatus="branchStatus" items="${instance.branches}" minimum="1" noAddButton="false">
            <table width="100%">
                <f:entry title="Branch Specifier (blank for default):" field="name">
                     <f:textbox value="${branch.name}" />
                </f:entry>
-               
+
                <f:entry>
             <div align="right">
                 <input type="button" value="Delete Branch" class="repeatable-delete" style="margin-left: 1em;" />
             </div>
           </f:entry>
-               
+
            </table>
-          
+
         </f:repeatable>
-  
+
   </f:entry>
 
   <f:advanced>
@@ -93,32 +93,32 @@
     <f:entry title="Config user.email Value" field="gitConfigEmail">
       <f:textbox />
     </f:entry>
-    
+
     <!-- This needs more thought
   <f:entry title="Autogenerate submodule configurations">
     <f:checkbox name="git.generate" checked="${scm.doGenerate}"/>
     <label class="attach-previous">Generate submodule configurations</label>
-    
+
     <f:repeatable var="smcfg" name="smcfg" varStatus="cfgStatus" items="${scm.submoduleCfg}" noAddButton="false">
            <table width="100%">
            <f:entry title="Name of submodule">
              <f:textbox name="git.submodule.name" value="${smcfg.submoduleName}" />
            </f:entry>
-           
+
            <f:entry title="Matching Branches">
             <f:textbox name="git.submodule.match" value="${smcfg.branchesString}" />
            </f:entry>
-           
-          
+
+
            <f:entry>
             <div align="right">
                 <input type="button" value="Delete" class="repeatable-delete" style="margin-left: 1em;" />
             </div>
           </f:entry>
           </table>
-          
+
         </f:repeatable>
-    
+
   </f:entry>
      -->
 
@@ -153,6 +153,10 @@
     <f:entry title="Wipe out workspace before build" field="wipeOutWorkspace" help="/plugin/git/wipeOutWorkspace.html">
       <f:checkbox />
     </f:entry>
+    <f:entry title="Ignore this repository during notify commit" field="ignoreNotifyCommit" help="/plugin/git/ignoreNotifyCommit.html">
+      <f:checkbox/>
+    </f:entry>
+
     <f:dropdownList name="buildChooser" title="${%Choosing strategy}" help="/plugin/git/choosingStrategy.html">
       <j:scope>
         <j:set var="current" value="${instance.buildChooser}"/>
@@ -184,6 +188,6 @@
           </select>
       </f:entry>
   </f:advanced>
-  
+
   <t:listScmBrowsers name="git.browser" />
 </j:jelly>

--- a/src/main/webapp/ignoreNotifyCommit.html
+++ b/src/main/webapp/ignoreNotifyCommit.html
@@ -1,0 +1,4 @@
+<div>
+    If checked, this repository will be ignored when the notifyCommit-URL is accessed regardless of if the repository
+    matches or not.
+</div>

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -546,7 +546,7 @@ public class GitSCMTest extends AbstractGitTestCase {
                 false, Collections.<SubmoduleConfig>emptyList(), false,
                 false, new DefaultBuildChooser(), null, null, authorOrCommitter, relativeTargetDir, null,
                 excludedRegions, excludedUsers, localBranch, false, false, false, fastRemotePoll, null, null, false,
-                includedRegions));
+                includedRegions, false));
         project.getBuildersList().add(new CaptureEnvironmentBuilder());
         return project;
     }

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -37,17 +37,17 @@ public class GitStatusTest extends HudsonTestCase {
 
     public void testGetIconFileName() {
         assertNull(this.gitStatus.getIconFileName());
-   }
+    }
 
     public void testGetUrlName() {
         assertEquals("git", this.gitStatus.getUrlName());
     }
 
     public void testDoNotifyCommitWithNoBranches() throws Exception {
-        SCMTrigger aMasterTrigger = setupProject("a", "master");
-        SCMTrigger aTopicTrigger = setupProject("a", "topic");
-        SCMTrigger bMasterTrigger = setupProject("b", "master");
-        SCMTrigger bTopicTrigger = setupProject("b", "topic");
+        SCMTrigger aMasterTrigger = setupProject("a", "master", false);
+        SCMTrigger aTopicTrigger = setupProject("a", "topic", false);
+        SCMTrigger bMasterTrigger = setupProject("b", "master", false);
+        SCMTrigger bTopicTrigger = setupProject("b", "topic", false);
 
         this.gitStatus.doNotifyCommit("a", "");
         Mockito.verify(aMasterTrigger).run();
@@ -57,10 +57,10 @@ public class GitStatusTest extends HudsonTestCase {
     }
 
     public void testDoNotifyCommitWithNoMatchingUrl() throws Exception {
-        SCMTrigger aMasterTrigger = setupProject("a", "master");
-        SCMTrigger aTopicTrigger = setupProject("a", "topic");
-        SCMTrigger bMasterTrigger = setupProject("b", "master");
-        SCMTrigger bTopicTrigger = setupProject("b", "topic");
+        SCMTrigger aMasterTrigger = setupProject("a", "master", false);
+        SCMTrigger aTopicTrigger = setupProject("a", "topic", false);
+        SCMTrigger bMasterTrigger = setupProject("b", "master", false);
+        SCMTrigger bTopicTrigger = setupProject("b", "topic", false);
 
         this.gitStatus.doNotifyCommit("nonexistent", "");
         Mockito.verify(aMasterTrigger, Mockito.never()).run();
@@ -70,10 +70,10 @@ public class GitStatusTest extends HudsonTestCase {
     }
 
     public void testDoNotifyCommitWithOneBranch() throws Exception {
-        SCMTrigger aMasterTrigger = setupProject("a", "master");
-        SCMTrigger aTopicTrigger = setupProject("a", "topic");
-        SCMTrigger bMasterTrigger = setupProject("b", "master");
-        SCMTrigger bTopicTrigger = setupProject("b", "topic");
+        SCMTrigger aMasterTrigger = setupProject("a", "master", false);
+        SCMTrigger aTopicTrigger = setupProject("a", "topic", false);
+        SCMTrigger bMasterTrigger = setupProject("b", "master", false);
+        SCMTrigger bTopicTrigger = setupProject("b", "topic", false);
 
         this.gitStatus.doNotifyCommit("a", "master");
         Mockito.verify(aMasterTrigger).run();
@@ -83,10 +83,10 @@ public class GitStatusTest extends HudsonTestCase {
     }
 
     public void testDoNotifyCommitWithTwoBranches() throws Exception {
-        SCMTrigger aMasterTrigger = setupProject("a", "master");
-        SCMTrigger aTopicTrigger = setupProject("a", "topic");
-        SCMTrigger bMasterTrigger = setupProject("b", "master");
-        SCMTrigger bTopicTrigger = setupProject("b", "topic");
+        SCMTrigger aMasterTrigger = setupProject("a", "master", false);
+        SCMTrigger aTopicTrigger = setupProject("a", "topic", false);
+        SCMTrigger bMasterTrigger = setupProject("b", "master", false);
+        SCMTrigger bTopicTrigger = setupProject("b", "topic", false);
 
         this.gitStatus.doNotifyCommit("a", "master,topic");
         Mockito.verify(aMasterTrigger).run();
@@ -96,10 +96,10 @@ public class GitStatusTest extends HudsonTestCase {
     }
 
     public void testDoNotifyCommitWithNoMatchingBranches() throws Exception {
-        SCMTrigger aMasterTrigger = setupProject("a", "master");
-        SCMTrigger aTopicTrigger = setupProject("a", "topic");
-        SCMTrigger bMasterTrigger = setupProject("b", "master");
-        SCMTrigger bTopicTrigger = setupProject("b", "topic");
+        SCMTrigger aMasterTrigger = setupProject("a", "master", false);
+        SCMTrigger aTopicTrigger = setupProject("a", "topic", false);
+        SCMTrigger bMasterTrigger = setupProject("b", "master", false);
+        SCMTrigger bTopicTrigger = setupProject("b", "topic", false);
 
         this.gitStatus.doNotifyCommit("a", "nonexistent");
         Mockito.verify(aMasterTrigger, Mockito.never()).run();
@@ -108,7 +108,14 @@ public class GitStatusTest extends HudsonTestCase {
         Mockito.verify(bTopicTrigger, Mockito.never()).run();
     }
 
-    private SCMTrigger setupProject(String url, String branchString) throws Exception {
+    public void testDoNotifyCommitWithIgnoredRepository() throws Exception {
+        SCMTrigger aMasterTrigger = setupProject("a", "master", true);
+
+        this.gitStatus.doNotifyCommit("a", "");
+        Mockito.verify(aMasterTrigger, Mockito.never()).run();
+    }
+
+    private SCMTrigger setupProject(String url, String branchString, boolean ignoreNotifyCommit) throws Exception {
         FreeStyleProject project = createFreeStyleProject();
         project.setScm(new GitSCM(
                 null,
@@ -118,7 +125,7 @@ public class GitStatusTest extends HudsonTestCase {
                 false, Collections.<SubmoduleConfig>emptyList(), false,
                 false, new DefaultBuildChooser(), null, null, false, null,
                 null,
-                null, null, null, false, false, false, false, null, null, false, null));
+                null, null, null, false, false, false, false, null, null, false, null, ignoreNotifyCommit));
         SCMTrigger trigger = Mockito.mock(SCMTrigger.class);
         project.addTrigger(trigger);
         return trigger;


### PR DESCRIPTION
I have added a checkbox to the advanced-part of the git repository configuration to make it possible to ignore a repository from notify commit.

My nightly builds are setup as polling jobs since I only want to execute them if anything has changed but when using the notifyCommit-URL, the nightly jobs are executed along with the other jobs. This pull request fixes that.
