### PR TITLE
upgrade token-macro 1.5.1 (circular dependency on 1.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -57,7 +57,7 @@
       <name>Eclipse JGit Repository</name>
       <url>http://download.eclipse.org/jgit/maven</url>
     </repository>
-    
+
     <repository>
       <id>guice-maven</id>
       <name>guice maven</name>
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>
-      <version>1.0</version>
+      <version>1.5.1</version>
       <optional>true</optional>
     </dependency>
   </dependencies>
@@ -133,7 +133,7 @@
       <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
     </repository>
   </distributionManagement>
-  
+
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/git-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/git-plugin.git</developerConnection>


### PR DESCRIPTION
Using maven 3.0.4, I get 31 errors but only 1 if I upgrade to 1.5.1 with the latest branch:

INFO: Stopping maven-plugin
Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 64.582 sec

Results :

Tests in error:
  testMatrixBuild(hudson.plugins.git.GitPublisherTest): johnDoe

Tests run: 94, Failures: 0, Errors: 1, Skipped: 0
