### PR TITLE
[JENKINS-13356] ignore stderr when launching external git command

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -759,16 +759,24 @@ public class GitAPI implements IGitAPI {
      */
     private String launchCommandIn(ArgumentListBuilder args, FilePath workDir) throws GitException {
         ByteArrayOutputStream fos = new ByteArrayOutputStream();
+        // JENKINS-13356: capture the output of stderr separately
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
 
         try {
             args.prepend(getGitExe());
             int status = launcher.launch().cmds(args.toCommandArray()).
-                envs(environment).stdout(fos).pwd(workDir).join();
+                envs(environment).stdout(fos).stderr(err).pwd(workDir).join();
 
             String result = fos.toString();
+            
+            // JENKINS-13356: do not return the output of stderr, but at least print it somewhere
+            // (disabled again, creates too much unwanted output, for example when cloning a repository)
+//            if (err.size() > 0) {
+//                listener.getLogger().print("Command \""+StringUtils.join(args.toCommandArray(), " ")+"printed on stderr: "+err.toString());
+//            }
 
             if (status != 0) {
-                throw new GitException("Command \""+StringUtils.join(args.toCommandArray(), " ")+"\" returned status code " + status + ": " + result);
+                throw new GitException("Command \""+StringUtils.join(args.toCommandArray(), " ")+"\" returned status code " + status + ":\nstdout: " + result + "\nstderr: "+ err.toString());
             }
 
             return result;


### PR DESCRIPTION
This patches GitAPI.launchCommand() to ignore stderr and only return the stdout to the caller. If the command fails, stderr is appended in the exception message, otherwise it's discarded.

Rationale: The output of stderr is not reliably defined by the git commands and therefore might not be parsable by the caller. In the case of JENKINS-13356 it contained some unexpected and unhandled warning about a missing locale.

Backward compatibility: Any commands that rely on the contents of stderr would be broken by this patch. I hereby assume that such commands do not exist.
