### PR TITLE
Updated versions in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
       <plugin>
         <groupId>com.infradna.tool</groupId>
         <artifactId>bridge-method-injector</artifactId>
+        <version>1.4</version>
         <executions>
           <execution>
             <goals>
@@ -122,7 +123,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
       <optional>true</optional>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Some dependencies were quite old, and this plugin would not even run correctly when doing a simple mvn hpi:run
- updated jenkins to latest version 1.458
- updated token-macro to 1.1 to avoid cyclic dependence warning. That version is also used in the jenkins poms
- set the dependency on the com.infradna.tool.bridge-method-injector plugin to the latest 1.4 to avoid a maven warning
