### PR TITLE
The "^" in rev-parse command was not being escaped

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -251,7 +251,7 @@ public class GitAPI implements IGitAPI {
     }
 
     public ObjectId revParse(String revName) throws GitException {
-        String result = launchCommand("rev-parse", revName + "^{commit}");
+        String result = launchCommand("rev-parse", "\"" + revName + "^{commit}\"");
         return ObjectId.fromString(firstLine(result).trim());
     }
 


### PR DESCRIPTION
This was causing errors on some windows machines.  Adding quotes around entire arg.
