### PR TITLE
[FIXED JENKINS-13413] Git icon(git-48x48.png) missing in job page.

### DIFF
--- a/src/main/resources/hudson/plugins/git/util/BuildData/summary.jelly
+++ b/src/main/resources/hudson/plugins/git/util/BuildData/summary.jelly
@@ -1,7 +1,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
 	xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
 	xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-	<t:summary icon="${resURL}/plugin/git/icons/git-48x48.png">
+	<t:summary icon="/plugin/git/icons/git-48x48.png">
 
  	<b>Revision</b>: ${it.lastBuiltRevision.sha1.name()}
         <j:if test="${it.scmName}"> from <b>SCM:</b> ${it.scmName}</j:if>


### PR DESCRIPTION
<:summary>  supports cached static resources since 1.463. So it does not require ${res}.
See https://github.com/jenkinsci/jenkins/commit/bb55c07579b03f8aa39d91bd5ce2a283bce40610
