### PR TITLE
Suggesting a ForceTag field instead of CreateTag. Behavior should allow ...

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -259,7 +259,10 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                                             listener.getLogger().println("No repository found for target repo name " + targetRepo);
                                             return false;
                                         }
-                                        
+                                        // What about when you want to update a tag that already exists in the repo
+                                        // to the most recent successful build?
+                                        // ie: git tag -f tagname
+                                        // I propose a isForceTag boolean instead of CreateTag
                                         if (t.isCreateTag()) {
                                             if (git.tagExists(tagName)) {
                                                 listener.getLogger().println("Tag " + tagName + " already exists and Create Tag is specified, so failing.");


### PR DESCRIPTION
...for situations when you just want to update an existing tag to the current (successful) build. For example, I may have a tag `goodbuild` that I want to push to the repository every time a successful build happens. Currently this isn't possible, as it doesn't use the `-f` flag in the tag process.
