### PR TITLE
use 'git whatchanged' instead of 'git show'

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -326,7 +326,7 @@ public class GitAPI implements IGitAPI {
         String result = "";
 
         if (revName != null) {
-            result = launchCommand("show", "--no-abbrev", "--format=raw", "-M", "--raw", revName);
+            result = launchCommand("whatchanged", "--no-abbrev", "-M", "-m", "--pretty=raw", "-1", revName);
         }
 
         List<String> revShow = new ArrayList<String>();


### PR DESCRIPTION
This forces file-by-file evaluation necessary for included/excluded
regions to be applied correctly to merge commits.

See: https://issues.jenkins-ci.org/browse/JENKINS-13580, which we
believe is resolved here.
