### PR TITLE
git show shall compare with last build sha1

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -6,6 +6,7 @@ import hudson.Launcher;
 import hudson.FilePath.FileCallable;
 import hudson.Launcher.LocalLauncher;
 import hudson.model.TaskListener;
+import hudson.plugins.git.util.BuildData;
 import hudson.remoting.VirtualChannel;
 import hudson.util.ArgumentListBuilder;
 
@@ -321,11 +322,12 @@ public class GitAPI implements IGitAPI {
      * @return The git show output, in List form.
      * @throws GitException if errors were encountered running git show.
      */
-    public List<String> showRevision(Revision r) throws GitException {
-        String revName = r.getSha1String();
+    public List<String> showRevision(Revision r, BuildData buildData) throws GitException {
+    	//   String revName =  r.getSha1String();
         String result = "";
-
-        if (revName != null) {
+        
+        if (r.getSha1String() != null) {
+        	String revName = buildData.lastBuild.revision.sha1.name() +".." + r.getSha1String();
             result = launchCommand("show", "--no-abbrev", "--format=raw", "-M", "--raw", revName);
         }
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -749,7 +749,7 @@ public class GitSCM extends SCM implements Serializable {
                     List<Revision> candidates = new ArrayList<Revision>();
 
                     for (Revision c : origCandidates) {
-                        if (!isRevExcluded(git, c, listener)) {
+                        if (!isRevExcluded(git, c, listener, buildData)) {
                             candidates.add(c);
                         }
                     }
@@ -1782,9 +1782,11 @@ public class GitSCM extends SCM implements Serializable {
      * @param listener
      * @return true if any exclusion files are matched, false otherwise.
      */
-    private boolean isRevExcluded(IGitAPI git, Revision r, TaskListener listener) {
-        try {
-            List<String> revShow = git.showRevision(r);
+    private boolean isRevExcluded(IGitAPI git, Revision r, TaskListener listener, BuildData buildData) {
+        
+    	
+    	try {
+            List<String> revShow = git.showRevision(r, buildData);
 
             // If the revision info is empty, something went weird, so we'll just
             // return false.

--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -2,6 +2,7 @@ package hudson.plugins.git;
 
 import hudson.EnvVars;
 import hudson.model.TaskListener;
+import hudson.plugins.git.util.BuildData;
 
 import java.io.File;
 import java.io.IOException;
@@ -110,7 +111,7 @@ public interface IGitAPI {
     ObjectId mergeBase(ObjectId sha1, ObjectId sha12);
     String getAllLogEntries(String branch);
 
-    List<String> showRevision(Revision r) throws GitException;
+    List<String> showRevision(Revision r, BuildData buildData) throws GitException;
     String getHeadRev(String remoteRepoUrl, String branch) throws GitException;
 
     String getReference();


### PR DESCRIPTION
use git show --no-abbrev --format=raw -M --raw 'old sha1'..'new sha1'
instead of 
git show --no-abbrev --format=raw -M --raw 'new sha1'

This is the correction for
"Git plug-in & included regions : build not triggered in case of mutiple commits in one push."
 https://issues.jenkins-ci.org/browse/JENKINS-13368.

I think think this correction also solves
"git plugin "included regions" feature is bypassed when evaluating a merge commit"
 https://issues.jenkins-ci.org/browse/JENKINS-13580

We shall find a common correction for both issues are they are linked to include region feature.
