### PR TITLE
Fixed a windows bug caused by unneeded escaping of curly brackets.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -257,7 +257,7 @@ public class GitAPI implements IGitAPI {
     }
 
     public ObjectId revParse(String revName) throws GitException {
-        String rpCommit = Functions.isWindows() ? "^^\\{commit\\}" : "^{commit}";
+        String rpCommit = Functions.isWindows() ? "^^{commit}" : "^{commit}";
         String result = launchCommand("rev-parse", revName + rpCommit);
         return ObjectId.fromString(firstLine(result).trim());
     }


### PR DESCRIPTION
This is related to a reported bug https://issues.jenkins-ci.org/browse/JENKINS-13007 which I have reopened.
