### PR TITLE
Jenkins GIT plugin - notes support

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -738,6 +738,24 @@ public class GitAPI implements IGitAPI {
         }
     }
 
+    public void appendNote(String note, String namespace ) throws GitException {
+        try {
+        	launchCommand("notes", "--ref="+namespace, "append", "-m", "\'"+note+"\'" );
+        } catch (GitException e) {
+            throw new GitException("Could not apply note " + note, e);
+        }
+
+    }
+
+    public void addNote(String note, String namespace ) throws GitException {
+        try {
+            launchCommand("notes", "--ref="+namespace,"add", "-m", "\'"+note+"\'" );
+        } catch (GitException e) {
+            throw new GitException("Could not apply note " + note, e);
+        }
+
+    }
+    
     /**
      * Launch command using the workspace as working directory
      * @param args

--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -78,6 +78,11 @@ public interface IGitAPI {
     List<Tag> getTagsOnCommit(String revName) throws GitException, IOException;
 
     void tag(String tagName, String comment) throws GitException;
+    
+    void appendNote(String note, String namespace ) throws GitException;
+    void addNote(String note, String namespace ) throws GitException;
+    	
+   
     boolean tagExists(String tagName) throws GitException;
     void deleteTag(String tagName) throws GitException;
     Set<String> getTagNames(String tagPattern) throws GitException;

--- a/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
@@ -71,4 +71,35 @@
         </div>
       </f:repeatable>
     </f:entry>
+    
+    <f:entry field="notesToPush" title="${%Notes}" description="${%Notes to push to remote repositories}">
+    
+      <f:repeatable field="notesToPush"  add="${%Add Note}">
+      
+        <table width="100%">
+          <br/>
+          <f:entry title="${%Note to push}"    field="noteMsg" >
+            <f:textbox checkUrl="'descriptorByName/GitPublisher/checkNoteMsg?value='+escape(this.value)" />
+          </f:entry>
+          
+          <f:entry field="targetRepoName" title="${%Target remote name}">
+            <f:textbox/>
+          </f:entry>
+          
+          <f:entry title="${%Note's namespace}" field="noteNamespace">
+            <f:textbox/>
+          </f:entry>
+          
+          <f:entry title="${%Abort if note exists}" field="noteReplace" >
+            <f:checkbox />
+          </f:entry>
+          
+        </table>
+        <div align="right">
+          <input type="button" value="Delete Note" class="repeatable-delete" style="margin-left: 1em;" />
+        </div>
+         
+      </f:repeatable>
+    </f:entry>
+    
 </j:jelly>

--- a/src/main/resources/hudson/plugins/git/GitPublisher/help-notesToPush.html
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/help-notesToPush.html
@@ -1,0 +1,3 @@
+Specify notes to push at the completion of the build.
+Environment variables may be used in notes - they will be replaced at build time.
+Note's namespace and remote repository's name are optional. Those are master and origin by default.


### PR DESCRIPTION
Hello!

I have created notes support into Jenkins GIT plugin. This upgrade allows generating notes as post-build action. For example Git plugin can add a note to git project if test build is successful. There is also options to note's namespace, target's remote repository and failure if note already exists. 

Environment variables are also supported. Note namespace and remote repository name are optional. Those are master and origin by default. Overall notes support property follows the same guidelines as post-build action "Add Tags" feature.

Best Regards, 
Joel Huttunen
