### PR TITLE
[FIXED JENKINS-14321] Use the master environment for fast remote polls

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -678,7 +678,7 @@ public class GitSCM extends SCM implements Serializable {
                     break;
                 }
             }
-            final EnvVars environment = GitUtils.getPollEnvironment(project, workspace, launcher, listener);
+            final EnvVars environment = new EnvVars(System.getenv());
             IGitAPI git = new GitAPI(gitExe, workspace, listener, environment, reference);
             String gitRepo = getParamExpandedRepos(lastBuild).get(0).getURIs().get(0).toString();
             String headRevision = git.getHeadRev(gitRepo, getBranches().get(0).getName());


### PR DESCRIPTION
Since the master is used for doing the fast remote polls, it should
be the master's environment that is passed to the git executable
not the environment of the last build's slave.

Signed-off-by: ciaranj ciaranj@gmail.com
