### PR TITLE
Adds branch information to the change set log

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -32,6 +32,8 @@ public class GitChangeSet extends ChangeLogSet.Entry {
     private static final String PREFIX_AUTHOR = "author ";
     private static final String PREFIX_COMMITTER = "committer ";
     private static final String IDENTITY = "(.*)<(.*)> (.*) (.*)";
+    private static final String PREFIX_BRANCH = "Changes in branch ";
+    private static final String BRANCH_PATTERN = "([-_a-zA-Z0-9/]*),";
     
 
     private static final Pattern FILE_LOG_ENTRY = Pattern.compile("^:[0-9]{6} [0-9]{6} ([0-9a-f]{40}) ([0-9a-f]{40}) ([ACDMRTUX])(?>[0-9]+)?\t(.*)$");
@@ -40,8 +42,11 @@ public class GitChangeSet extends ChangeLogSet.Entry {
     private static final Pattern COMMITTER_ENTRY = Pattern.compile("^"
             + PREFIX_COMMITTER + IDENTITY + "$");
     private static final Pattern RENAME_SPLIT = Pattern.compile("^(.*?)\t(.*)$");
+    private static final Pattern BRANCH_ENTRY = Pattern.compile("^"
+            + PREFIX_BRANCH + BRANCH_PATTERN + " .*$");
     
     private static final String NULL_HASH = "0000000000000000000000000000000000000000";
+    private String branch;
     private String committer;
     private String committerEmail;
     private String committerTime;
@@ -82,6 +87,12 @@ public class GitChangeSet extends ChangeLogSet.Entry {
             } else if (line.startsWith("tree ")) {
             } else if (line.startsWith("parent ")) {
                 this.parentCommit = line.split(" ")[1];
+            } else if (line.startsWith(PREFIX_BRANCH)) {
+                Matcher branchMatcher = BRANCH_ENTRY.matcher(line);
+                if (branchMatcher.matches()
+                        && branchMatcher.groupCount() >= 1) {
+                    this.branch = branchMatcher.group(1).trim();
+                }
             } else if (line.startsWith(PREFIX_COMMITTER)) {
                 Matcher committerMatcher = COMMITTER_ENTRY.matcher(line);
                 if (committerMatcher.matches()
@@ -310,6 +321,10 @@ public class GitChangeSet extends ChangeLogSet.Entry {
             a.annotate(getParent().build,this,markup);
 
         return markup.toString(false);
+    }
+
+    public String getBranch() {
+        return this.branch;
     }
 
     @ExportedBean(defaultVisibility=999)

--- a/src/main/resources/hudson/plugins/git/GitChangeSetList/index.jelly
+++ b/src/main/resources/hudson/plugins/git/GitChangeSetList/index.jelly
@@ -27,6 +27,9 @@
               </j:if>
               by <a href="${rootURL}/${cs.author.url}/">${cs.author}</a>
             </b>
+            <j:if test="${cs.branch!=null}">
+              <j:whitespace trim="false"> in ${cs.branch}</j:whitespace>
+            </j:if>
             <pre>${cs.commentAnnotated}</pre>
           </div>
         </td>


### PR DESCRIPTION
In the ChangeSetList screen (${BUILD_URL}/changes), if a branch was
discovered in the SCM changelog, display the branch name in the changeset
detail.

See https://issues.jenkins-ci.org/browse/JENKINS-14350
