### PR TITLE
Remove -t option from fetch command

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -186,7 +186,7 @@ public class GitAPI implements IGitAPI {
                                      + (repository != null ? " from " + repository : ""));
 
         ArgumentListBuilder args = new ArgumentListBuilder();
-        args.add("fetch", "-t");
+        args.add("fetch");
 
         if (repository != null) {
             args.add(repository);


### PR DESCRIPTION
I've removed the -t option from the fetch command, as requested in https://issues.jenkins-ci.org/browse/JENKINS-6124.
