### PR TITLE
Add reset before clean

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -197,7 +197,11 @@ public class GitAPI implements IGitAPI {
         launchCommand(args);
     }
 
-    public void reset(boolean hard) {
+    public void fetch() throws GitException {
+        fetch(null, null);
+    }
+
+    public void reset(boolean hard) throws GitException {
         listener.getLogger().println("Resetting working tree");
 
         ArgumentListBuilder args = new ArgumentListBuilder();
@@ -209,12 +213,8 @@ public class GitAPI implements IGitAPI {
         launchCommand(args);
     }
 
-    public void reset() {
+    public void reset() throws GitException {
         reset(false);
-    }
-
-    public void fetch() throws GitException {
-        fetch(null, null);
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -57,6 +57,8 @@ public interface IGitAPI {
     void fetch(RemoteConfig remoteRepository);
 
     void fetch() throws GitException;
+    void reset(boolean hard) throws GitException;
+    void reset() throws GitException;
     void push(RemoteConfig repository, String revspec) throws GitException;
     void merge(String revSpec) throws GitException;
     void clone(RemoteConfig source) throws GitException;


### PR DESCRIPTION
This ensures that clean takes care of any local artifacts,
so that we're back on index. That way, when we later pull in a new
revision, we make sure that git doesn't get confused by anything
that might have changed in files it's tracking as part of a build.
