### PR TITLE
Changed if statement for setting git user's email address such that it is actually run when creating a new user

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -266,7 +266,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
             user = User.get(csAuthorEmail.split("@")[0], true);
     
         // set email address for user if none is already available
-        if (fixEmpty(csAuthorEmail) != null && user.getProperty(Mailer.UserProperty.class)==null) {
+        if (fixEmpty(csAuthorEmail) != null) { // && user.getProperty(Mailer.UserProperty.class)==null) {
             try {
                 user.addProperty(new Mailer.UserProperty(csAuthorEmail));
             } catch (IOException e) {


### PR DESCRIPTION
Using git, user.getProperty(Mailer.UserProperty.class) never ends up being null, and an email address never gets set.

Just set the email address no matter what (provided one is given). If a user changes their git email address, we want them to get the email to their new address anyways. This wouldn't happen if bob@hotmail.com switches to bob@gmail.com; the username remains 'bob'.
