### PR TITLE
[FIXED JENKINS-14849] switch to using User.getByCommitName() for revision information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.424</version>
+        <version>1.477</version>
     </parent>
 
     <groupId>org.jenkinsci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -263,7 +263,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
         User user = User.get(csAuthor, false);
 
         if (user == null) 
-            user = User.get(csAuthorEmail.split("@")[0], true);
+            user = User.getByCommitName(csAuthorEmail.split("@")[0]);
     
         // set email address for user if none is already available
         if (fixEmpty(csAuthorEmail) != null && user.getProperty(Mailer.UserProperty.class)==null) {


### PR DESCRIPTION
This updates the User.get() function call on a revision for an author to User.getByCommitName() to prevent possible duplicate Jenkins user creation.  If you have user "john" committing from location one as "j.doe" and location two as "john.doe", it is now possible to prevent automatic new Jenkins user creation by mapping both of those commit names.

This change requires [this pull request](https://github.com/jenkinsci/jenkins/pull/534)'s integration into Jenkins core.
