### PR TITLE
Allow specifying an alternative GIT_COMMIT environment variable name

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -93,6 +93,9 @@
     <f:entry title="Config user.email Value" field="gitConfigEmail">
       <f:textbox />
     </f:entry>
+    <f:entry title="Commit Environment Variable Name" field="gitCommitEnvVarName">
+      <f:textbox />
+    </f:entry>
 
     <!-- This needs more thought
   <f:entry title="Autogenerate submodule configurations">

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-gitCommitEnvVarName.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-gitCommitEnvVarName.html
@@ -1,0 +1,4 @@
+<div>
+  <p>An alternative name for the git commit environment variable (defaults to 'GIT_COMMIT'). Useful when using the
+      multiple SCM plugin.</p>
+</div>

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -130,7 +130,7 @@ public class GitStatusTest extends HudsonTestCase {
                 false, Collections.<SubmoduleConfig>emptyList(), false,
                 false, new DefaultBuildChooser(), null, null, false, null,
                 null,
-                null, null, null, false, false, false, false, null, null, false, null, ignoreNotifyCommit));
+                null, null, null, false, false, false, false, null, null, false, null, ignoreNotifyCommit, null));
         SCMTrigger trigger = Mockito.mock(SCMTrigger.class);
         project.addTrigger(trigger);
         return trigger;

--- a/src/test/java/hudson/plugins/git/MultipleSCMTest.java
+++ b/src/test/java/hudson/plugins/git/MultipleSCMTest.java
@@ -100,7 +100,8 @@ public class MultipleSCMTest extends HudsonTestCase {
 				  null,
 				  false,
 				  null,
-				  false);
+				  false,
+                  null);
 
 		SCM repo1Scm = new GitSCM("repo1",
 				  repo1.remoteConfigs(),
@@ -127,7 +128,8 @@ public class MultipleSCMTest extends HudsonTestCase {
 				  null,
 				  false,
 				  null,
-				  false);
+				  false,
+                  null);
 		
 		List<SCM> testScms = new ArrayList<SCM>();
 		testScms.add(repo0Scm);


### PR DESCRIPTION
When using the multiple SCM plugin with a number of git sources, the build environment is injected with the 'GIT_COMMIT' variable; the value of this variable is the latest commit of only one of the sources.
With this improvement every source can specify and maintain it's own env var without overriding any of the others.
