### PR TITLE
Allows line breaks in note messages

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
@@ -79,7 +79,7 @@
         <table width="100%">
           <br/>
           <f:entry title="${%Note to push}"    field="noteMsg" >
-            <f:textbox checkUrl="'descriptorByName/GitPublisher/checkNoteMsg?value='+escape(this.value)" />
+            <f:textarea checkUrl="'descriptorByName/GitPublisher/checkNoteMsg?value='+escape(this.value)" />
           </f:entry>
           
           <f:entry field="targetRepoName" title="${%Target remote name}">


### PR DESCRIPTION
Converts input field from text box to text area. This makes easier to write longer notes and allows line breaks in notes.

Jonux
