### PR TITLE
Stop building excluded revisions when multiple branches are configured

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -385,7 +385,7 @@ public class GitAPI implements IGitAPI {
         String result = "";
 
         if (revName != null) {
-            result = launchCommand("whatchanged", "--no-abbrev", "-M", "-m", "--pretty=raw", "-1", revName);
+            result = launchCommand("whatchanged", "--no-abbrev", "-M", "-m", "--first-parent", "--pretty=raw", "-1", revName);
         }
 
         List<String> revShow = new ArrayList<String>();

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -744,16 +744,8 @@ public class GitSCM extends SCM implements Serializable {
 
                     listener.getLogger().println("Polling for changes in");
 
-                    Collection<Revision> origCandidates = buildChooser.getCandidateRevisions(
+                    Collection<Revision> candidates = buildChooser.getCandidateRevisions(
                             true, singleBranch, git, listener, buildData, context);
-
-                    List<Revision> candidates = new ArrayList<Revision>();
-
-                    for (Revision c : origCandidates) {
-                        if (!isRevExcluded(git, c, listener)) {
-                            candidates.add(c);
-                        }
-                    }
 
                     return (candidates.size() > 0);
                 } else {
@@ -1816,6 +1808,16 @@ public class GitSCM extends SCM implements Serializable {
     }
 
     /**
+     * Is there any exclusion rule?
+     */
+    public boolean hasExclusionRule() {
+        String[] includedRegions = getIncludedRegionsNormalized();
+        String[] excludedRegions = getExcludedRegionsNormalized();
+        Set<String> excludedUsers = getExcludedUsersNormalized();
+        return excludedRegions != null || !excludedUsers.isEmpty() || includedRegions != null;
+    }
+
+    /**
      * Given a Revision, check whether it matches any exclusion rules.
      *
      * @param git IGitAPI object
@@ -1823,7 +1825,7 @@ public class GitSCM extends SCM implements Serializable {
      * @param listener
      * @return true if any exclusion files are matched, false otherwise.
      */
-    private boolean isRevExcluded(IGitAPI git, Revision r, TaskListener listener) {
+    public boolean isRevExcluded(IGitAPI git, Revision r, TaskListener listener) {
         try {
             List<String> revShow = git.showRevision(r);
 

--- a/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java
@@ -91,6 +91,9 @@ public class InverseBuildChooser extends BuildChooser {
             }
         }
 
+        // Don't want branches with only excluded revisions
+        branchRevs = utils.filterExcludedRevs(branchRevs, gitSCM, buildData);
+
         // If we're in a build (not an SCM poll) and nothing new was found, run the last build again
         if (!isPollCall && branchRevs.isEmpty() && buildData.getLastBuiltRevision() != null) {
             listener.getLogger().println(Messages.BuildChooser_BuildingLastRevision());


### PR DESCRIPTION
This prevents excluded revisions from being built when a change on another branch triggers a build.

This should also fix [JENKINS-13368](https://issues.jenkins-ci.org/browse/JENKINS-13368) (Git plug-in & included regions : build not triggered in case of mutiple commits in one push)
