### PR TITLE
Don't consider workspace corrupt if multiple lines returned from rev-parse

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -315,7 +315,7 @@ public class GitAPI implements IGitAPI {
 
     public ObjectId validateRevision(String revName) throws GitException {
         String result = launchCommand("rev-parse", "--verify", revName);
-        return ObjectId.fromString(lastLine(result).trim());
+        return ObjectId.fromString(firstLine(result).trim());
     }
 
     public String describe(String commitIsh) throws GitException {
@@ -340,30 +340,9 @@ public class GitAPI implements IGitAPI {
             line = reader.readLine();
             if (line == null)
                 return null;
-            if (reader.readLine() != null)
-                throw new GitException("Result has multiple lines");
-        } catch (IOException e) {
-            throw new GitException("Error parsing result", e);
-        }
-
-        return line;
-    }
-
-    private String lastLine(String result) {
-        BufferedReader reader = new BufferedReader(new StringReader(result));
-        String line;
-        try {
-            line = reader.readLine();
-            if (line == null)
-                return null;
-            String next = reader.readLine();
-            if (next != null) {
+            if (reader.readLine() != null) {
                 listener.getLogger().println("Result has multiple lines:");
                 listener.getLogger().println(result);
-            }
-            while (next != null) {
-                line = next;
-                next = reader.readLine();
             }
         } catch (IOException e) {
             throw new GitException("Error parsing result", e);


### PR DESCRIPTION
On Windows, rev-parse will occasionally result in two lines of output - the expected SHA1 hash followed by a "The process has leaked file descriptors" message. This is not a problem in the Git repo - it is NOT corrupt - but instead a process-handling problem.

This patch changes the polling process so that it does not fail if multiple lines are returned. Instead, it logs the extra lines but returns the first line, expecting it to hold the SHA1 hash. If the repo is truly corrupt, a failure will occur later on when trying to interpret the first line text as a hash value.

This addresses Jenkins-11547.
