### PR TITLE
Fix include/exclude filters to consider every new commit

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1799,6 +1799,8 @@ public class GitSCM extends SCM implements Serializable {
             Pattern[] excludedPatterns = getExcludedRegionsPatterns();
             Set<String> excludedUsers = getExcludedUsersNormalized();
 
+            listener.getLogger().println("Examining commit: " + r.getSha1String());
+            
             String author = change.getAuthorName();
             if (excludedUsers.contains(author)) {
                 // If the author is an excluded user, don't count this entry as a change
@@ -1809,31 +1811,37 @@ public class GitSCM extends SCM implements Serializable {
             List<String> paths = new ArrayList<String>(change.getAffectedPaths());
             if (paths.isEmpty()) {
                 // If there weren't any changed files here, we're just going to return false.
+                listener.getLogger().println("no changed files found");
                 return false;
             }
 
-	    // Assemble the list of included paths
+            // Assemble the list of included paths
             List<String> includedPaths = new ArrayList<String>();
             if (includedPatterns.length > 0) {
                 for (String path : paths) {
                     for (Pattern pattern : includedPatterns) {
                         if (pattern.matcher(path).matches()) {
                             includedPaths.add(path);
+                            listener.getLogger().println("included path: " + path);
                             break;
                         }
                     }
+                    listener.getLogger().println("path NOT included: " + path);
                 }
             } else {
-		includedPaths = paths;
-	    }
+                includedPaths = paths;
+                listener.getLogger().println("included all paths");
+            }
 
-	    // Assemble the list of excluded paths
+            // Assemble the list of excluded paths
+            // these are excluded from the final list of includes, NOT from the original list     
             List<String> excludedPaths = new ArrayList<String>();
             if (excludedPatterns.length > 0) {
                 for (String path : includedPaths) {
                     for (Pattern pattern : excludedPatterns) {
                         if (pattern.matcher(path).matches()) {
                             excludedPaths.add(path);
+                            listener.getLogger().println("excluded path: " + path);
                             break;
                         }
                     }

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1808,8 +1808,6 @@ public class GitSCM extends SCM implements Serializable {
             Pattern[] excludedPatterns = getExcludedRegionsPatterns();
             Set<String> excludedUsers = getExcludedUsersNormalized();
 
-            listener.getLogger().println("Examining commit: " + r.getSha1String());
-            
             String author = change.getAuthorName();
             if (excludedUsers.contains(author)) {
                 // If the author is an excluded user, don't count this entry as a change
@@ -1820,7 +1818,6 @@ public class GitSCM extends SCM implements Serializable {
             List<String> paths = new ArrayList<String>(change.getAffectedPaths());
             if (paths.isEmpty()) {
                 // If there weren't any changed files here, we're just going to return false.
-                listener.getLogger().println("no changed files found");
                 return false;
             }
 
@@ -1831,15 +1828,12 @@ public class GitSCM extends SCM implements Serializable {
                     for (Pattern pattern : includedPatterns) {
                         if (pattern.matcher(path).matches()) {
                             includedPaths.add(path);
-                            listener.getLogger().println("included path: " + path);
                             break;
                         }
                     }
-                    listener.getLogger().println("path NOT included: " + path);
                 }
             } else {
                 includedPaths = paths;
-                listener.getLogger().println("included all paths");
             }
 
             // Assemble the list of excluded paths
@@ -1850,7 +1844,6 @@ public class GitSCM extends SCM implements Serializable {
                     for (Pattern pattern : excludedPatterns) {
                         if (pattern.matcher(path).matches()) {
                             excludedPaths.add(path);
-                            listener.getLogger().println("excluded path: " + path);
                             break;
                         }
                     }

--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -74,6 +74,7 @@ public interface IGitAPI {
 
     List<ObjectId> revListBranch(String branchId) throws GitException;
     List<ObjectId> revListAll() throws GitException;
+    List<ObjectId> revList(String... args) throws GitException;
 
     String describe(String commitIsh) throws GitException;
 

--- a/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
@@ -70,6 +70,22 @@ public abstract class AbstractGitTestCase extends HudsonTestCase {
         git.launchCommand("commit", "-m", message);
     }
 
+    protected void commit(final String fileNames[], final PersonIdent committer, final String message) throws GitException {
+        setAuthor(committer);
+        setCommitter(committer);
+        for (String fileName: fileNames) {
+            FilePath file = workspace.child(fileName);
+            try {
+                file.write(fileName, null);
+            } catch (Exception e) {
+                throw new GitException("unable to write file", e);
+            }
+
+            git.add(fileName);
+        }
+        git.launchCommand("commit", "-m", message);
+    }
+
     protected void commit(final String fileName, final PersonIdent author, final PersonIdent committer,
                         final String message) throws GitException {
         setAuthor(author);

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -157,6 +157,108 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertFalse("scm polling should not detect any more changes after build", project.pollSCMChanges(listener));
     }
 
+    public void testIncludeAndExclude() throws Exception {
+        FreeStyleProject project = setupProject("master", false, null, ".*2", null, ".*2");
+
+        // create initial commit and then run the build against it:
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit number 1");
+        build(project, Result.SUCCESS, commitFile1);
+
+        assertFalse("scm polling should not detect any more changes after build", project.pollSCMChanges(listener));
+
+        final String commitFile2 = "commitFile2";
+        commit(commitFile2, janeDoe, "Commit number 2");
+        // according to the help, excludes should win if a file is included and excluded
+        assertFalse("scm polling detected commit2 change, which should have been excluded", project.pollSCMChanges(listener));
+        //... and build it...
+        final FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile2);
+        final Set<User> culprits = build2.getCulprits();
+        assertEquals("The build should have one culprit", 1, culprits.size());
+        assertEquals("", janeDoe.getName(), ((User)culprits.toArray()[0]).getFullName());
+        assertTrue(build2.getWorkspace().child(commitFile2).exists());
+        assertBuildStatusSuccess(build2);
+        assertFalse("scm polling should not detect any more changes after build", project.pollSCMChanges(listener));
+    }
+
+    public void testIncludeAndExcludeOverlap() throws Exception {
+        FreeStyleProject project = setupProject("master", false, null, ".*2\n.*3", null, ".*3\n.*4");
+
+        // create initial commit and then run the build against it:
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit number 1");
+        build(project, Result.SUCCESS, commitFile1);
+
+        assertFalse("scm polling should not detect any more changes after build", project.pollSCMChanges(listener));
+
+        // 2 is included, 3 is included and excluded (exclude wins) and 4 is included == build it!
+        final String commitFile2 = "commitFile2";
+        final String commitFile3 = "commitFile3";
+        final String commitFile4 = "commitFile4";
+        commit(new String[]{commitFile2, commitFile3, commitFile4}, janeDoe, "Commit number 2");
+        assertTrue("scm polling did not detect commit4 change", project.pollSCMChanges(listener));
+        //... and build it...
+        final FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile2, commitFile3, commitFile4);
+        final Set<User> culprits = build2.getCulprits();
+        assertEquals("The build should have one culprit", 1, culprits.size());
+        assertEquals("", janeDoe.getName(), ((User)culprits.toArray()[0]).getFullName());
+        assertTrue(build2.getWorkspace().child(commitFile2).exists());
+        assertTrue(build2.getWorkspace().child(commitFile3).exists());
+        assertTrue(build2.getWorkspace().child(commitFile4).exists());
+        assertBuildStatusSuccess(build2);
+        assertFalse("scm polling should not detect any more changes after build", project.pollSCMChanges(listener));
+    }
+
+    public void testNeitherIncludeNorExclude() throws Exception {
+        FreeStyleProject project = setupProject("master", false, null, ".*3", null, ".*4");
+
+        // create initial commit and then run the build against it:
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit number 1");
+        build(project, Result.SUCCESS, commitFile1);
+
+        assertFalse("scm polling should not detect any more changes after build", project.pollSCMChanges(listener));
+
+        // if a file is neither included nor excluded, assume we don't want it (exclude)
+        final String commitFile2 = "commitFile2";
+        commit(commitFile2, johnDoe, "Commit number 2");
+        assertFalse("scm polling detected commit2 change, which should have been ignored (by default)", project.pollSCMChanges(listener));
+        //... and build it...
+        final FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile2);
+        final Set<User> culprits = build2.getCulprits();
+        assertEquals("The build should have one culprit", 1, culprits.size());
+        assertEquals("", johnDoe.getName(), ((User)culprits.toArray()[0]).getFullName());
+        assertTrue(build2.getWorkspace().child(commitFile2).exists());
+        assertBuildStatusSuccess(build2);
+        assertFalse("scm polling should not detect any more changes after build", project.pollSCMChanges(listener));
+    }
+
+    public void testDisjointIncludeAndExcludeRegions() throws Exception {
+        FreeStyleProject project = setupProject("master", false, null, ".*2", null, ".*3");
+
+        // create initial commit and then run the build against it:
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit number 1");
+        build(project, Result.SUCCESS, commitFile1);
+
+        assertFalse("scm polling should not detect any more changes after build", project.pollSCMChanges(listener));
+
+        // 1 exclude and 1 include == build it
+        final String commitFile2 = "commitFile2";
+        final String commitFile3 = "commitFile3";
+        commit(new String[]{commitFile2, commitFile3}, janeDoe, "Commit number 2");
+        assertTrue("scm polling did not detect commit3 change", project.pollSCMChanges(listener));
+        //... and build it...
+        final FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile2, commitFile3);
+        final Set<User> culprits = build2.getCulprits();
+        assertEquals("The build should have one culprit", 1, culprits.size());
+        assertEquals("", janeDoe.getName(), ((User)culprits.toArray()[0]).getFullName());
+        assertTrue(build2.getWorkspace().child(commitFile2).exists());
+        assertTrue(build2.getWorkspace().child(commitFile3).exists());
+        assertBuildStatusSuccess(build2);
+        assertFalse("scm polling should not detect any more changes after build", project.pollSCMChanges(listener));
+    }
+
     @Bug(value = 8342)
     public void testExcludedRegionMultiCommit() throws Exception {/*
         // Got 2 projects, each one should only build if changes in its own file


### PR DESCRIPTION
Currently the git-plugin only checks the head revision on each candidate branch against the include and exclude filters. This can lead to it failing to trigger when there are new commits that should be included, but the head revision contains only excluded changes.

This patch changes polling to test every commit since the last build for changes that should be included.
