### PR TITLE
Fix Jenkins-15048 - shorten build data display name

### DIFF
--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -69,16 +69,19 @@ public class BuildData implements Action, Serializable, Cloneable {
         }
     }
 
+    /**
+     * Returns the build data display name, optionally with SCM name.
+     * This string needs to be relatively short because it is
+     * displayed in a column with other short links.  If it is
+     * lengthened, it causes the other data on the page to shift
+     * right.  The page is then difficult to read.
+     *
+     * @return build data display name
+     */
     public String getDisplayName() {
-        String out_name = "Git Build Data";
-
-        if (!remoteUrls.isEmpty())
-            out_name = out_name + " - " + remoteUrls;
-
         if (scmName != null && !scmName.isEmpty())
-            out_name = out_name + " (" + scmName + ")";
-
-        return out_name;
+            return "Git Build Data:" + scmName;
+        return "Git Build Data";
     }
 
     public String getIconFileName() {

--- a/src/test/java/hudson/plugins/git/util/BuildDataTest.java
+++ b/src/test/java/hudson/plugins/git/util/BuildDataTest.java
@@ -1,0 +1,27 @@
+package hudson.plugins.git.util;
+
+import hudson.plugins.git.AbstractGitTestCase;
+
+import hudson.plugins.git.util.BuildData;
+
+/**
+ * @author Mark Waite
+ */
+public class BuildDataTest extends AbstractGitTestCase {
+    /**
+     * Verifies that the display name is "Git Build Data".
+     */
+    public void testDisplayNameWithoutSCM() throws Exception {
+        final BuildData data = new BuildData();
+        assertEquals(data.getDisplayName(), "Git Build Data");
+    }
+
+    /**
+     * Verifies that the display name is "Git Build Data:scmName".
+     */
+    public void testDisplayNameWithSCM() throws Exception {
+        final String scmName = "testSCM";
+        final BuildData data = new BuildData(scmName);
+        assertEquals("Git Build Data:" + scmName, data.getDisplayName());
+    }
+}


### PR DESCRIPTION
The most recent git plugin update (extending the BuildData object to work more effectively with the Multiple SCM plugin), inadvertently made the user interface worse.

The longer display name moves crucial data off screen to the right.  This change reduces the BuildData display name back to what it was before the Multiple SCM plugin additions.  It does not remove any other changes related to Multiple SCM plugin, just the length of the display name.

This submission also adds a test, though the test is of questionable value, since all it does is check that the BuildData object returns the expected display name value.

The plugin passed all tests as run by "mvn install" on my 64 bit Debian Squeeze machine with Oracle JDK 7.0.
