### PR TITLE
Support for gitorious webhook

### DIFF
--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -11,6 +11,8 @@ import hudson.scm.SCM;
 import hudson.security.ACL;
 import hudson.triggers.SCMTrigger;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+
 import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.lang.StringUtils;
@@ -53,6 +55,12 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
 
     public String getUrlName() {
         return "git";
+    }
+
+    public HttpResponse doGitoriousNotifyCommit(@QueryParameter String payload)  throws ServletException, IOException {
+    	JSONObject jsonObject = JSONObject.fromObject( payload );
+    	String url = jsonObject.getJSONObject("repository").getString("url");
+    	return doNotifyCommit(url + ".git", null);
     }
 
     public HttpResponse doNotifyCommit(@QueryParameter(required=true) String url, @QueryParameter(required=false) String branches) throws ServletException, IOException {
@@ -167,7 +175,7 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
      * especially given that Git tends to support multiple access protocols.
      */
     boolean looselyMatches(URIish lhs, URIish rhs) {
-        return StringUtils.equals(lhs.getHost(),rhs.getHost())
+        return (StringUtils.equals(lhs.getHost(),rhs.getHost()) || StringUtils.equals("git." + lhs.getHost(),rhs.getHost()))
             && StringUtils.equals(normalizePath(lhs.getPath()), normalizePath(rhs.getPath()));
     }
 


### PR DESCRIPTION
The default gitorious webhook mechanism sends a POST similar to http://pastebin.com/iEZDkWWR to a URL.  It strips off any hard coded query parameters, so it wouldn't work with notifyCommit without help.

This commit adds a gitoriousNotifyCommit endpoint that will parse the default JSON payload and convert the repository URL into a usable form.

HTTP clone access for gitorious is done by adding "git." to the front of the hostname, but the payload URL doesn't come that way.  So I added a check in looselyMatches in case someone is using HTTP access in jenkins.
