### PR TITLE
[FIXES JENKINS-15391] - Fix for NullPointerException on tag publishing

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -261,7 +261,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                     }
                     if (tagResult) {
                         final String tagName = environment.expand(t.getTagName());
-                        final String tagMessage = environment.expand(t.getTagMessage());
+                        final String tagMessage = hudson.Util.fixNull(environment.expand(t.getTagMessage()));
                         final String targetRepo = environment.expand(t.getTargetRepoName());
                         
                         try {


### PR DESCRIPTION
Use hudson.Util.fixNull to convert a null tagMessage to an empty string
