### PR TITLE
New commit URL in Gitlab 3

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/GitLab.java
+++ b/src/main/java/hudson/plugins/git/browser/GitLab.java
@@ -22,9 +22,11 @@ public class GitLab extends GitRepositoryBrowser {
 
     private static final long serialVersionUID = 1L;
     private final URL url;
+    private final double version;
 
     @DataBoundConstructor
-    public GitLab(String url) throws MalformedURLException {
+    public GitLab(String url, String version) throws MalformedURLException {
+        this.version = Double.valueOf(version);
         this.url = normalizeToEndWithSlash(new URL(url));
     }
 
@@ -32,6 +34,9 @@ public class GitLab extends GitRepositoryBrowser {
         return url;
     }
 
+    public double getVersion() {
+        return version;
+    }
 
     /**
      * Creates a link to the changeset
@@ -44,7 +49,9 @@ public class GitLab extends GitRepositoryBrowser {
      */
     @Override
     public URL getChangeSetLink(GitChangeSet changeSet) throws IOException {
-        return new URL(url, "commits/" + changeSet.getId().toString());
+        String  commitPrefix;
+
+        return new URL(url, calculatePrefix() + changeSet.getId().toString());
     }
 
     /**
@@ -59,7 +66,7 @@ public class GitLab extends GitRepositoryBrowser {
     @Override
     public URL getDiffLink(Path path) throws IOException {
         final GitChangeSet changeSet = path.getChangeSet();
-        return new URL(url, "commits/" + changeSet.getId().toString() + "#" + path.getPath());
+        return new URL(url, calculatePrefix() + changeSet.getId().toString() + "#" + path.getPath());
     }
 
     /**
@@ -91,5 +98,13 @@ public class GitLab extends GitRepositoryBrowser {
             return req.bindParameters(GitLab.class, "Gitlab.");
         }
     }
+
+    private String calculatePrefix() {
+        if(getVersion() >= 3){
+            return "commit/";
+        }
+
+        return "commits/";
+    } 
 
 }

--- a/src/main/resources/hudson/plugins/git/browser/GitLab/config.jelly
+++ b/src/main/resources/hudson/plugins/git/browser/GitLab/config.jelly
@@ -2,4 +2,7 @@
   <f:entry field="url" title="URL">
     <f:textbox/>
   </f:entry>
+  <f:entry field="version" title="Version">
+    <f:textbox/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/git/browser/GitLab/help-version.html
+++ b/src/main/resources/hudson/plugins/git/browser/GitLab/help-version.html
@@ -1,0 +1,3 @@
+<div>
+  Specify the major and minor version of gitlab you use (such as 3.1).
+</div>


### PR DESCRIPTION
Now it's possible to specify the version of GitLab in order to get the correct URL scheme it changed from `/commits/<sha1>` to `/commit/<sha1>`
