### PR TITLE
re-schedule project when multiple candidate revisions are left

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -33,6 +33,7 @@ import hudson.scm.PollingResult;
 import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
 import hudson.scm.SCMRevisionState;
+import hudson.triggers.SCMTrigger;
 import hudson.util.FormValidation;
 import hudson.util.IOUtils;
 
@@ -1099,6 +1100,16 @@ public class GitSCM extends SCM implements Serializable {
                 if (candidates.size() == 0) {
                     log.println("No candidate revisions");
                     return null;
+                }
+                if (candidates.size() > 1) {
+                    log.println("Multiple candidate revisions");
+                    AbstractProject<?, ?> project = build.getProject();
+                    if (!project.isDisabled()) {
+                        log.println("Scheduling another build to catch up with " + project.getFullDisplayName());
+                        if (!project.scheduleBuild(0, new SCMTrigger.SCMTriggerCause())) {
+                            log.println("WARNING: multiple candidate revisions, but unable to schedule build of " + project.getFullDisplayName());
+                        }
+                    }
                 }
                 return candidates.iterator().next();
             }


### PR DESCRIPTION
Multiple candidate revisions probably means that you missed a commit notification.
This can happen because Jenkins is down, or the notifier was flaky.

In this case, the git plugin currently builds the oldest, but we should also
schedule another build of the project so that we don't permanently stay "behind"
the latest.
