### PR TITLE
[FIXES JENKINS-15235] Add whitespace trimming of branch name.

### DIFF
--- a/src/main/java/hudson/plugins/git/BranchSpec.java
+++ b/src/main/java/hudson/plugins/git/BranchSpec.java
@@ -29,18 +29,18 @@ public class BranchSpec implements Serializable {
         return name;
     }
 
-    public void setName(String value) {
-        this.name = value;
-    }
-
-    @DataBoundConstructor
-    public BranchSpec(String name) {
-        if(name == null)
+    public void setName(String name) {
+    	if(name == null)
             throw new IllegalArgumentException();
         else if(name.length() == 0)
             this.name = "**";
         else
-            this.name = name;
+            this.name = name.trim();
+    }
+
+    @DataBoundConstructor
+    public BranchSpec(String name) {
+        setName(name);
     }
 
     public String toString() {

--- a/src/test/java/hudson/plugins/git/TestBranchSpec.java
+++ b/src/test/java/hudson/plugins/git/TestBranchSpec.java
@@ -61,4 +61,11 @@ public class TestBranchSpec extends TestCase {
     	assertTrue(correctExceptionThrown);
     }
     
+    public void testNameTrimming() {
+    	BranchSpec branchSpec = new BranchSpec(" master ");
+    	assertEquals("master",branchSpec.getName());
+    	branchSpec.setName(" other ");
+    	assertEquals("other",branchSpec.getName());
+    }
+    
 }


### PR DESCRIPTION
- Trim branch name before storing it, since a valid branch name does
  not begin or end with whitespace.
- Use same code for setting name in constructor and in setName().
  Previously, there were no check for valid values in setName().
