### PR TITLE
expand parameters in the remote branch name of merge options

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1173,7 +1173,7 @@ public class GitSCM extends SCM implements Serializable {
                     // us..
                     listener.getLogger().println(
                             "Merging " + revToBuild + " onto "
-                            + mergeOptions.getMergeTarget());
+                            + getParameterString(mergeOptions.getMergeTarget(), build));
 
                     // checkout origin/blah
                     ObjectId target = git.revParse(remoteBranchName);


### PR DESCRIPTION
Perform parameter expansion on the branch name in merge options. When building pull requests for example it is important to merge against the target of the pull request, instead of a fixed value.
