### PR TITLE
Support multiple reference directories

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -263,9 +263,14 @@ public class GitAPI implements IGitAPI {
                             args.add("--progress");
                         }
                         if (reference != null) {
-                            File referencePath = new File(reference);
-                            if (referencePath.exists() && referencePath.isDirectory()) {
-                                args.add("--reference", reference);
+                            String[] references = reference.split(";");
+                            for (int i = 0; i < references.length; i ++)
+                            {
+                                File referencePath = new File(references[i]);
+                                if (referencePath.exists() && referencePath.isDirectory()) {
+                                    args.add("--reference", references[i]);
+                                    break;
+                                }
                             }
                         }
                         args.add("-o", remoteConfig.getName());

--- a/src/main/webapp/help-reference.html
+++ b/src/main/webapp/help-reference.html
@@ -1,4 +1,5 @@
 <div>
   Specify a folder containing a repository that will be used by Git as a reference during clone operations.<br/>
-  This option will be ignored if the folder is not available on the master or slave where the clone is being executed.
+  This option will be ignored if the folder is not available on the master or slave where the clone is being executed.<br/>
+  You can specify several repository paths by separating them with semi-colon (;), Jekins will use the first path that exists.
 </div>


### PR DESCRIPTION
This patch makes it possible to define reference directories like this:
/tmp/foo;c:\tmp\foo, good in setups where the directories can differ.
