### PR TITLE
set changeSet.kind to "git" in build details

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSetList.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSetList.java
@@ -7,6 +7,10 @@ import java.util.List;
 import java.util.Collections;
 import java.util.Iterator;
 
+import org.kohsuke.stapler.*;
+import org.kohsuke.stapler.export.Exported;
+
+
 /**
  * List of changeset that went into a particular build.
  * @author Nigel Magnay
@@ -33,4 +37,10 @@ public class GitChangeSetList extends ChangeLogSet<GitChangeSet> {
     public List<GitChangeSet> getLogs() {
         return changeSets;
     }
+
+    @Exported
+    public String getKind() {
+        return "git";
+    }
+
 }


### PR DESCRIPTION
It's hard to understand from build history of git project what SCM plugin has been used. changeSet section contain optional field "kind" - it make sense set it to identify SCM used.  SVN and Mercurial plugins also set corresponding value in this field, like 'changeSet': 'kind': 'svn'
