### PR TITLE
Validate reference path before cloning

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -256,11 +256,15 @@ public class GitAPI implements IGitAPI {
                         if ((gitVer[0] >= 1) && (gitVer[1] >= 7)) {
                             args.add("--progress");
                         }
-                        if (reference != null) {
+                        if (reference != null && !reference.equals("")) {
                             File referencePath = new File(reference);
-                            if (referencePath.exists() && referencePath.isDirectory()) {
-                                args.add("--reference", reference);
+                            if (!referencePath.exists()) {
+                                throw new GitException("Reference path does not exist: " + reference);
                             }
+                            if (!referencePath.isDirectory()) {
+                                throw new GitException("Reference path is not a directory: " + reference);
+                            }
+                            args.add("--reference", reference);
                         }
                         args.add("-o", remoteConfig.getName());
                         if(useShallowClone) args.add("--depth", "1");


### PR DESCRIPTION
It took me a while to figure out why my configuration for "Path of the reference repo to use during clone" was not operating properly.  Apparently, the plugin ignores your configuration if the configuration is invalid, instead of reporting an issue to the user.  This change reports a fatal error if the reference repo does not exist.
