### PR TITLE
Print the actual number of repos changes are being fetched from.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1010,7 +1010,7 @@ public class GitSCM extends SCM implements Serializable {
                     else
                         log.println(MessageFormat
                                 .format("Fetching changes from {0} remote Git repositories",
-                                        repos));
+                                        repos.size()));
 
                     boolean fetched = false;
 


### PR DESCRIPTION
Use repos.size() instead of the (implicit) toString().

Before fix: Fetching changes from [org.eclipse.jgit.transport.RemoteConfig@1d8687a, org.eclipse.jgit.transport.RemoteConfig@b34776] remote Git repositories
After fix: Fetching changes from 2 remote Git repositories
