### PR TITLE
Jobs should not fail if because if failures in computing changelog

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1301,8 +1301,16 @@ public class GitSCM extends SCM implements Serializable {
      */
     private void computeChangeLog(IGitAPI git, Revision revToBuild, BuildListener listener, BuildData buildData, FilePath changelogFile, BuildChooserContext context) throws IOException, InterruptedException {
         int histories = 0;
+        PrintStream out = null;
+        listener.getLogger().println("Attempting to write changelog to local file " +
+                                     changelogFile.getName() + ", remotely " + changelogFile.getRemote());
+        try {
+            out = new PrintStream(changelogFile.write());
+        } catch (IOException io) {
+            listener.getLogger().println("Failed to open changelog file for write");
+            return;
+        }
 
-        PrintStream out = new PrintStream(changelogFile.write());
         try {
             for (Branch b : revToBuild.getBranches()) {
                 Build lastRevWas = buildChooser.prevBuildForChangelog(b.getName(), buildData, git, context);
@@ -1335,8 +1343,16 @@ public class GitSCM extends SCM implements Serializable {
                                          + ", does not exist in the current repository.");
         } else {
             int histories = 0;
+            PrintStream out = null;
+            listener.getLogger().println("Attempting to write merge changelog to local file " +
+                                         changelogFile.getName() + ", remotely " + changelogFile.getRemote());
+            try {
+                out = new PrintStream(changelogFile.write());
+            } catch (IOException io) {
+                listener.getLogger().println("Failed to open changelog file for write");
+                return;
+            }
 
-            PrintStream out = new PrintStream(changelogFile.write());
             try {
                 for (Branch b : revToBuild.getBranches()) {
                     putChangelogDiffs(git, b.name, revFrom, revToBuild.getSha1().name(), out);


### PR DESCRIPTION
JENKINS-16732 Catch and handle IOException when opening changelog file for write

In the current build, if the plug-in failed to open the changelog file, the exception would rise high and fail the build.
Instead, just report the error and move on
(cherry picked from commit 6a01d2a426ce7b3db17c526c5df1afd8a846a8e7)

Signed-off-by: Guy Rozendorn guy@rzn.co.il
