### PR TITLE
Use git protocol for test repos rather than ssh?

### DIFF
--- a/src/test/java/hudson/plugins/git/client/GitAPITestCase.java
+++ b/src/test/java/hudson/plugins/git/client/GitAPITestCase.java
@@ -61,15 +61,15 @@ public abstract class GitAPITestCase extends TestCase {
 
     public void test_getRemoteURL() throws Exception {
         launchCommand("git init");
-        launchCommand("git remote add origin git@github.com:jenkinsci/git-plugin.git");
+        launchCommand("git remote add origin git://github.com/jenkinsci/git-plugin.git");
         launchCommand("git ndeloof add origin git@github.com:ndeloof/git-plugin.git");
         String remoteUrl = git.getRemoteUrl("origin");
-        assertEquals("unexepected remote URL " + remoteUrl, "git@github.com:jenkinsci/git-plugin.git", remoteUrl);
+        assertEquals("unexepected remote URL " + remoteUrl, "git://github.com/jenkinsci/git-plugin.git", remoteUrl);
     }
 
     public void test_setRemoteURL() throws Exception {
         launchCommand("git init");
-        launchCommand("git remote add origin git@github.com:jenkinsci/git-plugin.git");
+        launchCommand("git remote add origin git://github.com/jenkinsci/git-plugin.git");
         git.setRemoteUrl("origin", "git@github.com:ndeloof/git-plugin.git");
         String remotes = launchCommand("git remote -v");
         assertTrue("remote URL has not been updated", remotes.contains("origin\tgit@github.com:ndeloof/git-plugin.git"));
@@ -209,8 +209,8 @@ public abstract class GitAPITestCase extends TestCase {
 
     public void test_get_HEAD_revision() throws Exception {
         // TODO replace with an embedded JGit server so that test run offline ?
-        String sha1 = launchCommand("git ls-remote --heads git@github.com:jenkinsci/git-plugin.git refs/heads/master").substring(0,40);
-        assertEquals(sha1, git.getHeadRev("git@github.com:jenkinsci/git-plugin.git", "master").name());
+        String sha1 = launchCommand("git ls-remote --heads git://github.com/jenkinsci/git-plugin.git refs/heads/master").substring(0,40);
+        assertEquals(sha1, git.getHeadRev("git://github.com/jenkinsci/git-plugin.git", "master").name());
     }
 
     public void test_revparse_sha1_HEAD_or_tag() throws Exception {


### PR DESCRIPTION
Since most users do not have ssh access to the reference repositories from their development machines or from their continuous integration servers, it seems like it might be better to use git protocol for the reference repositories in the tests rather than using ssh protocol.

Ugh, I thought that would request to pull a single submission rather than the intervening "junk commits".  Please DO NOT pull this into the repository.  I'll recreate the pull request as a single submission.  Sorry about the waste of time.
