### PR TITLE
Use git protocol for GitTestCase reference repo instead of ssh protocol

### DIFF
--- a/src/test/java/hudson/plugins/git/client/GitAPITestCase.java
+++ b/src/test/java/hudson/plugins/git/client/GitAPITestCase.java
@@ -61,15 +61,15 @@ public abstract class GitAPITestCase extends TestCase {
 
     public void test_getRemoteURL() throws Exception {
         launchCommand("git init");
-        launchCommand("git remote add origin git@github.com:jenkinsci/git-plugin.git");
+        launchCommand("git remote add origin git://github.com/jenkinsci/git-plugin.git");
         launchCommand("git ndeloof add origin git@github.com:ndeloof/git-plugin.git");
         String remoteUrl = git.getRemoteUrl("origin");
-        assertEquals("unexepected remote URL " + remoteUrl, "git@github.com:jenkinsci/git-plugin.git", remoteUrl);
+        assertEquals("unexepected remote URL " + remoteUrl, "git://github.com/jenkinsci/git-plugin.git", remoteUrl);
     }
 
     public void test_setRemoteURL() throws Exception {
         launchCommand("git init");
-        launchCommand("git remote add origin git@github.com:jenkinsci/git-plugin.git");
+        launchCommand("git remote add origin git://github.com/jenkinsci/git-plugin.git");
         git.setRemoteUrl("origin", "git@github.com:ndeloof/git-plugin.git");
         String remotes = launchCommand("git remote -v");
         assertTrue("remote URL has not been updated", remotes.contains("origin\tgit@github.com:ndeloof/git-plugin.git"));
@@ -209,8 +209,8 @@ public abstract class GitAPITestCase extends TestCase {
 
     public void test_get_HEAD_revision() throws Exception {
         // TODO replace with an embedded JGit server so that test run offline ?
-        String sha1 = launchCommand("git ls-remote --heads git@github.com:jenkinsci/git-plugin.git refs/heads/master").substring(0,40);
-        assertEquals(sha1, git.getHeadRev("git@github.com:jenkinsci/git-plugin.git", "master").name());
+        String sha1 = launchCommand("git ls-remote --heads git://github.com/jenkinsci/git-plugin.git refs/heads/master").substring(0,40);
+        assertEquals(sha1, git.getHeadRev("git://github.com/jenkinsci/git-plugin.git", "master").name());
     }
 
     public void test_revparse_sha1_HEAD_or_tag() throws Exception {


### PR DESCRIPTION
The git protocol can be read by anyone and does not require ssh keys.  If the reference repository is switched to use the git protocol, it allows my test job on BuildHive to pass tests   successfully.
