### PR TITLE
Support for GIT_URL in environment JENKINS-16684

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1376,7 +1376,7 @@ public class GitSCM extends SCM implements Serializable {
       }else{
     	  int count=1;
     	  for(UserRemoteConfig config:userRemoteConfigs)   {
-      		env.put("GIT_URL"+count, config.getUrl());
+      		env.put("GIT_URL_"+count, config.getUrl());
       		count++;
          }  
       }


### PR DESCRIPTION
This changeset will add GIT_URL support.
Incase of SINGLE URL it will GIT_URL and multiple URLs it will be GIT_URL_n
