### PR TITLE
Expand reference repo

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -998,8 +998,9 @@ public class GitSCM extends SCM implements Serializable {
                     //
                     boolean successfullyCloned = false;
                     for (RemoteConfig rc : repos) {
+                    	final String expandedReference = environment.expand(reference);
                         try {
-                            git.clone(rc.getURIs().get(0).toPrivateString(), rc.getName(), useShallowClone, reference);
+                            git.clone(rc.getURIs().get(0).toPrivateString(), rc.getName(), useShallowClone, expandedReference);
                             successfullyCloned = true;
                             break;
                         } catch (GitException ex) {


### PR DESCRIPTION
The reference repository is not expanded.It is not possible to set environment variable in this filed. When using different types of build machines ( linux, windows, mac)  in matrix jobs it is necessary to have this expanded as the reference path cannot be the same. 
