### PR TITLE
JENKINS-7087: support for using regex directly in BranchSpec if spec string starts with colon.

### DIFF
--- a/src/main/java/hudson/plugins/git/BranchSpec.java
+++ b/src/main/java/hudson/plugins/git/BranchSpec.java
@@ -79,6 +79,13 @@ public class BranchSpec implements Serializable {
         if (pattern != null)
             return pattern;
         
+        // use regex syntax directly if name starts with colon
+        if (name.startsWith(":") && name.length() > 1) {
+        	String regexSubstring = name.substring(1, name.length());
+        	pattern = Pattern.compile(regexSubstring);
+        	return pattern;
+        }
+        
         // if an unqualified branch was given add a "*/" so it will match branches
         // from remote repositories as the user probably intended
         String qualifiedName;

--- a/src/test/java/hudson/plugins/git/TestBranchSpec.java
+++ b/src/test/java/hudson/plugins/git/TestBranchSpec.java
@@ -68,4 +68,14 @@ public class TestBranchSpec extends TestCase {
     	assertEquals("other",branchSpec.getName());
     }
     
+    public void testUsesJavaPatternDirectlyIfPrefixedWithColon() {
+    	BranchSpec m = new BranchSpec(":^(?!(origin/prefix)).*");
+    	assertTrue(m.matches("origin"));
+    	assertTrue(m.matches("origin/master"));
+    	assertTrue(m.matches("origin/feature"));
+
+    	assertFalse(m.matches("origin/prefix_123"));
+    	assertFalse(m.matches("origin/prefix"));
+    	assertFalse(m.matches("origin/prefix-abc"));
+    }
 }


### PR DESCRIPTION
Example: `:^(?!(origin/prefix)).*` would match any branch except
'origin/prefix*'.
