### PR TITLE
Replace spaces in project name so that tag creation doesn't fail

### DIFF
--- a/src/main/java/hudson/plugins/git/GitTagAction.java
+++ b/src/main/java/hudson/plugins/git/GitTagAction.java
@@ -187,7 +187,7 @@ public class GitTagAction extends AbstractScmTagAction implements Describable<Gi
                                     .in(localWorkspace)
                                     .getClient();
 
-                            String buildNum = "hudson-" + build.getProject().getName() + "-" + tagSet.get(b);
+                            String buildNum = "hudson-" + build.getProject().getName().replace(" ", "_") + "-" + tagSet.get(b);
                             git.tag(tagSet.get(b), "Hudson Build #" + buildNum);
                             return new Object[]{null, build};
                         }


### PR DESCRIPTION
Replaces spaces with underscores in project name for tag creation which should fix https://issues.jenkins-ci.org/browse/JENKINS-17195
