### PR TITLE
Adding support for merge targets to be of a variable name.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -214,7 +214,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
             
             final EnvVars environment = tempEnvironment;
             final FilePath workingDirectory = gitSCM.workingDirectory(workspacePath,environment);
-            
+
             boolean pushResult = true;
             // If we're pushing the merge back...
             if (pushMerge) {
@@ -241,12 +241,14 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                                 git.tag(buildnumber, "Jenkins Build #" + buildNumber);
                                 
                                 PreBuildMergeOptions mergeOptions = gitSCM.getMergeOptions();
-                                
+
+                                String mergeTarget = environment.expand(mergeOptions.getMergeTarget());
+
                                 if (mergeOptions.doMerge() && buildResult.isBetterOrEqualTo(Result.SUCCESS)) {
                                     RemoteConfig remote = mergeOptions.getMergeRemote();
-                                    listener.getLogger().println("Pushing HEAD to branch " + mergeOptions.getMergeTarget() + " of " + remote.getName() + " repository");
+                                    listener.getLogger().println("Pushing HEAD to branch " + mergeTarget + " of " + remote.getName() + " repository");
 
-                                    git.push(remote.getName(), "HEAD:" + mergeOptions.getMergeTarget());
+                                    git.push(remote.getName(), "HEAD:" + mergeTarget);
                                 } else {
                                     //listener.getLogger().println("Pushing result " + buildnumber + " to origin repository");
                                     //git.push(null);


### PR DESCRIPTION
This allows variables to be put into the field for what branch the working directory should be merged into (And pushed to later on).

Looks like GitSCMTest#testMergeFailed is failing - but I'm not sure why, when I tested a merge conflict manually it worked fine. Looks like that test was just added recently, so possibly it didn't get a thorough enough of a look over? Although it could very well be this commit - First time playing with a Jenkins plugin.

Cheers!
