### PR TITLE
Exposing the AbstractBuild to the BuildChooserContext

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -891,6 +891,10 @@ public class GitSCM extends SCM implements Serializable {
             return callable.invoke(project, MasterComputer.localChannel);
         }
 
+        public AbstractBuild<?, ?> getBuild() {
+            return build;
+        }
+
         private Object writeReplace() {
             return Channel.current().export(BuildChooserContext.class,new BuildChooserContext() {
                 public <T> T actOnBuild(ContextCallable<AbstractBuild<?,?>, T> callable) throws IOException, InterruptedException {
@@ -899,6 +903,10 @@ public class GitSCM extends SCM implements Serializable {
 
                 public <T> T actOnProject(ContextCallable<AbstractProject<?,?>, T> callable) throws IOException, InterruptedException {
                     return callable.invoke(project,Channel.current());
+                }
+
+                public AbstractBuild<?, ?> getBuild() {
+                    return build;
                 }
             });
         }

--- a/src/main/java/hudson/plugins/git/util/BuildChooserContext.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooserContext.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 public interface BuildChooserContext {
     public <T> T actOnBuild(ContextCallable<AbstractBuild<?,?>,T> callable) throws IOException,InterruptedException;
     public <T> T actOnProject(ContextCallable<AbstractProject<?,?>,T> callable) throws IOException,InterruptedException;
-
+    public AbstractBuild<?,?> getBuild();
 
     public static interface ContextCallable<P,T> extends Serializable {
         /**


### PR DESCRIPTION
To enable BuildChooser extensions to use build attributes (parameters, history, etc..) in making build selection decisions.
