### PR TITLE
Add repository browser for Kiln Harmony

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/KilnGit.java
+++ b/src/main/java/hudson/plugins/git/browser/KilnGit.java
@@ -1,0 +1,122 @@
+package hudson.plugins.git.browser;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.plugins.git.GitChangeSet;
+import hudson.plugins.git.GitChangeSet.Path;
+import hudson.scm.EditType;
+import hudson.scm.RepositoryBrowser;
+import hudson.scm.RepositoryBrowser;
+import hudson.scm.browsers.QueryBuilder;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+
+/**
+ * @author Chris Klaiber (cklaiber@gmail.com)
+ */
+public class KilnGit extends GitRepositoryBrowser {
+
+    private static final long serialVersionUID = 1L;
+    private final URL url;
+
+    @DataBoundConstructor
+    public KilnGit(String url) throws MalformedURLException {
+        this.url = normalizeToEndWithSlash(new URL(url));
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    private QueryBuilder param() {
+        return new QueryBuilder(url.getQuery());
+    }
+
+    /**
+     * Creates a link to the change set
+     * http://[KilnGit URL]/History/[commit]
+     *
+     * @param changeSet commit hash
+     * @return change set link
+     * @throws IOException
+     */
+    @Override
+    public URL getChangeSetLink(GitChangeSet changeSet) throws IOException {
+        return new URL(url, url.getPath() + "History/" + changeSet.getId() + param().toString());
+    }
+
+    /**
+     * Creates a link to the file diff.
+     * http://[KilnGit URL]/History/[commit]#diff-N
+     *
+     * @param path affected file path
+     * @return diff link
+     * @throws IOException
+     */
+    @Override
+    public URL getDiffLink(Path path) throws IOException {
+        if (path.getEditType() != EditType.EDIT || path.getSrc() == null || path.getDst() == null
+                || path.getChangeSet().getParentCommit() == null) {
+            return null;
+        }
+        return getDiffLinkRegardlessOfEditType(path);
+    }
+
+    /**
+     * Return a diff link regardless of the edit type by appending the index of the pathname in the changeset.
+     *
+     * @param path
+     * @return
+     * @throws IOException
+     */
+    private URL getDiffLinkRegardlessOfEditType(Path path) throws IOException {
+        final GitChangeSet changeSet = path.getChangeSet();
+        final ArrayList<String> affectedPaths = new ArrayList<String>(changeSet.getAffectedPaths());
+        // Kiln seems to sort the output alphabetically by the path.
+        Collections.sort(affectedPaths);
+        final String pathAsString = path.getPath();
+        final int i = Collections.binarySearch(affectedPaths, pathAsString);
+        if (i >= 0) {
+            // Kiln diff indices begin at 1.
+            return new URL(getChangeSetLink(changeSet), param().toString() + "#diff-" + String.valueOf(i + 1));
+        }
+        return getChangeSetLink(changeSet);
+    }
+
+    /**
+     * Creates a link to the file.
+     * http://[KilnGit URL]/FileHistory/[path]?rev=[commit]
+     *
+     * @param path affected file path
+     * @return diff link
+     * @throws IOException
+     */
+    @Override
+    public URL getFileLink(Path path) throws IOException {
+        if (path.getEditType().equals(EditType.DELETE)) {
+            return getDiffLinkRegardlessOfEditType(path);
+        } else {
+            GitChangeSet changeSet = path.getChangeSet();
+            return new URL(url, url.getPath() + "FileHistory/" + path.getPath() + param().add("rev=" + changeSet.getId()).toString());
+        }
+    }
+
+    @Extension
+    public static class KilnGitDescriptor extends Descriptor<RepositoryBrowser<?>> {
+        public String getDisplayName() {
+            return "Kiln";
+        }
+
+        @Override
+        public KilnGit newInstance(StaplerRequest req, JSONObject jsonObject) throws FormException {
+            return req.bindParameters(KilnGit.class, "kilngit.");
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/git/browser/KilnGit/config.jelly
+++ b/src/main/resources/hudson/plugins/git/browser/KilnGit/config.jelly
@@ -1,0 +1,5 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry field="url" title="URL">
+    <f:textbox/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/git/browser/KilnGit/help-url.html
+++ b/src/main/resources/hudson/plugins/git/browser/KilnGit/help-url.html
@@ -1,0 +1,3 @@
+<div>
+  Specify the root URL serving this repository (e.g., https://khanacademy.kilnhg.com/Code/Website/Group/webapp)
+</div>

--- a/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
+++ b/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
@@ -1,0 +1,123 @@
+package hudson.plugins.git.browser;
+
+import hudson.plugins.git.GitChangeLogParser;
+import hudson.plugins.git.GitChangeSet;
+import hudson.plugins.git.GitChangeSet.Path;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import junit.framework.TestCase;
+
+import org.xml.sax.SAXException;
+
+/**
+ * @author Chris Klaiber (cklaiber@gmail.com)
+ */
+public class KilnGitTest extends TestCase {
+
+    private static final String KILN_URL = "http://USER.kilnhg.com/Code/PROJECT/Group/REPO";
+    private final KilnGit kilnGit;
+
+    {
+        try {
+            kilnGit = new KilnGit(KILN_URL);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Test method for {@link hudson.plugins.git.browser.KilnGit#getUrl()}.
+     * @throws MalformedURLException
+     */
+    public void testGetUrl() throws MalformedURLException {
+        assertEquals(String.valueOf(kilnGit.getUrl()), KILN_URL  + "/");
+    }
+
+    /**
+     * Test method for {@link hudson.plugins.git.browser.KilnGit#getUrl()}.
+     * @throws MalformedURLException
+     */
+    public void testGetUrlForRepoWithTrailingSlash() throws MalformedURLException {
+        assertEquals(String.valueOf(new KilnGit(KILN_URL + "/").getUrl()), KILN_URL  + "/");
+    }
+
+    /**
+     * Test method for {@link hudson.plugins.git.browser.KilnGit#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
+     * @throws SAXException
+     * @throws IOException
+     */
+    public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
+        final URL changeSetLink = kilnGit.getChangeSetLink(createChangeSet("rawchangelog"));
+        assertEquals(KILN_URL + "/History/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
+    }
+
+    /**
+     * Test method for {@link hudson.plugins.git.browser.KilnGit#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * @throws SAXException
+     * @throws IOException
+     */
+    public void testGetDiffLinkPath() throws IOException, SAXException {
+        final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
+        final Path path1 = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
+        assertEquals(KILN_URL + "/History/396fc230a3db05c427737aa5c2eb7856ba72b05d#diff-1", kilnGit.getDiffLink(path1).toString());
+        final Path path2 = pathMap.get("src/test/java/hudson/plugins/git/browser/GithubWebTest.java");
+        assertEquals(KILN_URL + "/History/396fc230a3db05c427737aa5c2eb7856ba72b05d#diff-2", kilnGit.getDiffLink(path2).toString());
+        final Path path3 = pathMap.get("src/test/resources/hudson/plugins/git/browser/rawchangelog-with-deleted-file");
+        assertNull("Do not return a diff link for added files.", kilnGit.getDiffLink(path3));
+    }
+
+    /**
+     * Test method for {@link hudson.plugins.git.browser.KilnGit#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * @throws SAXException
+     * @throws IOException
+     */
+    public void testGetFileLinkPath() throws IOException, SAXException {
+        final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
+        final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
+        final URL fileLink = kilnGit.getFileLink(path);
+        assertEquals(KILN_URL  + "/FileHistory/src/main/java/hudson/plugins/git/browser/GithubWeb.java?rev=396fc230a3db05c427737aa5c2eb7856ba72b05d", String.valueOf(fileLink));
+    }
+
+    /**
+     * Test method for {@link hudson.plugins.git.browser.KilnGit#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * @throws SAXException
+     * @throws IOException
+     */
+    public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
+        final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
+        final Path path = pathMap.get("bar");
+        final URL fileLink = kilnGit.getFileLink(path);
+        assertEquals(KILN_URL + "/History/fc029da233f161c65eb06d0f1ed4f36ae81d1f4f#diff-1", String.valueOf(fileLink));
+    }
+
+    private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
+        final File rawchangelog = new File(KilnGitTest.class.getResource(rawchangelogpath).getFile());
+        final GitChangeLogParser logParser = new GitChangeLogParser(false);
+        final List<GitChangeSet> changeSetList = logParser.parse(null, rawchangelog).getLogs();
+        return changeSetList.get(0);
+    }
+
+    /**
+     * @param changelog
+     * @return
+     * @throws IOException
+     * @throws SAXException
+     */
+    private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
+        final HashMap<String, Path> pathMap = new HashMap<String, Path>();
+        final Collection<Path> changeSet = createChangeSet(changelog).getPaths();
+        for (final Path path : changeSet) {
+            pathMap.put(path.getPath(), path);
+        }
+        return pathMap;
+    }
+
+
+}


### PR DESCRIPTION
Fog Creek's Kiln now supports Git.  This repository browser
implementation borrows heavily from the GithubWeb and CGit browsers.

I tested the implementation by running "mvn install", then copied target/git.hpi to $JENKINS_HOME/plugins/, restarted the server, and configured the plugin with my repo's URL.  I then verified that the links on a changeset for an edited file were as expected and the same as those that Kiln generates in all 3 cases: full changeset diff, the diff of a single file in a changeset, and single file history.
