### PR TITLE
[FIXED JENKINS-17970] so that GitChangeSet IDENTITY regex can match e.g. Swedish

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -10,7 +10,6 @@ import hudson.scm.ChangeLogSet.AffectedFile;
 import hudson.scm.EditType;
 import hudson.tasks.Mailer;
 import hudson.tasks.Mailer.UserProperty;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -34,7 +33,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
 
     private static final String PREFIX_AUTHOR = "author ";
     private static final String PREFIX_COMMITTER = "committer ";
-    private static final String IDENTITY = "(.*)<(.*)> (.*) (.*)";
+    private static final String IDENTITY = "([^<]*)<(.*)> (.*) (.*)";//starts with everything-but
     private static final String PREFIX_BRANCH = "Changes in branch ";
     private static final String BRANCH_PATTERN = "([-_a-zA-Z0-9/]*),";
     

--- a/src/test/java/hudson/plugins/git/GitChangeSetTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTest.java
@@ -13,7 +13,6 @@ import java.util.HashSet;
 import org.jvnet.hudson.test.HudsonTestCase;
 
 import junit.framework.Assert;
-import junit.framework.TestCase;
 
 public class GitChangeSetTest extends HudsonTestCase {
     
@@ -129,5 +128,40 @@ public class GitChangeSetTest extends HudsonTestCase {
 		String address = property.getAddress();
 		Assert.assertNotNull(address);
 		Assert.assertEquals(csAuthorEmail, address);
+    }
+
+    private GitChangeSet genChangeSetForSwedCase(boolean authorOrCommitter) {
+        ArrayList<String> lines = new ArrayList<String>();
+        lines.add("commit 1567861636cd854f4dd6fa40bf94c0c657681dd5");
+        lines.add("tree 66236cf9a1ac0c589172b450ed01f019a5697c49");
+        lines.add("parent e74a24e995305bd67a180f0ebc57927e2b8783ce");
+        lines.add("author mistera <mister.ahlander@ericsson.com> 1363879004 +0100");
+        lines.add("committer Mister Åhlander <mister.ahlander@ericsson.com> 1364199539 -0400");
+        lines.add("");
+        lines.add("    [task] Updated version.");
+        lines.add("    ");
+        lines.add("    Including earlier updates.");
+        lines.add("    ");
+        lines.add("    Changes in this version:");
+        lines.add("    - Changed to take the gerrit url from gerrit query command.");
+        lines.add("    - Aligned reason information with our new commit hooks");
+        lines.add("    ");
+        lines.add("    Change-Id: Ife96d2abed5b066d9620034bec5f04cf74b8c66d");
+        lines.add("    Reviewed-on: https://gerrit.e.se/12345");
+        lines.add("    Tested-by: Jenkins <jenkins@no-mail.com>");
+        lines.add("    Reviewed-by: Mister Another <mister.another@ericsson.com>");
+        lines.add("");
+        //above lines all on purpose vs specific troublesome case @ericsson.
+        return new GitChangeSet(lines, authorOrCommitter);
+    }
+
+    public void testAuthorOrCommitterSwedCase() {
+        GitChangeSet committerCS = genChangeSetForSwedCase(false);
+
+        Assert.assertEquals("Mister Åhlander", committerCS.getAuthorName());//swedish char on purpose
+
+        GitChangeSet authorCS = genChangeSetForSwedCase(true);
+
+        Assert.assertEquals("mistera", authorCS.getAuthorName());
     }
 }


### PR DESCRIPTION
[FIXED JENKINS-17970] so that GitChangeSet IDENTITY regex can match e.g. Swedish name (utf8 with non-latin1 chars) -even when assuming latin-1; fix may be temporary if undetermined part of regex behavior changes in the future.
