### PR TITLE
[FIXED JENKINS-18328] Defective file link for GitLab browsers

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/GitLab.java
+++ b/src/main/java/hudson/plugins/git/browser/GitLab.java
@@ -82,7 +82,7 @@ public class GitLab extends GitRepositoryBrowser {
             return getDiffLink(path);
         } else {
             String spec;
-            if(getVersion() >= 5.2) {
+            if(getVersion() >= 5.1) {
                 spec = "blob/" + path.getChangeSet().getId() + "/" + path.getPath();
             } else {
                 spec = path.getChangeSet().getId() + "/tree/" + path.getPath();


### PR DESCRIPTION
Fix the defective file link for GitLab browsers:

For older GitLab versions, there was a duplicate slash and for
newer versions the link is completely wrong. Fix both:

Old: http://urlbase//0123456789...01234567/tree/file.name
<5.1: http://urlbase/0123456789...01234567/tree/file.name
>=5.1: http://urlbase/blob/0123456789...01234567/file.name

Note: This supersedes pull request #157, which switched over at too high a version number.
