### PR TITLE
RhodeCode changeset URL

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/RhodeCode.java
+++ b/src/main/java/hudson/plugins/git/browser/RhodeCode.java
@@ -46,7 +46,7 @@ public class RhodeCode extends GitRepositoryBrowser {
      */
     @Override
     public URL getChangeSetLink(GitChangeSet changeSet) throws IOException {
-        return new URL(url, url.getPath() + "changeset/" + changeSet.getId() + "/");
+        return new URL(url, url.getPath() + "changeset/" + changeSet.getId());
     }
 
     /**


### PR DESCRIPTION
This patch corrects the URL of changesets in the RhodeCode browser.

In the current version of Git Plugin (1.4.0, Jenkins 1.509.1), clicking on a changeset link takes you to the 'files' view -- not the 'changeset' view.

The patch has not been tested, as I don't have the development environment set up.
