### PR TITLE
Bugfix: missing DataBoundConstructors.

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
@@ -10,6 +10,7 @@ import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.plugins.git.util.BuildData;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,6 +32,7 @@ public class PathRestriction extends GitSCMExtension {
     // compiled cache
     private transient volatile List<Pattern> includedPatterns,excludedPatterns;
 
+    @DataBoundConstructor
     public PathRestriction(String includedRegions, String excludedRegions) {
         this.includedRegions = includedRegions;
         this.excludedRegions = excludedRegions;

--- a/src/main/java/hudson/plugins/git/extensions/impl/PerBuildTag.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PerBuildTag.java
@@ -8,6 +8,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
 
@@ -17,6 +18,10 @@ import java.io.IOException;
  * @author Kohsuke Kawaguchi
  */
 public class PerBuildTag extends GitSCMExtension {
+    @DataBoundConstructor
+    public PerBuildTag() {
+    }
+
     @Override
     public void onCheckoutCompleted(GitSCM scm, AbstractBuild<?, ?> build, GitClient git, BuildListener listener) throws IOException, InterruptedException, GitException {
         int buildNumber = build.getNumber();


### PR DESCRIPTION
When you try to save job with related parameter, Jenkins simply crashes without this stuff.
