### PR TITLE
Sort the branch list used to rebuild the last commit

### DIFF
--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -217,20 +217,29 @@ public class DefaultBuildChooser extends BuildChooser {
 
         // 4. Finally, remove any revisions that have already been built.
         verbose(listener, "Removing what''s already been built: {0}", data.getBuildsByBranchName());
+        Revision lastBuiltRevision = data.getLastBuiltRevision();
         for (Iterator<Revision> i = revs.iterator(); i.hasNext();) {
             Revision r = i.next();
 
             if (data.hasBeenBuilt(r.getSha1())) {
                 i.remove();
+                
+                // keep track of new branches pointing to the last built revision
+                if (lastBuiltRevision != null && lastBuiltRevision.getSha1().equals(r.getSha1())) {
+                	lastBuiltRevision = r;
+                }
             }
         }
         verbose(listener, "After filtering out what''s already been built: {0}", revs);
 
         // if we're trying to run a build (not an SCM poll) and nothing new
-        // was found then just run the last build again
-        if (!isPollCall && revs.isEmpty() && data.getLastBuiltRevision() != null) {
+        // was found then just run the last build again but ensure that the branch list
+        // is ordered according to the configuration. Sorting the branch list ensures
+        // a deterministic value for GIT_BRANCH and allows a git-flow style workflow
+        // with fast-forward merges between branches
+        if (!isPollCall && revs.isEmpty() && lastBuiltRevision != null) {
             verbose(listener, "Nothing seems worth building, so falling back to the previously built revision: {0}", data.getLastBuiltRevision());
-            return Collections.singletonList(data.getLastBuiltRevision());
+            return Collections.singletonList(utils.sortBranchesForRevision(lastBuiltRevision, gitSCM.getBranches()));
         }
 
         // 5. sort them by the date of commit, old to new

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -6,6 +6,7 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.*;
 import hudson.plugins.git.Branch;
+import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.Revision;
 import hudson.slaves.NodeProperty;
@@ -75,6 +76,24 @@ public class GitUtils {
                 return revision;
         }
         return null;
+    }
+
+    public Revision sortBranchesForRevision(Revision revision, List<BranchSpec> branchOrder) {
+        ArrayList<Branch> orderedBranches = new ArrayList<Branch>(revision.getBranches().size());
+        ArrayList<Branch> revisionBranches = new ArrayList<Branch>(revision.getBranches());
+    	
+        for(BranchSpec branchSpec : branchOrder) {
+            for (Iterator<Branch> i = revisionBranches.iterator(); i.hasNext();) {
+                Branch b = i.next();
+                if (branchSpec.matches(b.getName())) {
+                    i.remove();
+                    orderedBranches.add(b);
+                }
+            }
+        }
+
+        orderedBranches.addAll(revisionBranches);
+        return new Revision(revision.getSha1(), orderedBranches);
     }
 
     /**


### PR DESCRIPTION
Hi,

This patch sorts the branch list used to rebuild the last commit. It also filters out */HEAD from the branch list if more than one branch exists, so GIT_BRANCH can never be equals to */HEAD if another branch is also built. This fixes JENKINS-17150. As we use GIT_BRANCH to route built artifact to different repositories, having */HEAD as a value doesn't make sense.

Sorting the branch list ensures a deterministic value for GIT_BRANCH and allows a git-flow style workflow with fast-forward merge between branches.

It's written on top of 1.x branch but merges successfully on master.
