### PR TITLE
[FIXED JENKINS-17417] Expand Branch Specifier

### DIFF
--- a/src/main/java/hudson/plugins/git/BranchSpec.java
+++ b/src/main/java/hudson/plugins/git/BranchSpec.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git;
 
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -27,7 +28,6 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
     private static final long serialVersionUID = -6177158367915899356L;
 
     private String name;
-    private transient Pattern pattern;
     
     public String getName() {
         return name;
@@ -48,54 +48,59 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
     }
 
     public String toString() {
-        return pattern + " (" + name + ")";
+        return name;
     }
 
     public boolean matches(String item) {
-        return getPattern().matcher(item).matches();
+        EnvVars env = new EnvVars();
+        return getPattern(env).matcher(item).matches();
+    }
+
+    public boolean matches(String item, EnvVars env) {
+        return getPattern(env).matcher(item).matches();
     }
     
-    public List<String> filterMatching(Collection<String> branches) {
+    public List<String> filterMatching(Collection<String> branches, EnvVars env) {
         List<String> items = new ArrayList<String>();
         
         for(String b : branches) {
-            if(matches(b))
+            if(matches(b, env))
                 items.add(b);
         }
         
         return items;
     }
     
-    public List<Branch> filterMatchingBranches(Collection<Branch> branches) {
+    public List<Branch> filterMatchingBranches(Collection<Branch> branches, EnvVars env) {
         List<Branch> items = new ArrayList<Branch>();
         
         for(Branch b : branches) {
-            if(matches(b.getName()))
+            if(matches(b.getName(), env))
                 items.add(b);
         }
         
         return items;
     }
+
+    private String getExpandedName(EnvVars env) {
+        return env.expand(name);
+    }
     
-    private Pattern getPattern() {
-        // return the saved pattern if available
-        if (pattern != null)
-            return pattern;
-        
+    private Pattern getPattern(EnvVars env) {
+        String expandedName = getExpandedName(env);
         // use regex syntax directly if name starts with colon
-        if (name.startsWith(":") && name.length() > 1) {
-        	String regexSubstring = name.substring(1, name.length());
-        	pattern = Pattern.compile(regexSubstring);
-        	return pattern;
+        if (expandedName.startsWith(":") && expandedName.length() > 1) {
+        	String regexSubstring = expandedName.substring(1, expandedName.length());
+        	return Pattern.compile(regexSubstring);
         }
         
         // if an unqualified branch was given add a "*/" so it will match branches
         // from remote repositories as the user probably intended
         String qualifiedName;
-        if (!name.contains("**") && !name.contains("/"))
-            qualifiedName = "*/" + name;
+        if (!expandedName.contains("**") && !expandedName.contains("/"))
+            qualifiedName = "*/" + expandedName;
         else
-            qualifiedName = name;
+            qualifiedName = expandedName;
         
         // build a pattern into this builder
         StringBuilder builder = new StringBuilder();
@@ -140,10 +145,7 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
             builder.append("[^/]*");
         }
         
-        // save the pattern
-        pattern = Pattern.compile(builder.toString());
-        
-        return pattern;
+        return Pattern.compile(builder.toString());
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -81,14 +81,14 @@ public class GitUtils implements Serializable {
         return new Revision(sha1);
     }
 
-    public Revision sortBranchesForRevision(Revision revision, List<BranchSpec> branchOrder) {
+    public Revision sortBranchesForRevision(Revision revision, List<BranchSpec> branchOrder, EnvVars env) {
         ArrayList<Branch> orderedBranches = new ArrayList<Branch>(revision.getBranches().size());
         ArrayList<Branch> revisionBranches = new ArrayList<Branch>(revision.getBranches());
     	
         for(BranchSpec branchSpec : branchOrder) {
             for (Iterator<Branch> i = revisionBranches.iterator(); i.hasNext();) {
                 Branch b = i.next();
-                if (branchSpec.matches(b.getName())) {
+                if (branchSpec.matches(b.getName(), env)) {
                     i.remove();
                     orderedBranches.add(b);
                 }

--- a/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java
@@ -1,6 +1,7 @@
 package hudson.plugins.git.util;
 
 import hudson.Extension;
+import hudson.EnvVars;
 import hudson.model.TaskListener;
 import hudson.plugins.git.*;
 import hudson.remoting.VirtualChannel;
@@ -41,6 +42,7 @@ public class InverseBuildChooser extends BuildChooser {
             String singleBranch, GitClient git, TaskListener listener,
             BuildData buildData, BuildChooserContext context) throws GitException, IOException, InterruptedException {
 
+        EnvVars env = context.getBuild().getEnvironment();
         GitUtils utils = new GitUtils(listener, git);
         List<Revision> branchRevs = new ArrayList<Revision>(utils.getAllBranchRevisions());
         List<BranchSpec> specifiedBranches = gitSCM.getBranches();
@@ -56,7 +58,7 @@ public class InverseBuildChooser extends BuildChooser {
                 // Check whether this branch matches a branch spec from the job config
                 for (BranchSpec spec : specifiedBranches) {
                     // If the branch matches, throw it away as we do *not* want to build it
-                    if (spec.matches(branch.getName()) || HEAD.matches(branch.getName())) {
+                    if (spec.matches(branch.getName(), env) || HEAD.matches(branch.getName(), env)) {
                         j.remove();
                         break;
                     }

--- a/src/test/java/hudson/plugins/git/TestBranchSpec.java
+++ b/src/test/java/hudson/plugins/git/TestBranchSpec.java
@@ -1,5 +1,8 @@
 package hudson.plugins.git;
 
+import hudson.EnvVars;
+import java.util.HashMap;
+
 import junit.framework.Assert;
 import junit.framework.TestCase;
 
@@ -41,6 +44,57 @@ public class TestBranchSpec extends TestCase {
         Assert.assertTrue(o.matches("remote/origin/my.branch/b1"));
       
         BranchSpec p = new BranchSpec("*");
+
+        Assert.assertTrue(p.matches("origin/x"));
+        Assert.assertFalse(p.matches("origin/my-branch/b1"));
+    }
+    
+    public void testMatchEnv() {
+        HashMap<String, String> envMap = new HashMap<String, String>();
+        envMap.put("master", "master");
+        envMap.put("origin", "origin");
+        envMap.put("magnayn", "magnayn");
+        envMap.put("mybranch", "my.branch");
+        envMap.put("anyLong", "**");
+        envMap.put("anyShort", "*");
+        EnvVars env = new EnvVars();
+
+        BranchSpec l = new BranchSpec("${master}");
+        Assert.assertTrue(l.matches("origin/master"));
+        Assert.assertFalse(l.matches("origin/something/master"));
+        Assert.assertFalse(l.matches("master"));
+        Assert.assertFalse(l.matches("dev"));
+        
+        
+        BranchSpec est = new BranchSpec("${origin}/*/${dev}");
+        
+        Assert.assertFalse(est.matches("origintestdev"));
+        Assert.assertTrue(est.matches("origin/test/dev"));
+        Assert.assertFalse(est.matches("origin/test/release"));
+        Assert.assertFalse(est.matches("origin/test/somthing/release"));
+        
+        BranchSpec s = new BranchSpec("${origin}/*");
+        
+        Assert.assertTrue(s.matches("${origin}/${master}"));
+      
+        BranchSpec m = new BranchSpec("**/${magnayn}/*");
+        
+        Assert.assertTrue(m.matches("origin/magnayn/b1"));
+        Assert.assertTrue(m.matches("remote/origin/magnayn/b1"));
+      
+        BranchSpec n = new BranchSpec("*/${mybranch}/*");
+        
+        Assert.assertTrue(n.matches("origin/my.branch/b1"));
+        Assert.assertFalse(n.matches("origin/my-branch/b1"));
+        Assert.assertFalse(n.matches("remote/origin/my.branch/b1"));
+      
+        BranchSpec o = new BranchSpec("${anyLong}");
+        
+        Assert.assertTrue(o.matches("origin/my.branch/b1"));
+        Assert.assertTrue(o.matches("origin/my-branch/b1"));
+        Assert.assertTrue(o.matches("remote/origin/my.branch/b1"));
+      
+        BranchSpec p = new BranchSpec("${anyShort}");
 
         Assert.assertTrue(p.matches("origin/x"));
         Assert.assertFalse(p.matches("origin/my-branch/b1"));


### PR DESCRIPTION
Expand Branch Specifier with build environment variables.

Note that the Branch Specifier is not expanded for repository polling
because no build environment is available at that time.
