### PR TITLE
Make checkout lock failure retryable

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -878,7 +878,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             environment.put(GIT_BRANCH, branch.getName());
 
         listener.getLogger().println("Checking out " + revToBuild.revision);
-        git.checkoutBranch(getParamLocalBranch(build), revToBuild.revision.getSha1String());
+        try {
+            git.checkoutBranch(getParamLocalBranch(build), revToBuild.revision.getSha1String());
+        } catch(GitLockFailedException e) {
+            // Rethrow IOException so the retry will be able to catch it
+            throw new IOException("Could not checkout " + revToBuild.revision.getSha1String(), e);
+        }
 
         buildData.saveBuild(revToBuild);
         build.addAction(new GitTagAction(build, buildData));


### PR DESCRIPTION
In a shared workspace environment, git checkout occasionally fails because another concurrent build has lock on the git repository(.git/index.lock).
(e.g http://jenkins-ci.361315.n4.nabble.com/Git-index-lock-problem-on-a-common-directory-td4488918.html)
This change resolves this problem by rethrowing IOException on lock failure to make operation retryable.

Refs: jenkinsci/git-client-plugin#31, jenkinsci/git-client-plugin#17
