### PR TITLE
Fix for JENKINS-13634

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -749,19 +749,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                                               final BuildListener listener) throws IOException, InterruptedException {
         PrintStream log = listener.getLogger();
 
-        // every MatrixRun should build the exact same commit ID
-        if (build instanceof MatrixRun) {
-            MatrixBuild parentBuild = ((MatrixRun) build).getParentBuild();
-            if (parentBuild != null) {
-                BuildData parentBuildData = getBuildData(parentBuild);
-                if (parentBuildData != null) {
-                    Build lastBuild = parentBuildData.lastBuild;
-                    if (lastBuild!=null)
-                        return lastBuild;
-                }
-            }
-        }
-
         // parameter forcing the commit ID to build
         final RevisionParameterAction rpa = build.getAction(RevisionParameterAction.class);
         if (rpa != null)


### PR DESCRIPTION
Fix for JENKINS-13634:
https://issues.jenkins-ci.org/browse/JENKINS-13634

The Git plugin would force each permutation in a matrix build to use the same SCM commit number or SHA hash (for git).

In the case of a multiple SCM Git build using a matrix configuration, this would have the unintended effect of causing all the different SCMs to use the same commit SHA and hence cause JENKINS-13634.

The fix for this problem is to remove the code forcing the same commit/SHA for each matrix configuration.

Note: This change may have some side effects in that continuous integration matrix builds might possibly use different SHAs for different matrix permutations if a commit is made while building. For release builds this is probably not so much an issue since we would generally build from a fixed tag for a release. I think this side effect is the lesser of two evils so accepting this as a slight downside/tradeoff to the fix. There may be a better way to fix this issue in the long term though...
