### PR TITLE
[FIXED JENKINS-20561] fix migration of skipTag property for job using configuration format version 1

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
+++ b/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
@@ -193,7 +193,7 @@ public abstract class GitSCMBackwardCompatibility extends SCM implements Seriali
                 addIfMissing(new RelativeTargetDirectory(relativeTargetDir));
                 relativeTargetDir = null;
             }
-            if (skipTag!=null && skipTag) {
+            if (skipTag!=null && !skipTag) {
                 addIfMissing(new PerBuildTag());
                 skipTag = null;
             }


### PR DESCRIPTION
If skipTag is set to true, the migration process adds a 'Create a tag for every build' behavior instead of doing nothing.
