### PR TITLE
[JENKINS-20607] Force commit downloads when filtering by commit attributes.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -446,9 +446,23 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
     @Override
     public boolean requiresWorkspaceForPolling() {
-        String singleBranch = getSingleBranch(new EnvVars());
-        return singleBranch == null || getExtensions().get(DisableRemotePoll.class) != null;
+        return isSingleBranch() || anyExtensionRequiresWorkspace();
     }
+
+	private boolean anyExtensionRequiresWorkspace() {
+		DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> extensions = getExtensions();
+        for (GitSCMExtension extension: extensions) {
+        	if (extension.requiresWorkspaceForPolling()) {
+        		return true;
+        	}
+        }
+        return false;
+	}
+
+	private boolean isSingleBranch() {
+		String singleBranch = getSingleBranch(new EnvVars());
+        return singleBranch == null;
+	}
 
     @Override
     protected PollingResult compareRemoteRevisionWith(AbstractProject<?, ?> project, Launcher launcher, FilePath workspace, final TaskListener listener, SCMRevisionState baseline) throws IOException, InterruptedException {
@@ -479,7 +493,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         final String singleBranch = getSingleBranch(lastBuild.getEnvironment());
 
         // fast remote polling needs a single branch and an existing last build
-        if (getExtensions().get(DisableRemotePoll.class)==null && singleBranch != null && buildData.lastBuild != null && buildData.lastBuild.getMarked() != null) {
+        if (!anyExtensionRequiresWorkspace() && singleBranch != null && buildData.lastBuild != null && buildData.lastBuild.getMarked() != null) {
             final EnvVars environment = GitUtils.getPollEnvironment(project, workspace, launcher, listener, false);
 
             GitClient git = createClient(listener, environment, project, Jenkins.getInstance(), null);

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -31,7 +31,9 @@ import java.util.Map;
  */
 public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExtension> {
     /**
-     * Given a commit found during polling, check whether it should be disregarded.
+     * Given a commit found during polling, check whether it should be disregarded. This operation requires a workspace,
+     * as it operates on the revision history; if you override this, you will need to override
+     * {@link #requiresWorkspaceForPolling()} as well.
      *
      *
      * @param scm
@@ -154,4 +156,14 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
     public GitSCMExtensionDescriptor getDescriptor() {
         return (GitSCMExtensionDescriptor) super.getDescriptor();
     }
+
+    /**
+	 * Allows extensions to force a workspace and disable "fast" polling. Some extensions need to walk the changelog,
+	 * which means the changelog must be available locally; Jenkins can't make the build/no-build decision purely
+	 * remotely in these cases.
+     */
+	public boolean requiresWorkspaceForPolling() {
+		/* If you override isRevExcluded, you probably want to override this, too. */
+		return false;
+	}
 }

--- a/src/main/java/hudson/plugins/git/extensions/impl/DisableRemotePoll.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/DisableRemotePoll.java
@@ -3,6 +3,7 @@ package hudson.plugins.git.extensions.impl;
 import hudson.Extension;
 import hudson.plugins.git.extensions.FakeGitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -21,5 +22,10 @@ public class DisableRemotePoll extends FakeGitSCMExtension {
         public String getDisplayName() {
             return "Force polling using workspace";
         }
+    }
+    
+    @Override
+    public boolean requiresWorkspaceForPolling () {
+    	return true;
     }
 }

--- a/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
@@ -38,6 +38,11 @@ public class PathRestriction extends GitSCMExtension {
         this.excludedRegions = excludedRegions;
     }
 
+    @Override
+    public boolean requiresWorkspaceForPolling () {
+    	return true;
+    }
+    
     public String getIncludedRegions() {
         return includedRegions;
     }

--- a/src/main/java/hudson/plugins/git/extensions/impl/UserExclusion.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/UserExclusion.java
@@ -7,6 +7,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.plugins.git.util.BuildData;
+
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -30,6 +31,11 @@ public class UserExclusion extends GitSCMExtension {
     @DataBoundConstructor
     public UserExclusion(String excludedUsers) {
         this.excludedUsers = excludedUsers;
+    }
+
+    @Override
+    public boolean requiresWorkspaceForPolling () {
+    	return true;
     }
 
     public String getExcludedUsers() {


### PR DESCRIPTION
The new "fast polling" mechanism in git-2.0 does a hard build/no-build decision based solely on whether the remote branch tip is not/is equal to the last commit built on that branch. This works well in the simple case, but bypasses configurable checks such as "ignore commits from these users" or "ignore commits in these directories". It's possible for users to work around this by enabling the "force polling using workspace" option. However, the dependency isn't clear or documented (or, I suspect, well understood).

I've allowed `GitSCM` extensions such as `UserExclusion` and `PathRestriction` to individually tell `GitSCM` that they require a work tree to evaluate the restriction, and updated `GitSCM` to pay attention to these requirements rather than special-casing `DisableRemotePoll`. This feels more elegant to me; the user doesn't need to be aware of the dependency at all, and Jenkins doesn't need to "magically" add extra options. I believe this is compatible with existing git-2.0 and git-1.x configurations without any change to the stored configuration, to boot.

It's not clear to me how this interacts with JENKINS-10131. Better documentation of why the workspace requirement exists may be in order.
