### PR TITLE
[FIXED JENKINS-17417] Expand Branch Specifier

### DIFF
--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -82,13 +82,18 @@ public class GitUtils implements Serializable {
     }
 
     public Revision sortBranchesForRevision(Revision revision, List<BranchSpec> branchOrder) {
+        EnvVars env = new EnvVars();
+        return sortBranchesForRevision(revision, branchOrder, env);
+    }
+
+    public Revision sortBranchesForRevision(Revision revision, List<BranchSpec> branchOrder, EnvVars env) {
         ArrayList<Branch> orderedBranches = new ArrayList<Branch>(revision.getBranches().size());
         ArrayList<Branch> revisionBranches = new ArrayList<Branch>(revision.getBranches());
     	
         for(BranchSpec branchSpec : branchOrder) {
             for (Iterator<Branch> i = revisionBranches.iterator(); i.hasNext();) {
                 Branch b = i.next();
-                if (branchSpec.matches(b.getName())) {
+                if (branchSpec.matches(b.getName(), env)) {
                     i.remove();
                     orderedBranches.add(b);
                 }

--- a/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java
@@ -1,6 +1,7 @@
 package hudson.plugins.git.util;
 
 import hudson.Extension;
+import hudson.EnvVars;
 import hudson.model.TaskListener;
 import hudson.plugins.git.*;
 import hudson.remoting.VirtualChannel;
@@ -41,6 +42,7 @@ public class InverseBuildChooser extends BuildChooser {
             String singleBranch, GitClient git, TaskListener listener,
             BuildData buildData, BuildChooserContext context) throws GitException, IOException, InterruptedException {
 
+        EnvVars env = context.getBuild().getEnvironment();
         GitUtils utils = new GitUtils(listener, git);
         List<Revision> branchRevs = new ArrayList<Revision>(utils.getAllBranchRevisions());
         List<BranchSpec> specifiedBranches = gitSCM.getBranches();
@@ -56,7 +58,7 @@ public class InverseBuildChooser extends BuildChooser {
                 // Check whether this branch matches a branch spec from the job config
                 for (BranchSpec spec : specifiedBranches) {
                     // If the branch matches, throw it away as we do *not* want to build it
-                    if (spec.matches(branch.getName()) || HEAD.matches(branch.getName())) {
+                    if (spec.matches(branch.getName(), env) || HEAD.matches(branch.getName(), env)) {
                         j.remove();
                         break;
                     }

--- a/src/test/java/hudson/plugins/git/TestBranchSpec.java
+++ b/src/test/java/hudson/plugins/git/TestBranchSpec.java
@@ -1,5 +1,8 @@
 package hudson.plugins.git;
 
+import hudson.EnvVars;
+import java.util.HashMap;
+
 import junit.framework.Assert;
 import junit.framework.TestCase;
 
@@ -46,6 +49,58 @@ public class TestBranchSpec extends TestCase {
         Assert.assertFalse(p.matches("origin/my-branch/b1"));
     }
     
+    public void testMatchEnv() {
+        HashMap<String, String> envMap = new HashMap<String, String>();
+        envMap.put("master", "master");
+        envMap.put("origin", "origin");
+        envMap.put("dev", "dev");
+        envMap.put("magnayn", "magnayn");
+        envMap.put("mybranch", "my.branch");
+        envMap.put("anyLong", "**");
+        envMap.put("anyShort", "*");
+        EnvVars env = new EnvVars(envMap);
+
+        BranchSpec l = new BranchSpec("${master}");
+        Assert.assertTrue(l.matches("origin/master", env));
+        Assert.assertFalse(l.matches("origin/something/master", env));
+        Assert.assertFalse(l.matches("master", env));
+        Assert.assertFalse(l.matches("dev", env));
+
+
+        BranchSpec est = new BranchSpec("${origin}/*/${dev}");
+
+        Assert.assertFalse(est.matches("origintestdev", env));
+        Assert.assertTrue(est.matches("origin/test/dev", env));
+        Assert.assertFalse(est.matches("origin/test/release", env));
+        Assert.assertFalse(est.matches("origin/test/somthing/release", env));
+
+        BranchSpec s = new BranchSpec("${origin}/*");
+
+        Assert.assertTrue(s.matches("origin/master", env));
+
+        BranchSpec m = new BranchSpec("**/${magnayn}/*");
+
+        Assert.assertTrue(m.matches("origin/magnayn/b1", env));
+        Assert.assertTrue(m.matches("remote/origin/magnayn/b1", env));
+
+        BranchSpec n = new BranchSpec("*/${mybranch}/*");
+
+        Assert.assertTrue(n.matches("origin/my.branch/b1", env));
+        Assert.assertFalse(n.matches("origin/my-branch/b1", env));
+        Assert.assertFalse(n.matches("remote/origin/my.branch/b1", env));
+
+        BranchSpec o = new BranchSpec("${anyLong}");
+
+        Assert.assertTrue(o.matches("origin/my.branch/b1", env));
+        Assert.assertTrue(o.matches("origin/my-branch/b1", env));
+        Assert.assertTrue(o.matches("remote/origin/my.branch/b1", env));
+
+        BranchSpec p = new BranchSpec("${anyShort}");
+
+        Assert.assertTrue(p.matches("origin/x", env));
+        Assert.assertFalse(p.matches("origin/my-branch/b1", env));
+    }
+
     public void testEmptyName() {
     	BranchSpec branchSpec = new BranchSpec("");
     	assertEquals("**",branchSpec.getName());


### PR DESCRIPTION
Expand Branch Specifier with build environment variables.

Note that the Branch Specifier is not expanded for repository polling
because no build environment is available at that time.
