### PR TITLE
[JENKINS-19994] Close files opened by computeChangeLog, use abort()

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -938,6 +938,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     private void computeChangeLog(GitClient git, Revision revToBuild, BuildListener listener, BuildData previousBuildData, FilePath changelogFile, BuildChooserContext context) throws IOException, InterruptedException {
         Writer out = new OutputStreamWriter(changelogFile.write(),"UTF-8");
 
+        boolean executed = false;
         ChangelogCommand changelog = git.changelog();
         changelog.includes(revToBuild.getSha1());
         try {
@@ -955,10 +956,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 listener.getLogger().println("First time build. Skipping changelog.");
             } else {
                 changelog.to(out).max(MAX_CHANGELOG).execute();
+                executed = true;
             }
         } catch (GitException ge) {
             ge.printStackTrace(listener.error("Unable to retrieve changeset"));
         } finally {
+            if (!executed) changelog.abort();
             IOUtils.closeQuietly(out);
         }
     }


### PR DESCRIPTION
Fix JENKINS-19994 - cannot delete Windows workspace - open files

All calls to a changelog instance must conclude with either a call to
execute() or a call to abort().  Files will be left open if one of
those two methods is not called before the changelog instance goes out
of scope.
