### PR TITLE
[FIXED JENKINS-14026] git plugin doesn't support branch name containing /

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -435,6 +435,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         // Check for empty string - replace with "**" when seen.
         if (branch.equals("")) {
             branch = "**";
+        } else if (!branch.startsWith(repository)) {
+            // we can hit this case if the given branch name contains a slash.
+            // Since we have a single repository, it makes sense to prepend it anyway
+            branch = repository + "/" + branch;
         }
 
         return branch;

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -494,6 +494,20 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertEquals("origin/master", getEnvVars(project).get(GitSCM.GIT_BRANCH));
     }
 
+    public void testBranchContainsSlash() throws Exception {
+      FreeStyleProject project = setupSimpleProject("my/branch");
+
+      final String commitFile1 = "commitFile1";
+      commit(commitFile1, johnDoe, "Commit number 1");
+      git.branch("my/branch");
+      git.checkout("my/branch");
+      final String commitFile2 = "commitFile2";
+      commit(commitFile2, johnDoe, "Commit number 2");
+      build(project, Result.SUCCESS, commitFile1, commitFile2);
+
+      assertEquals("origin/my/branch", getEnvVars(project).get(GitSCM.GIT_BRANCH));
+    }
+
     // For HUDSON-7411
     public void testNodeEnvVarsAvailable() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");


### PR DESCRIPTION
The main issue is to determine whether an input containing a slash is a
qualified branch (remote followed by branch name) or a branch name on
which the remote name needs to be prepended.

When there is only one remote involved, that can be solved by prepending
the remote name to the branch name if the branch name doesn't already
start with the remote name.

Note : This commit doesn't cover cases where the given branch name is a
pattern
