### PR TITLE
Added an option to GitSCMSource to ignore on-push notifications. 

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -71,13 +71,20 @@ public class GitSCMSource extends AbstractGitSCMSource {
 
     private final String excludes;
 
+    private final boolean ignoreOnPushNotifications;
+
     @DataBoundConstructor
-    public GitSCMSource(String id, String remote, String credentialsId, String includes, String excludes) {
+    public GitSCMSource(String id, String remote, String credentialsId, String includes, String excludes, boolean ignoreOnPushNotifications) {
         super(id);
         this.remote = remote;
         this.credentialsId = credentialsId;
         this.includes = includes;
         this.excludes = excludes;
+        this.ignoreOnPushNotifications = ignoreOnPushNotifications;
+    }
+
+    public boolean isIgnoreOnPushNotifications() {
+      return ignoreOnPushNotifications;
     }
 
     @Override
@@ -147,6 +154,9 @@ public class GitSCMSource extends AbstractGitSCMSource {
                     for (SCMSource source : owner.getSCMSources()) {
                         if (source instanceof GitSCMSource) {
                             GitSCMSource git = (GitSCMSource) source;
+                            if (git.ignoreOnPushNotifications) {
+                              continue;
+                            }
                             URIish remote;
                             try {
                                 remote = new URIish(git.getRemote());

--- a/src/main/resources/jenkins/plugins/git/GitSCMSource/config-detail.jelly
+++ b/src/main/resources/jenkins/plugins/git/GitSCMSource/config-detail.jelly
@@ -29,6 +29,9 @@
   <f:entry title="${%Credentials}" field="credentialsId">
     <c:select/>
   </f:entry>
+  <f:entry title="${%Ignore on push notifications}" field="ignoreOnPushNotifications">
+    <f:checkbox/>
+  </f:entry>
   <f:advanced>
     <f:entry title="${%Include branches}" field="includes">
       <f:textbox default="*"/>


### PR DESCRIPTION
This can be useful for some jobs like sonar analysis, relying on polling rather than on-push.
