### PR TITLE
Ignore remote branches not on the same remote

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -183,6 +183,9 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             try {
                 walk.setRetainBody(false);
                 for (Branch b : client.getRemoteBranches()) {
+                    if (!b.getName().startsWith(remoteName + "/")) {
+                      continue;
+                    }
                     final String branchName = StringUtils.removeStart(b.getName(), remoteName + "/");
                     listener.getLogger().println("Checking branch " + branchName);
                     if (branchCriteria != null) {


### PR DESCRIPTION
When several GitSCMSource (or derivatives) are set up with different remote names, they may use the same cache (if they share the same url but different refspecs for instance).
When checking branches, it should consider only branches from its own remote.
