### PR TITLE
Update to JGit 3.2.0 and latest of other components (except guava)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,12 +221,12 @@
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
-      <version>3.1.0.201310021548-r</version>
+      <version>3.2.0.201312181205-r</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>1.5.1</version>
+      <version>2.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -236,7 +236,7 @@
     <dependency>
       <groupId>com.infradna.tool</groupId>
       <artifactId>bridge-method-annotation</artifactId>
-      <version>1.4</version>
+      <version>1.12</version>
     </dependency>
 
     <dependency>
@@ -247,17 +247,17 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1.9.3</version>
+      <version>1.9.4</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.5.1</version>
+      <version>1.6</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>0.1</version>
+      <version>0.2</version>
     </dependency>
 
 
@@ -270,7 +270,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.8.5</version>
+      <version>1.9.5</version>
       <scope>test</scope>
     </dependency>
 
@@ -290,19 +290,19 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>
-      <version>1.5.1</version>
+      <version>1.9</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>multiple-scms</artifactId>
-      <version>0.2</version>
+      <version>0.3</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>promoted-builds</artifactId>
-      <version>2.7</version>
+      <version>2.14</version>
       <optional>true</optional>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Guava stays at version consistent with the version provided by jenkins core
