### PR TITLE
[FIXED JENKINS-20445] [FIXED JENKINS-20387] [FIXED JENKINS-20750]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>1.6.1</version>
+      <version>1.6.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -3,12 +3,15 @@ package hudson.plugins.git.extensions.impl;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitClientType;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+
 import org.jenkinsci.plugins.gitclient.CloneCommand;
+import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -20,11 +23,13 @@ import java.io.IOException;
 public class CloneOption extends GitSCMExtension {
     private boolean shallow;
     private String reference;
+    private Integer timeout;
 
     @DataBoundConstructor
-    public CloneOption(boolean shallow, String reference) {
+    public CloneOption(boolean shallow, String reference, Integer timeout) {
         this.shallow = shallow;
         this.reference = reference;
+        this.timeout = timeout;
     }
 
     public boolean isShallow() {
@@ -34,6 +39,10 @@ public class CloneOption extends GitSCMExtension {
     public String getReference() {
         return reference;
     }
+    
+    public Integer getTimeout() {
+        return timeout;
+    }
 
     @Override
     public void decorateCloneCommand(GitSCM scm, AbstractBuild<?, ?> build, GitClient git, BuildListener listener, CloneCommand cmd) throws IOException, InterruptedException, GitException {
@@ -41,7 +50,13 @@ public class CloneOption extends GitSCMExtension {
             listener.getLogger().println("Using shallow clone");
             cmd.shallow();
         }
+        cmd.timeout(timeout);
         cmd.reference(build.getEnvironment(listener).expand(reference));
+    }
+    
+    @Override
+    public void decorateFetchCommand(GitSCM scm, GitClient git, TaskListener listener, FetchCommand cmd) throws IOException, InterruptedException, GitException {
+    	cmd.timeout(timeout);
     }
 
     @Override

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
@@ -8,3 +8,6 @@ f.entry(title:_("Shallow clone"), field:"shallow") {
 f.entry(title:_("Path of the reference repo to use during clone"), field:"reference") {
     f.textbox()
 }
+f.entry(title:_("Timeout (in minutes) for clone and fetch operation"), field:"timeout") {
+    f.textbox()
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-timeout.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-timeout.html
@@ -1,0 +1,5 @@
+<div>
+  Specify a timeout (in minutes) for clone and fetch operations.<br/>
+  This option overrides the default timeout of 10 minutes. <br/>
+  You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeout (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-11286" target="_blank">JENKINS-11286</a>).
+</div>


### PR DESCRIPTION
Timeout for clone and fetch is configurable via Additional Behaviours - Advanced clone behaviours

! This pull request depends on git-client-plugin pull request #92 !
see https://github.com/jenkinsci/git-client-plugin/pull/92
