### PR TITLE
fixed compile error on backward compatibility

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
+++ b/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
@@ -238,7 +238,7 @@ public abstract class GitSCMBackwardCompatibility extends SCM implements Seriali
                 addIfMissing(new BuildChooserSetting(buildChooser));
             }
             if (isNotBlank(reference) || useShallowClone) {
-                addIfMissing(new CloneOption(useShallowClone, reference));
+                addIfMissing(new CloneOption(useShallowClone, reference,null));
             }
         } catch (IOException e) {
             throw new AssertionError(e); // since our extensions don't have any real Saveable


### PR DESCRIPTION
added default timeout to GitSCMBackwardCompatibility.useShallowClone

fixes build https://jenkins.ci.cloudbees.com/job/plugins/job/git-plugin/253/
