### PR TITLE
Update dependency versions - git-client and promoted-builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>1.6.2-SNAPSHOT</version>
+      <version>1.6.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -302,7 +302,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>promoted-builds</artifactId>
-      <version>2.14</version>
+      <version>2.15</version>
       <optional>true</optional>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Since the git-client-plugin just released 1.6.2, this is a good time to update the dependency in the git plugin to require that new git-client-plugin version.  I believe there are dependencies which won't be satisfied if someone installs the git-client-plugin 1.6.2 without a matching release of the git plugin.
