### PR TITLE
fix change log encoding problem on Asia language Windows

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -949,7 +949,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
      *      or else we won't know where to stop.
      */
     private void computeChangeLog(GitClient git, Revision revToBuild, BuildListener listener, BuildData previousBuildData, FilePath changelogFile, BuildChooserContext context) throws IOException, InterruptedException {
-        Writer out = new OutputStreamWriter(changelogFile.write(),"UTF-8");
+        Writer out = new OutputStreamWriter(changelogFile.write());
 
         boolean executed = false;
         ChangelogCommand changelog = git.changelog();


### PR DESCRIPTION
latest version of Git for Windows supported unicode, and git log output using system encoding. delete "utf-8" encoding to resolve change log encoding problem on Windows which using asia language.

It's hard to write a unit test for this issue, but I've tested on my Windows system with simplified Chinese.
