### PR TITLE
[JENKINS-21952] Resolve tags with slashes

### DIFF
--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -108,7 +108,7 @@ public class DefaultBuildChooser extends BuildChooser {
         if (revisions.isEmpty()) {
             // the 'branch' could actually be a non branch reference (for example a tag or a gerrit change)
 
-            revisions.addAll(getHeadRevision(isPollCall, singleBranch, git, listener, data));
+            revisions = getHeadRevision(isPollCall, singleBranch, git, listener, data);
             if (!revisions.isEmpty()) {
                 verbose(listener, "{0} seems to be a non-branch reference (tag?)");
             }


### PR DESCRIPTION
If no revisions are found, try to use the branch as explicit reference.
This could be a tag rel/my-tags or any other explicit reference like a
gerrit changeset (refs/changes/xx/yy/z).
