### PR TITLE
JENKINS-14575: Make failed Git fetch throw IOException

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -618,7 +618,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 }
                 fetch.execute();
             } catch (GitException ex) {
-                throw new GitException("Failed to fetch from "+url.toString(), ex);
+                // Convert GitException to IOException, since the SCM retry functionality only checks that kind
+                throw new IOException("Failed to fetch from "+url.toString(), ex);
             }
         }
     }

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -618,8 +618,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 }
                 fetch.execute();
             } catch (GitException ex) {
-                // Convert GitException to IOException, since the SCM retry functionality only checks that kind
-                throw new IOException("Failed to fetch from "+url.toString(), ex);
+                if (ex.getMessage().contains("stderr: ssh_exchange_identification: Connection closed by remote host"))
+                    // Convert GitException to IOException, since the SCM retry functionality only checks that kind
+                    throw new IOException("Failed to fetch from "+url.toString(), ex);
+                else
+                    throw ex;
             }
         }
     }


### PR DESCRIPTION
This is a port of a fix for version 1 of the plugin. The previous fix
was in [old-fix] and reviewed at [github]. This version is smaller,
because a failed clone in version 2 throws AbortException instead of
GitException, and it makes sense to keep it that way.

[old-fix] 3ab1db8..f49bc41
[github]  https://github.com/jenkinsci/git-plugin/pull/143
