### PR TITLE
Do polling using a shared repository with a single fetch

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPollingManager.java
+++ b/src/main/java/hudson/plugins/git/GitPollingManager.java
@@ -1,0 +1,161 @@
+package hudson.plugins.git;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.text.MessageFormat;
+import java.util.List;
+
+import hudson.AbortException;
+import hudson.EnvVars;
+import hudson.model.TaskListener;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import hudson.plugins.git.util.BuildData;
+import hudson.util.DescribableList;
+
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
+import org.jenkinsci.plugins.gitclient.CloneCommand;
+import org.jenkinsci.plugins.gitclient.FetchCommand;
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+public class GitPollingManager {
+	private static GitPollingManager instance;
+	private GitPoller poller;
+	
+	private class GitPoller implements Runnable {
+		private TaskListener listener;
+		private GitClient git;
+		private AbstractProject<?, ?> project;
+		private EnvVars environment;
+		private DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> extensions;
+		private GitSCM gitSCM;
+		private BuildData buildData;
+
+		public GitPoller(GitSCM gitSCM, TaskListener listener, GitClient git, AbstractProject<?, ?> project, BuildData buildData, EnvVars environment, DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> extensions) {
+			this.gitSCM = gitSCM;
+			this.listener = listener;
+			// TODO Auto-generated constructor stub
+			this.git = git;
+			this.project = project;
+			this.buildData = buildData;
+			this.environment = environment;
+			this.extensions = extensions;
+		}
+
+		public void run() {
+			final PrintStream log = listener.getLogger();
+            try {
+                log.println("running");
+                List<RemoteConfig> repos = gitSCM.getParamExpandedRepos(project.getLastBuild());
+                if (repos.isEmpty())    return; // defensive check even though this is an invalid configuration
+
+                if (git.hasGitRepo()) {
+                    // It's an update
+                	
+                    if (repos.size() == 1)
+                        log.println("Fetching changes from the remote Git repository");
+                    else
+                        log.println(MessageFormat.format("Fetching changes from {0} remote Git repositories", repos.size()));
+                    
+                    for (RemoteConfig remoteRepository : repos) {
+                        fetchFrom(git, listener, remoteRepository);
+                    }
+                } else {
+                    log.println("Cloning the remote Git repository");
+
+                    RemoteConfig rc = repos.get(0);
+                        CloneCommand cmd = git.clone_().url(rc.getURIs().get(0).toPrivateString()).repositoryName(rc.getName());
+                        
+//                        for (GitSCMExtension ext : extensions) {
+//                            ext.decorateCloneCommand(gitSCM, project.getLastBuild(), git, listener, cmd);
+//                        }
+
+                        cmd.execute();
+
+                }
+
+			} catch (Exception e) {
+				log.println("Error: " + e.getMessage());
+				log.println("Cause: " + e.getCause().getMessage());
+				e.printStackTrace();
+			} finally {
+				log.println("notify all");
+				synchronized (this) {
+					this.notifyAll();
+				}
+			}
+		}
+		
+	    /**
+	     * Fetch information from a particular remote repository.
+	     *
+	     * @param git
+	     * @param listener
+	     * @param remoteRepository
+	     * @throws
+	     */
+	    private void fetchFrom(GitClient git,
+	            TaskListener listener,
+	            RemoteConfig remoteRepository) throws InterruptedException, IOException {
+
+	        boolean first = true;
+	        for (URIish url : remoteRepository.getURIs()) {
+	            try {
+	                if (first) {
+	                    git.setRemoteUrl(remoteRepository.getName(), url.toPrivateASCIIString());
+	                    first = false;
+	                } else {
+	                    git.addRemoteUrl(remoteRepository.getName(), url.toPrivateASCIIString());
+	                }
+
+	                FetchCommand fetch = git.fetch_().from(url, remoteRepository.getFetchRefSpecs());
+	                for (GitSCMExtension extension : extensions) {
+	                    extension.decorateFetchCommand(gitSCM, git, listener, fetch);
+	                }
+	                fetch.execute();
+	            } catch (GitException ex) {
+	                throw new GitException("Failed to fetch from "+url.toString(), ex);
+	            }
+	        }
+	    }	
+	}
+	
+	public static synchronized GitPollingManager getInstance() {
+		if (instance == null) {
+			instance = new GitPollingManager();
+		}
+		return instance;
+	}
+
+	public void doFetch(GitSCM gitSCM, TaskListener listener, GitClient git, AbstractProject<?, ?> project, BuildData buildData, EnvVars environment, DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> extensions) {
+		try {
+			listener.getLogger().println("Project " + project.getName() + " requesting a fetch");
+			synchronized (this) {
+				if (poller == null) {
+					listener.getLogger().println("Project " + project.getName() + " starting poller");
+					poller = new GitPoller(gitSCM, listener, git, project, buildData, environment, extensions);
+					Thread t = new Thread(poller);
+					t.start();
+				}
+			}
+
+			listener.getLogger().println("Project " + project.getName() + " waiting for fetch");
+			synchronized (poller) {
+				poller.wait();				
+			}
+			
+			synchronized (this) {
+				listener.getLogger().println("Project " + project.getName() + " destroying poller");
+				poller = null;				
+			}
+
+			listener.getLogger().println("Project " + project.getName() + " done waiting for fetch");
+		} catch (InterruptedException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/hudson/plugins/git/GitPollingManager.java
+++ b/src/main/java/hudson/plugins/git/GitPollingManager.java
@@ -1,20 +1,17 @@
 package hudson.plugins.git;
 
-import java.io.IOException;
-import java.io.PrintStream;
-import java.text.MessageFormat;
-import java.util.List;
-import java.util.Map;
-
-import hudson.AbortException;
-import hudson.EnvVars;
 import hudson.model.TaskListener;
-import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
-import hudson.plugins.git.util.BuildData;
 import hudson.util.DescribableList;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
@@ -24,8 +21,8 @@ import org.jenkinsci.plugins.gitclient.GitClient;
 
 public class GitPollingManager {
 	private static GitPollingManager instance;
-	private Map<String, GitPoller> pollers;
-	
+	private Map<String, GitPoller> pollers = new HashMap<String, GitPoller>();
+
 	private class GitPoller implements Runnable {
 		private TaskListener listener;
 		private GitClient git;
@@ -33,7 +30,8 @@ public class GitPollingManager {
 		private DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> extensions;
 		private GitSCM gitSCM;
 
-		public GitPoller(GitSCM gitSCM, TaskListener listener, GitClient git, AbstractProject<?, ?> project, DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> extensions) {
+		public GitPoller(GitSCM gitSCM, TaskListener listener, GitClient git, AbstractProject<?, ?> project,
+				DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> extensions) {
 			this.gitSCM = gitSCM;
 			this.listener = listener;
 			this.git = git;
@@ -43,35 +41,38 @@ public class GitPollingManager {
 
 		public void run() {
 			final PrintStream log = listener.getLogger();
-            try {
-                log.println("running");
-                List<RemoteConfig> repos = gitSCM.getParamExpandedRepos(project.getLastBuild());
-                if (repos.isEmpty())    return; // defensive check even though this is an invalid configuration
+			try {
+				log.println("running");
+				List<RemoteConfig> repos = gitSCM.getParamExpandedRepos(project.getLastBuild());
+				if (repos.isEmpty())
+					return; // defensive check even though this is an invalid configuration
 
-                if (git.hasGitRepo()) {
-                    // It's an update
-                	
-                    if (repos.size() == 1)
-                        log.println("Fetching changes from the remote Git repository");
-                    else
-                        log.println(MessageFormat.format("Fetching changes from {0} remote Git repositories", repos.size()));
-                    
-                    for (RemoteConfig remoteRepository : repos) {
-                        fetchFrom(git, listener, remoteRepository);
-                    }
-                } else {
-                    log.println("Cloning the remote Git repository");
+				if (git.hasGitRepo()) {
+					// It's an update
 
-                    RemoteConfig rc = repos.get(0);
-                        CloneCommand cmd = git.clone_().url(rc.getURIs().get(0).toPrivateString()).repositoryName(rc.getName());
-                        
-//                        for (GitSCMExtension ext : extensions) {
-//                            ext.decorateCloneCommand(gitSCM, project.getLastBuild(), git, listener, cmd);
-//                        }
+					if (repos.size() == 1)
+						log.println("Fetching changes from the remote Git repository");
+					else
+						log.println(MessageFormat.format("Fetching changes from {0} remote Git repositories",
+								repos.size()));
 
-                        cmd.execute();
+					for (RemoteConfig remoteRepository : repos) {
+						fetchFrom(git, listener, remoteRepository);
+					}
+				} else {
+					log.println("Cloning the remote Git repository");
 
-                }
+					RemoteConfig rc = repos.get(0);
+					CloneCommand cmd = git.clone_().url(rc.getURIs().get(0).toPrivateString())
+							.repositoryName(rc.getName());
+
+					// for (GitSCMExtension ext : extensions) {
+					// ext.decorateCloneCommand(gitSCM, project.getLastBuild(), git, listener, cmd);
+					// }
+
+					cmd.execute();
+
+				}
 
 			} catch (Exception e) {
 				log.println("Error: " + e.getMessage());
@@ -84,41 +85,44 @@ public class GitPollingManager {
 				}
 			}
 		}
-		
-	    /**
-	     * Fetch information from a particular remote repository.
-	     *
-	     * @param git
-	     * @param listener
-	     * @param remoteRepository
-	     * @throws
-	     */
-	    private void fetchFrom(GitClient git,
-	            TaskListener listener,
-	            RemoteConfig remoteRepository) throws InterruptedException, IOException {
 
-	        boolean first = true;
-	        for (URIish url : remoteRepository.getURIs()) {
-	            try {
-	                if (first) {
-	                    git.setRemoteUrl(remoteRepository.getName(), url.toPrivateASCIIString());
-	                    first = false;
-	                } else {
-	                    git.addRemoteUrl(remoteRepository.getName(), url.toPrivateASCIIString());
-	                }
+		/**
+		 * Fetch information from a particular remote repository.
+		 * 
+		 * @param git
+		 * @param listener
+		 * @param remoteRepository
+		 * @throws
+		 */
+		private void fetchFrom(GitClient git, TaskListener listener, RemoteConfig remoteRepository)
+				throws InterruptedException, IOException {
 
-	                FetchCommand fetch = git.fetch_().from(url, remoteRepository.getFetchRefSpecs());
-	                for (GitSCMExtension extension : extensions) {
-	                    extension.decorateFetchCommand(gitSCM, git, listener, fetch);
-	                }
-	                fetch.execute();
-	            } catch (GitException ex) {
-	                throw new GitException("Failed to fetch from "+url.toString(), ex);
-	            }
-	        }
-	    }	
+			boolean first = true;
+			for (URIish url : remoteRepository.getURIs()) {
+				try {
+					if (first) {
+						git.setRemoteUrl(remoteRepository.getName(), url.toPrivateASCIIString());
+						first = false;
+					} else {
+						git.addRemoteUrl(remoteRepository.getName(), url.toPrivateASCIIString());
+					}
+
+					FetchCommand fetch = git.fetch_().from(url, remoteRepository.getFetchRefSpecs());
+					for (GitSCMExtension extension : extensions) {
+						extension.decorateFetchCommand(gitSCM, git, listener, fetch);
+					}
+					fetch.execute();
+				} catch (GitException ex) {
+					throw new GitException("Failed to fetch from " + url.toString(), ex);
+				}
+			}
+		}
+
+		public String getStartProject() {
+			return project.getName();
+		}
 	}
-	
+
 	public static synchronized GitPollingManager getInstance() {
 		if (instance == null) {
 			instance = new GitPollingManager();
@@ -126,13 +130,16 @@ public class GitPollingManager {
 		return instance;
 	}
 
-	public void doFetch(GitSCM gitSCM, TaskListener listener, GitClient git, AbstractProject<?, ?> project, String urlHash, DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> extensions) {
+	public void doFetch(GitSCM gitSCM, TaskListener listener, GitClient git, AbstractProject<?, ?> project,
+			String urlHash, DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> extensions) {
 		try {
 			listener.getLogger().println("Project " + project.getName() + " requesting a fetch");
 			GitPoller poller = null;
+			boolean pollerStarted = false;
 			synchronized (this) {
 				poller = pollers.get(urlHash);
 				if (poller == null) {
+					pollerStarted = true;
 					listener.getLogger().println("Project " + project.getName() + " starting poller");
 					poller = new GitPoller(gitSCM, listener, git, project, extensions);
 					pollers.put(urlHash, poller);
@@ -141,22 +148,22 @@ public class GitPollingManager {
 				}
 			}
 
-			listener.getLogger().println("Project " + project.getName() + " waiting for fetch");
+			listener.getLogger().println(
+					"Project " + project.getName() + " waiting for fetch (started by project "
+							+ poller.getStartProject() + ")");
 			synchronized (poller) {
-				poller.wait();				
+				poller.wait();
 			}
-			
-			synchronized (this) {
-				if(pollers.containsKey(urlHash)) {
-					listener.getLogger().println("Project " + project.getName() + " destroying poller");
-					pollers.remove(poller);
-				}
+
+			if (pollers.containsKey(urlHash) && pollerStarted) {
+				listener.getLogger().println("Project " + project.getName() + " destroying poller");
+				pollers.remove(urlHash);
 			}
 
 			listener.getLogger().println("Project " + project.getName() + " done waiting for fetch");
 		} catch (InterruptedException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
+			listener.getLogger().println("Poller thread interupted: " + e.getMessage());
 		}
 	}
 }

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -528,7 +528,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
         }
         
-
         GitClient git = null;
         
         if (isUseCentralizedPolling()) {
@@ -542,12 +541,13 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
 
             String home = environment.get("JENKINS_HOME");
-            FilePath fp = new FilePath(new File(home + "/git_centralized/" + DigestUtils.shaHex(urls) + "/"));
+            final String urlHash = DigestUtils.shaHex(urls);
+            FilePath fp = new FilePath(new File(home + "/git_centralized/" + urlHash + "/"));
             listener.getLogger().println("File path is " + fp);
         	
-        	git = createClient(listener, environment, project, n, fp);
+            git = createClient(listener, environment, project, n, fp);
         	
-        	pollMan.doFetch(this, listener, git, project, buildData, environment, extensions);
+            pollMan.doFetch(this, listener, git, project, urlHash, extensions);
         } else {
         	git = createClient(listener, environment, project, n, workingDirectory);
         }

--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -10,6 +10,9 @@
     <f:entry title="Create new accounts base on author/committer's email" field="createAccountBasedOnEmail">
            <f:checkbox name="createAccountBasedOnEmail" checked="${descriptor.createAccountBasedOnEmail}"/>
     </f:entry>
+    <f:entry title="Do the polling centralized for all projects using the same repository" field="useCentralizedPolling">
+           <f:checkbox name="useCentralizedPolling" checked="${descriptor.useCentralizedPolling}"/>
+    </f:entry>
     <!--
     <f:entry title="Default git client implementation" field="defaultClientType">
         <select>


### PR DESCRIPTION
Okay so this is a fairly experimental change we are running on our local jenkins installation currently. It changes the git polling mechanism to no longer do a fetch on the workspace repository and do a check for changes on that, but to do only a single fetch on a central, shared clone of the remote and use that for change detection.

The motivation for this is that due to past decissions we are currently maintaining a jenkins setup with over 200 build jobs all building from the same git repo. So every push to the repo triggered polling for all those jobs, meaning 200+ concurrent git fetch commands. This caused huge IO load on our build servers, which lead to it sometimes taking 15+ minutes between a push and a project starting to build.

So with this change, there is only a single fetch being done, on a central repository (one per git url) that can then be used by all projects for detecting changes. For us this cut the time to check all projects for changes down to ~10 sec, obviously a huge improvement.

So this is all a little bit unknown territory for us, so we would appreciate any advice on how to improve this and feedback if this is something that would be possible to get merged. We would be more than happy to work on getting this to a merged state.
