### PR TITLE
Document and improve test for building a sha1 rev

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -402,7 +402,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
     /**
      * If the configuration is such that we are tracking just one branch of one repository
-     * return that branch specifier (in the form of something like "origin/master"
+     * return that branch specifier (in the form of something like "origin/master" or a SHA1-hash
      *
      * Otherwise return null.
      */

--- a/src/main/resources/hudson/plugins/git/BranchSpec/help-name.html
+++ b/src/main/resources/hudson/plugins/git/BranchSpec/help-name.html
@@ -11,4 +11,6 @@
   If you are using namespaces to structure branches (e.g. feature1/master, or team1/requestA/rel-1.0) you have to
   specify the full branch specifier (including "remotes/"): <tt>remotes/REPOSITORYNAME/BRANCH/WITH/NAMESPACE</tt>.<br/>
   E.g. "remotes/origin/feature1/master"
+  <br/>
+  A specific revision can be checked out by specifying the SHA1 hash of that revision in this field.
 </div>

--- a/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
@@ -1,0 +1,27 @@
+package hudson.plugins.git.util;
+
+import java.util.Collection;
+
+import hudson.plugins.git.AbstractGitTestCase;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.Revision;
+
+/**
+ * @author Arnout Engelen
+ */
+public class DefaultBuildChooserTest extends AbstractGitTestCase {
+    public void testChooseGitRevisionToBuildByShaHash() throws Exception {
+        git.commit("Commit 1");
+        String shaHashCommit1 = git.getBranches().iterator().next().getSHA1String();
+        git.commit("Commit 2");
+        String shaHashCommit2 = git.getBranches().iterator().next().getSHA1String();
+        assertNotSame(shaHashCommit1, shaHashCommit2);
+
+        DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
+
+        Collection<Revision> candidateRevisions = buildChooser.getCandidateRevisions(false, shaHashCommit1, git, null, null, null);
+
+        assertEquals(1, candidateRevisions.size());
+        assertEquals(shaHashCommit1, candidateRevisions.iterator().next().getSha1String());
+    }
+}


### PR DESCRIPTION
The 'branch to build' option already also accepts a SHA1-hash to specify
the specific revision to build, but this was not really obvious (neither
in the online help nor in the code). Added a note to the documentation and
a test which covers part of this functionality more explicitly, though part
of this still happens in GitSCM which isn't really under test.

See also JENKINS-22278
