### PR TITLE
Switch branch of a submodule before update

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleBranch.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleBranch.java
@@ -1,0 +1,43 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.model.Hudson;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.Serializable;
+
+public class SubmoduleBranch extends AbstractDescribableImpl<SubmoduleBranch> implements Serializable {
+
+    private static final long serialVersionUID = -1234567890L;
+
+    private String submodule;
+    private String branch;
+
+    @DataBoundConstructor
+    public SubmoduleBranch(String submodule, String branch) {
+        this.submodule = submodule;
+        this.branch = branch;
+    }
+
+    public String getSubmodule() {
+        return submodule;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    // public Descriptor<SubmoduleBranch> getDescriptor() {
+    //     return Hudson.getInstance().getDescriptor(getClass());
+    // }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<SubmoduleBranch> {
+        @Override
+        public String getDisplayName() {
+            return "SubmoduleBranch";
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleBranch/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleBranch/config.groovy
@@ -1,0 +1,17 @@
+package hudson.plugins.git.extensions.impl.SubmoduleBranch;
+
+def f = namespace(lib.FormTagLib);
+
+f.entry(title:_("Submodule Name"), field:"submodule") {
+    f.textbox()
+}
+
+f.entry(title:_("Submodule Branch"), field:"branch") {
+    f.textbox()
+}
+
+f.entry {
+    div(align:"right") {
+        f.repeatableDeleteButton()
+    }
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
@@ -12,6 +12,10 @@ f.entry(title:_("Update tracking submodules to tip of branch"), field:"trackingS
     f.checkbox()
 }
 
+f.entry(title:_("Submodules to switch branches")) {
+    f.repeatableProperty(field:"submoduleBranches")
+}
+
 /*
   This needs more thought
 


### PR DESCRIPTION
This feature allows a project to switch the branch of submodule before
the update occurs so that they can test it with the new code of that
submodule's branch.  This is useful if need to build your main project
with 2+ different versions of the submodule, but don't want to setup
different Jenkins projects to do the different submodule builds.

Requires git-client-plugin pull request #128 to be merged before it
will compile.
