### PR TITLE
Small fix to GitSCM.compareRemoteRevisionWithImpl(...)

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -489,7 +489,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             GitClient git = createClient(listener, environment, project, Jenkins.getInstance(), null);
 
             String gitRepo = getParamExpandedRepos(lastBuild).get(0).getURIs().get(0).toString();
-            ObjectId head = git.getHeadRev(gitRepo, getBranches().get(0).getName());
+            ObjectId head = git.getHeadRev(gitRepo, singleBranch);
 
             if (head != null && buildData.lastBuild.getMarked().getSha1().equals(head)) {
                 return NO_CHANGES;


### PR DESCRIPTION
String singleBranch not used when checking for head revision.
If the Git branch name is represented by an environment variable the *variable name* is passed to git.getHeadRev(...), instead of the expanded value in singleBranch.

This causes head to always be null, and the build is triggered continuously after polling, without any changes being present in the branch.