### PR TITLE
Fix remotes wildcard branch spec

### DIFF
--- a/src/main/java/hudson/plugins/git/BranchSpec.java
+++ b/src/main/java/hudson/plugins/git/BranchSpec.java
@@ -114,6 +114,12 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
         
         // build a pattern into this builder
         StringBuilder builder = new StringBuilder();
+
+        // optionally match "remotes/" if specified
+        if (qualifiedName.startsWith("remotes/")) {
+            builder.append("(?:remotes/)?");
+            qualifiedName = qualifiedName.substring(8);
+        }
         
         // was the last token a wildcard?
         boolean foundWildcard = false;

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -115,7 +115,16 @@ public class GitSCMTest extends AbstractGitTestCase {
         commit(commitFile1, johnDoe, "Commit number 1");
         build(projectMasterBranch, Result.SUCCESS, commitFile1);
       }
-    
+
+    public void testBranchSpecWithRemotesWildcard() throws Exception {
+        FreeStyleProject project = setupProject("remotes/origin/*", false, null, null, null, true, null);
+
+        // create initial commit and build
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit number 1");
+        build(project, Result.SUCCESS, commitFile1);
+    }
+
     public void testBranchSpecWithRemotesHierarchical() throws Exception {
       FreeStyleProject projectMasterBranch = setupProject("master", false, null, null, null, true, null);
       FreeStyleProject projectHierarchicalBranch = setupProject("remotes/origin/rel-1/xy", false, null, null, null, true, null);


### PR DESCRIPTION
This fixes a bug when using `remotes/` in a wildcard branch spec, such as:

```
remotes/origin/*
```

Without this patch, new builds fail if using `remotes/` and a wildcard in the branch name.  If a build has previously run, the previous branch will aways be used instead of the modified branch.

This makes matching "remotes/" optional in BranchSpec.
