### PR TITLE
Fix multiple repository bugs

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -409,15 +409,35 @@ public class GitSCM extends GitSCMBackwardCompatibility {
      */
     private String getSingleBranch(EnvVars env) {
         // if we have multiple branches skip to advanced usecase
-        if (getBranches().size() != 1 || getRepositories().size() != 1) {
+        if (getBranches().size() != 1) {
             return null;
         }
 
         String branch = getBranches().get(0).getName();
-        String repository = getRepositories().get(0).getName();
+
+        // substitute build parameters if available
+        branch = getParameterString(branch, env);
+
+        if (branch.startsWith("remotes/")) {
+            branch = branch.substring(8);
+        }
+
+        if (getRepositories().size() > 1) {
+            Boolean oneRemote = false;
+            for (RemoteConfig r : getRepositories()) {
+                if (branch.startsWith(r.getName() + "/")) {
+                    oneRemote = true;
+                    break;
+                }
+            }
+            if (!oneRemote) {
+                return null;
+            }
+        }
 
         // replace repository wildcard with repository name
-        if (branch.startsWith("*/")) {
+        if (branch.startsWith("*/") && getRepositories().size() == 1) {
+            String repository = getRepositories().get(0).getName();
             branch = repository + branch.substring(1);
         }
 
@@ -426,9 +446,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         if (branch.contains("*")) {
             return null;
         }
-
-        // substitute build parameters if available
-        branch = getParameterString(branch, env);
 
         // Check for empty string - replace with "**" when seen.
         if (branch.equals("")) {
@@ -488,13 +505,26 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
             GitClient git = createClient(listener, environment, project, Jenkins.getInstance(), null);
 
-            String gitRepo = getParamExpandedRepos(lastBuild).get(0).getURIs().get(0).toString();
-            ObjectId head = git.getHeadRev(gitRepo, getBranches().get(0).getName());
-
-            if (head != null && buildData.lastBuild.getMarked().getSha1().equals(head)) {
-                return NO_CHANGES;
+            String gitRepo = null;
+            if (getRepositories().size() > 1) {
+                for (RemoteConfig r : getParamExpandedRepos(lastBuild)) {
+                    if (singleBranch.startsWith(r.getName() + "/")) {
+                        gitRepo = r.getURIs().get(0).toString();
+                        break;
+                    }
+                }
             } else {
-                return BUILD_NOW;
+                gitRepo = getParamExpandedRepos(lastBuild).get(0).getURIs().get(0).toString();
+            }
+
+            if (gitRepo != null) {
+                ObjectId head = git.getHeadRev(gitRepo, getParameterString(getBranches().get(0).getName(), environment));
+
+                if (head != null && buildData.lastBuild.getMarked().getSha1().equals(head)) {
+                    return NO_CHANGES;
+                } else {
+                    return BUILD_NOW;
+                }
             }
         }
 

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -119,6 +119,13 @@ public class BuildData implements Action, Serializable, Cloneable {
                     return true;
             }
 
+            // We don't keep track of non-branch builds (such as tags, sha1s, etc.).
+            // But we can compare against the last build.
+            Revision lastBuiltRevision = getLastBuiltRevision();
+            if (lastBuiltRevision != null && lastBuiltRevision.getSha1().equals(sha1)) {
+                return true;
+            }
+
             return false;
     	}
     	catch(Exception ex) {

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -835,6 +835,44 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
+    public void testSingleBranchFromMultipleRepositories() throws Exception {
+        FreeStyleProject project = setupSimpleProject("master");
+
+        TestGitRepo secondTestRepo = new TestGitRepo("second", this, listener);
+        List<UserRemoteConfig> remotes = new ArrayList<UserRemoteConfig>();
+        remotes.addAll(testRepo.remoteConfigs());
+        remotes.addAll(secondTestRepo.remoteConfigs());
+
+        // Create some commits
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit number 1");
+        final String commitFile2 = "commitFile2";
+        secondTestRepo.commit(commitFile2, johnDoe, "Commit number 2");
+
+        GitSCM scm1 = new GitSCM(
+                remotes,
+                Collections.singletonList(new BranchSpec("remotes/origin/master")),
+                false, Collections.<SubmoduleConfig>emptyList(),
+                null, null,
+                Collections.<GitSCMExtension>emptyList());
+        GitSCM scm2 = new GitSCM(
+                remotes,
+                Collections.singletonList(new BranchSpec("remotes/origin1/master")),
+                false, Collections.<SubmoduleConfig>emptyList(),
+                null, null,
+                Collections.<GitSCMExtension>emptyList());
+
+        // build from 1st repository
+        project.setScm(scm1);
+        build(project, Result.SUCCESS, commitFile1);
+        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+
+        // build from 2nd repository
+        project.setScm(scm2);
+        build(project, Result.SUCCESS, commitFile2);
+        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+    }
+
     public void testMerge() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");
 


### PR DESCRIPTION
This PR fixes a few bugs and adds improvements when using multiple repositories (multiple forks of the same repo, not MultiSCM):

1. Fix bug when building tags (previously tags failed to build with multiple repositories)
2. Properly detect changes when changing branch between builds
3. Use *single branch* mode when specifying a single branch in a single remote
4. Fix bug when polling tags (previously polling always detected changes when branch spec was a tag) [JENKINS-23299](https://issues.jenkins-ci.org/browse/JENKINS-23299).  This requires the user to specify tags as `regs/tags/mytag`.  A proper fix would be to either fix `getHeadRevision` in [git-client-plugin](https://github.com/jenkinsci/git-client-plugin.git) or add a new function for tags.

We use git-plugin's multiple repository support to build different user forks of the same repository.  Users specify the branch to build via a build parameter, like `remotes/myfork/master`.  Previously the above bugs forced us to use separate build jobs for each fork.

This PR does two main things:

1. Adds support for using *single branch mode* with multiple repositories.  Previously single branch mode only worked if you only had one repository.  But users can still specify a single branch when multiple repositories are configured (e.g. `remotes/origin/master`).  This is often the case when using a build parameter to specify the branch.  This PR refactors single branch mode to support multiple repositories where applicable.  Without this or #233 builds failed to detect the branch properly when using a fully qualified branch name (e.g. branch with `remotes/` in it).

2. Fixes tag support.   Building tags with multiple repositories configured was broken.  This uses single branch mode to build tags if the user uses a fully qualified branch name (e.g. `refs/tags/mytag`).  If an unqualified tag is given, the `getAdvancedCandidateRevisions` method now supports tags as well.  Finally, we force workspace polling because currently [git-client-plugin](https://github.com/jenkinsci/git-client-plugin.git) does not provide a way to query tags without a workspace.