### PR TITLE
JENKINS-20531

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -902,7 +902,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         for (RemoteConfig remoteRepository : repos) {
-            fetchFrom(git, listener, remoteRepository);
+            try {
+                fetchFrom(git, listener, remoteRepository);
+            } catch (GitException ex) {
+                ex.printStackTrace(listener.error("Error fetching changes from repo '%s'", remoteRepository.getName()));
+                throw new AbortException();
+            }
         }
     }
 


### PR DESCRIPTION
A fix for https://issues.jenkins-ci.org/browse/JENKINS-20531

Catches the GitException and throws an AbortException instead, using the same pattern as 10 lines above.
