### PR TITLE
[JENKINS-21464] Save build data before doing checkout.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -842,7 +842,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 AbstractProject project = (AbstractProject) job;
             if (!project.isDisabled()) {
                 log.println("Scheduling another build to catch up with " + project.getFullDisplayName());
-                if (!project.scheduleBuild(0, new SCMTrigger.SCMTriggerCause())) {
+                if (!project.scheduleBuild(10, new SCMTrigger.SCMTriggerCause("This build was triggered by build "
+                                           + build.getNumber() + " because more than one build candidate was found.\n"))) {
                     log.println("WARNING: multiple candidate revisions, but unable to schedule build of " + project.getFullDisplayName());
                 }
             }
@@ -918,6 +919,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         retrieveChanges(build, git, listener);
         Build revToBuild = determineRevisionToBuild(build, buildData, environment, git, listener);
 
+        buildData.saveBuild(revToBuild);
+
         environment.put(GIT_COMMIT, revToBuild.revision.getSha1String());
         Branch branch = Iterables.getFirst(revToBuild.revision.getBranches(),null);
         if (branch!=null)   // null for a detached HEAD
@@ -937,7 +940,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             throw new IOException("Could not checkout " + revToBuild.revision.getSha1String(), e);
         }
 
-        buildData.saveBuild(revToBuild);
         build.addAction(new GitTagAction(build, workspace, buildData));
 
         if (changelogFile != null) {


### PR DESCRIPTION
This should hopefully fix JENKINS-21464 and JENKINS-18588.

The problem is the following: When determineRevisionToBuild finds more
than one candidate for building, it triggers a new build without any quiet
period. If "Execute concurrent builds" is active for this project, Jenkins
will immediately start another build on another slave. However, the Git
plugin will do the checkout before saving its build data, which for bigger
projects can take quite some time, in which case the newly triggered build
will take the _same_ revision and yet trigger _another_ build. This happens
until either the first build hits the queue because all executors are busy,
or until the first build has finished its checkout and saved the build data.

Fix this by saving the build data immediately after calling
determineRevisionToBuild and also add a quiet period of 10 seconds to the
trigger. While at it, also note in the polling log why this build was
triggered.
