### PR TITLE
[FIXED JENKINS-23675] Expand parameters on repository url 

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -570,6 +570,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         for (UserRemoteConfig uc : getUserRemoteConfigs()) {
             if (uc.getCredentialsId() != null) {
                 String url = uc.getUrl();
+                url = getParameterString(url, environment);
                 StandardUsernameCredentials credentials = CredentialsMatchers
                         .firstOrNull(
                                 CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, project,


### PR DESCRIPTION
[FIXED JENKINS-23675] Expand parameters on repository url before associate one url to one credential.

If we use job parameters as a repository URL, the plugin associates the URL with parameter and user credentials. After this, the parameters are expanted to final values, and git tries to connect to final repository and does not find any credentials to use with expanded URL.
I changed the code to associate expanded URL to credentials and it solve this bug.
