### PR TITLE
[FIXED JENKINS-23608] Git plugin doesn't build jobs that use the inverse...

### DIFF
--- a/src/main/java/hudson/plugins/git/util/BuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooser.java
@@ -7,6 +7,7 @@ import hudson.model.Describable;
 import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.model.TaskListener;
+import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.IGitAPI;
@@ -43,7 +44,7 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
     public final String getDisplayName() {
         return getDescriptor().getDisplayName();
     }
-    
+
     /**
      * Get a list of revisions that are candidates to be built.
      *
@@ -139,6 +140,24 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
 
     public BuildChooserDescriptor getDescriptor() {
         return (BuildChooserDescriptor)Hudson.getInstance().getDescriptorOrDie(getClass());
+    }
+
+    /**
+     * Determines whether the supplied branch matches the branch configuration.
+     *
+     * @param branch
+     *      The qualified branch name, ex: origin/branch-name
+     */
+
+    public boolean isMatchingBranch(String branch)
+    {
+        for (BranchSpec bspec : gitSCM.getBranches()) {
+            if (bspec.matches(branch)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java
@@ -103,6 +103,18 @@ public class InverseBuildChooser extends BuildChooser {
         });
     }
 
+    @Override
+    public boolean isMatchingBranch(String branch)
+    {
+        for (BranchSpec bspec : gitSCM.getBranches()) {
+            if (bspec.matches(branch)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     @Extension
     public static final class DescriptorImpl extends BuildChooserDescriptor {
         @Override

--- a/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
@@ -1,10 +1,16 @@
 package hudson.plugins.git.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import hudson.plugins.git.AbstractGitTestCase;
+import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
+import hudson.plugins.git.SubmoduleConfig;
+import hudson.plugins.git.UserRemoteConfig;
 
 /**
  * @author Arnout Engelen
@@ -23,5 +29,31 @@ public class DefaultBuildChooserTest extends AbstractGitTestCase {
 
         assertEquals(1, candidateRevisions.size());
         assertEquals(shaHashCommit1, candidateRevisions.iterator().next().getSha1String());
+    }
+
+    public void testMatchBranch() throws Exception {
+        ArrayList<BranchSpec> branches = new ArrayList<BranchSpec>();
+        branches.add(new BranchSpec("*/master"));
+        branches.add(new BranchSpec("*/example"));
+
+        GitSCM gitSCM = createGitSCMForTest( branches );
+        DefaultBuildChooser buildChooser = (DefaultBuildChooser) gitSCM.getBuildChooser();
+
+        assertTrue( buildChooser.isMatchingBranch( "origin/master" ) );
+        assertFalse( buildChooser.isMatchingBranch( "origin/awesome" ) );
+        assertTrue( buildChooser.isMatchingBranch( "origin/example" ) );
+    }
+
+    private GitSCM createGitSCMForTest( ArrayList<BranchSpec> branches ) {
+        return new GitSCM( createRepoList("foo"), branches, false,
+                           Collections.<SubmoduleConfig>emptyList(),
+                           null, null, null);
+    }
+
+    // Copied from GitSCM.java
+    static private List<UserRemoteConfig> createRepoList(String url) {
+        List<UserRemoteConfig> repoList = new ArrayList<UserRemoteConfig>();
+        repoList.add(new UserRemoteConfig(url, null, null, null));
+        return repoList;
     }
 }

--- a/src/test/java/hudson/plugins/git/util/InverseBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/InverseBuildChooserTest.java
@@ -1,0 +1,45 @@
+package hudson.plugins.git.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import junit.framework.TestCase;
+import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.SubmoduleConfig;
+import hudson.plugins.git.UserRemoteConfig;
+
+/**
+ * @author Shy Aberman
+ */
+public class InverseBuildChooserTest extends TestCase {
+    public void testMatchBranch() throws Exception {
+        ArrayList<BranchSpec> branches = new ArrayList<BranchSpec>();
+        branches.add(new BranchSpec("*/master"));
+        branches.add(new BranchSpec("*/example"));
+
+        GitSCM gitSCM = createGitSCMForTest( branches );
+        gitSCM.setBuildChooser( new InverseBuildChooser() );
+
+        InverseBuildChooser buildChooser = (InverseBuildChooser) gitSCM.getBuildChooser();
+
+        assertFalse( buildChooser.isMatchingBranch( "origin/master" ) );
+        assertTrue( buildChooser.isMatchingBranch( "origin/awesome" ) );
+        assertFalse( buildChooser.isMatchingBranch( "origin/example" ) );
+    }
+
+    private GitSCM createGitSCMForTest( ArrayList<BranchSpec> branches ) {
+        return new GitSCM( createRepoList("foo"), branches, false,
+                           Collections.<SubmoduleConfig>emptyList(),
+                           null, null, null);
+    }
+
+    // Copied from GitSCM.java
+    static private List<UserRemoteConfig> createRepoList(String url) {
+        List<UserRemoteConfig> repoList = new ArrayList<UserRemoteConfig>();
+        repoList.add(new UserRemoteConfig(url, null, null, null));
+        return repoList;
+    }
+
+}


### PR DESCRIPTION
... build strategy for new branches

Summary of changes:
- Added the ability for BuildChoosers to detect whether a supplied branch would be chosen by them (isMatchingBranch)
- Changed GitStatus$JenkinsAbstractProjectListener.onNotifyCommit to use the BuildChooser supplied by GitSCM when looking for a match.

Also, added tests for the BuildChoosers (DefaultBuildChooser and InverseBuildChooser). I looked into adding a test for GitStatus, but it seemed to go against the grain to test this area in GitStatusTest. Please advise.

Changes tested live on 1.532.2.
