### PR TITLE
Refactor 'browser guesser'

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -15,6 +15,7 @@ import hudson.model.*;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Hudson.MasterComputer;
 import hudson.plugins.git.browser.GitRepositoryBrowser;
+import hudson.plugins.git.browser.RepositoryBrowserGuesser;
 import hudson.plugins.git.extensions.GitClientConflictException;
 import hudson.plugins.git.extensions.GitClientType;
 import hudson.plugins.git.extensions.GitSCMExtension;
@@ -69,12 +70,9 @@ import java.util.logging.Logger;
 import static hudson.Util.*;
 import static hudson.init.InitMilestone.JOB_LOADED;
 import static hudson.init.InitMilestone.PLUGINS_STARTED;
-import hudson.plugins.git.browser.GithubWeb;
 import static hudson.scm.PollingResult.*;
 import hudson.util.IOUtils;
 import hudson.util.LogTaskListener;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import static org.apache.commons.lang.StringUtils.isBlank;
 
 /**
@@ -314,17 +312,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     @Override public RepositoryBrowser<?> guessBrowser() {
         if (remoteRepositories != null && remoteRepositories.size() == 1) {
             List<URIish> uris = remoteRepositories.get(0).getURIs();
-            if (uris.size() == 1) {
-                String uri = uris.get(0).toString();
-                // TODO make extensible by introducing an abstract GitRepositoryBrowserDescriptor
-                Matcher m = Pattern.compile("(https://github[.]com/[^/]+/[^/]+)[.]git").matcher(uri);
-                if (m.matches()) {
-                    return new GithubWeb(m.group(1) + "/");
-                }
-                m = Pattern.compile("git@github[.]com:([^/]+/[^/]+)[.]git").matcher(uri);
-                if (m.matches()) {
-                    return new GithubWeb("https://github.com/" + m.group(1) + "/");
-                }
+            if (uris.size() >= 1) {
+                return RepositoryBrowserGuesser.guess(uris.get(0));
             }
         }
         return null;

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -5,11 +5,17 @@ import hudson.model.Job;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitChangeSet;
 import hudson.scm.RepositoryBrowser;
+
+import org.eclipse.jgit.transport.URIish;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.net.URL;
+
+interface RepositoryGuesser {
+	String getRepoUrl(URIish repoUrl);
+}
 
 public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSet> {
 

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -13,10 +13,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import java.io.IOException;
 import java.net.URL;
 
-interface RepositoryGuesser {
-	String getRepoUrl(URIish repoUrl);
-}
-
 public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSet> {
 
     private /* mostly final */ String url;

--- a/src/main/java/hudson/plugins/git/browser/GithubWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GithubWeb.java
@@ -13,6 +13,8 @@ import hudson.plugins.git.GitChangeSet.Path;
 import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import net.sf.json.JSONObject;
+
+import org.eclipse.jgit.transport.URIish;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -22,6 +24,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Git Browser URLs
@@ -109,4 +113,19 @@ public class GithubWeb extends GitRepositoryBrowser {
 		}
 	}
 
+    public static class GithubWebRepositoryGuesser {
+		public String getRepoUrl(URIish repoUrl) {
+			String uri = repoUrl.toString();
+	        Matcher m = Pattern.compile("(https://github[.]com/[^/]+/[^/]+)[.]git").matcher(uri);
+	        if (m.matches()) {
+	            return m.group(1) + "/";
+	        }
+	        m = Pattern.compile("git@github[.]com:([^/]+/[^/]+)[.]git").matcher(uri);
+	        if (m.matches()) {
+	            return "https://github.com/" + m.group(1) + "/";
+	        }
+			
+			return null;
+		}
+    }
 }

--- a/src/main/java/hudson/plugins/git/browser/RepositoryBrowserGuesser.java
+++ b/src/main/java/hudson/plugins/git/browser/RepositoryBrowserGuesser.java
@@ -3,6 +3,7 @@ package hudson.plugins.git.browser;
 import org.eclipse.jgit.transport.URIish;
 
 import hudson.plugins.git.browser.GithubWeb.GithubWebRepositoryGuesser;
+import hudson.plugins.git.browser.Stash.StashRepositoryGuesser;
 import hudson.scm.RepositoryBrowser;
 
 public class RepositoryBrowserGuesser {
@@ -10,7 +11,7 @@ public class RepositoryBrowserGuesser {
 		String repoUrl;
 		if ( (repoUrl = new GithubWebRepositoryGuesser().getRepoUrl(uri)) != null) {
 			return new GithubWeb(repoUrl);
-		} else if ( (repoUrl = new StashRepositoryGuesser()getRepoUrl(uri)) != null) {
+		} else if ( (repoUrl = new StashRepositoryGuesser().getRepoUrl(uri)) != null) {
 			return new Stash(repoUrl);
 		}
 		return null;

--- a/src/main/java/hudson/plugins/git/browser/RepositoryBrowserGuesser.java
+++ b/src/main/java/hudson/plugins/git/browser/RepositoryBrowserGuesser.java
@@ -1,0 +1,18 @@
+package hudson.plugins.git.browser;
+
+import org.eclipse.jgit.transport.URIish;
+
+import hudson.plugins.git.browser.GithubWeb.GithubWebRepositoryGuesser;
+import hudson.scm.RepositoryBrowser;
+
+public class RepositoryBrowserGuesser {
+	public static RepositoryBrowser<?> guess(URIish uri) {
+		String repoUrl;
+		if ( (repoUrl = new GithubWebRepositoryGuesser().getRepoUrl(uri)) != null) {
+			return new GithubWeb(repoUrl);
+		} else if ( (repoUrl = new StashRepositoryGuesser()getRepoUrl(uri)) != null) {
+			return new Stash(repoUrl);
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
This pull extracts the GitHub specific guess code from GitSCM.java into a static class in the GithubWeb class. A thin adaptor class is added as RepositroyBrowserGuesser.java, which currently checks the supported GitRepositoryBrowser classes for match and returns the RepositoryBrowser that matches. As a trial, a Stash guesser is also implemented.