### PR TITLE
When polling - show retrieved HEAD sha1 revision

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -541,10 +541,15 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
             String gitRepo = getParamExpandedRepos(lastBuild, listener).get(0).getURIs().get(0).toString();
             ObjectId head = git.getHeadRev(gitRepo, getBranches().get(0).getName());
-            listener.getLogger().println("[poll] Latest remote head revision is: " + head.getName());
-            if (head != null && buildData.lastBuild.getMarked().getSha1().equals(head)) {
-                return NO_CHANGES;
+            if (head != null){
+                listener.getLogger().println("[poll] Latest remote head revision is: " + head.getName());
+                if (buildData.lastBuild.getMarked().getSha1().equals(head)) {
+                    return NO_CHANGES;
+                } else {
+                    return BUILD_NOW;
+                }
             } else {
+                listener.getLogger().println("[poll] Couldn't get remote head revision");
                 return BUILD_NOW;
             }
         }


### PR DESCRIPTION
Git poll log shows the last build revision, checks the remote HEAD but does not print what the revision it retrieved from remote. It only prints "changes found" or "no changes found".

In order to verify the polling mechanism worked correctly, I think we should add print to the remote HEAD sha1 code so we can see that the conclusion to build or not to build is correct.

Added null check for avoiding NPE.
