### PR TITLE
JENKINS-24880 Support publishing a list of tags resolved from the enviro...

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -291,11 +291,21 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                                                      + targetRepo);
 
                         remoteURI = remote.getURIs().get(0);
-                        PushCommand push = git.push().to(remoteURI).ref(tagName);
-                        if (forcePush) {
-                          push.force();
+                        
+                        String tagParts[] = tagName.split(",");
+                        
+                        for (String tag : tagParts) {
+                        
+                        	PushCommand push = git.push().to(remoteURI).ref(tag);
+                        
+                        	if (forcePush) {
+                        		push.force();
+                        	}
+                        
+                        	push.execute();
+                        
                         }
-                        push.execute();
+                        
                     } catch (GitException e) {
                         e.printStackTrace(listener.error("Failed to push tag " + tagName + " to " + targetRepo));
                         return false;


### PR DESCRIPTION
...ment

Check to see if the name of a tag contains comma's and if so split and treat
each element as its own tag name.

This will allow multiple tags to be pushed into the upstream repository without
having to know their names before the job runs.
