### PR TITLE
[JENKINS-23641] - Annotate BuildData::getLastBuiltRevision()

### DIFF
--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git.util;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Functions;
 import hudson.model.AbstractBuild;
 import hudson.model.Action;
@@ -140,8 +141,13 @@ public class BuildData implements Action, Serializable, Cloneable {
         return buildsByBranchName.get(branch);
     }
 
+    /**
+     * Gets revision of the previous build.
+     * @return revision of the last build. 
+     *    May be null will be returned if nothing has been checked out (e.g. due to wrong repository or branch)
+     */
     @Exported
-    public Revision getLastBuiltRevision() {
+    public @CheckForNull Revision getLastBuiltRevision() {
         return lastBuild==null?null:lastBuild.revision;
     }
 


### PR DESCRIPTION
The change aims errors in publishers when the checkout failed.

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
