### PR TITLE
Prefer using parent's RevisionParameterAction for matrix builds

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -823,11 +823,20 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         if (build instanceof MatrixRun) {
             MatrixBuild parentBuild = ((MatrixRun) build).getParentBuild();
             if (parentBuild != null) {
-                BuildData parentBuildData = getBuildData(parentBuild);
-                if (parentBuildData != null) {
-                    Build lastBuild = parentBuildData.lastBuild;
-                    if (lastBuild!=null)
-                        candidates = Collections.singleton(lastBuild.getMarked());
+                // parent can have more than one build data:
+                // for example ghprb-plugin uses it to generate correct diff
+                // in this case, we should enforce parent revision if it
+                // has been passed explicitly
+                final RevisionParameterAction rpa = parentBuild.getAction(RevisionParameterAction.class);
+                if (rpa != null) {
+                    candidates = Collections.singleton(rpa.toRevision(git));
+                } else {
+                    BuildData parentBuildData = getBuildData(parentBuild);
+                    if (parentBuildData != null) {
+                        Build lastBuild = parentBuildData.lastBuild;
+                        if (lastBuild!=null)
+                            candidates = Collections.singleton(lastBuild.getMarked());
+                    }
                 }
             }
         }


### PR DESCRIPTION
In some cases, parent can have more than one build data - for example [ghprb-plugin](https://github.com/jenkinsci/ghprb-plugin) uses it to generate correct diff between current and previous build run on this pull request (see [code](https://github.com/janinko/ghprb/blob/a6d794f974fb66be7e2945be4dd62065ddcb585a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java#L170-L172)). Thus, child builds may use revision from previous build, not the correct one.

This pull request forces using `RevisionParameterAction` if it has been explicitly passed to parent build.

P.S. Unfortunately, my Java is pretty bad so I couldn't write tests for it.