### PR TITLE
Simplify the abort exception case

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -887,7 +887,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 }
                 cmd.execute();
             } catch (GitException ex) {
-                throw new AbortException("Error cloning remote repo '" + rc.getName() + "'");
+                String message = "Error cloning remote repo '" + rc.getName() + "'";
+                listener.error(message);
+                throw new AbortException(message);
             }
         }
 
@@ -897,7 +899,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             } catch (GitException ex) {
                 /* Allow retry by throwing AbortException instead of
                  * GitException. See JENKINS-20531. */
-                throw new AbortException("Error fetching remote repo '" + remoteRepository.getName() + "'");
+                String message = "Error fetching remote repo '" + remoteRepository.getName() + "'";
+                listener.error(message);
+                throw new AbortException(message);
             }
         }
     }


### PR DESCRIPTION
Is this simplification reasonable?
