### PR TITLE
Allow remotePolling on single (qualified) branch with multiple repositories

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -453,12 +453,26 @@ public class GitSCM extends GitSCMBackwardCompatibility {
      */
     private String getSingleBranch(EnvVars env) {
         // if we have multiple branches skip to advanced usecase
-        if (getBranches().size() != 1 || getRepositories().size() != 1) {
+        if (getBranches().size() != 1) {
             return null;
         }
-
         String branch = getBranches().get(0).getName();
-        String repository = getRepositories().get(0).getName();
+        String repository = null;
+
+        if (getRepositories().size() != 1) {
+        	for (RemoteConfig repo : getRepositories()) {
+        		if (branch.startsWith(repo.getName() + "/")) {
+        			repository = repo.getName();
+        			break;
+        		}
+        	}
+        	if (repository == null) {
+        		return null;
+        	}
+        } else {
+        	repository = getRepositories().get(0).getName();
+        }
+
 
         // replace repository wildcard with repository name
         if (branch.startsWith("*/")) {

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1417,6 +1417,26 @@ public class GitSCMTest extends AbstractGitTestCase {
         final int gitMinor = Integer.parseInt(fields[1]);
         return gitMajor >= neededMajor && gitMinor >= neededMinor;
     }
+    
+	public void testPolling_CanDoRemotePollingIfOneBranchButMultipleRepositories() throws Exception {
+		FreeStyleProject project = createFreeStyleProject();
+		List<UserRemoteConfig> remoteConfigs = new ArrayList<UserRemoteConfig>();
+		remoteConfigs.add(new UserRemoteConfig(testRepo.gitDir.getAbsolutePath(), "origin", "", null));
+		remoteConfigs.add(new UserRemoteConfig(testRepo.gitDir.getAbsolutePath(), "someOtherRepo", "", null));
+		GitSCM scm = new GitSCM(remoteConfigs,
+				Collections.singletonList(new BranchSpec("origin/master")), false,
+				Collections.<SubmoduleConfig> emptyList(), null, null,
+				Collections.<GitSCMExtension> emptyList());
+		project.setScm(scm);
+		commit("commitFile1", johnDoe, "Commit number 1");
+
+		FreeStyleBuild first_build = project.scheduleBuild2(0, new Cause.UserCause()).get();
+		assertBuildStatus(Result.SUCCESS, first_build);
+
+		first_build.getWorkspace().deleteContents();
+		PollingResult pollingResult = scm.poll(project, null, first_build.getWorkspace(), listener, null);
+		assertFalse(pollingResult.hasChanges());
+	}
 
     /**
      * Test for JENKINS-24467.


### PR DESCRIPTION
[FIXED [JENKINS-25414](https://issues.jenkins-ci.org/browse/JENKINS-25414)]

cherry-picked 0c250cd1c53e351f119b819c879290ce111cd5ef for master branch.
See [this pull request](https://github.com/jenkinsci/git-plugin/pull/267) for 2.2.x branch
