### PR TITLE
[JENKINS-25389] Extend "git publisher" so it will be able to push external tags.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -50,6 +50,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
     private Long configVersion;
 
     private boolean pushMerge;
+    private boolean pushLocalTags;
     private boolean pushOnlyIfSuccess;
     private boolean forcePush;
     
@@ -64,12 +65,14 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         List<BranchToPush> branchesToPush,
                         List<NoteToPush> notesToPush,
                         boolean pushOnlyIfSuccess,
+                        boolean pushLocalTags,
                         boolean pushMerge,
                         boolean forcePush) {
         this.tagsToPush = tagsToPush;
         this.branchesToPush = branchesToPush;
         this.notesToPush = notesToPush;
         this.pushMerge = pushMerge;
+        this.pushLocalTags = pushLocalTags;
         this.pushOnlyIfSuccess = pushOnlyIfSuccess;
         this.forcePush = forcePush;
         this.configVersion = 2L;
@@ -81,6 +84,10 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
     
     public boolean isPushMerge() {
         return pushMerge;
+    }
+
+    public boolean isPushLocalTags() {
+        return pushLocalTags;
     }
 
     public boolean isForcePush() {
@@ -239,6 +246,10 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         if (forcePush) {
                           push.force();
                         }
+                        if(pushLocalTags) {
+                            listener.getLogger().println("Pushing local tags");
+                            push.tags(true);
+                        }
                         push.execute();
                     } else {
                         //listener.getLogger().println("Pushing result " + buildnumber + " to origin repository");
@@ -326,6 +337,10 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         PushCommand push = git.push().to(remoteURI).ref("HEAD:" + branchName);
                         if (forcePush) {
                           push.force();
+                        }
+                        if(pushLocalTags) {
+                            listener.getLogger().println("Pushing local tags");
+                            push.tags(true);
                         }
                         push.execute();
                     } catch (GitException e) {

--- a/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
@@ -28,6 +28,11 @@
              description="${%Add force option to git push}">
       <f:checkbox />
     </f:entry>
+    <f:entry field="pushLocalTags"
+             title="${%Push Local Tags}"
+             description="${%Also push tags created by local build}">
+      <f:checkbox />
+    </f:entry>
     <f:entry field="tagsToPush"
              title="${%Tags}"
              description="${%Tags to push to remote repositories}">

--- a/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
@@ -28,11 +28,6 @@
              description="${%Add force option to git push}">
       <f:checkbox />
     </f:entry>
-    <f:entry field="pushLocalTags"
-             title="${%Push Local Tags}"
-             description="${%Also push tags created by local build}">
-      <f:checkbox />
-    </f:entry>
     <f:entry field="tagsToPush"
              title="${%Tags}"
              description="${%Tags to push to remote repositories}">
@@ -67,6 +62,11 @@
         </div>
       </f:repeatable>
     </f:entry>
+    <f:entry field="pushLocalTags"
+             title="${%Push Local Tags}"
+             description="${%Also push tags created by local build}">
+      <f:checkbox />
+    </f:entry>
     <f:entry field="branchesToPush"
              title="${%Branches}"
              description="${%Branches to push to remote repositories}">
@@ -89,35 +89,35 @@
         </div>
       </f:repeatable>
     </f:entry>
-    
+
     <f:entry field="notesToPush" title="${%Notes}" description="${%Notes to push to remote repositories}">
-    
+
       <f:repeatable field="notesToPush"  add="${%Add Note}">
-      
+
         <table width="100%">
           <br/>
           <f:entry title="${%Note to push}"    field="noteMsg" >
             <f:textarea checkUrl="'descriptorByName/GitPublisher/checkNoteMsg?value='+escape(this.value)" />
           </f:entry>
-          
+
           <f:entry field="targetRepoName" title="${%Target remote name}">
             <f:textbox/>
           </f:entry>
-          
+
           <f:entry title="${%Note's namespace}" field="noteNamespace">
             <f:textbox/>
           </f:entry>
-          
+
           <f:entry title="${%Abort if note exists}" field="noteReplace" >
             <f:checkbox />
           </f:entry>
-          
+
         </table>
         <div align="right">
           <input type="button" value="Delete Note" class="repeatable-delete" style="margin-left: 1em;" />
         </div>
-         
+
       </f:repeatable>
     </f:entry>
-    
+
 </j:jelly>

--- a/src/main/resources/hudson/plugins/git/GitPublisher/help-pushLocalTags.html
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/help-pushLocalTags.html
@@ -1,0 +1,3 @@
+<div>
+   Push Tags created during build if the merge is pushed back or a branch is being bushed.
+</div>

--- a/src/test/java/hudson/plugins/git/GitPublisherTest.java
+++ b/src/test/java/hudson/plugins/git/GitPublisherTest.java
@@ -70,7 +70,7 @@ public class GitPublisherTest extends AbstractGitTestCase {
                 Collections.singletonList(new TagToPush("origin","foo","message",true, false)),
                 Collections.<BranchToPush>emptyList(),
                 Collections.<NoteToPush>emptyList(),
-                true, true, false) {
+                true, false, true, false) {
             @Override
             public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
                 run.incrementAndGet();
@@ -119,7 +119,7 @@ public class GitPublisherTest extends AbstractGitTestCase {
                 Collections.<TagToPush>emptyList(),
                 Collections.singletonList(new BranchToPush("origin", "integration")),
                 Collections.<NoteToPush>emptyList(),
-                true, true, false));
+                true, false, true, false));
 
         // create initial commit and then run the build against it:
         commit("commitFileBase", johnDoe, "Initial Commit");
@@ -153,7 +153,7 @@ public class GitPublisherTest extends AbstractGitTestCase {
                 Collections.<TagToPush>emptyList(),
                 Collections.singletonList(new BranchToPush("origin", "otherbranch")),
                 Collections.<NoteToPush>emptyList(),
-                true, true, true));
+                true, false, true, true));
 
         commit("commitFile", johnDoe, "Initial Commit");
 
@@ -192,7 +192,7 @@ public class GitPublisherTest extends AbstractGitTestCase {
           Collections.<TagToPush>emptyList(),
           Collections.singletonList(new BranchToPush("origin", "integration")),
           Collections.<NoteToPush>emptyList(),
-          true, true, false));
+          true, false, true, false));
 
       // create initial commit and then run the build against it:
       commit("commitFileBase", johnDoe, "Initial Commit");
@@ -262,7 +262,7 @@ public class GitPublisherTest extends AbstractGitTestCase {
                 Collections.singletonList(new TagToPush("origin", tagNameReference, tagMessageReference, false, true)),
                 Collections.singletonList(new BranchToPush("origin", envReference)),
                 Collections.singletonList(new NoteToPush("origin", noteReference, Constants.R_NOTES_COMMITS, false)),
-                true, true, true);
+                true, false, true, true);
         assertTrue(publisher.isForcePush());
         assertTrue(publisher.isPushBranches());
         assertTrue(publisher.isPushMerge());


### PR DESCRIPTION
The Git Plugin can currently only push back a previously defined tag, but not arbitrary tags created during a build.

I used the new method to push tags introduced in git-client-plugin 1.11.1 and added an option to the Jelly to push all local tags created during the build.

I wish I had a test to verify this, but I have no clue how to add a build step to a FreeStyleProject in the GitPublisherTests to create a tag.
