### PR TITLE
Fix possible null pointer when a previous revision was null

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1065,7 +1065,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             } else {
                 for (Branch b : revToBuild.getBranches()) {
                     Build lastRevWas = getBuildChooser().prevBuildForChangelog(b.getName(), previousBuildData, git, context);
-                    if (lastRevWas != null && git.isCommitInRepo(lastRevWas.getSHA1())) {
+                    if (lastRevWas != null && lastRevWas.revision != null && git.isCommitInRepo(lastRevWas.getSHA1())) {
                         changelog.excludes(lastRevWas.getSHA1());
                         exclusion = true;
                     }


### PR DESCRIPTION
I'll prefix this saying I'm not a java developer myself, so this may not be the most appropriate fix for the problem (but was the best solution I could find while trying to get 800+ builds passing before Monday).

I recently encountered an issue in which some combination of upgrading the git plugin and purging some data on old builds caused any version of the git plugin to completely choke on new builds throwing the following trace (obviously differing slightly based on version, but I used the git-plugin 2.3.1 for the example trace):

```
java.lang.NullPointerException
    at hudson.plugins.git.util.Build.getSHA1(Build.java:38)
    at hudson.plugins.git.GitSCM.computeChangeLog(GitSCM.java:1310)
    at hudson.plugins.git.GitSCM.access$1300(GitSCM.java:72)
    at hudson.plugins.git.GitSCM$4.invoke(GitSCM.java:1273)
    at hudson.plugins.git.GitSCM$4.invoke(GitSCM.java:1231)
    at hudson.FilePath$FileCallableWrapper.call(FilePath.java:2677)
    at hudson.remoting.UserRequest.perform(UserRequest.java:121)
    at hudson.remoting.UserRequest.perform(UserRequest.java:49)
    at hudson.remoting.Request$2.run(Request.java:324)
    at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
    at java.util.concurrent.FutureTask.run(FutureTask.java:262)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
    at ......remote call to [redacted](Native Method)
    at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1356)
    at hudson.remoting.UserResponse.retrieve(UserRequest.java:221)
    at hudson.remoting.Channel.call(Channel.java:752)
    at hudson.FilePath.act(FilePath.java:970)
    at hudson.FilePath.act(FilePath.java:959)
    at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1231)
    at hudson.model.AbstractProject.checkout(AbstractProject.java:1265)
    at hudson.model.AbstractBuild$AbstractBuildExecution.defaultCheckout(AbstractBuild.java:622)
    at jenkins.scm.SCMCheckoutStrategy.checkout(SCMCheckoutStrategy.java:86)
    at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:528)
    at hudson.model.Run.execute(Run.java:1759)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
    at hudson.model.ResourceController.execute(ResourceController.java:89)
    at hudson.model.Executor.run(Executor.java:240)
```

I believe this is an issue relating to how the git plugin builds the changelog, and a small change (simply checking if a previous revision actually had a `Revision` object associated with it) seems to fix this problem. A catch to this is that the changelog for a single build will appear empty. Again, I'm not positive this fixes the root cause, but it seems like an acceptable change for weird state-full/lingering data issues.
