### PR TITLE
Altered changes view to hide excluded commits

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSetList.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSetList.java
@@ -1,14 +1,29 @@
 package hudson.plugins.git;
 
+import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.Run;
+import hudson.model.BuildListener;
+import hudson.model.Item;
+import hudson.model.ModelObject;
+import hudson.model.StreamBuildListener;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.impl.ExcludedCommitsBehaviour;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.RepositoryBrowser;
+import hudson.scm.SCM;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.export.Exported;
 
+import com.google.common.collect.Sets;
+
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
+import java.util.Set;
 
 /**
  * List of changeset that went into a particular build.
@@ -16,6 +31,7 @@ import java.util.List;
  */
 public class GitChangeSetList extends ChangeLogSet<GitChangeSet> {
     private final List<GitChangeSet> changeSets;
+    private volatile Set<GitChangeSet> excluded = null;
 
     /*package*/ GitChangeSetList(Run build, RepositoryBrowser<?> browser, List<GitChangeSet> logs) {
         super(build, browser);
@@ -42,4 +58,107 @@ public class GitChangeSetList extends ChangeLogSet<GitChangeSet> {
         return "git";
     }
 
+    public boolean isExcluded(GitChangeSet change) {
+        return getExcluded().contains(change);
+    }
+
+    public int getExcludedCount() {
+        return getExcluded().size();
+    }
+
+    private Set<GitChangeSet> getExcluded() {
+        if (excluded == null) {
+            synchronized (this) {
+                if (excluded == null) {
+                    final GitSCM git = getGitSCM();
+                    if (git != null) {
+                        final BuildListener buildListener = new StreamBuildListener(
+                                new NullOutputStream());
+                        try {
+                            final GitClient gitClient = git.createClient(buildListener, getRun()
+                                    .getEnvironment(buildListener), getRun(), null);
+                            excluded = Sets.newHashSet();
+                            for (GitChangeSet change : changeSets) {
+                                final boolean commitExcluded = isExcludedImpl(git, gitClient,
+                                        buildListener, change);
+                                if (commitExcluded) {
+                                    excluded.add(change);
+                                }
+                            }
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException("Error creating git client", e);
+                        } catch (IOException e) {
+                            throw new RuntimeException("Error creating git client", e);
+                        }
+                    } else {
+                        excluded = Collections.emptySet();
+                    }
+
+                }
+            }
+        }
+        return excluded;
+    }
+
+    private static boolean isExcludedImpl(GitSCM git, GitClient gitClient,
+            BuildListener buildListener, GitChangeSet change) throws GitException, IOException,
+            InterruptedException {
+        Boolean excludeThisCommit = false;
+        for (GitSCMExtension ext : git.getExtensions()) {
+            excludeThisCommit = ext.isRevExcluded(git, gitClient, change, buildListener, null);
+            if (excludeThisCommit != null)
+                break;
+        }
+        return Boolean.TRUE.equals(excludeThisCommit);
+    }
+
+    /**
+     * Returns Git SCM object, associated with this build
+     * @param job build to search Git SCM for
+     * @return Git SCM object or <code>null</code> if nothing found
+     */
+    private GitSCM getGitSCM(Run<?, ?> job) {
+        final AbstractProject<?, ?> project = getProject(job);
+        if (project == null) {
+            return null;
+        }
+        final SCM scm = project.getScm();
+        if (scm instanceof GitSCM) {
+            return (GitSCM) scm;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Returns first found project in the Jenkins model hierarchy.
+     * @param job job search project of
+     * @return abstract project object, or <code>null</code> if nothing found.
+     */
+    private AbstractProject<?, ?> getProject(Run<?, ?> job) {
+        ModelObject nextParent = job.getParent();
+        while (nextParent instanceof Item) {
+            final Item nextItem = (Item) nextParent;
+            if (nextParent instanceof AbstractProject) {
+                return (AbstractProject<?, ?>) nextParent;
+            }
+            nextParent = nextItem.getParent();
+        }
+        return null;
+    }
+
+    /**
+     * GitSCM is not cached, as the new SCM object is created on every job
+     * configuration change.
+     * @return SCM object
+     */
+    private GitSCM getGitSCM() {
+        return getGitSCM(getRun());
+    }
+
+    public boolean isHideExludedCommits() {
+        final ExcludedCommitsBehaviour config = getGitSCM().getExtensions().get(
+                ExcludedCommitsBehaviour.class);
+        return config == null ? true : config.isHideExcludedCommits();
+    }
 }

--- a/src/main/java/hudson/plugins/git/extensions/impl/ExcludedCommitsBehaviour.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/ExcludedCommitsBehaviour.java
@@ -1,0 +1,33 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Extension, specifying special behaviour for excluded commits.
+ * @author Pavel Baranchikov
+ */
+public class ExcludedCommitsBehaviour extends GitSCMExtension {
+    private final boolean hideExcludedCommits;
+
+    @DataBoundConstructor
+    public ExcludedCommitsBehaviour(boolean hideExcludedCommits) {
+        this.hideExcludedCommits = hideExcludedCommits;
+    }
+
+    public boolean isHideExcludedCommits() {
+        return hideExcludedCommits;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Excluded commits behaviour";
+        }
+    }
+
+}

--- a/src/main/resources/hudson/plugins/git/GitChangeSetList/digest.jelly
+++ b/src/main/resources/hudson/plugins/git/GitChangeSetList/digest.jelly
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <?jelly escape-by-default='true'?>
 <!--
   Displays the Git change log digest for the build top page 
@@ -13,9 +14,45 @@
     </j:when>
     <j:otherwise>
       Changes
-      <ol>
+      <j:if test="${it.excludedCount != 0}">
+        <style type="text/css">
+            .git-ignored-changes {
+              opacity: 0.6;
+              display: none;
+            }
+        </style>
+        <script>
+          function gitDigestSetExcludedDisplayType(displayType) {
+            var excludedObjects = document.querySelectorAll('.git-ignored-changes'),
+            i = 0,
+            l = excludedObjects.length;
+            for (i; i &lt; l; i++) {
+              excludedObjects[i].style.display = displayType;
+            }
+          }
+          function gitDigestShowExcluded(showExcluded) {
+            if (showExcluded) {
+              gitDigestSetExcludedDisplayType('list-item');
+            } else {
+              gitDigestSetExcludedDisplayType('none');
+            }
+            document.getElementById('git.plugin.GitChangeSetList.digest.hide').style.display =
+              showExcluded ? 'inline' : 'none';
+            document.getElementById('git.plugin.GitChangeSetList.digest.show').style.display =
+              showExcluded ? 'none' : 'inline';
+          }
+        </script>
+        <st:nbsp/>
+        <a id="git.plugin.GitChangeSetList.digest.show" href="javascript:void(0);" onclick="gitDigestShowExcluded(true);">Show ${it.excludedCount} excluded</a>
+        <a id="git.plugin.GitChangeSetList.digest.hide" href="javascript:void(0);" onclick="gitDigestShowExcluded(false);" style="display:none;">Hide excluded</a>
+      </j:if>
+      <ol id="git.plugin.chageSetList">
         <j:forEach var="cs" items="${it.logs}" varStatus="loop">
-          <li>
+          <j:set var="commitClass" value=""/>
+          <j:if test="${it.isExcluded(cs)}">
+            <j:set var="commitClass" value="git-ignored-changes"/>
+          </j:if>
+          <li class="${commitClass}">
             <j:out value="${cs.msgAnnotated}"/>
             (<a href="changes#detail${loop.index}">detail</a>
             <j:set var="cslink" value="${browser.getChangeSetLink(cs)}"/>
@@ -27,6 +64,11 @@
           </li>
         </j:forEach>
       </ol>
+      <j:if test="${!it.hideExludedCommits}">
+        <script>
+          gitDigestShowExcluded(true);
+        </script>
+      </j:if>
     </j:otherwise>
   </j:choose>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/git/GitChangeSetList/index.jelly
+++ b/src/main/resources/hudson/plugins/git/GitChangeSetList/index.jelly
@@ -1,53 +1,115 @@
+<?xml version="1.0"?>
 <?jelly escape-by-default='true'?>
 <!--
   Displays Git change log.
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="browser" value="${it.browser}"/>
-
-  <h2>Summary</h2>
-  <ol>
-    <j:forEach var="cs" items="${it.logs}">
-      <li><j:out value="${cs.msgAnnotated}"/> (<a href="#${cs.id}">details</a>)</li>
-    </j:forEach>
-  </ol>
-  <table class="pane" style="border:none">
-    <j:forEach var="cs" items="${it.logs}">
-      <tr class="pane">
-        <td colspan="2" class="changeset">
-          <a name="${cs.id}"></a>
-          <div class="changeset-message">
-            <b>
-              Commit
-              <j:set var="cslink" value="${browser.getChangeSetLink(cs)}"/>
-              <j:if test="${cslink!=null}">
-                <a href="${cslink}">${cs.id}</a>
-              </j:if>
-              <j:if test="${cslink==null}">
-                ${cs.id}
-              </j:if>
-              by <a href="${rootURL}/${cs.author.url}/">${cs.author}</a>
-            </b>
-            <j:if test="${cs.branch!=null}">
-              <j:whitespace trim="false"> in ${cs.branch}</j:whitespace>
-            </j:if>
-            <pre><j:out value="${cs.commentAnnotated}"/></pre>
-          </div>
-        </td>
-      </tr>
-      <j:forEach var="p" items="${cs.paths}">
-        <tr>
-          <td width="16"><t:editTypeIcon type="${p.editType}"/></td>
-          <td>
-            <a href="${browser.getFileLink(p)}">${p.path}</a>
-            <j:set var="diff" value="${browser.getDiffLink(p)}"/>
-            <j:if test="${diff!=null}">
-              <st:nbsp/>
-              <a href="${diff}">(diff)</a>
-            </j:if>
-          </td>
-        </tr>
-      </j:forEach>
-    </j:forEach>
-  </table>
+  <j:choose>
+    <j:when test="${it.emptySet}">
+    No changes.
+  </j:when>
+    <j:otherwise>
+      <h2>Summary</h2>
+      <j:if test="${it.excludedCount != 0}">
+        <style type="text/css">
+          li.git-ignored-changes {
+            opacity: 0.6;
+            display: none;
+          }
+          tr.git-ignored-changes div.changeset-message {
+            opacity: 0.6;
+          }
+          tr.git-ignored-changes {
+            display: none;
+          }
+        </style>
+        <script>
+            function gitDigestSetExcludedDisplayType(displayType, selector) {
+            var excludedObjects = document.querySelectorAll(selector),
+            i = 0,
+            l = excludedObjects.length;
+            for (i; i &lt; l; i++) {
+              excludedObjects[i].style.display = displayType;
+            }
+          }
+          function gitDigestShowExcluded(showExcluded) {
+            if (showExcluded) {
+              gitDigestSetExcludedDisplayType('list-item', 'li.git-ignored-changes');
+              gitDigestSetExcludedDisplayType('table-row', 'tr.git-ignored-changes');
+            } else {
+              gitDigestSetExcludedDisplayType('none', 'li.git-ignored-changes');
+              gitDigestSetExcludedDisplayType('none', 'tr.git-ignored-changes');
+            }
+            document.getElementById('git.plugin.GitChangeSetList.digest.hide').style.display =
+              showExcluded ? 'inline' : 'none';
+            document.getElementById('git.plugin.GitChangeSetList.digest.show').style.display =
+              showExcluded ? 'none' : 'inline';
+          }
+        </script>
+        <p>
+          <a id="git.plugin.GitChangeSetList.digest.show" href="javascript:void(0);" onclick="gitDigestShowExcluded(true);">Show ${it.excludedCount} excluded</a>
+          <a id="git.plugin.GitChangeSetList.digest.hide" href="javascript:void(0);" onclick="gitDigestShowExcluded(false);" style="display:none;">Hide excluded</a>
+        </p>
+      </j:if>
+      <ol id="git.plugin.chageSetList">
+        <j:forEach var="cs" items="${it.logs}">
+          <j:set var="commitClass" value=""/>
+          <j:if test="${it.isExcluded(cs)}">
+            <j:set var="commitClass" value="git-ignored-changes"/>
+          </j:if>
+          <li class="${commitClass}"><j:out value="${cs.msgAnnotated}"/> (<a href="#detail${cs.id}">details</a>)
+        </li>
+        </j:forEach>
+      </ol>
+      <table class="pane" style="border:none">
+        <j:forEach var="cs" items="${it.logs}">
+          <j:set var="commitClass" value=""/>
+          <j:if test="${it.isExcluded(cs)}">
+            <j:set var="commitClass" value="git-ignored-changes"/>
+          </j:if>
+          <tr class="pane, ${commitClass}">
+            <td colspan="2" class="changeset">
+            <a name="${cs.id}"></a>
+              <div class="changeset-message">
+                <b>
+                Commit
+                <j:set var="cslink" value="${browser.getChangeSetLink(cs)}"/>
+                <j:if test="${cslink!=null}"><a href="${cslink}">${cs.id}</a></j:if>
+                <j:if test="${cslink==null}">
+                  ${cs.id}
+                </j:if>
+                by <a href="${rootURL}/${cs.author.url}/">${cs.author}</a>
+              </b>
+                <j:if test="${cs.branch!=null}">
+                  <j:whitespace trim="false"> in ${cs.branch}</j:whitespace>
+                </j:if>
+                <pre><j:out value="${cs.commentAnnotated}"/></pre>
+              </div>
+            </td>
+          </tr>
+          <j:forEach var="p" items="${cs.paths}">
+            <tr class="${commitClass}">
+              <td width="16">
+                <t:editTypeIcon type="${p.editType}"/>
+              </td>
+              <td>
+                <a href="${browser.getFileLink(p)}">${p.path}</a>
+                <j:set var="diff" value="${browser.getDiffLink(p)}"/>
+                <j:if test="${diff!=null}">
+                  <st:nbsp/>
+                  <a href="${diff}">(diff)</a>
+                </j:if>
+              </td>
+            </tr>
+          </j:forEach>
+        </j:forEach>
+      </table>
+      <j:if test="${!it.hideExludedCommits}">
+        <script>
+          gitDigestShowExcluded(true);
+        </script>
+      </j:if>
+    </j:otherwise>
+  </j:choose>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/git/GitSCM/project-changes.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/project-changes.jelly
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <?jelly escape-by-default='true'?>
 <!--
 The MIT License
@@ -39,17 +40,67 @@ THE SOFTWARE.
       ${%No builds.}
     </j:when>
     <j:otherwise>
+      <j:set var="totalExcludedChanges" value="${0}"/>
+      <j:set var="hideExcludedCommits" value="${true}"/>
+      <j:forEach var="b" items="${builds}">
+        <j:forEach var="changeSet" items="${b.changeSets}">
+          <j:set var="totalExcludedChanges" value="${totalExcludedChanges + changeSet.excludedCount}"/>
+          <j:set var="hideExcludedCommits" value="${hideExcludedCommits &amp;&amp; changeSet.hideExludedCommits}"/>
+        </j:forEach>
+      </j:forEach>
+      <j:if test="${totalExcludedChanges != 0}">
+        <style type="text/css">
+           .git-ignored-changes {
+              opacity: 0.6;
+              display: none;
+           }
+        </style>
+        <script>
+          function gitDigestSetExcludedDisplayType(querySelector, displayType) {
+            var excludedObjects = document.querySelectorAll(querySelector),
+            i = 0,
+            l = excludedObjects.length;
+            for (i; i &lt; l; i++) {
+              excludedObjects[i].style.display = displayType;
+            }
+          }
+          function gitDigestShowExcluded(showExcluded) {
+            if (showExcluded) {
+              gitDigestSetExcludedDisplayType('.git-ignored-changes', 'list-item');
+              gitDigestSetExcludedDisplayType('div.git-ignored-changes-count', 'none');
+            } else {
+              gitDigestSetExcludedDisplayType('.git-ignored-changes','none');
+              gitDigestSetExcludedDisplayType('div.git-ignored-changes-count', 'block');
+            }
+            document.getElementById('git.plugin.GitChangeSetList.digest.hide').style.display =
+              showExcluded ? 'inline' : 'none';
+            document.getElementById('git.plugin.GitChangeSetList.digest.show').style.display =
+              showExcluded ? 'none' : 'inline';
+          }
+        </script>
+        <st:nbsp/>
+        <a id="git.plugin.GitChangeSetList.digest.show" href="javascript:void(0);" onclick="gitDigestShowExcluded(true);">Show ${totalExcludedChanges} excluded changes</a>
+        <a id="git.plugin.GitChangeSetList.digest.hide" href="javascript:void(0);" onclick="gitDigestShowExcluded(false);" style="display: none;">Hide excluded changes</a>
+      </j:if>
       <j:set var="hadChanges" value="${false}"/>
       <j:forEach var="b" items="${builds}">
         <j:forEach var="changeSet" items="${b.changeSets}">
           <j:set var="browser" value="${changeSet.browser}"/>
           <j:set var="hadChanges" value="${true}"/>
           <h2><a href="${b.number}/changes">${b.displayName}
-            (<i:formatDate value="${b.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)</a></h2>
+            (<i:formatDate value="${b.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)</a>
+          </h2>
+          <j:if test="${changeSet.excludedCount != 0}">
+            <div class="git-ignored-changes-count">${changeSet.excludedCount} commits excluded</div>
+          </j:if>
 
           <ol>
             <j:forEach var="c" items="${changeSet.iterator()}">
-              <li>
+              <j:set var="commitClass" value=""/>
+              <j:if test="${changeSet.isExcluded(c)}">
+                <j:set var="commitClass" value="git-ignored-changes"/>
+              </j:if>
+              <li class="${commitClass}">
                 <j:out value="${c.msgAnnotated}"/>
 
                 &#8212;
@@ -70,6 +121,11 @@ THE SOFTWARE.
           </ol>
         </j:forEach>
       </j:forEach>
+      <j:if test="${(totalExcludedChanges != 0) &amp;&amp; (!hideExcludedCommits)}">
+        <script>
+          gitDigestShowExcluded(true);
+        </script>
+      </j:if>
       <j:if test="${!hadChanges}">
         ${%No changes in any of the builds.}
       </j:if>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/ExcludedCommitsBehaviour/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/ExcludedCommitsBehaviour/config.groovy
@@ -1,0 +1,7 @@
+package hudson.plugins.git.extensions.impl.ExcludedCommitsBehaviour;
+
+def f = namespace(lib.FormTagLib);
+
+f.entry(title:_("Hide excluded commits"), field:"hideExcludedCommits") {
+    f.checkbox(default:true)
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/ExcludedCommitsBehaviour/help-hideExcludedCommits.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/ExcludedCommitsBehaviour/help-hideExcludedCommits.html
@@ -1,0 +1,6 @@
+<div>
+  Specify, whether commits, excluded from polling should be hidden in changes listings.<br/>
+  If a commit is excluded and this option is set, you should be able to see the commit by clicking on <i>Show X exluded</i> link.<br/>
+  If the options is not set, all commits should be shown in changes list with ability to hide excluded commits by clicking <i>Hide excluded</i>.<br/>
+  Default behaviour (if the git extension is not added at all) is to hide excluded commits.
+</div>

--- a/src/test/java/hudson/plugins/git/ui/ChangeSetListTest.java
+++ b/src/test/java/hudson/plugins/git/ui/ChangeSetListTest.java
@@ -1,0 +1,350 @@
+package hudson.plugins.git.ui;
+
+import hudson.model.Result;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.git.AbstractGitTestCase;
+import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitChangeSetList;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.SubmoduleConfig;
+import hudson.plugins.git.TestGitRepo;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.scm.SCM;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.jenkinsci.plugins.multiplescms.MultiSCM;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.xml.sax.SAXException;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+/**
+ * Unit test for {@link GitChangeSetList} generated HTML code. Ideally, this UT
+ * should run on newer HtmlUnit, than one we have in Jenkins test harness (at
+ * least version 2.9, which supports <code>document.querySelectorAll()</code>.
+ * @author Pavel Baranchikov
+ * @see http://htmlunit.sourceforge.net/changes-report.html#a2.9
+ * @see https://groups.google.com/d/msgid/jenkinsci-dev/664bb4c6-f6d7-4178-9c11-
+ *      d759974aa49f%40googlegroups.com?utm_medium=email&utm_source=footer
+ * @see JENKINS-25995
+ */
+public class ChangeSetListTest extends AbstractGitTestCase {
+
+    private com.gargoylesoftware.htmlunit.WebClient webClient;
+    private FreeStyleProject project;
+    private int fileCounter;
+    private static final String HIDE_ID = "git.plugin.GitChangeSetList.digest.hide";
+    private static final String SHOW_ID = "git.plugin.GitChangeSetList.digest.show";
+    private static final String CHAHGE_SET_LIST = "git.plugin.chageSetList";
+    private static final String MIME = "text/html";
+    private static final String TAG_ITEM = "li";
+    private static final String CHANGES_SHOULD_NOT_BE_NULL = "Changes list should not exist";
+    private static final String CHANGES_SHOULD_BE_NULL = "Changes list should exist";
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // Use directly HtmlUnit's webclient to switch easily to newer Html
+        // (manually) to perform JavaScript tests
+        webClient = new com.gargoylesoftware.htmlunit.WebClient();
+        // We are to ignore Javascript errors, as HtmlUnit is obsolete
+        webClient.setThrowExceptionOnScriptError(false);
+        fileCounter = 0;
+    }
+
+    /**
+     * Test for various behaviour on changes list. Javascript dinamic showing
+     * and hiding elements is not testable because of obsolete HtmlUnit. So,
+     * this test still try to open pages, and see for HTTP status code is not
+     * 5xx
+     * @throws Exception on exception occurs
+     */
+    @Test
+    public void testGitProjectChanges() throws Exception {
+        project = setupProject("master", false, null, "exclude.*", null, null);
+        commitIncluded();
+        build(project, Result.SUCCESS);
+        testWithHtml(new PageTester() {
+            public void testPage(HtmlObjects input) throws Exception {
+                input.assertButtonsExist(false);
+                Assert.assertNull(CHANGES_SHOULD_BE_NULL, input.changesList);
+            }
+        });
+        checkRecentChanges(false);
+
+        commitIncluded();
+        build(project, Result.SUCCESS);
+        testWithHtml(new PageTester() {
+            public void testPage(HtmlObjects input) throws Exception {
+                input.assertButtonsExist(false);
+                Assert.assertNotNull(CHANGES_SHOULD_NOT_BE_NULL, input.changesList);
+            }
+        });
+        checkRecentChanges(false);
+
+        commitExcluded();
+        build(project, Result.SUCCESS);
+        testWithHtml(new PageTester() {
+            public void testPage(HtmlObjects input) throws Exception {
+                input.assertButtonsExist(true);
+                Assert.assertNotNull(CHANGES_SHOULD_NOT_BE_NULL, input.changesList);
+                // Ignoring because of obsolete HtmlUnit
+                // testAnchors(input, 1, 1);
+            }
+        });
+        checkRecentChanges(true);
+
+        commitIncluded();
+        commitExcluded();
+        commitIncluded();
+        build(project, Result.SUCCESS);
+        testWithHtml(new PageTester() {
+            public void testPage(HtmlObjects input) throws Exception {
+                input.assertButtonsExist(true);
+                Assert.assertNotNull(CHANGES_SHOULD_BE_NULL, input.changesList);
+                // Ignoring because of obsolete HtmlUnit
+                // testAnchors(input, 3, 1);
+            }
+        });
+        checkRecentChanges(true);
+    }
+
+    @SuppressWarnings("unused")
+    private static void testAnchors(HtmlObjects htmlObj, int changes, int excluded)
+            throws IOException {
+        htmlObj.assertShowVisible();
+        htmlObj.expectChanges(changes);
+        htmlObj.expectVisibleChanges(changes - excluded);
+        htmlObj.showElement.click();
+        htmlObj.expectChanges(changes);
+        htmlObj.expectVisibleChanges(changes);
+        htmlObj.assertHideVisible();
+        htmlObj.hideElement.click();
+        htmlObj.assertShowVisible();
+        htmlObj.expectChanges(changes);
+        htmlObj.expectVisibleChanges(changes - excluded);
+    }
+
+    private static HtmlObjects getHtmlObjects(HtmlPage page) throws Exception {
+        final HtmlAnchor hideElement = (HtmlAnchor) page.getElementById(HIDE_ID);
+        final HtmlAnchor showElement = (HtmlAnchor) page.getElementById(SHOW_ID);
+        final HtmlElement changeElement = (HtmlElement) page.getElementById(CHAHGE_SET_LIST);
+        return new HtmlObjects(hideElement, showElement, changeElement);
+    }
+
+    private String getBuildUrl(AbstractProject<?, ?> project, AbstractBuild<?, ?> build) {
+        return String.format("job/%s/%d/", project.getName(), build.getNumber());
+    }
+
+    private String getChangesUrl(AbstractProject<?, ?> project, AbstractBuild<?, ?> build) {
+        return String.format("job/%s/%d/changes", project.getName(), build.getNumber());
+    }
+
+    private String getRecentChangesUrl(AbstractProject<?, ?> project) {
+        return String.format("job/%s/changes", project.getName());
+    }
+
+    private HtmlPage goTo(String relative, String expectedContentType) throws IOException,
+            SAXException {
+        final Page p = webClient.getPage(getURL() + relative);
+        assertEquals(expectedContentType, p.getWebResponse().getContentType());
+        if (p instanceof HtmlPage) {
+            return (HtmlPage) p;
+        } else {
+            throw new AssertionError("Expected text/html but instead the content type was "
+                    + p.getWebResponse().getContentType());
+        }
+    }
+
+    /**
+     * Method performs same tests on different Html pages: summary digest (build
+     * page) and changes page.
+     * @param function test to perform on pages
+     * @throws Exception on exceptions occur
+     */
+    private void testWithHtml(PageTester function) throws Exception {
+        final HtmlPage digest = goTo(getBuildUrl(project, project.getLastBuild()), MIME);
+        final HtmlObjects digestObjects = getHtmlObjects(digest);
+        function.testPage(digestObjects);
+        final HtmlPage changes = goTo(getChangesUrl(project, project.getLastBuild()), MIME);
+        final HtmlObjects changesObjects = getHtmlObjects(changes);
+        function.testPage(changesObjects);
+    }
+
+    private void commit(String commitFile) throws Exception {
+        commit(commitFile, johnDoe, "File " + commitFile + " committed");
+    }
+
+    private void commitExcluded() throws Exception {
+        commit("excluded" + getNextFileName());
+    }
+
+    private void commitIncluded() throws Exception {
+        commit(getNextFileName());
+    }
+
+    private String getNextFileName() {
+        return "file" + fileCounter++;
+    }
+
+    private void checkRecentChanges(boolean buttonsExist) throws Exception {
+        final HtmlPage changesPage = goTo(getRecentChangesUrl(project), MIME);
+        final HtmlObjects changesObj = getHtmlObjects(changesPage);
+        changesObj.assertButtonsExist(buttonsExist);
+    }
+
+    /**
+     * Simple test to ensure, that nothing fails on projects with no SCM.
+     * @throws Exception on exceptions occur
+     */
+    @Test
+    public void testNoScmProject() throws Exception {
+        final FreeStyleProject project = createFreeStyleProject();
+        build(project, Result.SUCCESS);
+
+        final HtmlObjects objects1 = getHtmlObjects(goTo(
+                getBuildUrl(project, project.getLastBuild()), MIME));
+        objects1.assertButtonsExist(false);
+        Assert.assertNull(objects1.changesList);
+        goTo(getRecentChangesUrl(project), MIME);
+
+        build(project, Result.SUCCESS);
+        final HtmlObjects objects2 = getHtmlObjects(goTo(
+                getBuildUrl(project, project.getLastBuild()), MIME));
+        objects2.assertButtonsExist(false);
+        Assert.assertNull(objects2.changesList);
+        goTo(getRecentChangesUrl(project), MIME);
+    }
+
+    /**
+     * Simple test to ensure, that nothing fails on projects with multiple SCMs,
+     * including Git.
+     * @throws Exception on exceptions occur
+     */
+    @Test
+    public void testMultipleScmProject() throws Exception {
+        final TestGitRepo repo0 = new TestGitRepo("repo0", this, listener);
+        final TestGitRepo repo1 = new TestGitRepo("repo1", this, listener);
+        final FreeStyleProject project = setupMultiScmProject("project1", repo0, repo1);
+        repo0.commit("repo0-init", repo0.johnDoe, "repo0 initial commit");
+        repo1.commit("repo1-init", repo0.johnDoe, "repo1 initial commit");
+        build(project, Result.SUCCESS);
+        goTo(getBuildUrl(project, project.getLastBuild()), MIME);
+        goTo(getChangesUrl(project, project.getLastBuild()), MIME);
+        goTo(getRecentChangesUrl(project), MIME);
+
+        repo1.commit("repo1-1", repo1.johnDoe, "repo1 commit 1");
+        repo0.commit("repo0-1", repo0.johnDoe, "repo0 commit 1");
+        build(project, Result.SUCCESS);
+        goTo(getBuildUrl(project, project.getLastBuild()), MIME);
+        goTo(getChangesUrl(project, project.getLastBuild()), MIME);
+        goTo(getRecentChangesUrl(project), MIME);
+    }
+
+    private FreeStyleProject setupMultiScmProject(String name, TestGitRepo repo0, TestGitRepo repo1)
+            throws IOException {
+        final FreeStyleProject project = createFreeStyleProject(name);
+
+        final List<BranchSpec> branch = Collections.singletonList(new BranchSpec("master"));
+
+        final SCM repo0Scm = new GitSCM(repo0.remoteConfigs(), branch, false,
+                Collections.<SubmoduleConfig> emptyList(), null, null,
+                Collections.<GitSCMExtension> emptyList());
+
+        final SCM repo1Scm = new GitSCM(repo1.remoteConfigs(), branch, false,
+                Collections.<SubmoduleConfig> emptyList(), null, null,
+                Collections.<GitSCMExtension> emptyList());
+
+        final List<SCM> testScms = new ArrayList<SCM>();
+        testScms.add(repo0Scm);
+        testScms.add(repo1Scm);
+
+        final MultiSCM scm = new MultiSCM(testScms);
+
+        project.setScm(scm);
+        project.getBuildersList().add(new CaptureEnvironmentBuilder());
+        return project;
+    }
+
+    /**
+     * Class to hold hide and show anchors and changes list.
+     */
+    private static class HtmlObjects {
+        /**
+         * Hide excluded changes anchor.
+         */
+        final HtmlElement hideElement;
+        /**
+         * Show excluded changes anchor.
+         */
+        final HtmlElement showElement;
+        /**
+         * Changes list.
+         */
+        final HtmlElement changesList;
+
+        public HtmlObjects(HtmlElement hideElement, HtmlElement showElement, HtmlElement changeList) {
+            this.hideElement = hideElement;
+            this.showElement = showElement;
+            this.changesList = changeList;
+        }
+
+        public void assertShowVisible() {
+            Assert.assertTrue("Show buttonshould be visible", showElement.isDisplayed());
+            Assert.assertFalse("Hide button should not be visible", hideElement.isDisplayed());
+        }
+
+        public void assertHideVisible() {
+            Assert.assertTrue("Hide button should be visible", hideElement.isDisplayed());
+            Assert.assertFalse("Show button should not be visible", showElement.isDisplayed());
+        }
+
+        public void expectChanges(int changesCount) {
+            Assert.assertTrue("Changes count should be " + changesCount, changesList
+                    .getElementsByTagName(TAG_ITEM).size() == changesCount);
+        }
+
+        public void expectVisibleChanges(int changesCount) {
+            final Collection<HtmlElement> items = changesList.getElementsByTagName(TAG_ITEM);
+            int visibleChanges = 0;
+            for (HtmlElement item : items) {
+                if (item.isDisplayed()) {
+                    visibleChanges++;
+                }
+            }
+            Assert.assertTrue("Visible changes count should be " + changesCount,
+                    changesCount == visibleChanges);
+        }
+
+        public void assertButtonsExist(boolean exist) {
+            Assert.assertTrue((hideElement != null) == exist);
+            Assert.assertTrue((showElement != null) == exist);
+        }
+
+    }
+
+    /**
+     * Interface to tests, that should be performed on different pages.
+     */
+    private interface PageTester {
+        /**
+         * Method performs tests on the specified page.
+         * @param htmlObjects anchors and list object
+         * @throws Exception on exceptions occur
+         */
+        void testPage(HtmlObjects htmlObjects) throws Exception;
+    }
+
+}


### PR DESCRIPTION
The main build view now have excluded changes hidden by default (and a linke _Show 15 hidden_) to show them. Excluded changes, when shown, are grayed to make them look different from included changes.

I have not found any _true_ way to get GitSCM to analyze the changes, whether they are excluded or not.

Also the suggested implementation only supports projects with a single git SCM. MultiSCM is not supported, because, I have not found any way to detect which SCM the certain change belongs.

I had some problems with embedded HtmlUnit. So, some tests should be activated only after HtmlUnit is upgraded to modern version.
