### PR TITLE
[JENKINS-24786] Environment variables are not expanded in git publisher

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -232,10 +232,10 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
 
                     if (mergeOptions.doMerge() && buildResult.isBetterOrEqualTo(Result.SUCCESS)) {
                         RemoteConfig remote = mergeOptions.getMergeRemote();
-                        
+
                         // expand environment variables in remote repository
                         remote = gitSCM.getParamExpandedRepo(environment, remote);
-                        
+
                         listener.getLogger().println("Pushing HEAD to branch " + mergeTarget + " of " + remote.getName() + " repository");
 
                         remoteURI = remote.getURIs().get(0);
@@ -275,10 +275,10 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
 
                         if (remote == null)
                             throw new AbortException("No repository found for target repo name " + targetRepo);
-                        
+
                         // expand environment variables in remote repository
                         remote = gitSCM.getParamExpandedRepo(environment, remote);
-                        
+
                         boolean tagExists = git.tagExists(tagName.replace(' ', '_'));
                         if (t.isCreateTag() || t.isUpdateTag()) {
                             if (tagExists && !t.isUpdateTag()) {
@@ -328,10 +328,10 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
 
                         if (remote == null)
                             throw new AbortException("No repository found for target repo name " + targetRepo);
-                        
+
                         // expand environment variables in remote repository
                         remote = gitSCM.getParamExpandedRepo(environment, remote);
-                        
+
                         listener.getLogger().println("Pushing HEAD to branch " + branchName + " at repo "
                                                      + targetRepo);
                         remoteURI = remote.getURIs().get(0);
@@ -367,10 +367,10 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                             listener.getLogger().println("No repository found for target repo name " + targetRepo);
                             return false;
                         }
-                        
+
                         // expand environment variables in remote repository
                         remote = gitSCM.getParamExpandedRepo(environment, remote);
-                        
+
                         listener.getLogger().println("Adding note to namespace \""+noteNamespace +"\":\n" + noteMsg + "\n******" );
 
                         if ( noteReplace )

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -397,7 +397,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         return expandedRepos;
     }
-    
+
     /**
      * Expand Parameters in the supplied remote repository with the parameter values provided in the given environment variables }
      * @param env Environment variables with parameter values

--- a/src/test/java/hudson/plugins/git/GitPublisherTest.java
+++ b/src/test/java/hudson/plugins/git/GitPublisherTest.java
@@ -39,7 +39,6 @@ import hudson.plugins.git.extensions.impl.LocalBranch;
 import hudson.plugins.git.extensions.impl.PreBuildMerge;
 import hudson.scm.NullSCM;
 import hudson.tasks.BuildStepDescriptor;
-
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jvnet.hudson.test.Bug;
@@ -146,11 +145,11 @@ public class GitPublisherTest extends AbstractGitTestCase {
     	TestGitRepo testTargetRepo = new TestGitRepo("target", this, listener);
     	testTargetRepo.git.init_().workspace(testTargetRepo.gitDir.getAbsolutePath()).bare(true).execute();
     	testTargetRepo.commit("lostTargetFile", johnDoe, "Initial Target Commit");
-    	
+
     	// add second test repository as remote repository with environment variables
     	List<UserRemoteConfig> remoteRepositories = createRemoteRepositories();
     	remoteRepositories.add(new UserRemoteConfig("$TARGET_URL", "$TARGET_NAME", "+refs/heads/$TARGET_BRANCH:refs/remotes/$TARGET_NAME/$TARGET_BRANCH", null));
-    	
+
         GitSCM scm = new GitSCM(
                 remoteRepositories,
                 Collections.singletonList(new BranchSpec("origin/master")),
@@ -158,16 +157,16 @@ public class GitPublisherTest extends AbstractGitTestCase {
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(scm);
-        
-        // add parameters for remote repository configuration 
+
+        // add parameters for remote repository configuration
         project.addProperty(new ParametersDefinitionProperty(
         		new StringParameterDefinition("TARGET_URL", testTargetRepo.gitDir.getAbsolutePath()),
         		new StringParameterDefinition("TARGET_NAME", "target"),
         		new StringParameterDefinition("TARGET_BRANCH", "master")));
-        
+
         String tag_name = "test-tag";
         String note_content = "Test Note";
-        
+
         project.getPublishersList().add(new GitPublisher(
         		Collections.singletonList(new TagToPush("$TARGET_NAME", tag_name, "", false, false)),
                 Collections.singletonList(new BranchToPush("$TARGET_NAME", "$TARGET_BRANCH")),
@@ -177,15 +176,15 @@ public class GitPublisherTest extends AbstractGitTestCase {
         commit("commitFile", johnDoe, "Initial Commit");
         testRepo.git.tag(tag_name, "Comment");
         ObjectId expectedCommit = testRepo.git.revParse("master");
-        
+
         build(project, Result.SUCCESS, "commitFile");
-        
+
         // check if everything reached target repository
         assertEquals(expectedCommit, testTargetRepo.git.revParse("master"));
         assertTrue(existsTagInRepo(testTargetRepo, tag_name));
-        
+
     }
-    
+
     @Issue("JENKINS-24082")
     public void testForcePush() throws Exception {
     	FreeStyleProject project = setupSimpleProject("master");
@@ -364,7 +363,7 @@ public class GitPublisherTest extends AbstractGitTestCase {
     private boolean existsTag(String tag) throws InterruptedException {
         return existsTagInRepo(testRepo, tag);
     }
-    
+
     private boolean existsTagInRepo(TestGitRepo gitRepo, String tag) throws InterruptedException {
         Set<String> tags = gitRepo.git.getTagNames("*");
         return tags.contains(tag);


### PR DESCRIPTION
Fix: Git publisher fails if remote repository configuration contains
environment variables
