### PR TITLE
Correctly set the SCM name in build data when set or unset.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1454,8 +1454,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         BuildData base = getBuildData(build);
         if (base==null)
             return new BuildData(getScmName(), getUserRemoteConfigs());
-        else
-            return base.clone();
+        else {
+           BuildData buildData = base.clone();
+           buildData.setScmName(getScmName());
+           return buildData;
+        }
     }
 
     /**
@@ -1479,6 +1482,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 break;
             }
             build = build.getPreviousBuild();
+        }
+        if (buildData != null) {
+            buildData.setScmName(getScmName());
         }
 
         return buildData;

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1483,9 +1483,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
             build = build.getPreviousBuild();
         }
-        if (buildData != null) {
-            buildData.setScmName(getScmName());
-        }
 
         return buildData;
     }

--- a/src/main/resources/hudson/plugins/git/util/BuildData/index.jelly
+++ b/src/main/resources/hudson/plugins/git/util/BuildData/index.jelly
@@ -6,7 +6,7 @@
        	<h1>Git Build Data</h1>
 
        	<b>Revision:</b> ${it.lastBuild.SHA1.name()}
-        <j:if test="${it.scmName}"> from <b>SCM:</b> ${it.scmName}</j:if>
+        <j:if test="${!empty(it.scmName)}"> from <b>SCM:</b> ${it.scmName}</j:if>
 	<ul>
 	<j:forEach var="branch" items="${it.lastBuild.revision.branches}">
 	<li>${branch.name}</li>

--- a/src/main/resources/hudson/plugins/git/util/BuildData/summary.jelly
+++ b/src/main/resources/hudson/plugins/git/util/BuildData/summary.jelly
@@ -4,7 +4,7 @@
 	<t:summary icon="/plugin/git/icons/git-48x48.png">
 
  	<b>Revision</b>: ${it.lastBuiltRevision.sha1.name()}
-        <j:if test="${it.scmName}"> from <b>SCM:</b> ${it.scmName}</j:if>
+        <j:if test="${!empty(it.scmName)}"> from <b>SCM:</b> ${it.scmName}</j:if>
         <ul>
         <j:forEach var="branch" items="${it.lastBuiltRevision.branches}">
           <j:if test="${branch!=''}">

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1522,6 +1522,100 @@ public class GitSCMTest extends AbstractGitTestCase {
     }
 
     /**
+     * Tests that builds have the correctly specified Custom SCM names, associated with
+     * each build.
+     * @throws Exception on various exceptions
+     */
+    public void testCustomSCMName() throws Exception {
+        final String branchName = "master";
+        final FreeStyleProject project = setupProject(branchName, false);
+        GitSCM git = (GitSCM) project.getScm();
+        setupJGit(git);
+
+        final String commitFile1 = "commitFile1";
+        final String scmNameString1 = "";
+        commit(commitFile1, johnDoe, "Commit number 1");
+        assertTrue("scm polling should not detect any more changes after build",
+                project.poll(listener).hasChanges());
+        build(project, Result.SUCCESS, commitFile1);
+        final ObjectId commit1 = testRepo.git.revListAll().get(0);
+
+        // Check unset build SCM Name carries
+        final int buildNumber1 = notifyAndCheckScmName(
+            project, commit1, scmNameString1, 1, git);
+
+        final String scmNameString2 = "ScmName2";
+        git.getExtensions().replace(new ScmName(scmNameString2));
+
+        commit("commitFile2", johnDoe, "Commit number 2");
+        assertTrue("scm polling should detect commit 2", project.poll(listener).hasChanges());
+        final ObjectId commit2 = testRepo.git.revListAll().get(0);
+
+        // Check second set SCM Name
+        final int buildNumber2 = notifyAndCheckScmName(
+            project, commit2, scmNameString2, 2, git);
+        checkNumberedBuildScmName(project, buildNumber1, scmNameString1, git);
+
+        final String scmNameString3 = "ScmName3";
+        git.getExtensions().replace(new ScmName(scmNameString3));
+
+        commit("commitFile3", johnDoe, "Commit number 3");
+        assertTrue("scm polling should detect commit 3", project.poll(listener).hasChanges());
+        final ObjectId commit3 = testRepo.git.revListAll().get(0);
+
+        // Check third set SCM Name
+        final int buildNumber3 = notifyAndCheckScmName(
+            project, commit3, scmNameString3, 3, git);
+        checkNumberedBuildScmName(project, buildNumber1, scmNameString1, git);
+        checkNumberedBuildScmName(project, buildNumber2, scmNameString2, git);
+
+        commit("commitFile4", johnDoe, "Commit number 4");
+        assertTrue("scm polling should detect commit 4", project.poll(listener).hasChanges());
+        final ObjectId commit4 = testRepo.git.revListAll().get(0);
+
+        // Check third set SCM Name still set
+        final int buildNumber4 = notifyAndCheckScmName(
+            project, commit4, scmNameString3, 4, git);
+        checkNumberedBuildScmName(project, buildNumber1, scmNameString1, git);
+        checkNumberedBuildScmName(project, buildNumber2, scmNameString2, git);
+        checkNumberedBuildScmName(project, buildNumber3, scmNameString3, git);
+    }
+
+    /**
+     * Method performs HTTP get on "notifyCommit" URL, passing it commit by SHA1
+     * and tests for custom SCM name build data consistency.
+     * @param project project to build
+     * @param commit commit to build
+     * @param expectedBranch branch, that is expected to be built
+     * @param ordinal number of commit to log into errors, if any
+     * @param git git SCM
+     * @throws Exception on various exceptions occur
+     */
+    private int notifyAndCheckScmName(FreeStyleProject project, ObjectId commit,
+            String expectedScmName, int ordinal, GitSCM git) throws Exception {
+        assertTrue("scm polling should detect commit " + ordinal, notifyCommit(project, commit));
+
+        final Build build = project.getLastBuild();
+        final BuildData buildData = git.getBuildData(build);
+        assertEquals("Commit " + ordinal + " should be built", commit, buildData
+                .getLastBuiltRevision().getSha1());
+
+        assertEquals("SCM Name should be <" + expectedScmName + ">", expectedScmName, buildData
+                .getScmName());
+
+        return build.getNumber();
+    }
+
+    private void checkNumberedBuildScmName(FreeStyleProject project, int buildNumber,
+            String expectedScmName, GitSCM git) throws Exception {
+
+        final BuildData buildData = git.getBuildData(project.getBuildByNumber(buildNumber));
+        System.out.println(buildData.toString());
+        assertEquals("SCM Name should be " + expectedScmName, expectedScmName, buildData
+                .getScmName());
+    }
+
+    /**
      * Tests that builds have the correctly specified branches, associated with
      * the commit id, passed with "notifyCommit" URL.
      * @see JENKINS-24133


### PR DESCRIPTION
When custom SCM name feature is enabled, the custom name is not propagated between builds.  Likewise the custom SCM name is not shown in the build log due to an error in the template language syntax.  This feature is commonly used in conjunction with the MultiSCM plugin.