### PR TITLE
[JENKINS-26268] Fix build with 2 repo URLs and remotes/ specifier

### DIFF
--- a/src/main/java/hudson/plugins/git/BranchSpec.java
+++ b/src/main/java/hudson/plugins/git/BranchSpec.java
@@ -119,6 +119,12 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
         // build a pattern into this builder
         StringBuilder builder = new StringBuilder();
         
+        // optionally match "remotes/" if specified
+        if (qualifiedName.startsWith("remotes/")) {
+            builder.append("(?:remotes/)?");
+            qualifiedName = qualifiedName.substring(8);
+        }
+
         // was the last token a wildcard?
         boolean foundWildcard = false;
         

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -461,7 +461,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         if (getRepositories().size() != 1) {
         	for (RemoteConfig repo : getRepositories()) {
-        		if (branch.startsWith(repo.getName() + "/")) {
+        		if (branch.startsWith(repo.getName() + "/") || branch.startsWith("remotes/" + repo.getName() + "/"))  {
         			repository = repo.getName();
         			break;
         		}

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -145,6 +145,15 @@ public class GitSCMTest extends AbstractGitTestCase {
       build(projectHierarchicalBranch, Result.SUCCESS, commitFile1);
     }
 
+    public void testBranchSpecWithRemotesWildcard() throws Exception {
+        FreeStyleProject project = setupProject("remotes/origin/*", false, null, null, null, true, null);
+
+        // create initial commit and build
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit number 1");
+        build(project, Result.SUCCESS, commitFile1);
+    }
+
     public void testBranchSpecUsingTagWithSlash() throws Exception {
         FreeStyleProject projectMasterBranch = setupProject("path/tag", false, null, null, null, true, null);
         // create initial commit and build

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -154,6 +154,28 @@ public class GitSCMTest extends AbstractGitTestCase {
         build(project, Result.SUCCESS, commitFile1);
     }
 
+    @Bug(26268)
+    public void testBranchSpecWithRemotesFromMultipleRepos() throws Exception {
+        FreeStyleProject project = setupSimpleProject("master");
+
+        TestGitRepo secondTestRepo = new TestGitRepo("second", this, listener);
+        List<UserRemoteConfig> remotes = new ArrayList<UserRemoteConfig>();
+        remotes.addAll(testRepo.remoteConfigs());
+        remotes.addAll(secondTestRepo.remoteConfigs());
+
+        project.setScm(new GitSCM(
+                remotes,
+                Collections.singletonList(new BranchSpec("remotes/origin/master")),
+                false, Collections.<SubmoduleConfig>emptyList(),
+                null, null,
+                Collections.<GitSCMExtension>emptyList()));
+
+        // Create some commits
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit number 1");
+        build(project, Result.SUCCESS, commitFile1);
+    }
+
     public void testBranchSpecUsingTagWithSlash() throws Exception {
         FreeStyleProject projectMasterBranch = setupProject("path/tag", false, null, null, null, true, null);
         // create initial commit and build


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-26268

This fixes a bug where a build will not run if Git is configured to have two repo URLs (note: not MultiSCM plugin) and you specify a branch with the "remotes/" prefix:

    remotes/origin/master

Previously, if you had never run the job successfully before, the job would fail with a log similar to:

    Seen branch in repository origin/master
    Seen branch in repository upstream/master
    Seen branch in repository upstream/test2-only
    Seen 3 remote branches
    ERROR: Couldn't find any revision to build. Verify the repository and branch configuration for this job.

NOTE: As a workaround you can run the job with "master" once, and then future runs with "remotes/origin/master" will work.

This is the same code as #233, but now associated with a Jira issue and a more common failure-case.  The bug is still present as of git-plugin 2.3.2, git-client 1.14.0.