### PR TITLE
[JENKINS-26269] Fix polling with multiple remotes

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -459,6 +459,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         String branch = getBranches().get(0).getName();
         String repository = null;
 
+        // substitute build parameters if available
+        branch = getParameterString(branch, env);
+
         if (getRepositories().size() != 1) {
         	for (RemoteConfig repo : getRepositories()) {
         		if (branch.startsWith(repo.getName() + "/")) {
@@ -485,8 +488,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             return null;
         }
 
-        // substitute build parameters if available
-        branch = getParameterString(branch, env);
 
         // Check for empty string - replace with "**" when seen.
         if (branch.equals("")) {

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -88,24 +88,34 @@ public class DefaultBuildChooser extends BuildChooser {
             List<String> possibleQualifiedBranches = new ArrayList<String>();
             for (RemoteConfig config : gitSCM.getRepositories()) {
                 String repository = config.getName();
-                String fqbn;
+                String fqbn = null;
                 if (branchSpec.startsWith(repository + "/")) {
                     fqbn = "refs/remotes/" + branchSpec;
                 } else if(branchSpec.startsWith("remotes/" + repository + "/")) {
                     fqbn = "refs/" + branchSpec;
-                } else if(branchSpec.startsWith("refs/heads/")) {
-                    fqbn = "refs/remotes/" + repository + "/" + branchSpec.substring("refs/heads/".length());
-                } else {
-                    //Try branchSpec as it is - e.g. "refs/tags/mytag"
-                    fqbn = branchSpec;
                 }
-                verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
+                if (fqbn != null) {
+                    verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
+                    possibleQualifiedBranches.add(fqbn);
+                }
+            }
+            // if no remote matched, try as is and in every remote
+            if (possibleQualifiedBranches.isEmpty()) {
+                // Try branchSpec as it is - e.g. "refs/tags/mytag"
+                String fqbn = branchSpec;
+                verbose(listener, "Qualifying {0} as is -> {1}", branchSpec, fqbn);
                 possibleQualifiedBranches.add(fqbn);
 
-                //Check if exact branch name <branchSpec> existss
-                fqbn = "refs/remotes/" + repository + "/" + branchSpec;
-                verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
-                possibleQualifiedBranches.add(fqbn);
+                for (RemoteConfig config : gitSCM.getRepositories()) {
+                    String repository = config.getName();
+                    if(branchSpec.startsWith("refs/heads/")) {
+                        fqbn = "refs/remotes/" + repository + "/" + branchSpec.substring("refs/heads/".length());
+                    } else {
+                        fqbn = "refs/remotes/" + repository + "/" + branchSpec;
+                    }
+                    verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
+                    possibleQualifiedBranches.add(fqbn);
+                }
             }
             for (String fqbn : possibleQualifiedBranches) {
               revisions.addAll(getHeadRevision(isPollCall, fqbn, git, listener, data));


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-26269

This always polls the correct remote when multiple remotes are configured.  It also always checks out from the correct remote if a remote is specified.

This also fixes: https://issues.jenkins-ci.org/browse/JENKINS-14846 by expanding branch parameters before processing multiple remote information.
