### PR TITLE
[JENKINS-26271] Fix building tags with multiple remotes configured

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -459,6 +459,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         String branch = getBranches().get(0).getName();
         String repository = null;
 
+        // substitute build parameters if available
+        branch = getParameterString(branch, env);
+
         if (getRepositories().size() != 1) {
         	for (RemoteConfig repo : getRepositories()) {
         		if (branch.startsWith(repo.getName() + "/")) {
@@ -485,8 +488,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             return null;
         }
 
-        // substitute build parameters if available
-        branch = getParameterString(branch, env);
 
         // Check for empty string - replace with "**" when seen.
         if (branch.equals("")) {

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -462,6 +462,17 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         // substitute build parameters if available
         branch = getParameterString(branch, env);
 
+        // if the branch name is a tag, qualify as a tag
+        String tag = null;
+        if (branch.startsWith("refs/tags/")) {
+            tag = branch.substring("refs/tags/".length());
+        } else if (branch.startsWith("tags/")) {
+            tag = branch.substring("tags/".length());
+        }
+        if (tag != null && !tag.equals("") && !tag.contains("*")) {
+            return "refs/tags/" + tag;
+        }
+
         if (getRepositories().size() != 1) {
         	for (RemoteConfig repo : getRepositories()) {
         		if (branch.startsWith(repo.getName() + "/")) {

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -120,6 +120,13 @@ public class BuildData implements Action, Serializable, Cloneable {
                     return true;
             }
 
+            // We don't keep track of non-branch builds (such as tags, sha1s, etc.).
+            // But we can compare against the last build.
+            Revision lastBuiltRevision = getLastBuiltRevision();
+            if (lastBuiltRevision != null && lastBuiltRevision.getSha1().equals(sha1)) {
+                return true;
+            }
+
             return false;
     	}
     	catch(Exception ex) {

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -106,15 +106,17 @@ public class DefaultBuildChooser extends BuildChooser {
                 verbose(listener, "Qualifying {0} as is -> {1}", branchSpec, fqbn);
                 possibleQualifiedBranches.add(fqbn);
 
-                for (RemoteConfig config : gitSCM.getRepositories()) {
-                    String repository = config.getName();
-                    if(branchSpec.startsWith("refs/heads/")) {
-                        fqbn = "refs/remotes/" + repository + "/" + branchSpec.substring("refs/heads/".length());
-                    } else {
-                        fqbn = "refs/remotes/" + repository + "/" + branchSpec;
+                if (!branchSpec.startsWith("refs/tags/")) {
+                    for (RemoteConfig config : gitSCM.getRepositories()) {
+                        String repository = config.getName();
+                        if(branchSpec.startsWith("refs/heads/")) {
+                            fqbn = "refs/remotes/" + repository + "/" + branchSpec.substring("refs/heads/".length());
+                        } else {
+                            fqbn = "refs/remotes/" + repository + "/" + branchSpec;
+                        }
+                        verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
+                        possibleQualifiedBranches.add(fqbn);
                     }
-                    verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
-                    possibleQualifiedBranches.add(fqbn);
                 }
             }
             for (String fqbn : possibleQualifiedBranches) {

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -88,24 +88,34 @@ public class DefaultBuildChooser extends BuildChooser {
             List<String> possibleQualifiedBranches = new ArrayList<String>();
             for (RemoteConfig config : gitSCM.getRepositories()) {
                 String repository = config.getName();
-                String fqbn;
+                String fqbn = null;
                 if (branchSpec.startsWith(repository + "/")) {
                     fqbn = "refs/remotes/" + branchSpec;
                 } else if(branchSpec.startsWith("remotes/" + repository + "/")) {
                     fqbn = "refs/" + branchSpec;
-                } else if(branchSpec.startsWith("refs/heads/")) {
-                    fqbn = "refs/remotes/" + repository + "/" + branchSpec.substring("refs/heads/".length());
-                } else {
-                    //Try branchSpec as it is - e.g. "refs/tags/mytag"
-                    fqbn = branchSpec;
                 }
-                verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
+                if (fqbn != null) {
+                    verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
+                    possibleQualifiedBranches.add(fqbn);
+                }
+            }
+            // if no remote matched, try as is and in every remote
+            if (possibleQualifiedBranches.isEmpty()) {
+                // Try branchSpec as it is - e.g. "refs/tags/mytag"
+                String fqbn = branchSpec;
+                verbose(listener, "Qualifying {0} as is -> {1}", branchSpec, fqbn);
                 possibleQualifiedBranches.add(fqbn);
 
-                //Check if exact branch name <branchSpec> existss
-                fqbn = "refs/remotes/" + repository + "/" + branchSpec;
-                verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
-                possibleQualifiedBranches.add(fqbn);
+                for (RemoteConfig config : gitSCM.getRepositories()) {
+                    String repository = config.getName();
+                    if(branchSpec.startsWith("refs/heads/")) {
+                        fqbn = "refs/remotes/" + repository + "/" + branchSpec.substring("refs/heads/".length());
+                    } else {
+                        fqbn = "refs/remotes/" + repository + "/" + branchSpec;
+                    }
+                    verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
+                    possibleQualifiedBranches.add(fqbn);
+                }
             }
             for (String fqbn : possibleQualifiedBranches) {
               revisions.addAll(getHeadRevision(isPollCall, fqbn, git, listener, data));


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-26271
**NOTE:** This includes commits from #286.  Please land that first.

This fixes a bug that prevents building tags when multiple repositories are configured (note: two remotes, not MultiSCM).
