### PR TITLE
cleaned up if to make assignment obvious

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -164,7 +164,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             List<GitSCMExtension> extensions) {
 
         // moved from createBranches
-        this.branches = (isEmpty(branches))? newArrayList(new BranchSpec("*/master")):branches;
+        this.branches = isEmpty(branches) ? newArrayList(new BranchSpec("*/master")) : branches;
 
         this.userRemoteConfigs = userRemoteConfigs;
         updateFromUserData();

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -70,6 +70,7 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static hudson.Util.*;
 import static hudson.init.InitMilestone.JOB_LOADED;
 import static hudson.init.InitMilestone.PLUGINS_STARTED;
@@ -79,6 +80,8 @@ import hudson.util.IOUtils;
 import hudson.util.LogTaskListener;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.isBlank;
 
 /**
@@ -161,13 +164,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             List<GitSCMExtension> extensions) {
 
         // moved from createBranches
-        if (branches == null) {
-            branches = new ArrayList<BranchSpec>();
-        }
-        if (branches.isEmpty()) {
-            branches.add(new BranchSpec("*/master"));
-        }
-        this.branches = branches;
+        this.branches = (isEmpty(branches))? newArrayList(new BranchSpec("*/master")):branches;
 
         this.userRemoteConfigs = userRemoteConfigs;
         updateFromUserData();


### PR DESCRIPTION
Very minor readability change. 

The CollectionUtils isEmpty null safe and gives us the same result as the two if statements. 

I then found that the branches attribute was getting assigned at a different level as the empty check so I replaces the if to make it obvious that this.branches was always going to be assigned. 
 