### PR TITLE
Add ability to configure timeout value for git push operations.

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -27,6 +27,7 @@ import org.jenkinsci.plugins.gitclient.CloneCommand;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
+import org.jenkinsci.plugins.gitclient.PushCommand;
 
 /**
  * Extension point to tweak the behaviour of {@link GitSCM}.
@@ -236,6 +237,22 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
     public void decorateCheckoutCommand(GitSCM scm, AbstractBuild<?, ?> build, GitClient git, BuildListener listener, CheckoutCommand cmd) throws IOException, InterruptedException, GitException {
         if (Util.isOverridden(GitSCMExtension.class, getClass(), "decorateCheckoutCommand", GitSCM.class, Run.class, GitClient.class, TaskListener.class, CheckoutCommand.class)) {
             decorateCheckoutCommand(scm, (Run) build, git, listener, cmd);
+        }
+    }
+    
+    /**
+     * Called before a {@link PushCommand} is executed to allow extensions to alter its behavior.
+     */
+    public void decoratePushCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, PushCommand cmd) throws IOException, InterruptedException, GitException {
+        if (build instanceof AbstractBuild && listener instanceof BuildListener) {
+            decoratePushCommand(scm, (AbstractBuild) build, git, (BuildListener) listener, cmd);
+        }
+    }
+    
+    @Deprecated
+    public void decoratePushCommand(GitSCM scm, AbstractBuild<?, ?> build, GitClient git, BuildListener listener, PushCommand cmd) throws IOException, InterruptedException, GitException {
+        if (Util.isOverridden(GitSCMExtension.class, getClass(), "decoratePushCommand", GitSCM.class, Run.class, GitClient.class, TaskListener.class, PushCommand.class)) {
+            decoratePushCommand(scm, (Run) build, git, listener, cmd);
         }
     }
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/PushOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PushOption.java
@@ -1,0 +1,52 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.extensions.FakeGitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import java.io.IOException;
+import org.jenkinsci.plugins.gitclient.PushCommand;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Add options to the push command.
+ *
+ * @author Tim Mertens
+ */
+public class PushOption extends FakeGitSCMExtension {
+
+    private Integer timeout;
+
+    @DataBoundConstructor
+    public PushOption(Integer timeout) {
+        this.timeout = timeout;
+    }
+
+    public Integer getTimeout() {
+        return timeout;
+    }
+
+    @Override
+    public boolean requiresWorkspaceForPolling() {
+        return false;
+    }
+
+    @Override
+    public void decoratePushCommand(GitSCM scm, AbstractBuild<?, ?> build, GitClient git, BuildListener listener, PushCommand cmd) throws IOException, InterruptedException, GitException {
+        cmd.timeout(timeout);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Advanced push behaviours";
+        }
+    }
+
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/PushOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/PushOption/config.groovy
@@ -1,0 +1,7 @@
+package hudson.plugins.git.extensions.impl.PushOption;
+
+def f = namespace(lib.FormTagLib);
+
+f.entry(title:_("Timeout (in minutes) for push operation"), field:"timeout") {
+    f.textbox()
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/PushOption/help-timeout.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/PushOption/help-timeout.html
@@ -1,0 +1,5 @@
+<div>
+  Specify a timeout (in minutes) for push operations.<br/>
+  This option overrides the default timeout of 10 minutes. <br/>
+  You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeout (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-11286" target="_blank">JENKINS-11286</a>).
+</div>


### PR DESCRIPTION
@MarkEWaite This adds a configuration option similar to those for checkout and clone operations to allow setting timeout for push operations.  This allows long push operations (e.g. push to Heroku) to succeed.