### PR TITLE
[JENKINS-27349] Fix polling for parametrized branchspec

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -510,11 +510,15 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
     @Override
     public boolean requiresWorkspaceForPolling() {
+        // TODO would need to use hudson.plugins.git.util.GitUtils.getPollEnvironment
+        return requiresWorkspaceForPolling(new EnvVars());
+    }
+
+    private boolean requiresWorkspaceForPolling(EnvVars environment) {
         for (GitSCMExtension ext : getExtensions()) {
             if (ext.requiresWorkspaceForPolling()) return true;
         }
-        // TODO would need to use hudson.plugins.git.util.GitUtils.getPollEnvironment
-        return getSingleBranch(new EnvVars()) == null;
+        return getSingleBranch(environment) == null;
     }
 
     @Override
@@ -558,9 +562,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             listener.getLogger().println("[poll] Last Built Revision: " + buildData.lastBuild.revision);
         }
 
-        final String singleBranch = getSingleBranch(lastBuild.getEnvironment(listener));
+        final EnvVars pollEnv = project instanceof AbstractProject ? GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener, false) : lastBuild.getEnvironment(listener);
 
-        if (!requiresWorkspaceForPolling()) {
+        final String singleBranch = getSingleBranch(pollEnv);
+
+        if (!requiresWorkspaceForPolling(pollEnv)) {
 
             final EnvVars environment = project instanceof AbstractProject ? GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener, false) : new EnvVars();
 

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -272,6 +272,17 @@ public class GitUtils implements Serializable {
                 }
             }
         }
+        
+        // Use the default parameter values (if any) instead of the ones from the last build
+        ParametersDefinitionProperty paramDefProp = (ParametersDefinitionProperty) b.getProject().getProperty(ParametersDefinitionProperty.class);
+        if (paramDefProp != null) {
+            for(ParameterDefinition paramDefinition : paramDefProp.getParameterDefinitions()) {
+               ParameterValue defaultValue  = paramDefinition.getDefaultParameterValue();
+               if (defaultValue != null) {
+                   defaultValue.buildEnvironment(b, env);
+               }
+            }
+        }
     }
 
     public static String[] fixupNames(String[] names, String[] urls) {


### PR DESCRIPTION
When polling with a parametrized branchpec, use the default value of the param, instead of the value from the last build