### PR TITLE
Filtered build's changes according to polling exclusions

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSetList.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSetList.java
@@ -1,40 +1,73 @@
 package hudson.plugins.git;
 
+import hudson.model.BuildListener;
+import hudson.model.Item;
+import hudson.model.ModelObject;
+import hudson.model.StreamBuildListener;
+import hudson.model.AbstractProject;
 import hudson.model.Run;
-import hudson.scm.ChangeLogSet;
+import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.scm.RepositoryBrowser;
-import org.kohsuke.stapler.export.Exported;
+import hudson.scm.ChangeLogSet;
+import hudson.scm.SCM;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
+import org.apache.commons.io.output.NullOutputStream;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.kohsuke.stapler.export.Exported;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * List of changeset that went into a particular build.
  * @author Nigel Magnay
  */
 public class GitChangeSetList extends ChangeLogSet<GitChangeSet> {
-    private final List<GitChangeSet> changeSets;
+    private final List<GitChangeSet> filteredChangeSets;
+    private final Set<GitChangeSet> excluded;
+    private final List<GitChangeSet> allChangeSets;
 
     /*package*/ GitChangeSetList(Run build, RepositoryBrowser<?> browser, List<GitChangeSet> logs) {
         super(build, browser);
         Collections.reverse(logs);  // put new things first
-        this.changeSets = Collections.unmodifiableList(logs);
+        this.allChangeSets = Collections.unmodifiableList(logs);
         for (GitChangeSet log : logs)
             log.setParent(this);
+        excluded = getExcluded(allChangeSets);
+        final List<GitChangeSet> filteredChanges = Lists.newLinkedList(logs);
+        filteredChanges.removeAll(excluded);
+        filteredChangeSets = Collections.unmodifiableList(filteredChanges);
     }
 
+    private List<GitChangeSet> getPublicChanges() {
+        final GitSCM git = getGitSCM();
+        final boolean hideExcludedChanges = git == null ? GitSCM.DEFAULT_HIDE_EXCLUDED_COMMITS_IN_CHANGESET
+                : git.isHideExcludedInChangeList();
+        return hideExcludedChanges ? filteredChangeSets : allChangeSets;
+    }
+
+    @Override
     public boolean isEmptySet() {
-        return changeSets.isEmpty();
+        return getPublicChanges().isEmpty();
     }
 
     public Iterator<GitChangeSet> iterator() {
-        return changeSets.iterator();
+        return getPublicChanges().iterator();
+    }
+
+    public boolean isLogsEmpty() {
+        return allChangeSets.isEmpty();
     }
 
     public List<GitChangeSet> getLogs() {
-        return changeSets;
+        return allChangeSets;
     }
 
     @Exported
@@ -42,4 +75,97 @@ public class GitChangeSetList extends ChangeLogSet<GitChangeSet> {
         return "git";
     }
 
+    public boolean isExcluded(GitChangeSet change) {
+        return excluded.contains(change);
+    }
+
+    public int getExcludedCount() {
+        return excluded.size();
+    }
+
+    private Set<GitChangeSet> getExcluded(Collection<GitChangeSet> allChangeSets) {
+        final GitSCM git = getGitSCM();
+        if (git != null) {
+            final BuildListener buildListener = new StreamBuildListener(new NullOutputStream());
+            try {
+                final GitClient gitClient = git.createClient(buildListener, getRun()
+                        .getEnvironment(buildListener), getRun(), null);
+                final Set<GitChangeSet> excluded = Sets.newHashSet();
+                for (GitChangeSet change : allChangeSets) {
+                    final boolean commitExcluded = isExcludedImpl(git, gitClient, buildListener,
+                            change);
+                    if (commitExcluded) {
+                        excluded.add(change);
+                    }
+                }
+                return excluded;
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Error creating git client", e);
+            } catch (IOException e) {
+                throw new RuntimeException("Error creating git client", e);
+            }
+        } else {
+            return Collections.emptySet();
+        }
+
+    }
+
+    private static boolean isExcludedImpl(GitSCM git, GitClient gitClient,
+            BuildListener buildListener, GitChangeSet change) throws GitException, IOException,
+            InterruptedException {
+        Boolean excludeThisCommit = false;
+        for (GitSCMExtension ext : git.getExtensions()) {
+            excludeThisCommit = ext.isRevExcluded(git, gitClient, change, buildListener, null);
+            if (excludeThisCommit != null)
+                break;
+        }
+        return Boolean.TRUE.equals(excludeThisCommit);
+    }
+
+    /**
+     * Returns Git SCM object, associated with this build
+     * @param job build to search Git SCM for
+     * @return Git SCM object or <code>null</code> if nothing found
+     */
+    private GitSCM getGitSCM(Run<?, ?> job) {
+        final AbstractProject<?, ?> project = getProject(job);
+        if (project == null) {
+            return null;
+        }
+        final SCM scm = project.getScm();
+        if (scm instanceof GitSCM) {
+            return (GitSCM) scm;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Returns first found project in the Jenkins model hierarchy.
+     * @param job job search project of
+     * @return abstract project object, or <code>null</code> if nothing found.
+     */
+    private AbstractProject<?, ?> getProject(Run<?, ?> job) {
+        if (job == null) {
+            return null;
+        }
+        ModelObject nextParent = job.getParent();
+        while (nextParent instanceof Item) {
+            final Item nextItem = (Item) nextParent;
+            if (nextParent instanceof AbstractProject) {
+                return (AbstractProject<?, ?>) nextParent;
+            }
+            nextParent = nextItem.getParent();
+        }
+        return null;
+    }
+
+    /**
+     * GitSCM is not cached, as the new SCM object is created on every job
+     * configuration change.
+     * @return SCM object
+     */
+    private GitSCM getGitSCM() {
+        return getGitSCM(getRun());
+    }
 }

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -119,6 +119,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     public static final String GIT_COMMIT = "GIT_COMMIT";
     public static final String GIT_PREVIOUS_COMMIT = "GIT_PREVIOUS_COMMIT";
     public static final String GIT_PREVIOUS_SUCCESSFUL_COMMIT = "GIT_PREVIOUS_SUCCESSFUL_COMMIT";
+    public static final boolean DEFAULT_HIDE_EXCLUDED_COMMITS_IN_CHANGESET = Boolean
+            .getBoolean(GitSCM.class.getName() + "hideExcludedCommitsInChangeSet");
 
     /**
      * All the configured extensions attached to this.
@@ -339,6 +341,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     public boolean isCreateAccountBasedOnEmail() {
         DescriptorImpl gitDescriptor = getDescriptor();
         return (gitDescriptor != null && gitDescriptor.isCreateAccountBasedOnEmail());
+    }
+
+    public boolean isHideExcludedInChangeList() {
+        final DescriptorImpl gitDescriptor = getDescriptor();
+        return (gitDescriptor != null && gitDescriptor.isHideExcludedInChangeList());
     }
 
     public BuildChooser getBuildChooser() {
@@ -1221,6 +1228,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         private String globalConfigName;
         private String globalConfigEmail;
         private boolean createAccountBasedOnEmail;
+        private boolean hideExcludedInChangeList = DEFAULT_HIDE_EXCLUDED_COMMITS_IN_CHANGESET;
+
 //        private GitClientType defaultClientType = GitClientType.GITCLI;
 
         public DescriptorImpl() {
@@ -1299,6 +1308,19 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         public void setCreateAccountBasedOnEmail(boolean createAccountBasedOnEmail) {
             this.createAccountBasedOnEmail = createAccountBasedOnEmail;
+        }
+
+        public void setHideExcludedInChangeList(boolean hideExcludedInChangeList) {
+            this.hideExcludedInChangeList = hideExcludedInChangeList;
+        }
+
+        /**
+         * Returns whether to exclude changes excluded from polling from
+         * external plugins
+         * @return <code>true</code> to exclude excluded changes
+         */
+        public boolean isHideExcludedInChangeList() {
+            return hideExcludedInChangeList;
         }
 
         /**

--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -11,6 +11,9 @@
     <f:entry title="Create new accounts base on author/committer's email" field="createAccountBasedOnEmail">
            <f:checkbox name="createAccountBasedOnEmail" checked="${descriptor.createAccountBasedOnEmail}"/>
     </f:entry>
+    <f:entry title="Hide changes, exluded from polling to other plugins" field="hideExcludedInChangeList">
+           <f:checkbox name="hideExcludedInChangeList" checked="${descriptor.hideExcludedInChangeList}"/>
+    </f:entry>
     <!--
     <f:entry title="Default git client implementation" field="defaultClientType">
         <select>

--- a/src/main/resources/hudson/plugins/git/GitSCM/project-changes.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/project-changes.jelly
@@ -48,7 +48,7 @@ THE SOFTWARE.
             (<i:formatDate value="${b.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)</a></h2>
 
           <ol>
-            <j:forEach var="c" items="${changeSet.iterator()}">
+            <j:forEach var="c" items="${changeSet.logs}">
               <li>
                 <j:out value="${c.msgAnnotated}"/>
 

--- a/src/test/java/hudson/plugins/git/GitChangeSetExlusionsTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetExlusionsTest.java
@@ -1,0 +1,118 @@
+package hudson.plugins.git;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.Result;
+import hudson.model.FreeStyleProject;
+import hudson.model.User;
+
+import java.util.Set;
+
+import org.eclipse.jgit.lib.PersonIdent;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+
+/**
+ * Unit test for change sets with various exclusions.
+ * @author Pavel Baranchikov
+ */
+public class GitChangeSetExlusionsTest extends AbstractGitTestCase {
+
+    private static final String EXCL_FILE_PREFIX = "excludedFile";
+    private static final String NON_EXCL_FILE_PREFIX = "neededFile";
+    private int counter = 0;
+    private FreeStyleProject project;
+    private GitSCM gitScm;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        project = setupProject("master", false, null, "ex.*", null, null);
+        gitScm = (GitSCM) project.getScm();
+        commitNonExcluded(johnDoe);
+        build(project, Result.SUCCESS);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        // Clean up to avoid collisions
+        project = null;
+    }
+
+    private void commit(PersonIdent committer, String prefix) throws Exception {
+        final String commitFile = prefix + counter++;
+        commit(commitFile, committer, "Commited file " + commitFile);
+    }
+
+    private void commitExcluded(PersonIdent committer) throws Exception {
+        commit(committer, EXCL_FILE_PREFIX);
+    }
+
+    private void commitNonExcluded(PersonIdent committer) throws Exception {
+        commit(committer, NON_EXCL_FILE_PREFIX);
+    }
+
+    private void testCulprits(PersonIdent... expectedCulprits) throws Exception {
+        final FreeStyleBuild build = build(project, Result.SUCCESS);
+        final Set<String> expected = Sets.newHashSet();
+        for (PersonIdent culprit : expectedCulprits) {
+            expected.add(culprit.getName());
+        }
+        final Set<String> actual = Sets.newHashSet();
+        for (User user : build.getCulprits()) {
+            actual.add(user.getFullName());
+        }
+        Assert.assertEquals("Expected culprits differ from actual", expected, actual);
+    }
+
+    @Test
+    public void testAllExcluded() throws Exception {
+        gitScm.getDescriptor().setHideExcludedInChangeList(true);
+        commitExcluded(johnDoe);
+        commitExcluded(janeDoe);
+        testCulprits();
+    }
+
+    @Test
+    public void testFirstExcluded() throws Exception {
+        gitScm.getDescriptor().setHideExcludedInChangeList(true);
+        commitExcluded(johnDoe);
+        commitNonExcluded(janeDoe);
+        testCulprits(janeDoe);
+    }
+
+    @Test
+    public void testSecondExcluded() throws Exception {
+        gitScm.getDescriptor().setHideExcludedInChangeList(true);
+        commitNonExcluded(johnDoe);
+        commitExcluded(janeDoe);
+        testCulprits(johnDoe);
+    }
+
+    @Test
+    public void testNoneExcluded() throws Exception {
+        gitScm.getDescriptor().setHideExcludedInChangeList(true);
+        commitNonExcluded(johnDoe);
+        commitNonExcluded(janeDoe);
+        testCulprits(johnDoe, janeDoe);
+    }
+
+    @Test
+    public void testAllExcludedNoHide() throws Exception {
+        gitScm.getDescriptor().setHideExcludedInChangeList(false);
+        commitExcluded(johnDoe);
+        commitExcluded(janeDoe);
+        testCulprits(johnDoe, janeDoe);
+    }
+
+    @Test
+    public void testNoneExcludedNoHide() throws Exception {
+        gitScm.getDescriptor().setHideExcludedInChangeList(false);
+        commitNonExcluded(johnDoe);
+        commitNonExcluded(janeDoe);
+        testCulprits(johnDoe, janeDoe);
+    }
+
+}


### PR DESCRIPTION
When exclusions (path, commit authors or commit messages) are used in the project, it should be convinient to hide excluded changes from other parts of build system:
- Jira plugin should not update issues, which commits do not affect the build
- Jenkins should not send email notifications on failed builds of authors of excluded plugins.

For backward compatibility option, the global configuration parameter added to hide excluded changes from external plugins (default state for parameter is off).
