### PR TITLE
Unhardcoded src branch for branch push + Fix build/publisher status

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -186,7 +186,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
         SCM scm = build.getProject().getScm();
 
         if (!(scm instanceof GitSCM)) {
-            return false;
+            return true; // just skip this publisher
         }
 
         final GitSCM gitSCM = (GitSCM) scm;
@@ -246,11 +246,9 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         //git.push(null);
                     }
                 } catch (FormException e) {
-                    e.printStackTrace(listener.error("Failed to push merge to origin repository"));
-                    return false;
+                    throw new AbortException("Failed to push merge to origin repository.\n" + e.getMessage());
                 } catch (GitException e) {
-                    e.printStackTrace(listener.error("Failed to push merge to origin repository"));
-                    return false;
+                    throw new AbortException("Failed to push merge to origin repository\n" + e.getMessage());
                 }
             }
 
@@ -298,8 +296,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         }
                         push.execute();
                     } catch (GitException e) {
-                        e.printStackTrace(listener.error("Failed to push tag " + tagName + " to " + targetRepo));
-                        return false;
+                        throw new AbortException("Failed to push tag " + tagName + " to " + targetRepo + "\n" + e.getMessage());
                     }
                 }
             }
@@ -334,9 +331,8 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         }
                         push.execute();
                     } catch (GitException e) {
-                        e.printStackTrace(listener.error("Failed to push " + srcBranchName + " to " + branchName
-                                + " to " + targetRepo));
-                        return false;
+                        throw new AbortException("Failed to push " + srcBranchName + " to " + branchName
+                                                 + " to " + targetRepo + "\n" + e.getMessage());
                     }
                 }
             }
@@ -357,8 +353,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         RemoteConfig remote = gitSCM.getRepositoryByName(targetRepo);
 
                         if (remote == null) {
-                            listener.getLogger().println("No repository found for target repo name " + targetRepo);
-                            return false;
+                            throw new AbortException("No repository found for target repo name " + targetRepo);
                         }
 
                         listener.getLogger().println("Adding note to namespace \""+noteNamespace +"\":\n" + noteMsg + "\n******" );
@@ -375,8 +370,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         }
                         push.execute();
                     } catch (GitException e) {
-                        e.printStackTrace(listener.error("Failed to add note: \n" + noteMsg  + "\n******"));
-                        return false;
+                        throw new AbortException("Failed to add note: \n" + noteMsg  + "\n******\n" + e.getMessage());
                     }
                 }
             }

--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -34,6 +34,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.annotation.CheckForNull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.Serializable;
@@ -54,7 +55,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
     private boolean forcePush;
     
     private List<TagToPush> tagsToPush;
-    // Pushes HEAD to these locations
+    // Pushes defined src to dst
     private List<BranchToPush> branchesToPush;
     // notes support
     private List<NoteToPush> notesToPush;
@@ -305,12 +306,16 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
             
             if (isPushBranches()) {
                 for (final BranchToPush b : branchesToPush) {
+                    if (b.getSrcBranchName() == null)
+                        throw new AbortException("No src branch to push defined");
+
                     if (b.getBranchName() == null)
-                        throw new AbortException("No branch to push defined");
+                        throw new AbortException("No dst branch to push defined");
 
                     if (b.getTargetRepoName() == null)
-                        throw new AbortException("No branch repo to push to defined");
+                        throw new AbortException("No target repo to push defined");
 
+                    final String srcBranchName = environment.expand(b.getSrcBranchName());
                     final String branchName = environment.expand(b.getBranchName());
                     final String targetRepo = environment.expand(b.getTargetRepoName());
                     
@@ -320,16 +325,17 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         if (remote == null)
                             throw new AbortException("No repository found for target repo name " + targetRepo);
 
-                        listener.getLogger().println("Pushing HEAD to branch " + branchName + " at repo "
+                        listener.getLogger().println("Pushing " + srcBranchName + " to " + branchName + " at repo "
                                                      + targetRepo);
                         remoteURI = remote.getURIs().get(0);
-                        PushCommand push = git.push().to(remoteURI).ref("HEAD:" + branchName);
+                        PushCommand push = git.push().to(remoteURI).ref(srcBranchName + ":" + branchName);
                         if (forcePush) {
                           push.force();
                         }
                         push.execute();
                     } catch (GitException e) {
-                        e.printStackTrace(listener.error("Failed to push branch " + branchName + " to " + targetRepo));
+                        e.printStackTrace(listener.error("Failed to push " + srcBranchName + " to " + branchName
+                                + " to " + targetRepo));
                         return false;
                     }
                 }
@@ -393,6 +399,14 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
             if (tagsToPush == null) {
                 this.pushMerge = true;
             }
+            this.configVersion = 1L;
+        }
+
+        if (this.configVersion < 2L && isPushBranches()) {
+            for (BranchToPush branch : branchesToPush){
+                 branch.setSrcBranchName("HEAD");
+            }
+            this.configVersion = 2L;
         }
 
         return this;
@@ -476,7 +490,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
     }
 
     public static abstract class PushConfig extends AbstractDescribableImpl<PushConfig> implements Serializable {
-        private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 2L;
         
         private String targetRepoName;
 
@@ -484,6 +498,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
             this.targetRepoName = Util.fixEmptyAndTrim(targetRepoName);
         }
         
+        @CheckForNull
         public String getTargetRepoName() {
             return targetRepoName;
         }
@@ -500,16 +515,47 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
     }
 
     public static final class BranchToPush extends PushConfig {
-        private String branchName;
+        private String branchName;   // dstBranchName
+        private String srcBranchName;
 
+        @CheckForNull
         public String getBranchName() {
             return branchName;
         }
 
-        @DataBoundConstructor
+        /**
+         * @deprecated This method doesn't allow to set source branch for push. Use
+         * {@link hudson.plugins.git.GitPublisher.BranchToPush#BranchToPush(java.lang.String, java.lang.String, java.lang.String)}
+         */
+        @Deprecated
         public BranchToPush(String targetRepoName, String branchName) {
+            this(targetRepoName, "HEAD", branchName);
+        }
+
+        /**
+         *
+         * @param targetRepoName Repository name to push to
+         * @param srcBranchName Source branch for push
+         * @param branchName Destination branch for push
+         */
+        @DataBoundConstructor
+        public BranchToPush(String targetRepoName, String srcBranchName, String branchName) {
             super(targetRepoName);
+            this.srcBranchName = Util.fixEmptyAndTrim(srcBranchName);
             this.branchName = Util.fixEmptyAndTrim(branchName);
+        }
+
+        @CheckForNull
+        public String getSrcBranchName() {
+            return srcBranchName;
+        }
+
+        public void setSrcBranchName(String srcBranchName) {
+            this.srcBranchName = srcBranchName;
+        }
+
+        public void setBranchName(String branchName) {
+            this.branchName = branchName;
         }
 
         @Extension

--- a/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
@@ -70,8 +70,13 @@
                     add="${%Add Branch}">
         <table width="100%">
           <br/>
+          <f:entry field="srcBranchName"
+                   title="${%Source branch}">
+            <f:textbox checkUrl="'descriptorByName/GitPublisher/checkBranchName?value='+escape(this.value)"
+                       default="HEAD"/>
+          </f:entry>
           <f:entry field="branchName"
-                   title="${%Branch to push}">
+                   title="${%Destination branch}">
             <f:textbox checkUrl="'descriptorByName/GitPublisher/checkBranchName?value='+escape(this.value)" />
           </f:entry>
           <f:entry field="targetRepoName"

--- a/src/main/resources/hudson/plugins/git/GitPublisher/help-branchesToPush.html
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/help-branchesToPush.html
@@ -1,5 +1,5 @@
 <div>
-  Specify remote branches to push the current HEAD to, as of the completion of the build.<br/>
+  Specify branches to push from "src" to "dst" branch, as of the completion of the build.<br/>
   The branch name above is the name of the remote branch.<br/>
   Environment variables may be used in the branch name - they will be replaced at build time.<br/>
   The repository name needs to be one of the repositories configured in the SCM section above.

--- a/src/test/java/hudson/plugins/git/GitPublisherTest.java
+++ b/src/test/java/hudson/plugins/git/GitPublisherTest.java
@@ -116,7 +116,7 @@ public class GitPublisherTest extends AbstractGitTestCase {
 
         project.getPublishersList().add(new GitPublisher(
                 Collections.<TagToPush>emptyList(),
-                Collections.singletonList(new BranchToPush("origin", "integration")),
+                Collections.singletonList(new BranchToPush("origin", "HEAD", "integration")),
                 Collections.<NoteToPush>emptyList(),
                 true, true, false));
 
@@ -150,7 +150,7 @@ public class GitPublisherTest extends AbstractGitTestCase {
 
         project.getPublishersList().add(new GitPublisher(
                 Collections.<TagToPush>emptyList(),
-                Collections.singletonList(new BranchToPush("origin", "otherbranch")),
+                Collections.singletonList(new BranchToPush("origin", "HEAD", "otherbranch")),
                 Collections.<NoteToPush>emptyList(),
                 true, true, true));
 
@@ -189,7 +189,7 @@ public class GitPublisherTest extends AbstractGitTestCase {
 
       project.getPublishersList().add(new GitPublisher(
           Collections.<TagToPush>emptyList(),
-          Collections.singletonList(new BranchToPush("origin", "integration")),
+          Collections.singletonList(new BranchToPush("origin", "HEAD", "integration")),
           Collections.<NoteToPush>emptyList(),
           true, true, false));
 
@@ -259,7 +259,7 @@ public class GitPublisherTest extends AbstractGitTestCase {
         String noteValue = "note for " + envValue;
         GitPublisher publisher = new GitPublisher(
                 Collections.singletonList(new TagToPush("origin", tagNameReference, tagMessageReference, false, true)),
-                Collections.singletonList(new BranchToPush("origin", envReference)),
+                Collections.singletonList(new BranchToPush("origin", "HEAD", envReference)),
                 Collections.singletonList(new NoteToPush("origin", noteReference, Constants.R_NOTES_COMMITS, false)),
                 true, true, true);
         assertTrue(publisher.isForcePush());


### PR DESCRIPTION
- The main idea is provide ability to define user what and where push
- Fix for build/publisher statuses to now work with return boolean that causes issues for other publishers.
Should also exclude stacktrace and provide real error in job output.