### PR TITLE
New repository browser for TFS2013

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
@@ -1,0 +1,144 @@
+package hudson.plugins.git.browser;
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
+import hudson.model.Hudson;
+import hudson.plugins.git.GitChangeSet;
+import hudson.plugins.git.GitSCM;
+import hudson.scm.RepositoryBrowser;
+import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.regex.Pattern;
+
+/**
+ * Browser for TFS 2013
+ */
+public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
+
+    @DataBoundConstructor
+    public TFS2013GitRepositoryBrowser(String repoUrl) {
+        super(repoUrl);
+    }
+
+    @Override
+    public URL getDiffLink(GitChangeSet.Path path) throws IOException {
+        String spec = String.format("commit/%s#path=%s&_a=compare", path.getChangeSet().getId(), path.getPath());
+        return new URL(getRepoUrl(path.getChangeSet()), spec);
+    }
+
+    @Override
+    public URL getFileLink(GitChangeSet.Path path) throws IOException {
+        String spec = String.format("commit/%s#path=%s&_a=history", path.getChangeSet().getId(), path.getPath());
+        return new URL(getRepoUrl(path.getChangeSet()), spec);
+    }
+
+    @Override
+    public URL getChangeSetLink(GitChangeSet gitChangeSet) throws IOException {
+        return new URL(getRepoUrl(gitChangeSet), "commit/" + gitChangeSet.getId());
+    }
+
+    /*default*/ URL getRepoUrl(GitChangeSet changeSet) throws IOException { // default visibility for tests
+        String result = getRepoUrl();
+        
+        if (StringUtils.isBlank(result))
+            return normalizeToEndWithSlash(getUrlFromFirstConfiguredRepository(changeSet));
+
+        else if (!result.contains("/"))
+            return normalizeToEndWithSlash(getResultFromNamedRepository(changeSet));
+
+        return getUrl();
+    }
+
+    private URL getResultFromNamedRepository(GitChangeSet changeSet) throws MalformedURLException {
+        GitSCM scm = getScmFromProject(changeSet);
+        return new URL(scm.getRepositoryByName(getRepoUrl()).getURIs().get(0).toString());
+    }
+
+    private URL getUrlFromFirstConfiguredRepository(GitChangeSet changeSet) throws MalformedURLException {
+        GitSCM scm = getScmFromProject(changeSet);
+        return new URL(scm.getRepositories().get(0).getURIs().get(0).toString());
+    }
+
+    private GitSCM getScmFromProject(GitChangeSet changeSet) {
+        AbstractProject<?,?> build = (AbstractProject<?, ?>) changeSet.getParent().getRun().getParent();
+
+        return (GitSCM) build.getScm();
+    }
+
+    @Extension
+    public static class TFS2013GitRepositoryBrowserDescriptor extends Descriptor<RepositoryBrowser<?>> {
+
+        public String getDisplayName() {
+            return "Microsoft TFS 2013";
+        }
+
+        @Override
+        public TFS2013GitRepositoryBrowser newInstance(StaplerRequest req, JSONObject jsonObject) throws FormException {
+            try {
+                JSONObject form = req.getSubmittedForm();
+            } catch (ServletException e) {
+                e.printStackTrace();
+            }
+            return req.bindJSON(TFS2013GitRepositoryBrowser.class, jsonObject);
+        }
+
+        /**
+         * Performs on-the-fly validation of the URL.
+         */
+        public FormValidation doCheckRepoUrl(@QueryParameter(fixEmpty = true) String value, @AncestorInPath AbstractProject project) throws IOException,
+                ServletException {
+            
+            if (value == null) // nothing entered yet
+                value = "origin";
+
+            if (!value.contains("/")) {
+                GitSCM scm = (GitSCM) project.getScm();
+                RemoteConfig remote = scm.getRepositoryByName(value);
+                if (remote == null)
+                    return FormValidation.errorWithMarkup("There is no remote with the name <tt>" + value + "</tt>");
+                
+                value = remote.getURIs().get(0).toString();
+            }
+            
+            if (!value.endsWith("/"))
+                value += '/';
+            if (!URL_PATTERN.matcher(value).matches())
+                return FormValidation.errorWithMarkup("The URL should end like <tt>.../_git/foobar/</tt>");
+
+            // Connect to URL and check content only if we have admin permission
+            if (!Jenkins.getInstance().hasPermission(Hudson.ADMINISTER))
+                return FormValidation.ok();
+
+            final String finalValue = value;
+            return new FormValidation.URLCheck() {
+                @Override
+                protected FormValidation check() throws IOException, ServletException {
+                    try {
+                        if (findText(open(new URL(finalValue)), "Team Foundation Server 2013")) {
+                            return FormValidation.ok();
+                        } else {
+                            return FormValidation.error("This is a valid URL but it doesn't look like Microsoft TFS 2013");
+                        }
+                    } catch (IOException e) {
+                        return handleIOException(finalValue, e);
+                    }
+                }
+            }.check();
+        }
+
+        private static final Pattern URL_PATTERN = Pattern.compile(".+/_git/[^/]+/");
+    }
+}

--- a/src/main/resources/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser/config.jelly
+++ b/src/main/resources/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry field="repoUrl" title="URL or Name">
+    <f:textbox/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser/help-repoUrl.html
+++ b/src/main/resources/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser/help-repoUrl.html
@@ -1,0 +1,6 @@
+<div>
+    Either the name of the remote whose URL should be used, or the URL of this
+    module in TFS (such as http://fisheye6.cenqua.com/tfs/myproject/_git/myrepo/). 
+    If empty (default), the URL of the "origin" repository is used.
+    <p>If TFS is also used as the repository server, this can usually be left blank.</p>
+</div>

--- a/src/test/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowserTest.java
+++ b/src/test/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowserTest.java
@@ -1,0 +1,106 @@
+package hudson.plugins.git.browser;
+
+import hudson.model.*;
+import hudson.plugins.git.*;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.impl.DisableRemotePoll;
+import hudson.plugins.git.extensions.impl.EnforceGitClient;
+import hudson.scm.ChangeLogSet;
+import hudson.scm.EditType;
+import hudson.triggers.SCMTrigger;
+import org.hamcrest.CoreMatchers;
+import org.jenkinsci.plugins.gitclient.JGitTool;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.HudsonTestCase;
+import org.mockito.Mockito;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TFS2013GitRepositoryBrowserTest {
+
+    private static final String projectName = "fisheyeProjectName";
+
+    private final String repoUrl;
+    private final GitChangeSetSample sample;
+
+    public TFS2013GitRepositoryBrowserTest() {
+        this.repoUrl = "http://tfs/tfs/project/_git/repo";
+        sample = new GitChangeSetSample(false);
+
+        GitSCM scm = new GitSCM(
+                Collections.singletonList(new UserRemoteConfig(repoUrl, null, null, null)),
+                new ArrayList<BranchSpec>(),
+                false, Collections.<SubmoduleConfig>emptyList(),
+                null, JGitTool.MAGIC_EXENAME,
+                Collections.<GitSCMExtension>emptyList());
+        
+        AbstractProject project = mock(AbstractProject.class);
+        AbstractBuild build = mock(AbstractBuild.class);
+        
+        when(project.getScm()).thenReturn(scm);
+        when(build.getProject()).thenReturn(project);
+
+        sample.changeSet.setParent(ChangeLogSet.createEmpty((Run) build));
+    }
+
+    @Test
+    public void testResolveURLFromSCM() throws Exception {
+        TFS2013GitRepositoryBrowser browser = new TFS2013GitRepositoryBrowser("");
+        assertThat(browser.getRepoUrl(sample.changeSet).toString(), is("http://tfs/tfs/project/_git/repo/"));
+    }
+
+    @Test
+    public void testResolveURLFromConfig() throws Exception {
+        TFS2013GitRepositoryBrowser browser = new TFS2013GitRepositoryBrowser("http://url/repo");
+        assertThat(browser.getRepoUrl(sample.changeSet).toString(), is("http://url/repo/"));
+    }
+
+    @Test
+    public void testResolveURLFromConfigWithTrailingSlash() throws Exception {
+        TFS2013GitRepositoryBrowser browser = new TFS2013GitRepositoryBrowser("http://url/repo/");
+        assertThat(browser.getRepoUrl(sample.changeSet).toString(), is("http://url/repo/"));
+    }
+
+    @Test
+    public void testGetChangeSetLink() throws Exception {
+        URL result = new TFS2013GitRepositoryBrowser(repoUrl).getChangeSetLink(sample.changeSet);
+        assertThat(result.toString(), is("http://tfs/tfs/project/_git/repo/commit/" + sample.id));
+    }
+
+    @Test
+    public void testGetDiffLink() throws Exception {
+        TFS2013GitRepositoryBrowser browser = new TFS2013GitRepositoryBrowser(repoUrl);
+        for (GitChangeSet.Path path : sample.changeSet.getPaths()) {
+            URL diffLink = browser.getDiffLink(path);
+            EditType editType = path.getEditType();
+            URL expectedDiffLink = new URL("http://tfs/tfs/project/_git/repo/commit/" + sample.id + "#path=" + path.getPath() + "&_a=compare");
+            String msg = "Wrong link for path: " + path.getPath() + ", edit type: " + editType.getName();
+            assertEquals(msg, expectedDiffLink, diffLink);
+        }
+    }
+
+    @Test
+    public void testGetFileLink() throws Exception {
+        TFS2013GitRepositoryBrowser browser = new TFS2013GitRepositoryBrowser(repoUrl);
+        for (GitChangeSet.Path path : sample.changeSet.getPaths()) {
+            URL fileLink = browser.getFileLink(path);
+            EditType editType = path.getEditType();
+            URL expectedFileLink = new URL("http://tfs/tfs/project/_git/repo/commit/" + sample.id + "#path=" + path.getPath() + "&_a=history");
+            String msg = "Wrong link for path: " + path.getPath() + ", edit type: " + editType.getName();
+            assertEquals(msg, expectedFileLink, fileLink);
+        }
+    }
+}


### PR DESCRIPTION
This pull requests includes a repository browser for Microsoft TFS 2013 (might work with older versions). If the browser is not configured (no URL), it will take the url of the repository with the name "origin". Otherwise, configuration can either be an URL or the name of a configured repository of the project.