### PR TITLE
MessageExclusion improvements

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
@@ -18,36 +18,55 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 /**
- * {@link GitSCMExtension} that ignores commits with specific messages.
+ * {@link GitSCMExtension} that ignores commits with specific messages or only includes commits with a message.
+ * Note that the class should be more aptly named "MessageInclusionExclusion" but this would break backward compatibility.
  *
  * @author Kanstantsin Shautsou
  */
 public class MessageExclusion extends GitSCMExtension {
 	/**
-	 * Java Pattern for matching messages to be ignored.
+	 * Java Pattern for matching messages to be ignored or needed.
 	 */
 	private String excludedMessage;
 
 	private transient volatile Pattern excludedPattern;
+    
+    private boolean includeInsteadOfExclude = false;
+    
+    private boolean partialMatch = false;
 
 	@DataBoundConstructor
-	public MessageExclusion(String excludedMessage) { this.excludedMessage = excludedMessage; }
+	public MessageExclusion(String excludedMessage, boolean includeInsteadOfExclude, boolean partialMatch) {
+        this.excludedMessage = excludedMessage;
+        this.includeInsteadOfExclude = includeInsteadOfExclude;
+        this.partialMatch = partialMatch;
+    }
 
 	@Override
 	public boolean requiresWorkspaceForPolling() { return true; }
 
 	public String getExcludedMessage() { return excludedMessage; }
 
+    public boolean isIncludeInsteadOfExclude() { return includeInsteadOfExclude; }
+    
+    public boolean isPartialMatch() { return partialMatch; }
+    
 	@Override
 	public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener, BuildData buildData) throws IOException, InterruptedException, GitException {
 		if (excludedPattern == null){
 			excludedPattern = Pattern.compile(excludedMessage);
 		}
 		String msg = commit.getComment();
-		if (excludedPattern.matcher(msg).matches()){
+        
+        boolean matched = isPartialMatch() ? excludedPattern.matcher(msg).find() : excludedPattern.matcher(msg).matches();
+
+        if (!includeInsteadOfExclude && matched){
 			listener.getLogger().println("Ignored commit " + commit.getId() + ": Found excluded message: " + msg);
 			return true;
-		}
+		} else if (includeInsteadOfExclude && !matched) {
+            listener.getLogger().println("Ignored commit " + commit.getId() + ": Message pattern not found: " + msg);
+            return true;
+        }
 
 		return null;
 	}
@@ -64,9 +83,30 @@ public class MessageExclusion extends GitSCMExtension {
 			return FormValidation.ok();
 		}
 
+        public FormValidation doMatchMessage(
+                @QueryParameter String excludedMessage,
+                @QueryParameter boolean includeInsteadOfExclude,
+                @QueryParameter boolean partialMatch,
+                @QueryParameter String testMessage) {
+            Pattern pattern = null;
+            
+            try {
+                pattern = Pattern.compile(excludedMessage);
+            } catch (PatternSyntaxException ex){
+                return FormValidation.error(ex.getMessage());
+            }
+            
+            boolean matches = partialMatch ? pattern.matcher(testMessage).find() : pattern.matcher(testMessage).matches();
+            
+            String matchMessage = matches ? "Pattern matches, " : "Pattern does not match, ";
+            String consider = includeInsteadOfExclude ^ matches ? "commit <b>would not</b> considered." : "commit <b>would</b> considered.";
+            
+            return FormValidation.okWithMarkup(matchMessage + consider);
+        }
+        
 		@Override
 		public String getDisplayName() {
-			return "Polling ignores commits with certain messages";
+			return "Polling acts only on commits with/without certain messages";
 		}
 	}
 }

--- a/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/config.groovy
@@ -5,13 +5,13 @@ def f = namespace(lib.FormTagLib);
 f.entry(title:_("Excluded Messages"), field:"excludedMessage") {
     f.textbox()
 }
-f.entry(title:_("Partial Matches"), field:"partialMatch") {
-    f.checkbox()
-}
-f.entry(title:_("Exclude <i>not</i> matching messages"), field:"includeInsteadOfExclude") {
-    f.checkbox()
-}
-f.advanced(title: 'Test') {
+f.advanced {
+    f.entry(title:_("Partial Matches"), field:"partialMatch") {
+        f.checkbox()
+    }
+    f.entry(title:_("Exclude <i>not</i> matching messages"), field:"includeInsteadOfExclude") {
+        f.checkbox()
+    }
     f.entry(title: 'Commit message to test', field: 'testMessage') {
         f.textarea(name: 'testMessage')
     }

--- a/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/config.groovy
@@ -5,3 +5,19 @@ def f = namespace(lib.FormTagLib);
 f.entry(title:_("Excluded Messages"), field:"excludedMessage") {
     f.textbox()
 }
+f.entry(title:_("Partial Matches"), field:"partialMatch") {
+    f.checkbox()
+}
+f.entry(title:_("Exclude <i>not</i> matching messages"), field:"includeInsteadOfExclude") {
+    f.checkbox()
+}
+f.advanced(title: 'Test') {
+    f.entry(title: 'Commit message to test', field: 'testMessage') {
+        f.textarea(name: 'testMessage')
+    }
+    f.validateButton(
+            title: 'Test Regexp', 
+            progress: 'Matching', 
+            method: 'matchMessage', 
+            with: 'excludedMessage,includeInsteadOfExclude,partialMatch,testMessage')
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/help-includeInsteadOfExclude.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/help-includeInsteadOfExclude.html
@@ -1,0 +1,3 @@
+<div>
+    If checked, the logic is inversed. Now, Jenkins will only consider changes <i>matching</i> the pattern instead.
+</div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/help-partialMatch.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/help-partialMatch.html
@@ -1,0 +1,4 @@
+<div>
+    If checked, partial matches are sufficient, i.e. if the given regexp is found anywhere in the commit message, it
+    will be considered a match. If unchecked, the whole commit message must match the regexp.
+</div>

--- a/src/test/java/hudson/plugins/git/extensions/impl/MessageExclusionSimpleTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/MessageExclusionSimpleTest.java
@@ -1,0 +1,31 @@
+package hudson.plugins.git.extensions.impl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Basic unit tests for MessageExclusion
+ */
+public class MessageExclusionSimpleTest {
+
+    MessageExclusion.DescriptorImpl descriptor = new MessageExclusion.DescriptorImpl();
+
+    @Test
+    public void testDoMatchMessage() throws Exception {
+        
+        assertMessageIsNotConsidered("TOKEN", false, true, "Commit Message with TOKEN"); // partial match of TOKEN
+        assertMessageIsConsidered("TOKEN", false, false, "Commit Message with TOKEN"); // global (legacy match)
+        assertMessageIsNotConsidered("TOKEN", true, false, "Commit Message with TOKEN"); // global, inverted match
+        assertMessageIsConsidered(".*TOKEN.*", true, false, "Commit Message with TOKEN"); // global, inverted match
+    }
+    
+    private void assertMessageIsConsidered(String pattern, boolean includeInsteadOfExclude, boolean partialMatch, String message) {
+        assertTrue("Message should be considered by polling", descriptor.doMatchMessage(pattern, includeInsteadOfExclude, partialMatch, message).getMessage().contains("<b>would</b>"));
+    }
+
+    private void assertMessageIsNotConsidered(String pattern, boolean includeInsteadOfExclude, boolean partialMatch, String message) {
+        assertTrue("Message should not be considered by polling", descriptor.doMatchMessage(pattern, includeInsteadOfExclude, partialMatch, message).getMessage().contains("<b>would not</b>"));
+    }
+}

--- a/src/test/java/hudson/plugins/git/extensions/impl/MessageExclusionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/MessageExclusionTest.java
@@ -17,25 +17,27 @@ import static org.junit.Assert.assertTrue;
 public class MessageExclusionTest extends GitSCMExtensionTest {
 	protected FreeStyleProject project;
 	protected TestGitRepo repo;
-
+    private boolean includeInsteadOfExclude;
+    private boolean partialMatch;
+    private String messagePattern = "(?s).*\\[maven-release-plugin\\].*";
+    
+    
 	@Override
 	protected GitSCMExtension getExtension() {
-		return new MessageExclusion("(?s).*\\[maven-release-plugin\\].*");
+		return new MessageExclusion(messagePattern, includeInsteadOfExclude, partialMatch);
 	}
 
 	@Override
 	public void before() throws Exception {
-		repo = new TestGitRepo("repo", tmp.newFolder(), listener);
-		project = setupBasicProject(repo);
+        repo = new TestGitRepo("repo", tmp.newFolder(), listener);
 	}
 
 	@Test
-	public void test() throws Exception {
+	public void testLegacyExclusion() throws Exception {
+        project = setupBasicProject(repo);
+
 		repo.commit("repo-init", repo.johnDoe, "repo0 initial commit");
-
-		assertTrue("scm polling should detect a change after initial commit", project.poll(listener).hasChanges());
-
-		build(project, Result.SUCCESS);
+        build(project, Result.SUCCESS); // first build is always included
 
 		assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
 
@@ -53,4 +55,41 @@ public class MessageExclusionTest extends GitSCMExtensionTest {
 
 		assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
 	}
+
+    @Test
+    public void testPartialMatches() throws Exception {
+        partialMatch = true;
+        messagePattern = "TOKEN";
+        project = setupBasicProject(repo);
+
+        repo.commit("repo-init", repo.johnDoe, "repo0 initial commit");
+        build(project, Result.SUCCESS); // first build is always included
+
+        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+
+        repo.commit("repo-init", repo.janeDoe, " TOKEN excluded message commit");
+
+        assertFalse("scm polling should not detect excluded message", project.poll(listener).hasChanges());
+
+        repo.commit("repo-init", repo.janeDoe, "first line in excluded commit\nsecond\nthird TOKEN\n");
+
+        assertFalse("scm polling should not detect multiline message", project.poll(listener).hasChanges());
+    }
+
+    @Test
+    public void testLegacyExclusionWithInvert() throws Exception {
+        includeInsteadOfExclude = true;
+        project = setupBasicProject(repo);
+
+        repo.commit("repo-init", repo.johnDoe, "repo0 initial commit");
+        build(project, Result.SUCCESS); // first build is never excluded
+
+        repo.commit("repo-init", repo.janeDoe, " [maven-release-plugin] excluded message commit");
+
+        assertTrue("scm polling should detect excluded message", project.poll(listener).hasChanges());
+
+        repo.commit("repo-init", repo.janeDoe, "first line in excluded commit\nsecond\nthird [maven-release-plugin]\n");
+
+        assertTrue("scm polling should detect multiline message", project.poll(listener).hasChanges());
+    }
 }


### PR DESCRIPTION
- MessageExclusion can now optionally work inversed, i.e. only act on messages _matching_ the pattern
- Added a partial matches flag the searches for the occurance of the regexp somewhere inside the commit message (which is more convenient for multiline matching)
- Included a test in the config form, allowing to conveniently test the form against a pasted commit message
