### PR TITLE
[JENKINS-26842] Pass all regexp branch specs to DefaultBuildChooser.getAdvancedCandidateRevisions

### DIFF
--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -49,7 +49,7 @@ public class DefaultBuildChooser extends BuildChooser {
 
         // if the branch name contains more wildcards then the simple usecase
         // does not apply and we need to skip to the advanced usecase
-        if (branchSpec == null || branchSpec.contains("*"))
+        if (isAdvancedSpec(branchSpec))
             return getAdvancedCandidateRevisions(isPollCall,listener,new GitUtils(listener,git),data, context);
 
         // check if we're trying to build a specific commit
@@ -306,5 +306,18 @@ public class DefaultBuildChooser extends BuildChooser {
         public String getLegacyId() {
             return "Default";
         }
+    }
+
+    /**
+     * Helper to determine if the branchSpec requires advanced matching
+     *
+     * - if the branch name contains more wildcards then the simple usecase
+     * - if the branch name should be treated as regexp
+     * @param branchSpec
+     * @return
+     */
+    boolean isAdvancedSpec(String branchSpec) {
+        // null or wildcards or regexp
+        return (branchSpec == null || branchSpec.contains("*") || branchSpec.startsWith(":"));
     }
 }

--- a/src/test/java/hudson/plugins/git/TestBranchSpec.java
+++ b/src/test/java/hudson/plugins/git/TestBranchSpec.java
@@ -147,4 +147,13 @@ public class TestBranchSpec extends TestCase {
     	assertFalse(m.matches("origin/prefix"));
     	assertFalse(m.matches("origin/prefix-abc"));
     }
+
+    public void testUsesJavaPatternWithRepetition() {
+    	// match pattern from JENKINS-26842
+    	BranchSpec m = new BranchSpec(":origin/release-\\d{8}");
+    	assertTrue(m.matches("origin/release-20150101"));
+    	assertFalse(m.matches("origin/release-2015010"));
+    	assertFalse(m.matches("origin/release-201501011"));
+    	assertFalse(m.matches("origin/release-20150101-something"));
+    }
 }

--- a/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
@@ -27,4 +27,18 @@ public class DefaultBuildChooserTest extends AbstractGitTestCase {
         candidateRevisions = buildChooser.getCandidateRevisions(false, "aaa" + shaHashCommit1.substring(3), git, null, null, null);
         assertTrue(candidateRevisions.isEmpty());
     }
+    /**
+     * RegExp patterns prefixed with : should pass through to DefaultBuildChooser.getAdvancedCandidateRevisions
+     * @throws Exception
+     */
+    public void testIsAdvancedSpec() throws Exception {
+        DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
+
+        assertFalse(buildChooser.isAdvancedSpec("origin/master"));
+        assertTrue(buildChooser.isAdvancedSpec("origin/master-*"));
+        assertTrue(buildChooser.isAdvancedSpec("origin**"));
+        // regexp use case
+        assertTrue(buildChooser.isAdvancedSpec(":origin/master"));
+        assertTrue(buildChooser.isAdvancedSpec(":origin/master-\\d{*}"));
+    }
 }


### PR DESCRIPTION
Make sure all regexp patterns trigger DefaultBuildChooser.getAdvancedCandidateRevisions

I moved the logic to determine advanced specs into a standalone method so it could be tested since I did not see any other test covering the internal `DefaultBuildChooser.getCandidateRevisions` -> `getAdvancedCandidateRevisions` logic