### PR TITLE
Fix NPE when the branch can't be found.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1167,7 +1167,13 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     
     private String getBranchName(Branch branch)
     {
+        if (branch == null) {
+            return "";
+        }
         String name = branch.getName();
+        if (name == null) {
+            return "";
+        }
         if(name.startsWith("refs/remotes/")) {
             //Restore expected previous behaviour
             name = name.substring("refs/remotes/".length());


### PR DESCRIPTION
With Gerrit Trigger plugin (and strategy), I got exception below.

* refspec set to: $GERRIT_REFSPEC or blank or refs/heads/master (it doesn't
  matter)
* The repo has no other branch than master
* Choosing strategy: "Gerrit Trigger"

FATAL: null
java.lang.NullPointerException
    at hudson.plugins.git.GitSCM.getBranchName(GitSCM.java:1174)
        at hudson.plugins.git.GitSCM.buildEnvVars(GitSCM.java:1138)
        at hudson.model.AbstractBuild.getEnvironment(AbstractBuild.java:922)
        at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1009)
        at hudson.scm.SCM.checkout(SCM.java:484)
        at hudson.model.AbstractProject.checkout(AbstractProject.java:1270)
        at hudson.model.AbstractBuild$AbstractBuildExecution.defaultCheckout(AbstractBuild.java:609)
        at jenkins.scm.SCMCheckoutStrategy.checkout(SCMCheckoutStrategy.java:86)
        at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:531)
        at hudson.model.Run.execute(Run.java:1750)
        at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
        at hudson.model.ResourceController.execute(ResourceController.java:89)
        at hudson.model.Executor.run(Executor.java:240)