### PR TITLE
[JENKINS-27315] Add environment variable for git commit author email

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
@@ -85,7 +85,8 @@ public class PreBuildMerge extends GitSCMExtension {
             // record the fact that we've tried building 'rev' and it failed, or else
             // BuildChooser in future builds will pick up this same 'rev' again and we'll see the exact same merge failure
             // all over again.
-            scm.getBuildData(build).saveBuild(new Build(marked,rev, build.getNumber(), FAILURE));
+            String revAuthor = scm.getCommitAuthorEmailAddress(git, rev);
+            scm.getBuildData(build).saveBuild(new Build(marked, rev, revAuthor, build.getNumber(), FAILURE));
             throw new AbortException("Branch not suitable for integration as it does not merge cleanly: " + ex.getMessage());
         }
 

--- a/src/main/java/hudson/plugins/git/util/Build.java
+++ b/src/main/java/hudson/plugins/git/util/Build.java
@@ -47,20 +47,23 @@ public class Build implements Serializable, Cloneable {
      */
     public Revision revision;
 
+    public String revisionAuthor;
+
     public int      hudsonBuildNumber;
     public Result   hudsonBuildResult;
 
     // TODO: We don't currently store the result correctly.
 
-    public Build(Revision marked, Revision revision, int buildNumber, Result result) {
+    public Build(Revision marked, Revision revision, String revisionAuthor, int buildNumber, Result result) {
         this.marked = marked;
         this.revision = revision;
+        this.revisionAuthor = revisionAuthor;
         this.hudsonBuildNumber = buildNumber;
         this.hudsonBuildResult = result;
     }
 
-    public Build(Revision revision, int buildNumber, Result result) {
-        this(revision,revision,buildNumber,result);
+    public Build(Revision revision, String revisionAuthor, int buildNumber, Result result) {
+        this(revision,revision,revisionAuthor,buildNumber,result);
     }
 
     public ObjectId getSHA1() {

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -157,6 +157,16 @@ public class BuildData implements Action, Serializable, Cloneable {
         return lastBuild==null?null:lastBuild.revision;
     }
 
+    /**
+     * Gets revision author of the previous build.
+     * @return revision author of the last build.
+     *    May be null will be returned if nothing has been checked out (e.g. due to wrong repository or branch)
+     */
+    @Exported
+    public @CheckForNull String getLastBuiltRevisionAuthor() {
+        return lastBuild==null?null:lastBuild.revisionAuthor;
+    }
+
     @Exported
     public Map<String,Build> getBuildsByBranchName() {
         return buildsByBranchName;

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -562,7 +562,11 @@ public class GitSCMTest extends AbstractGitTestCase {
     }
 
     private String checkoutString(FreeStyleProject project, String envVar) {
-        return "checkout -f " + getEnvVars(project).get(envVar);
+        return "checkout -f " + getEnvVar(project, envVar);
+    }
+
+    private String getEnvVar(FreeStyleProject project, String envVar) {
+        return getEnvVars(project).get(envVar);
     }
 
     public void testEnvVarsAvailable() throws Exception {
@@ -576,6 +580,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertLogContains(getEnvVars(project).get(GitSCM.GIT_BRANCH), build1);
 
         assertLogContains(checkoutString(project, GitSCM.GIT_COMMIT), build1);
+        assertEquals("Git commit author mismatch", getEnvVar(project, GitSCM.GIT_COMMIT_AUTHOR_EMAIL), "john@doe.com");
 
         final String commitFile2 = "commitFile2";
         commit(commitFile2, johnDoe, "Commit number 2");


### PR DESCRIPTION
Surprised no one had added this before. If someone could show me an alternative
way  to get the commit's author's email, that would be great.
This checks the commit's text for the author line and parses out the email
address.
The environment variable is set as GIT_COMMIT_AUTHOR_EMAIL.
My team use this to email the person who comitted a piece of code at the end of
a  build.