### PR TITLE
[JENKINS-27351] A parametrized branchspec that resolves to empty should match everything

### DIFF
--- a/src/main/java/hudson/plugins/git/BranchSpec.java
+++ b/src/main/java/hudson/plugins/git/BranchSpec.java
@@ -100,7 +100,11 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
     }
 
     private String getExpandedName(EnvVars env) {
-        return env.expand(name);
+        String expandedName = env.expand(name);
+        if (expandedName.length() == 0) {
+            return "**";
+        }
+        return expandedName;
     }
     
     private Pattern getPattern(EnvVars env) {

--- a/src/test/java/hudson/plugins/git/TestBranchSpec.java
+++ b/src/test/java/hudson/plugins/git/TestBranchSpec.java
@@ -62,6 +62,7 @@ public class TestBranchSpec extends TestCase {
         envMap.put("mybranch", "my.branch");
         envMap.put("anyLong", "**");
         envMap.put("anyShort", "*");
+        envMap.put("anyEmpty", "");
         EnvVars env = new EnvVars(envMap);
 
         BranchSpec l = new BranchSpec("${master}");
@@ -103,6 +104,12 @@ public class TestBranchSpec extends TestCase {
 
         Assert.assertTrue(p.matches("origin/x", env));
         Assert.assertFalse(p.matches("origin/my-branch/b1", env));
+
+        BranchSpec q = new BranchSpec("${anyEmpty}");
+
+        Assert.assertTrue(q.matches("origin/my.branch/b1", env));
+        Assert.assertTrue(q.matches("origin/my-branch/b1", env));
+        Assert.assertTrue(q.matches("remote/origin/my.branch/b1", env));
     }
 
     public void testEmptyName() {


### PR DESCRIPTION
Split from [PR 293](https://github.com/jenkinsci/git-plugin/pull/293), where it was hidden in the middle of the code.