### PR TITLE
[JENKINS-27352] Fix commit notification for a parametrized branchspec

### DIFF
--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -127,6 +127,17 @@ public class GitStatusTest extends HudsonTestCase {
         Mockito.verify(bTopicTrigger, Mockito.never()).run();
     }
 
+    public void testDoNotifyCommitWithParametrizedBranch() throws Exception {
+        SCMTrigger aMasterTrigger = setupProject("a", "$BRANCH_TO_BUILD", false);
+        SCMTrigger bMasterTrigger = setupProject("b", "master", false);
+        SCMTrigger bTopicTrigger = setupProject("b", "topic", false);
+
+        this.gitStatus.doNotifyCommit("a", "master", null);
+        Mockito.verify(aMasterTrigger).run();
+        Mockito.verify(bMasterTrigger, Mockito.never()).run();
+        Mockito.verify(bTopicTrigger, Mockito.never()).run();
+    }
+
     public void testDoNotifyCommitWithIgnoredRepository() throws Exception {
         SCMTrigger aMasterTrigger = setupProject("a", "master", true);
 


### PR DESCRIPTION
(split from [PR 293](https://github.com/jenkinsci/git-plugin/pull/293), now with its very own bug in JIRA)

When the branchspec is parametrized, and a commit notification is received for
the tracked repository, the polling is now always triggered, even if a sha1 was
received.

Also, add some FINE logs to the notifyCommit code.