### PR TITLE
Fixed NPE during getting branch name

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1131,7 +1131,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         Revision rev = fixNull(getBuildData(build)).getLastBuiltRevision();
         if (rev!=null) {
             Branch branch = Iterables.getFirst(rev.getBranches(), null);
-            if (branch!=null) {
+            if (branch!=null && branch.getName()!=null) {
                 env.put(GIT_BRANCH, getBranchName(branch));
 
                 String prevCommit = getLastBuiltCommitOfBranch(build, branch);


### PR DESCRIPTION
An NPE is thrown if the previous build does not contain a branch name.

java.lang.NullPointerException
	at hudson.plugins.git.GitSCM.getBranchName(GitSCM.java:1174)
	at hudson.plugins.git.GitSCM.buildEnvVars(GitSCM.java:1138)
	at hudson.model.AbstractBuild.getEnvironment(AbstractBuild.java:922)
	at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1009)
	at hudson.scm.SCM.checkout(SCM.java:484)
	at hudson.model.AbstractProject.checkout(AbstractProject.java:1270)
	at hudson.model.AbstractBuild$AbstractBuildExecution.defaultCheckout(AbstractBuild.java:609)
	at jenkins.scm.SCMCheckoutStrategy.checkout(SCMCheckoutStrategy.java:86)