### PR TITLE
[JENKINS-19022] purge deleted branches from BuildData

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1033,7 +1033,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             throw new IOException("Could not checkout " + revToBuild.revision.getSha1String(), e);
         }
 
-        build.addAction(new GitTagAction(build, workspace, buildData));
+        build.addAction(new GitTagAction(build, workspace, revToBuild.revision));
 
         if (changelogFile != null) {
             computeChangeLog(git, revToBuild.revision, listener, previousBuildData, new FilePath(changelogFile),

--- a/src/main/java/hudson/plugins/git/GitTagAction.java
+++ b/src/main/java/hudson/plugins/git/GitTagAction.java
@@ -37,10 +37,10 @@ public class GitTagAction extends AbstractScmTagAction implements Describable<Gi
 
     private final String ws;
 
-    protected GitTagAction(Run build, FilePath workspace, BuildData buildData) {
+    protected GitTagAction(Run build, FilePath workspace, Revision revision) {
         super(build);
         this.ws = workspace.getRemote();
-        for (Branch b : buildData.lastBuild.revision.getBranches()) {
+        for (Branch b : revision.getBranches()) {
             tags.put(b.getName(), new ArrayList<String>());
         }
     }

--- a/src/main/java/hudson/plugins/git/extensions/impl/PruneStaleBranch.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PruneStaleBranch.java
@@ -1,12 +1,13 @@
 package hudson.plugins.git.extensions.impl;
 
 import hudson.Extension;
-import hudson.model.BuildListener;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import hudson.plugins.git.util.BuildData;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -28,6 +29,12 @@ public class PruneStaleBranch extends GitSCMExtension {
     public void decorateFetchCommand(GitSCM scm, GitClient git, TaskListener listener, FetchCommand cmd) throws IOException, InterruptedException, GitException {
         listener.getLogger().println("Pruning obsolete local branches");
         cmd.prune();
+    }
+
+    @Override
+    public void onCheckoutCompleted(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener) throws IOException, InterruptedException, GitException {
+        build.getAction(BuildData.class).purgeStaleBranches(git.getBranches());
+
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -244,4 +244,21 @@ public class BuildData implements Action, Serializable, Cloneable {
                 ",buildsByBranchName="+buildsByBranchName+
                 ",lastBuild="+lastBuild+"]";
     }
+
+    /**
+     * Remove branches from BuildData that have been seen in the past but do not exist anymore
+     * @param keepBranches all branches available in current repository state
+     */
+    public void purgeStaleBranches(Set<Branch> keepBranches) {
+        Set<String> names = new HashSet<String>(buildsByBranchName.keySet());
+        for (Branch branch : keepBranches) {
+            String name = branch.getName();
+            if (name.startsWith("remotes/")) {
+                names.remove(name.substring(8));
+            }
+        }
+        for (String name : names) {
+            buildsByBranchName.remove(name);
+        }
+    }
 }


### PR DESCRIPTION
For team using a topic-branch workflow, BuildData is an always growing Map of (legacy) branches, copied from build to build. This enhancement to `PruneStaleBranch` removes obsolete entries from current BuildData object based on existing branches on remote repositori(es)

@reviewbybees