### PR TITLE
[WiP] Build data sucks

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1016,6 +1016,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         BuiltRevisionMap builtRevisions = BuiltRevisionMap.forProject(build.getParent());
         BuiltRevision revToBuild = determineRevisionToBuild(build, buildData, environment, git, listener);
+        Revision revision = revToBuild.revision;
 
         environment.put(GIT_COMMIT, revToBuild.revision.getSha1String());
         Branch branch = Iterables.getFirst(revToBuild.revision.getBranches(),null);
@@ -1040,7 +1041,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             throw new IOException("Could not checkout " + revToBuild.revision.getSha1String(), e);
         }
 
-        build.addAction(new GitTagAction(build, workspace, buildData));
+        build.addAction(new GitTagAction(build, workspace, revision));
 
         if (changelogFile != null) {
             computeChangeLog(git, revToBuild.revision, listener, previousBuildData, new FilePath(changelogFile),

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1019,6 +1019,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         BuiltRevisionMap builtRevisions = BuiltRevisionMap.forProject(build.getParent());
         BuiltRevision revToBuild = determineRevisionToBuild(build, builtRevisions, buildData, environment, git, listener);
+        builtRevisions.addBuild(revToBuild);
         buildData.saveBuild(revToBuild);
         build.addAction(revToBuild);
 
@@ -1028,9 +1029,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         Branch branch = Iterables.getFirst(revision.getBranches(), null);
         if (branch!=null) { // null for a detached HEAD
             environment.put(GIT_BRANCH, getBranchName(branch));
-            builtRevisions.addBuild(branch.getName(), revToBuild);
-        } else {
-            builtRevisions.addDetached(revToBuild);
         }
 
         listener.getLogger().println("Checking out " + revision);

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -886,14 +886,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             MatrixBuild parentBuild = ((MatrixRun) build).getParentBuild();
             if (parentBuild != null) {
                 BuiltRevision rev = parentBuild.getAction(BuiltRevision.class);
-                if (rev != null) return rev;
-
-                BuildData parentBuildData = getBuildData(parentBuild);
-                if (parentBuildData != null) {
-                    Build lastBuild = parentBuildData.lastBuild;
-                    if (lastBuild!=null)
-                        candidates = Collections.singleton(lastBuild.getMarked());
-                }
+                if (rev != null) candidates = Collections.singleton(rev.getMarked());
             }
         }
 

--- a/src/main/java/hudson/plugins/git/GitTagAction.java
+++ b/src/main/java/hudson/plugins/git/GitTagAction.java
@@ -37,10 +37,10 @@ public class GitTagAction extends AbstractScmTagAction implements Describable<Gi
 
     private final String ws;
 
-    protected GitTagAction(Run build, FilePath workspace, BuildData buildData) {
+    protected GitTagAction(Run build, FilePath workspace, Revision revision) {
         super(build);
         this.ws = workspace.getRemote();
-        for (Branch b : buildData.lastBuild.revision.getBranches()) {
+        for (Branch b : revision.getBranches()) {
             tags.put(b.getName(), new ArrayList<String>());
         }
     }

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -22,6 +22,8 @@ import hudson.scm.SCMRevisionState;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
+
+import jenkins.plugins.git.BuiltRevisionMap;
 import org.jenkinsci.plugins.gitclient.CheckoutCommand;
 import org.jenkinsci.plugins.gitclient.CloneCommand;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
@@ -58,7 +60,7 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
      *      false to trigger a build from this commit, regardless of what later {@link GitSCMExtension}s say.
      *      null to allow other {@link GitSCMExtension}s to decide.
      */
-    public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener, BuildData buildData) throws IOException, InterruptedException, GitException {
+    public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener) throws IOException, InterruptedException, GitException {
         return null;
     }
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
@@ -7,7 +7,6 @@ import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
-import hudson.plugins.git.util.BuildData;
 import hudson.util.FormValidation;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -39,7 +38,7 @@ public class MessageExclusion extends GitSCMExtension {
 	public String getExcludedMessage() { return excludedMessage; }
 
 	@Override
-	public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener, BuildData buildData) throws IOException, InterruptedException, GitException {
+	public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener) throws IOException, InterruptedException, GitException {
 		if (excludedPattern == null){
 			excludedPattern = Pattern.compile(excludedMessage);
 		}

--- a/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
@@ -7,7 +7,6 @@ import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
-import hudson.plugins.git.util.BuildData;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -90,7 +89,7 @@ public class PathRestriction extends GitSCMExtension {
     }
 
     @Override
-    public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener, BuildData buildData) {
+    public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener) {
         Collection<String> paths = commit.getAffectedPaths();
         if (paths.isEmpty()) {// nothing modified, so no need to compute any of this
             return null;

--- a/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
@@ -13,6 +13,8 @@ import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.GitUtils;
 import hudson.plugins.git.util.MergeRecord;
+import jenkins.plugins.git.BuiltRevision;
+import jenkins.plugins.git.BuiltRevisionMap;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.gitclient.CheckoutCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
@@ -85,7 +87,9 @@ public class PreBuildMerge extends GitSCMExtension {
             // record the fact that we've tried building 'rev' and it failed, or else
             // BuildChooser in future builds will pick up this same 'rev' again and we'll see the exact same merge failure
             // all over again.
-            scm.getBuildData(build).saveBuild(new Build(marked,rev, build.getNumber(), FAILURE));
+            BuiltRevision failure = new BuiltRevision(marked, rev, build.number, FAILURE);
+            build.addAction(failure);
+            BuiltRevisionMap.forProject(build.getParent()).addBuild(failure);
             throw new AbortException("Branch not suitable for integration as it does not merge cleanly: " + ex.getMessage());
         }
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -9,6 +9,7 @@ import hudson.plugins.git.SubmoduleCombinator;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.plugins.git.util.BuildData;
+import jenkins.plugins.git.BuiltRevision;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -74,12 +75,12 @@ public class SubmoduleOption extends GitSCMExtension {
 
     @Override
     public void onCheckoutCompleted(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener) throws IOException, InterruptedException, GitException {
-        BuildData revToBuild = scm.getBuildData(build);
+        BuiltRevision revToBuild = (BuiltRevision) build.getActions(BuiltRevision.class);
 
         if (!disableSubmodules && git.hasGitModules()) {
             // This ensures we don't miss changes to submodule paths and allows
             // seamless use of bare and non-bare superproject repositories.
-            git.setupSubmoduleUrls(revToBuild.lastBuild.getRevision(), listener);
+            git.setupSubmoduleUrls(revToBuild.revision, listener);
             git.submoduleUpdate()
                 .recursive(recursiveSubmodules)
                 .remoteTracking(trackingSubmodules)

--- a/src/main/java/hudson/plugins/git/extensions/impl/UserExclusion.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/UserExclusion.java
@@ -6,7 +6,6 @@ import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
-import hudson.plugins.git.util.BuildData;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -55,7 +54,7 @@ public class UserExclusion extends GitSCMExtension {
     }
 
     @Override
-    public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener, BuildData buildData) {
+    public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener) {
         String author = commit.getAuthorName();
         if (getExcludedUsersNormalized().contains(author)) {
             // If the author is an excluded user, don't count this entry as a change

--- a/src/main/java/hudson/plugins/git/util/AncestryBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/AncestryBuildChooser.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import jenkins.plugins.git.BuiltRevisionMap;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -49,10 +50,10 @@ public class AncestryBuildChooser extends DefaultBuildChooser {
 
     @Override
     public Collection<Revision> getCandidateRevisions(boolean isPollCall, String branchSpec,
-                GitClient git, final TaskListener listener, BuildData data, BuildChooserContext context)
+                GitClient git, final TaskListener listener, BuiltRevisionMap revisions, BuildChooserContext context)
                 throws GitException, IOException, InterruptedException {
         
-        final Collection<Revision> candidates = super.getCandidateRevisions(isPollCall, branchSpec, git, listener, data, context);
+        final Collection<Revision> candidates = super.getCandidateRevisions(isPollCall, branchSpec, git, listener, revisions, context);
         
         // filter candidates based on branch age and ancestry
         return git.withRepository(new RepositoryCallback<List<Revision>>() {

--- a/src/main/java/hudson/plugins/git/util/Build.java
+++ b/src/main/java/hudson/plugins/git/util/Build.java
@@ -1,8 +1,11 @@
 package hudson.plugins.git.util;
 
+import hudson.model.Items;
 import hudson.model.Result;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
+import hudson.scm.SCMRevisionState;
+import jenkins.plugins.git.BuiltRevision;
 import org.eclipse.jgit.lib.ObjectId;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -16,7 +19,7 @@ import java.io.Serializable;
  * @see BuildData#buildsByBranchName
  */
 @ExportedBean(defaultVisibility = 999)
-public class Build implements Serializable, Cloneable {
+public class Build extends SCMRevisionState implements Serializable, Cloneable {
     private static final long serialVersionUID = 1L;
 
     /**
@@ -92,10 +95,10 @@ public class Build implements Serializable, Cloneable {
     }
 
     @Override
-    public Build clone() {
-        Build clone;
+    public BuiltRevision clone() {
+        BuiltRevision clone;
         try {
-            clone = (Build) super.clone();
+            clone = (BuiltRevision) super.clone();
         }
         catch (CloneNotSupportedException e) {
             throw new RuntimeException("Error cloning Build", e);
@@ -116,6 +119,6 @@ public class Build implements Serializable, Cloneable {
     public Object readResolve() throws IOException {
         if (marked==null) // this field was introduced later than 'revision'
             marked = revision;
-        return this;
+        return new BuiltRevision(marked, revision, hudsonBuildNumber, hudsonBuildResult);
     }
 }

--- a/src/main/java/hudson/plugins/git/util/BuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooser.java
@@ -11,6 +11,7 @@ import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.IGitAPI;
 import hudson.plugins.git.Revision;
+import jenkins.plugins.git.BuiltRevisionMap;
 import org.jenkinsci.plugins.gitclient.GitClient;
 
 import java.io.IOException;
@@ -68,6 +69,22 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
      *
      * @throws IOException
      * @throws GitException
+     */
+    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch, GitClient git, TaskListener listener, BuiltRevisionMap builtRevisions, BuildChooserContext context) throws IOException, InterruptedException {
+        return null;
+    }
+
+    public final Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch, GitClient git, TaskListener listener, BuiltRevisionMap builtRevisions, BuildData buildData, BuildChooserContext context) throws IOException, InterruptedException {
+        Collection<Revision> candidates = getCandidateRevisions(isPollCall, singleBranch, git, listener, builtRevisions, context);
+        if (candidates == null) {
+            // legacy API
+            candidates = getCandidateRevisions(isPollCall, singleBranch, git, listener, buildData, context);
+        }
+        return candidates;
+    }
+
+    /**
+     * @deprecated
      */
     public Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch,
                                                       GitClient git, TaskListener listener, BuildData buildData, BuildChooserContext context) throws GitException, IOException, InterruptedException {

--- a/src/main/java/hudson/plugins/git/util/BuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooser.java
@@ -3,6 +3,7 @@ package hudson.plugins.git.util;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
+import hudson.Util;
 import hudson.model.Describable;
 import hudson.model.Hudson;
 import hudson.model.Item;
@@ -11,6 +12,7 @@ import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.IGitAPI;
 import hudson.plugins.git.Revision;
+import jenkins.plugins.git.BuiltRevision;
 import jenkins.plugins.git.BuiltRevisionMap;
 import org.jenkinsci.plugins.gitclient.GitClient;
 
@@ -124,7 +126,7 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
      *
      * @param branch
      *      The branch name.
-     * @param data
+     * @param builtRevisions
      *      Information that captures what we did during the last build.
      * @param git
      *      Used for invoking Git
@@ -132,6 +134,19 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
      *      Object that provides access back to the model object. This is because
      *      the build chooser can be invoked on a slave where there's no direct access
      *      to the build/project for which this is invoked.
+     */
+    public Revision previousRevisionForChangelog(String branch, BuiltRevisionMap builtRevisions, GitClient git, BuildChooserContext context) throws IOException, InterruptedException {
+        if (Util.isOverridden(BuildChooser.class, getClass(), "prevBuildForChangelog", String.class, BuildData.class, GitClient.class, BuildChooserContext.class)) {
+            return prevBuildForChangelog(branch, new BuildData(builtRevisions), git, context).getMarked();
+        }
+        BuiltRevision previous = builtRevisions==null ? null : builtRevisions.getLastBuildOfBranch(branch);
+        return previous != null ? previous.marked : null;
+    }
+
+
+    /**
+     * @deprecated
+     *     Use and override {@link #previousRevisionForChangelog(String, jenkins.plugins.git.BuiltRevisionMap, org.jenkinsci.plugins.gitclient.GitClient, BuildChooserContext)}
      */
     public Build prevBuildForChangelog(String branch, @Nullable BuildData data, GitClient git, BuildChooserContext context) throws IOException,InterruptedException {
         return prevBuildForChangelog(branch,data, (IGitAPI) git, context);

--- a/src/main/java/hudson/plugins/git/util/BuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooser.java
@@ -71,16 +71,7 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
      * @throws GitException
      */
     public Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch, GitClient git, TaskListener listener, BuiltRevisionMap builtRevisions, BuildChooserContext context) throws IOException, InterruptedException {
-        return null;
-    }
-
-    public final Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch, GitClient git, TaskListener listener, BuiltRevisionMap builtRevisions, BuildData buildData, BuildChooserContext context) throws IOException, InterruptedException {
-        Collection<Revision> candidates = getCandidateRevisions(isPollCall, singleBranch, git, listener, builtRevisions, context);
-        if (candidates == null) {
-            // legacy API
-            candidates = getCandidateRevisions(isPollCall, singleBranch, git, listener, buildData, context);
-        }
-        return candidates;
+        return getCandidateRevisions(isPollCall, singleBranch, git, listener, new BuildData(builtRevisions), context);
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -10,6 +10,7 @@ import hudson.plugins.git.Branch;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.UserRemoteConfig;
 import jenkins.plugins.git.BuiltRevision;
+import jenkins.plugins.git.BuiltRevisionMap;
 import org.eclipse.jgit.lib.ObjectId;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -67,6 +68,13 @@ public class BuildData implements Action, Serializable, Cloneable {
             remoteUrls.add(c.getUrl());
         }
     }
+
+    public BuildData(BuiltRevisionMap revisions) {
+        this.buildsByBranchName = revisions.getRevisions();
+        this.lastBuild = revisions.getLastBuiltRevision();
+    }
+
+
 
     /**
      * Returns the build data display name, optionally with SCM name.

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -253,7 +253,8 @@ public class DefaultBuildChooser extends BuildChooser {
 
         // 4. Finally, remove any revisions that have already been built.
         verbose(listener, "Removing what''s already been built: {0}", builtRevisions.getRevisions());
-        Revision lastBuiltRevision = builtRevisions.getLastBuiltRevision().revision;
+        Revision lastBuiltRevision =
+                builtRevisions.getLastBuiltRevision() != null ? builtRevisions.getLastBuiltRevision().revision : null;
         for (Iterator<Revision> i = revs.iterator(); i.hasNext();) {
             Revision r = i.next();
 

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -5,6 +5,7 @@ import hudson.EnvVars;
 import hudson.model.TaskListener;
 import hudson.plugins.git.*;
 import hudson.remoting.VirtualChannel;
+import jenkins.plugins.git.BuiltRevisionMap;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.RemoteConfig;
@@ -41,16 +42,17 @@ public class DefaultBuildChooser extends BuildChooser {
      * @throws GitException
      */
     @Override
-    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String branchSpec,
-                                                      GitClient git, TaskListener listener, BuildData data, BuildChooserContext context)
+    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String branchSpec, GitClient git, TaskListener listener,
+                                                      BuiltRevisionMap builtRevisions, BuildChooserContext context)
+
             throws GitException, IOException, InterruptedException {
 
-        verbose(listener,"getCandidateRevisions({0},{1},,,{2}) considering branches to build",isPollCall,branchSpec,data);
+        verbose(listener,"getCandidateRevisions({0},{1},,,{2}) considering branches to build",isPollCall,branchSpec,builtRevisions);
 
         // if the branch name contains more wildcards then the simple usecase
         // does not apply and we need to skip to the advanced usecase
         if (isAdvancedSpec(branchSpec))
-            return getAdvancedCandidateRevisions(isPollCall,listener,new GitUtils(listener,git),data, context);
+            return getAdvancedCandidateRevisions(isPollCall,listener,new GitUtils(listener,git),builtRevisions, context);
 
         // check if we're trying to build a specific commit
         // this only makes sense for a build, there is no
@@ -80,7 +82,7 @@ public class DefaultBuildChooser extends BuildChooser {
                 String repository = config.getName();
                 String fqbn = repository + "/" + branchSpec;
                 verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
-                revisions.addAll(getHeadRevision(isPollCall, fqbn, git, listener, data));
+                revisions.addAll(getHeadRevision(isPollCall, fqbn, git, listener, builtRevisions));
             }
         } else {
             // either the branch is qualified (first part should match a valid remote)
@@ -108,14 +110,14 @@ public class DefaultBuildChooser extends BuildChooser {
                 possibleQualifiedBranches.add(fqbn);
             }
             for (String fqbn : possibleQualifiedBranches) {
-              revisions.addAll(getHeadRevision(isPollCall, fqbn, git, listener, data));
+              revisions.addAll(getHeadRevision(isPollCall, fqbn, git, listener, builtRevisions));
             }
         }
 
         if (revisions.isEmpty()) {
             // the 'branch' could actually be a non branch reference (for example a tag or a gerrit change)
 
-            revisions = getHeadRevision(isPollCall, branchSpec, git, listener, data);
+            revisions = getHeadRevision(isPollCall, branchSpec, git, listener, builtRevisions);
             if (!revisions.isEmpty()) {
                 verbose(listener, "{0} seems to be a non-branch reference (tag?)");
             }
@@ -124,14 +126,14 @@ public class DefaultBuildChooser extends BuildChooser {
         return revisions;
     }
 
-    private Collection<Revision> getHeadRevision(boolean isPollCall, String singleBranch, GitClient git, TaskListener listener, BuildData data) throws InterruptedException {
+    private Collection<Revision> getHeadRevision(boolean isPollCall, String singleBranch, GitClient git, TaskListener listener, BuiltRevisionMap builtRevisions) throws InterruptedException {
         try {
             ObjectId sha1 = git.revParse(singleBranch);
             verbose(listener, "rev-parse {0} -> {1}", singleBranch, sha1);
 
             // if polling for changes don't select something that has
             // already been built as a build candidate
-            if (isPollCall && data.hasBeenBuilt(sha1)) {
+            if (isPollCall && builtRevisions.hasBeenBuilt(sha1)) {
                 verbose(listener, "{0} has already been built", sha1);
                 return emptyList();
             }
@@ -196,7 +198,7 @@ public class DefaultBuildChooser extends BuildChooser {
      * @throws IOException
      * @throws GitException
      */
-    private List<Revision> getAdvancedCandidateRevisions(boolean isPollCall, TaskListener listener, GitUtils utils, BuildData data, BuildChooserContext context) throws GitException, IOException, InterruptedException {
+    private List<Revision> getAdvancedCandidateRevisions(boolean isPollCall, TaskListener listener, GitUtils utils, BuiltRevisionMap builtRevisions, BuildChooserContext context) throws GitException, IOException, InterruptedException {
 
         EnvVars env = context.getEnvironment();
 
@@ -250,12 +252,12 @@ public class DefaultBuildChooser extends BuildChooser {
         verbose(listener, "After non-tip filtering: {0}", revs);
 
         // 4. Finally, remove any revisions that have already been built.
-        verbose(listener, "Removing what''s already been built: {0}", data.getBuildsByBranchName());
-        Revision lastBuiltRevision = data.getLastBuiltRevision();
+        verbose(listener, "Removing what''s already been built: {0}", builtRevisions.getRevisions());
+        Revision lastBuiltRevision = builtRevisions.getLastBuiltRevision().revision;
         for (Iterator<Revision> i = revs.iterator(); i.hasNext();) {
             Revision r = i.next();
 
-            if (data.hasBeenBuilt(r.getSha1())) {
+            if (builtRevisions.hasBeenBuilt(r.getSha1())) {
                 i.remove();
                 
                 // keep track of new branches pointing to the last built revision
@@ -272,7 +274,7 @@ public class DefaultBuildChooser extends BuildChooser {
         // a deterministic value for GIT_BRANCH and allows a git-flow style workflow
         // with fast-forward merges between branches
         if (!isPollCall && revs.isEmpty() && lastBuiltRevision != null) {
-            verbose(listener, "Nothing seems worth building, so falling back to the previously built revision: {0}", data.getLastBuiltRevision());
+            verbose(listener, "Nothing seems worth building, so falling back to the previously built revision: {0}", builtRevisions.getLastBuiltRevision().revision);
             return Collections.singletonList(utils.sortBranchesForRevision(lastBuiltRevision, gitSCM.getBranches(), env));
         }
 

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -383,17 +383,17 @@ public abstract class AbstractGitSCMSource extends SCMSource {
 
         @Override
         public Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch, GitClient git,
-                                                          TaskListener listener, BuildData buildData,
+                                                          TaskListener listener, BuiltRevisionMap builtRevisions,
                                                           BuildChooserContext context)
                 throws GitException, IOException, InterruptedException {
             return Collections.singleton(revision);
         }
 
         @Override
-        public Build prevBuildForChangelog(String branch, @Nullable BuildData data, GitClient git,
+        public Revision previousRevisionForChangelog(String branch, @Nullable BuiltRevisionMap builtRevisions, GitClient git,
                                            BuildChooserContext context) throws IOException, InterruptedException {
             // we have ditched that crazy multiple branch stuff from the regular GIT SCM.
-            return data == null ? null : data.lastBuild;
+            return builtRevisions == null ? null : builtRevisions.getLastBuiltRevision().getMarked();
         }
 
         @Extension

--- a/src/main/java/jenkins/plugins/git/BuiltRevision.java
+++ b/src/main/java/jenkins/plugins/git/BuiltRevision.java
@@ -1,0 +1,20 @@
+package jenkins.plugins.git;
+
+import hudson.model.Result;
+import hudson.plugins.git.Revision;
+import hudson.plugins.git.util.Build;
+
+/**
+ * Replacement class for legacy {@link hudson.plugins.git.util.Build} to prevent confusion with {@link hudson.model.Build}
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class BuiltRevision extends Build {
+
+    public BuiltRevision(Revision marked, Revision revision, int buildNumber, Result result) {
+        super(marked, revision, buildNumber, result);
+    }
+
+    public BuiltRevision(Revision revision, int buildNumber, Result result) {
+        super(revision, buildNumber, result);
+    }
+}

--- a/src/main/java/jenkins/plugins/git/BuiltRevisionMap.java
+++ b/src/main/java/jenkins/plugins/git/BuiltRevisionMap.java
@@ -49,7 +49,15 @@ public class BuiltRevisionMap implements Action, Saveable {
             it.configFile = configFile;
             return it;
         } else {
-            return new BuiltRevisionMap(configFile);
+            BuiltRevisionMap revisionMap = new BuiltRevisionMap(configFile);
+            // migrate legacy data
+            BuildData data = job.getLastBuild().getAction(BuildData.class);
+            if (data != null) {
+                for (Map.Entry<String, BuiltRevision> entry : data.getBuildsByBranchName().entrySet()) {
+                    revisionMap.addBuild(entry.getKey(), entry.getValue());
+                }
+            }
+            return revisionMap;
         }
     }
 

--- a/src/main/java/jenkins/plugins/git/BuiltRevisionMap.java
+++ b/src/main/java/jenkins/plugins/git/BuiltRevisionMap.java
@@ -7,6 +7,7 @@ import hudson.model.Action;
 import hudson.model.Job;
 import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
+import hudson.plugins.git.Branch;
 import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.BuildData;
 import org.eclipse.jgit.lib.ObjectId;
@@ -77,8 +78,13 @@ public class BuiltRevisionMap implements Action, Saveable {
         return Collections.unmodifiableCollection(detached);
     }
 
-    public synchronized void addBuild(String branch, BuiltRevision revision) throws IOException {
-        revisions.put(branch, revision);
+    public synchronized void addBuild(BuiltRevision revision) throws IOException {
+        for (Branch branch : revision.marked.getBranches()) {
+            revisions.put(fixNull(branch.getName()), revision);
+        }
+        for (Branch branch : revision.revision.getBranches()) {
+            revisions.put(fixNull(branch.getName()), revision);
+        }
         last = revision;
         save();
     }

--- a/src/main/java/jenkins/plugins/git/BuiltRevisionMap.java
+++ b/src/main/java/jenkins/plugins/git/BuiltRevisionMap.java
@@ -34,7 +34,6 @@ public class BuiltRevisionMap implements Action, Saveable {
     public static final String FILE = BuiltRevisionMap.class.getName() + ".xml";
 
     private Map<String, BuiltRevision> revisions;
-    private Set<BuiltRevision> detached;
     private BuiltRevision last;
 
     private transient XmlFile configFile;
@@ -42,7 +41,6 @@ public class BuiltRevisionMap implements Action, Saveable {
     private BuiltRevisionMap(XmlFile configFile) {
         this.configFile = configFile;
         this.revisions = new HashMap<String, BuiltRevision>();
-        this.detached = new HashSet<BuiltRevision>();
     }
 
     public static BuiltRevisionMap forProject(Job job) throws IOException {
@@ -83,10 +81,6 @@ public class BuiltRevisionMap implements Action, Saveable {
         return revisions.get(branch);
     }
 
-    public Collection<BuiltRevision> getDetached() {
-        return Collections.unmodifiableCollection(detached);
-    }
-
     public synchronized void addBuild(BuiltRevision revision) throws IOException {
         for (Branch branch : revision.marked.getBranches()) {
             revisions.put(fixNull(branch.getName()), revision);
@@ -94,12 +88,6 @@ public class BuiltRevisionMap implements Action, Saveable {
         for (Branch branch : revision.revision.getBranches()) {
             revisions.put(fixNull(branch.getName()), revision);
         }
-        last = revision;
-        save();
-    }
-
-    public synchronized void addDetached(BuiltRevision revision) throws IOException {
-        detached.add(revision);
         last = revision;
         save();
     }
@@ -114,8 +102,6 @@ public class BuiltRevisionMap implements Action, Saveable {
     private Object readResolve() {
         if (revisions == null)
             revisions = new HashMap<String, BuiltRevision>();
-        if (detached == null)
-            detached = new HashSet<BuiltRevision>();
         return this;
     }
 
@@ -154,7 +140,6 @@ public class BuiltRevisionMap implements Action, Saveable {
     public String toString() {
         return "BuiltRevisionMap{" +
                 "revisions=" + revisions +
-                ", detached=" + detached +
                 ", last=" + last +
                 '}';
     }

--- a/src/main/java/jenkins/plugins/git/BuiltRevisionMap.java
+++ b/src/main/java/jenkins/plugins/git/BuiltRevisionMap.java
@@ -19,9 +19,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import static hudson.Util.fixNull;
 
@@ -77,7 +75,7 @@ public class BuiltRevisionMap implements Action, Saveable {
         return Collections.unmodifiableMap(revisions);
     }
 
-    public @CheckForNull BuiltRevision lastBuiltOnBranch(String branch) {
+    public @CheckForNull BuiltRevision getLastBuildOfBranch(String branch) {
         return revisions.get(branch);
     }
 
@@ -132,6 +130,15 @@ public class BuiltRevisionMap implements Action, Saveable {
         return null;
     }
 
+    public BuiltRevision getBuildFor(String sha1) {
+        for(BuiltRevision b : revisions.values()) {
+            if(b.isFor(sha1))
+                return b;
+        }
+        return null;
+    }
+
+
     public BuiltRevision getLastBuiltRevision() {
         return last;
     }
@@ -143,4 +150,5 @@ public class BuiltRevisionMap implements Action, Saveable {
                 ", last=" + last +
                 '}';
     }
+
 }

--- a/src/main/java/jenkins/plugins/git/BuiltRevisionMapActionFactory.java
+++ b/src/main/java/jenkins/plugins/git/BuiltRevisionMapActionFactory.java
@@ -1,0 +1,29 @@
+package jenkins.plugins.git;
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.TransientProjectActionFactory;
+import hudson.plugins.git.GitSCM;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Extension
+public class BuiltRevisionMapActionFactory extends TransientProjectActionFactory {
+
+    @Override
+    public Collection<? extends Action> createFor(AbstractProject target) {
+        if (target.getScm() instanceof GitSCM)
+            try {
+                return Collections.singleton(BuiltRevisionMap.forProject(target));
+            } catch (IOException e) {
+                // FIXME
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/resources/jenkins/plugins/git/BuiltRevision/summary.jelly
+++ b/src/main/resources/jenkins/plugins/git/BuiltRevision/summary.jelly
@@ -1,0 +1,17 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
+	<t:summary icon="/plugin/git/icons/git-48x48.png">
+
+ 	<b>Revision</b>: ${it.marked.sha1.name()}
+    <j:if test="${it.marked != it.revision}">(actually built ${it.revision.sha1.name()})</j:if>
+    <ul>
+        <j:forEach var="branch" items="${it.marked.branches}">
+          <j:if test="${branch!=''}">
+            <li>${branch.name}</li>
+          </j:if>
+        </j:forEach>
+    </ul>
+
+
+	</t:summary>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/git/BuiltRevisionMap/index.jelly
+++ b/src/main/resources/jenkins/plugins/git/BuiltRevisionMap/index.jelly
@@ -1,0 +1,19 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" >
+	<l:layout title="Git Built Revisions">
+	
+    <l:main-panel>
+       	<h1>Git Built Revisions</h1>
+
+		<ul>
+			<j:forEach var="e" items="${it.revisions}">
+				<li>${e.value}</li>
+			</j:forEach>
+			<j:forEach var="rev" items="${it.detached}">
+				<li>${rev}</li>
+			</j:forEach>
+		</ul>
+
+	</l:main-panel>
+  	</l:layout>
+</j:jelly>

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -38,6 +38,7 @@ import hudson.util.StreamTaskListener;
 
 import java.io.ByteArrayOutputStream;
 
+import jenkins.plugins.git.BuiltRevisionMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.lib.Constants;
@@ -886,7 +887,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         for (RemoteConfig remoteConfig : gitSCM.getRepositories()) {
             git.fetch_().from(remoteConfig.getURIs().get(0), remoteConfig.getFetchRefSpecs());
         }
-        Collection<Revision> candidateRevisions = ((DefaultBuildChooser) (gitSCM).getBuildChooser()).getCandidateRevisions(false, "origin/master", git, listener, project.getLastBuild().getAction(BuildData.class), null);
+        Collection<Revision> candidateRevisions = ((DefaultBuildChooser) (gitSCM).getBuildChooser()).getCandidateRevisions(false, "origin/master", git, listener, project.getAction(BuiltRevisionMap.class), null);
         assertEquals(1, candidateRevisions.size());
     }
 

--- a/src/test/java/hudson/plugins/git/RevisionParameterActionTest.java
+++ b/src/test/java/hudson/plugins/git/RevisionParameterActionTest.java
@@ -29,6 +29,7 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
 import hudson.plugins.git.util.BuildData;
 import hudson.Functions;
+import jenkins.plugins.git.BuiltRevision;
 
 import java.util.concurrent.Future;
 import java.util.Collections;
@@ -177,7 +178,7 @@ public class RevisionParameterActionTest extends AbstractGitTestCase {
         commit(commitFile1, johnDoe, "Commit number 1");
         FreeStyleBuild b1 = build(p1, Result.SUCCESS, commitFile1);
         
-        Revision r1 = b1.getAction(BuildData.class).getLastBuiltRevision();
+        Revision r1 = b1.getAction(BuiltRevision.class).getRevision();
         
         // create a second commit
         final String commitFile2 = "commitFile2";
@@ -189,18 +190,16 @@ public class RevisionParameterActionTest extends AbstractGitTestCase {
         System.out.println(b2.getLog());
         
 		// Check revision built for b2 matches the r1 revision
-		assertEquals(b2.getAction(BuildData.class)
-				.getLastBuiltRevision().getSha1String(), r1.getSha1String());
-		assertEquals(b2.getAction(BuildData.class)
-				.getLastBuiltRevision().getBranches().iterator().next()
-				.getName(), r1.getBranches().iterator().next().getName());
+		assertEquals(b2.getAction(BuiltRevision.class).getRevision().getSha1String(),
+                     r1.getSha1String());
+		assertEquals(b2.getAction(BuiltRevision.class).getRevision().getBranches().iterator().next().getName(),
+                     r1.getBranches().iterator().next().getName());
 		
 		// create a third build
 		FreeStyleBuild b3 = build(p1, Result.SUCCESS, commitFile2);
 		
 		// Check revision built for b3 does not match r1 revision
-		assertFalse(b3.getAction(BuildData.class)
-				.getLastBuiltRevision().getSha1String().equals(r1.getSha1String()));		
+		assertFalse(b3.getAction(BuiltRevision.class).getRevision().getSha1String().equals(r1.getSha1String()));
 		
 		if (Functions.isWindows()) {
 		  System.gc(); // Prevents exceptions cleaning up temp dirs during tearDown

--- a/src/test/java/hudson/plugins/git/util/AncestryBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/AncestryBuildChooserTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import jenkins.plugins.git.BuiltRevisionMap;
 import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -136,8 +137,8 @@ public class AncestryBuildChooserTest extends AbstractGitTestCase {
         // mock necessary objects
         GitClient git = Mockito.spy(this.git);
         Mockito.when(git.getRemoteBranches()).thenReturn(this.git.getBranches());
-        
-        BuildData buildData = Mockito.mock(BuildData.class);
+
+        BuiltRevisionMap buildData = Mockito.mock(BuiltRevisionMap.class);
         Mockito.when(buildData.hasBeenBuilt(git.revParse(rootCommit))).thenReturn(false);
         
         BuildChooserContext context = Mockito.mock(BuildChooserContext.class);

--- a/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import hudson.plugins.git.AbstractGitTestCase;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
+import jenkins.plugins.git.BuiltRevisionMap;
 
 /**
  * @author Arnout Engelen
@@ -19,12 +20,12 @@ public class DefaultBuildChooserTest extends AbstractGitTestCase {
 
         DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
 
-        Collection<Revision> candidateRevisions = buildChooser.getCandidateRevisions(false, shaHashCommit1, git, null, null, null);
+        Collection<Revision> candidateRevisions = buildChooser.getCandidateRevisions(false, shaHashCommit1, git, null, (BuiltRevisionMap) null, null);
 
         assertEquals(1, candidateRevisions.size());
         assertEquals(shaHashCommit1, candidateRevisions.iterator().next().getSha1String());
 
-        candidateRevisions = buildChooser.getCandidateRevisions(false, "aaa" + shaHashCommit1.substring(3), git, null, null, null);
+        candidateRevisions = buildChooser.getCandidateRevisions(false, "aaa" + shaHashCommit1.substring(3), git, null, (BuiltRevisionMap) null, null);
         assertTrue(candidateRevisions.isEmpty());
     }
     /**


### PR DESCRIPTION
Replace per-build `BuildData` with a job-centric `BuiltRevisionMap` to avoid data duplication
drawbacks:
- drop support for scm names
- drop support for BuildData related to another repository (sic)
- still some test failure I need to investigate
