### PR TITLE
[JENKINS-27902] Allow to pass additional request parameter for notifyCommit

### DIFF
--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -178,7 +178,7 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
 
         public List<ResponseContributor> onNotifyCommit(URIish uri, @Nullable String sha1, String... branches) {
             List<ParameterValue> buildParameters = Collections.EMPTY_LIST;
-            return onNotifyCommit(uri, null, buildParameters, branches);
+            return onNotifyCommit(uri, sha1, buildParameters, branches);
         }
 
         public List<ResponseContributor> onNotifyCommit(URIish uri, @Nullable String sha1, List<ParameterValue> buildParameters, String... branches) {


### PR DESCRIPTION
Allows to pass additional parameters to the jobs triggered via the notifyCommit URL, see https://issues.jenkins-ci.org/browse/JENKINS-27902 for more details