### PR TITLE
Using the version that makes "mvn hpi:run" work.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.568</version>
+    <version>1.580</version>
   </parent>
   
   <licenses>
@@ -263,7 +263,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.4.1</version>
+      <version>1.4</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
I noticed that the current combination of core and matrix plugin in
pom.xml causes errors like the one I'm attaching below. This prevents
"mvn hpi:run" from working correctly --- you get errors when you try to
configure a freestyle job.

I forgot the intricate details of matrix-plugin security fix that
resulted in botched 1.4.1, but, I believe matrix-plugin 1.4.1 only works
correctly with a specific version of the core.

This combination works, though it is not the only combination that
works. I hope this is still OK enough for Mark, as 1.580 is still old
enough LTS release.

Stack trace:
```
May 21, 2015 4:23:36 PM hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1 error
WARNING: Failed to instantiate Key[type=hudson.plugins.git.GitPublisher$NoteToPush$DescriptorImpl, annotation=[none]]; skipping this component
com.google.inject.ProvisionException: Guice provision errors:

1) Error injecting constructor, java.lang.NoClassDefFoundError: hudson/matrix/MatrixAggregatable
  at hudson.plugins.git.GitPublisher$NoteToPush$DescriptorImpl.<init>(Unknown Source)

1 error
        at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:52)
        at com.google.inject.Scopes$1$1.get(Scopes.java:65)
        at hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1.get(ExtensionFinder.java:429)
        at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
        at com.google.inject.internal.InjectorImpl$3$1.call(InjectorImpl.java:1005)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1051)
        at com.google.inject.internal.InjectorImpl$3.get(InjectorImpl.java:1001)
        at hudson.ExtensionFinder$GuiceFinder._find(ExtensionFinder.java:391)
        at hudson.ExtensionFinder$GuiceFinder.find(ExtensionFinder.java:382)
        at hudson.ExtensionFinder._find(ExtensionFinder.java:151)
        at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:341)
        at hudson.ExtensionList.load(ExtensionList.java:295)
        at hudson.ExtensionList.ensureLoaded(ExtensionList.java:248)
        at hudson.ExtensionList.iterator(ExtensionList.java:138)
        at jenkins.model.Jenkins.getDescriptor(Jenkins.java:1169)
        at hudson.plugins.git.GitTool.onLoaded(GitTool.java:126)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:601)
        at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:105)
        at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:169)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
        at jenkins.model.Jenkins$7.runTask(Jenkins.java:905)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1110)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:603)
        at java.lang.Thread.run(Thread.java:722)
Caused by: java.lang.NoClassDefFoundError: hudson/matrix/MatrixAggregatable
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(ClassLoader.java:791)
        at jenkins.util.AntClassLoader.defineClassFromData(AntClassLoader.java:1138)
        at hudson.ClassicPluginStrategy$AntClassLoader2.defineClassFromData(ClassicPluginStrategy.java:755)
        at jenkins.util.AntClassLoader.getClassFromStream(AntClassLoader.java:1309)
        at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1365)
        at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1325)
        at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1078)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:356)
        at java.lang.Class.getDeclaringClass(Native Method)
        at java.lang.Class.getEnclosingClass(Class.java:1105)
        at hudson.model.Descriptor.<init>(Descriptor.java:266)
        at hudson.plugins.git.GitPublisher$NoteToPush$DescriptorImpl.<init>(GitPublisher.java:613)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:525)
        at com.google.inject.internal.DefaultConstructionProxyFactory$1.newInstance(DefaultConstructionProxyFactory.java:86)
        at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:108)
        at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:88)
        at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:269)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1058)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
        ... 28 more
Caused by: java.lang.ClassNotFoundException: hudson.matrix.MatrixAggregatable
        at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1375)
        at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1325)
        at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1078)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:356)
        ... 52 more
```