### PR TITLE
Add a validation check to GitLab version form

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/GitLab.java
+++ b/src/main/java/hudson/plugins/git/browser/GitLab.java
@@ -6,12 +6,15 @@ import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSet.Path;
 import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
+import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.net.URL;
+import javax.servlet.ServletException;
+import org.kohsuke.stapler.QueryParameter;
 
 /**
  * Git Browser for GitLab
@@ -21,22 +24,27 @@ public class GitLab extends GitRepositoryBrowser {
     private static final long serialVersionUID = 1L;
 
     private final double version;
-    
+
     /* package */
     static final double DEFAULT_VERSION = 7.11;
+
+    private static double valueOfVersion(String version) throws NumberFormatException {
+        double tmpVersion = Double.valueOf(version);
+        if (Double.isNaN(tmpVersion)) {
+            throw new NumberFormatException("Version cannot be NaN (not a number)");
+        }
+        if (Double.isInfinite(tmpVersion)) {
+            throw new NumberFormatException("Version cannot be infinite");
+        }
+        return tmpVersion;
+    }
 
     @DataBoundConstructor
     public GitLab(String repoUrl, String version) {
         super(repoUrl);
         double tmpVersion;
         try {
-            tmpVersion = Double.valueOf(version);
-            if (tmpVersion < 0
-                    || tmpVersion > DEFAULT_VERSION
-                    || Double.isNaN(tmpVersion)
-                    || Double.isInfinite(tmpVersion)) {
-                tmpVersion = DEFAULT_VERSION;
-            }
+            tmpVersion = valueOfVersion(version);
         } catch (NumberFormatException nfe) {
             tmpVersion = DEFAULT_VERSION;
         }
@@ -111,6 +119,27 @@ public class GitLab extends GitRepositoryBrowser {
         @Override
         public GitLab newInstance(StaplerRequest req, JSONObject jsonObject) throws FormException {
             return req.bindJSON(GitLab.class, jsonObject);
+        }
+
+        /**
+         * Validate the contents of the version field.
+         *
+         * @param version gitlab version value entered by the user
+         * @return validation result, either ok() or error(msg)
+         * @throws IOException
+         * @throws ServletException
+         */
+        public FormValidation doCheckVersion(@QueryParameter(fixEmpty = true) final String version)
+                throws IOException, ServletException {
+            if (version == null) {
+                return FormValidation.error("Version is required");
+            }
+            try {
+                valueOfVersion(version);
+            } catch (NumberFormatException nfe) {
+                return FormValidation.error("Can't convert '" + version + "' to a number: " + nfe.getMessage());
+            }
+            return FormValidation.ok();
         }
     }
 

--- a/src/test/java/hudson/plugins/git/browser/GitLabTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitLabTest.java
@@ -46,8 +46,8 @@ public class GitLabTest extends TestCase {
         assertEquals(GitLab.DEFAULT_VERSION, gitlabDefault.getVersion());
         assertEquals(GitLab.DEFAULT_VERSION, gitlabNaN.getVersion());
         assertEquals(GitLab.DEFAULT_VERSION, gitlabInfinity.getVersion());
-        assertEquals(GitLab.DEFAULT_VERSION, gitlabNegative.getVersion());
-        assertEquals(GitLab.DEFAULT_VERSION, gitlabGreater.getVersion());
+        assertEquals(-1.0, gitlabNegative.getVersion());
+        assertEquals(9999.0, gitlabGreater.getVersion());
     }
 
     /**
@@ -66,7 +66,7 @@ public class GitLabTest extends TestCase {
         assertEquals(expectedURL, gitlabDefault.getChangeSetLink(changeSet).toString());
         assertEquals(expectedURL, gitlabNaN.getChangeSetLink(changeSet).toString());
         assertEquals(expectedURL, gitlabInfinity.getChangeSetLink(changeSet).toString());
-        assertEquals(expectedURL, gitlabNegative.getChangeSetLink(changeSet).toString());
+        assertEquals(expectedURL.replace("commit/", "commits/"), gitlabNegative.getChangeSetLink(changeSet).toString());
         assertEquals(expectedURL, gitlabGreater.getChangeSetLink(changeSet).toString());
     }
 
@@ -87,7 +87,7 @@ public class GitLabTest extends TestCase {
         assertEquals(expectedURL, gitlabDefault.getDiffLink(modified1).toString());
         assertEquals(expectedURL, gitlabNaN.getDiffLink(modified1).toString());
         assertEquals(expectedURL, gitlabInfinity.getDiffLink(modified1).toString());
-        assertEquals(expectedURL, gitlabNegative.getDiffLink(modified1).toString());
+        assertEquals(expectedURL.replace("commit/", "commits/"), gitlabNegative.getDiffLink(modified1).toString());
         assertEquals(expectedURL, gitlabGreater.getDiffLink(modified1).toString());
     }
 
@@ -110,7 +110,7 @@ public class GitLabTest extends TestCase {
         assertEquals(expectedURL, gitlabDefault.getFileLink(path).toString());
         assertEquals(expectedURL, gitlabNaN.getFileLink(path).toString());
         assertEquals(expectedURL, gitlabInfinity.getFileLink(path).toString());
-        assertEquals(expectedURL, gitlabNegative.getFileLink(path).toString());
+        assertEquals(expectedV29, gitlabNegative.getFileLink(path).toString());
         assertEquals(expectedURL, gitlabGreater.getFileLink(path).toString());
     }
 
@@ -126,6 +126,13 @@ public class GitLabTest extends TestCase {
         assertEquals(expectedURL, gitlab42.getFileLink(path).toString());
         assertEquals(expectedURL, gitlab50.getFileLink(path).toString());
         assertEquals(expectedURL, gitlab51.getFileLink(path).toString());
+        assertEquals(expectedURL, gitlab711.getFileLink(path).toString());
+        assertEquals(expectedURL, gitlab7114ee.getFileLink(path).toString());
+        assertEquals(expectedURL, gitlabDefault.getFileLink(path).toString());
+        assertEquals(expectedURL, gitlabNaN.getFileLink(path).toString());
+        assertEquals(expectedURL, gitlabInfinity.getFileLink(path).toString());
+        assertEquals(expectedURL.replace("commit/", "commits/"), gitlabNegative.getFileLink(path).toString());
+        assertEquals(expectedURL, gitlabGreater.getFileLink(path).toString());
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {


### PR DESCRIPTION
Also fixes a bug that the most recent change I made to the GitLab object will not accept a version number larger than the default version. That bug would probably frustrate users with a new GitLab version when they entered "8.0" and the next time they opened the form it was "7.11"