### PR TITLE
[JENKINS-29066] potential fix

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -518,7 +518,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         for (GitSCMExtension ext : getExtensions()) {
             if (ext.requiresWorkspaceForPolling()) return true;
         }
-        return false;
+        return getSingleBranch(environment) == null;
     }
 
     @Override
@@ -565,6 +565,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         final EnvVars pollEnv = project instanceof AbstractProject ? GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener, false) : lastBuild.getEnvironment(listener);
+
+        final String singleBranch = getSingleBranch(pollEnv);
 
         if (!requiresWorkspaceForPolling(pollEnv)) {
 
@@ -654,7 +656,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
             listener.getLogger().println("Polling for changes in");
 
-            final String singleBranch = getSingleBranch(pollEnv);
             Collection<Revision> candidates = getBuildChooser().getCandidateRevisions(
                     true, singleBranch, git, listener, buildData, new BuildChooserContextImpl(project, null, environment));
 

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1428,6 +1428,29 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertFalse("No changes to git since last build, thus no new build is expected", project.poll(listener).hasChanges());
     }
 
+    @Issue("JENKINS-29066")
+    public void testPolling_parentHead() throws Exception {
+        // create parameterized project with environment value in branch specification
+        FreeStyleProject project = createFreeStyleProject();
+        GitSCM scm = new GitSCM(
+                createRemoteRepositories(),
+                Collections.singletonList(new BranchSpec("**")),
+                false, Collections.<SubmoduleConfig>emptyList(),
+                null, null,
+                Collections.<GitSCMExtension>emptyList());
+        project.setScm(scm);
+
+        // commit something in order to create an initial base version in git
+        commit("toto/commitFile1", johnDoe, "Commit number 1");
+        git.branch("someBranch");
+        commit("toto/commitFile2", johnDoe, "Commit number 2");
+
+        // build the project
+        build(project, Result.SUCCESS);
+
+        assertFalse("polling should not detect changes",project.poll(listener).hasChanges());
+    }
+
     public void testPollingAfterManualBuildWithParametrizedBranchSpec() throws Exception {
         // create parameterized project with environment value in branch specification
         FreeStyleProject project = createFreeStyleProject();


### PR DESCRIPTION
I was able to reproduce JENKINS-29066 using github.com/ndeloof/oki-docki-demo as a repository. JGit does return /ref/pull/1/merge as a candidate revision during polling, which is ignored by BuildChooser when looking for revisions to build, resulting in an infinite build loop.
This commit do ensure polling do only consider the configured refspecs. Probably need to also review the BuildChooser extension point to ensure it uses the same logic to avoid such issues