### PR TITLE
[JENKINS-14572] Add "Do not fetch tags" advanced clone option

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -20,13 +20,19 @@ import java.io.IOException;
  * @author Kohsuke Kawaguchi
  */
 public class CloneOption extends GitSCMExtension {
-    private boolean shallow;
-    private String reference;
-    private Integer timeout;
+    private final boolean shallow;
+    private final boolean noTags;
+    private final String reference;
+    private final Integer timeout;
+
+    public CloneOption(boolean shallow, String reference, Integer timeout) {
+        this(shallow, true, reference, timeout);
+    }
 
     @DataBoundConstructor
-    public CloneOption(boolean shallow, String reference, Integer timeout) {
+    public CloneOption(boolean shallow, boolean noTags, String reference, Integer timeout) {
         this.shallow = shallow;
+        this.noTags = noTags;
         this.reference = reference;
         this.timeout = timeout;
     }
@@ -35,10 +41,14 @@ public class CloneOption extends GitSCMExtension {
         return shallow;
     }
 
+    public boolean isNoTags() {
+        return noTags;
+    }
+
     public String getReference() {
         return reference;
     }
-    
+
     public Integer getTimeout() {
         return timeout;
     }
@@ -49,13 +59,18 @@ public class CloneOption extends GitSCMExtension {
             listener.getLogger().println("Using shallow clone");
             cmd.shallow();
         }
+        if (noTags) {
+            listener.getLogger().println("Avoid fetching tags");
+            cmd.tags(false);
+        }
         cmd.timeout(timeout);
         cmd.reference(build.getEnvironment(listener).expand(reference));
     }
     
     @Override
     public void decorateFetchCommand(GitSCM scm, GitClient git, TaskListener listener, FetchCommand cmd) throws IOException, InterruptedException, GitException {
-    	cmd.timeout(timeout);
+        cmd.tags(!noTags);
+        cmd.timeout(timeout);
     }
 
     @Override

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -26,7 +26,7 @@ public class CloneOption extends GitSCMExtension {
     private final Integer timeout;
 
     public CloneOption(boolean shallow, String reference, Integer timeout) {
-        this(shallow, true, reference, timeout);
+        this(shallow, false, reference, timeout);
     }
 
     @DataBoundConstructor

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
@@ -5,6 +5,9 @@ def f = namespace(lib.FormTagLib);
 f.entry(title:_("Shallow clone"), field:"shallow") {
     f.checkbox()
 }
+f.entry(title:_("Do not fetch tags"), field:"noTags") {
+	f.checkbox()
+}
 f.entry(title:_("Path of the reference repo to use during clone"), field:"reference") {
     f.textbox()
 }

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-noTags.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-noTags.html
@@ -1,0 +1,4 @@
+<div>
+  Perform a clone without tags, saving time and disk space when you just want to access
+  what is specified by the refspec.
+</div>

--- a/src/test/java/hudson/plugins/git/TestGitRepo.java
+++ b/src/test/java/hudson/plugins/git/TestGitRepo.java
@@ -93,6 +93,10 @@ public class TestGitRepo {
         git.commit(message);
     }
 
+    public void tag(String tagName, String comment) throws GitException, InterruptedException {
+        git.tag(tagName, comment);
+    }
+
     public List<UserRemoteConfig> remoteConfigs() throws IOException {
         List<UserRemoteConfig> list = new ArrayList<UserRemoteConfig>();
         list.add(new UserRemoteConfig(gitDir.getAbsolutePath(), "origin", "", null));

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionNoTagsTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionNoTagsTest.java
@@ -1,0 +1,77 @@
+package hudson.plugins.git.extensions.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Set;
+
+import hudson.model.Result;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.git.TestGitRepo;
+import hudson.plugins.git.extensions.GitSCMExtensionTest;
+import hudson.plugins.git.extensions.GitSCMExtension;
+
+import org.jenkinsci.plugins.gitclient.Git;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.junit.Test;
+
+/**
+ * @author Ronny Händel
+ */
+public class CloneOptionNoTagsTest extends GitSCMExtensionTest {
+
+    FreeStyleProject project;
+    TestGitRepo repo;
+
+    @Override
+    public void before() throws Exception {
+        repo = new TestGitRepo("repo", tmp.newFolder(), listener);
+        project = setupBasicProject(repo);
+    }
+
+    @Override
+    protected GitSCMExtension getExtension() {
+        final boolean shallowClone = true;
+        final boolean dontFetchTags = true;
+        final String noReference = null;
+        final Integer noTimeout = null;
+        return new CloneOption(shallowClone, dontFetchTags, noReference, noTimeout);
+    }
+
+    @Test
+    public void cloningShouldNotFetchTags() throws Exception {
+
+        repo.commit("repo-init", repo.johnDoe, "repo0 initial commit");
+        repo.tag("v0.0.1", "a tag that should never be fetched");
+
+        assertTrue("scm polling should detect a change after initial commit", project.poll(listener).hasChanges());
+
+        build(project, Result.SUCCESS);
+
+        assertTrue("there should no tags have been cloned from remote", allTagsInProjectWorkspace().isEmpty());
+    }
+
+    @Test
+    public void detectNoChangeAfterCreatingATag() throws Exception {
+
+        repo.commit("repo-init", repo.johnDoe, "repo0 initial commit");
+
+        assertTrue("scm polling should detect a change after initial commit", project.poll(listener).hasChanges());
+
+        build(project, Result.SUCCESS);
+
+        repo.tag("v0.0.1", "a tag that should never be fetched");
+
+        assertFalse("scm polling should not detect a change after creating a tag", project.poll(listener).hasChanges());
+
+        build(project, Result.SUCCESS);
+
+        assertTrue("there should no tags have been fetched from remote", allTagsInProjectWorkspace().isEmpty());
+    }
+
+    private Set<String> allTagsInProjectWorkspace() throws IOException, InterruptedException {
+        GitClient git = Git.with(listener, null).in(project.getWorkspace()).getClient();
+        return git.getTagNames("*");
+    }
+}

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionShallowDefaultTagsTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionShallowDefaultTagsTest.java
@@ -1,0 +1,58 @@
+package hudson.plugins.git.extensions.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import hudson.model.Result;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.git.TestGitRepo;
+import hudson.plugins.git.extensions.GitSCMExtensionTest;
+import hudson.plugins.git.extensions.GitSCMExtension;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.jenkinsci.plugins.gitclient.Git;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.junit.Test;
+
+/**
+ * @author Ronny Händel
+ */
+public class CloneOptionShallowDefaultTagsTest extends GitSCMExtensionTest {
+
+    FreeStyleProject project;
+    TestGitRepo repo;
+
+    @Override
+    public void before() throws Exception {
+        repo = new TestGitRepo("repo", tmp.newFolder(), listener);
+        project = setupBasicProject(repo);
+    }
+
+    @Override
+    protected GitSCMExtension getExtension() {
+        final boolean shallowClone = true;
+        final String noReference = null;
+        final Integer noTimeout = null;
+        return new CloneOption(shallowClone, noReference, noTimeout);
+    }
+
+    @Test
+    public void evenShallowCloningFetchesTagsByDefault() throws Exception {
+        final String tagName = "v0.0.1";
+
+        repo.commit("repo-init", repo.johnDoe, "repo0 initial commit");
+        repo.tag(tagName, "a tag that should be fetched by default");
+
+        assertTrue("scm polling should detect a change after initial commit", project.poll(listener).hasChanges());
+
+        build(project, Result.SUCCESS);
+
+        assertEquals("tag " + tagName + " should have been cloned from remote", 1, tagsInProjectWorkspaceWithName(tagName).size());
+    }
+
+    private Set<String> tagsInProjectWorkspaceWithName(String tagPattern) throws IOException, InterruptedException {
+        GitClient git = Git.with(listener, null).in(project.getWorkspace()).getClient();
+        return git.getTagNames(tagPattern);
+    }
+}


### PR DESCRIPTION
As discussed in [JENKINS-14572](https://issues.jenkins-ci.org/browse/JENKINS-14572), fetching all tags is the git plugin's default behaviour - even when making shallow clones using the appropriate advanced clone behaviour.

I've added a check box "Do not fetch tags" to the advanced clone behaviours. This way a user can explicitly override the default.