### PR TITLE
Reduce test time with @WithoutJenkins and switch to JUnit 4

### DIFF
--- a/src/test/java/hudson/plugins/git/AbstractGitProject.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitProject.java
@@ -1,0 +1,267 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Mark Waite.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.git;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
+import hudson.model.AbstractBuild;
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Node;
+import hudson.model.Result;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.impl.DisableRemotePoll;
+import hudson.plugins.git.extensions.impl.EnforceGitClient;
+import hudson.plugins.git.extensions.impl.PathRestriction;
+import hudson.plugins.git.extensions.impl.RelativeTargetDirectory;
+import hudson.plugins.git.extensions.impl.SparseCheckoutPath;
+import hudson.plugins.git.extensions.impl.SparseCheckoutPaths;
+import hudson.plugins.git.extensions.impl.UserExclusion;
+import hudson.remoting.VirtualChannel;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.triggers.SCMTrigger;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.jgit.lib.ObjectId;
+
+import org.jenkinsci.plugins.gitclient.Git;
+import org.jenkinsci.plugins.gitclient.JGitTool;
+
+import static org.junit.Assert.*;
+import org.junit.Rule;
+
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Abstract class that provides convenience methods to configure projects.
+ * @author Mark Waite
+ */
+public class AbstractGitProject extends AbstractGitRepository {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    protected FreeStyleProject setupProject(List<BranchSpec> branches, boolean authorOrCommitter) throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        GitSCM scm = new GitSCM(remoteConfigs(), branches, false,
+                Collections.<SubmoduleConfig>emptyList(), null, null,
+                Collections.<GitSCMExtension>singletonList(new DisableRemotePoll()));
+        project.setScm(scm);
+        project.getBuildersList().add(new CaptureEnvironmentBuilder());
+        return project;
+    }
+
+    protected FreeStyleProject setupSimpleProject(String branchString) throws Exception {
+        return setupProject(Collections.singletonList(new BranchSpec(branchString)), false);
+    }
+
+    protected FreeStyleProject setupProject(String branchString, boolean authorOrCommitter) throws Exception {
+        return setupProject(branchString, authorOrCommitter, null);
+    }
+
+    protected FreeStyleProject setupProject(String branchString, boolean authorOrCommitter,
+            String relativeTargetDir) throws Exception {
+        return setupProject(branchString, authorOrCommitter, relativeTargetDir, null, null, null);
+    }
+
+    protected FreeStyleProject setupProject(String branchString, boolean authorOrCommitter,
+            String relativeTargetDir,
+            String excludedRegions,
+            String excludedUsers,
+            String includedRegions) throws Exception {
+        return setupProject(branchString, authorOrCommitter, relativeTargetDir, excludedRegions, excludedUsers, null, false, includedRegions);
+    }
+
+    protected FreeStyleProject setupProject(String branchString, boolean authorOrCommitter,
+            String relativeTargetDir,
+            String excludedRegions,
+            String excludedUsers,
+            boolean fastRemotePoll,
+            String includedRegions) throws Exception {
+        return setupProject(branchString, authorOrCommitter, relativeTargetDir, excludedRegions, excludedUsers, null, fastRemotePoll, includedRegions);
+    }
+
+    protected FreeStyleProject setupProject(String branchString, boolean authorOrCommitter,
+            String relativeTargetDir, String excludedRegions,
+            String excludedUsers, String localBranch, boolean fastRemotePoll,
+            String includedRegions) throws Exception {
+        return setupProject(Collections.singletonList(new BranchSpec(branchString)),
+                authorOrCommitter, relativeTargetDir, excludedRegions,
+                excludedUsers, localBranch, fastRemotePoll,
+                includedRegions);
+    }
+
+    protected FreeStyleProject setupProject(List<BranchSpec> branches, boolean authorOrCommitter,
+            String relativeTargetDir, String excludedRegions,
+            String excludedUsers, String localBranch, boolean fastRemotePoll,
+            String includedRegions) throws Exception {
+        return setupProject(branches,
+                authorOrCommitter, relativeTargetDir, excludedRegions,
+                excludedUsers, localBranch, fastRemotePoll,
+                includedRegions, null);
+    }
+
+    protected FreeStyleProject setupProject(String branchString, List<SparseCheckoutPath> sparseCheckoutPaths) throws Exception {
+        return setupProject(Collections.singletonList(new BranchSpec(branchString)),
+                false, null, null,
+                null, null, false,
+                null, sparseCheckoutPaths);
+    }
+
+    protected FreeStyleProject setupProject(List<BranchSpec> branches, boolean authorOrCommitter,
+            String relativeTargetDir, String excludedRegions,
+            String excludedUsers, String localBranch, boolean fastRemotePoll,
+            String includedRegions, List<SparseCheckoutPath> sparseCheckoutPaths) throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        GitSCM scm = new GitSCM(
+                remoteConfigs(),
+                branches,
+                false, Collections.<SubmoduleConfig>emptyList(),
+                null, null,
+                Collections.<GitSCMExtension>emptyList());
+        scm.getExtensions().add(new DisableRemotePoll()); // don't work on a file:// repository
+        if (relativeTargetDir != null) {
+            scm.getExtensions().add(new RelativeTargetDirectory(relativeTargetDir));
+        }
+        if (excludedUsers != null) {
+            scm.getExtensions().add(new UserExclusion(excludedUsers));
+        }
+        if (excludedRegions != null || includedRegions != null) {
+            scm.getExtensions().add(new PathRestriction(includedRegions, excludedRegions));
+        }
+
+        scm.getExtensions().add(new SparseCheckoutPaths(sparseCheckoutPaths));
+
+        project.setScm(scm);
+        project.getBuildersList().add(new CaptureEnvironmentBuilder());
+        return project;
+    }
+
+    /**
+     * Creates a new project and configures the GitSCM according the parameters.
+     *
+     * @param repos
+     * @param branchSpecs
+     * @param scmTriggerSpec
+     * @param disableRemotePoll Disable Workspace-less polling via "git
+     * ls-remote"
+     * @return
+     * @throws Exception
+     */
+    protected FreeStyleProject setupProject(List<UserRemoteConfig> repos, List<BranchSpec> branchSpecs,
+            String scmTriggerSpec, boolean disableRemotePoll, EnforceGitClient enforceGitClient) throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        GitSCM scm = new GitSCM(
+                repos,
+                branchSpecs,
+                false, Collections.<SubmoduleConfig>emptyList(),
+                null, JGitTool.MAGIC_EXENAME,
+                Collections.<GitSCMExtension>emptyList());
+        if (disableRemotePoll) {
+            scm.getExtensions().add(new DisableRemotePoll());
+        }
+        if (enforceGitClient != null) {
+            scm.getExtensions().add(enforceGitClient);
+        }
+        project.setScm(scm);
+        if (scmTriggerSpec != null) {
+            SCMTrigger trigger = new SCMTrigger(scmTriggerSpec);
+            project.addTrigger(trigger);
+            trigger.start(project, true);
+        }
+        project.getBuildersList().add(new CaptureEnvironmentBuilder());
+        project.save();
+        return project;
+    }
+
+    protected FreeStyleBuild build(final FreeStyleProject project, final Result expectedResult, final String... expectedNewlyCommittedFiles) throws Exception {
+        final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserCause()).get();
+        for (final String expectedNewlyCommittedFile : expectedNewlyCommittedFiles) {
+            assertTrue(expectedNewlyCommittedFile + " file not found in workspace", build.getWorkspace().child(expectedNewlyCommittedFile).exists());
+        }
+        if (expectedResult != null) {
+            jenkins.assertBuildStatus(expectedResult, build);
+        }
+        return build;
+    }
+
+    protected FreeStyleBuild build(final FreeStyleProject project, final String parentDir, final Result expectedResult, final String... expectedNewlyCommittedFiles) throws Exception {
+        final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserCause()).get();
+        for (final String expectedNewlyCommittedFile : expectedNewlyCommittedFiles) {
+            assertTrue(build.getWorkspace().child(parentDir).child(expectedNewlyCommittedFile).exists());
+        }
+        if (expectedResult != null) {
+            jenkins.assertBuildStatus(expectedResult, build);
+        }
+        return build;
+    }
+
+    protected MatrixBuild build(final MatrixProject project, final Result expectedResult, final String... expectedNewlyCommittedFiles) throws Exception {
+        final MatrixBuild build = project.scheduleBuild2(0, new Cause.UserCause()).get();
+        for (final String expectedNewlyCommittedFile : expectedNewlyCommittedFiles) {
+            assertTrue(expectedNewlyCommittedFile + " file not found in workspace", build.getWorkspace().child(expectedNewlyCommittedFile).exists());
+        }
+        if (expectedResult != null) {
+            jenkins.assertBuildStatus(expectedResult, build);
+        }
+        return build;
+    }
+
+    protected String getHeadRevision(AbstractBuild build, final String branch) throws IOException, InterruptedException {
+        return build.getWorkspace().act(new FilePath.FileCallable<String>() {
+            public String invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+                try {
+                    ObjectId oid = Git.with(null, null).in(f).getClient().getRepository().resolve("refs/heads/" + branch);
+                    return oid.name();
+                } catch (GitException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+
+    protected EnvVars getEnvVars(FreeStyleProject project) {
+        for (hudson.tasks.Builder b : project.getBuilders()) {
+            if (b instanceof CaptureEnvironmentBuilder) {
+                return ((CaptureEnvironmentBuilder) b).getEnvVars();
+            }
+        }
+        return new EnvVars();
+    }
+
+    protected void setVariables(Node node, EnvironmentVariablesNodeProperty.Entry... entries) throws IOException {
+        node.getNodeProperties().replaceBy(
+                Collections.singleton(new EnvironmentVariablesNodeProperty(
+                                entries)));
+
+    }
+}

--- a/src/test/java/hudson/plugins/git/AbstractGitRepository.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitRepository.java
@@ -1,0 +1,97 @@
+package hudson.plugins.git;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+
+import hudson.EnvVars;
+import hudson.Functions;
+import hudson.model.TaskListener;
+import hudson.util.StreamTaskListener;
+
+import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
+
+import org.jenkinsci.plugins.gitclient.Git;
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+/**
+ * Temporary git repository for use with tests. Tests which need a git
+ * repository but do not need a running Jenkins instance should extend this
+ * class so that repository setup and teardown are handled for them.
+ *
+ * Provides convenience methods for various repository functions.
+ *
+ * @author Mark Waite
+ */
+public abstract class AbstractGitRepository {
+
+    protected File testGitDir;
+    protected GitClient testGitClient;
+
+    private TemporaryDirectoryAllocator tempAllocator;
+
+    @Before
+    public void createGitRepository() throws IOException, InterruptedException {
+        tempAllocator = new TemporaryDirectoryAllocator();
+        testGitDir = tempAllocator.allocate();
+        TaskListener listener = StreamTaskListener.fromStderr();
+        testGitClient = Git.with(listener, new EnvVars()).in(testGitDir).getClient();
+        testGitClient.init();
+    }
+
+    @After
+    public void removeGitRepository() throws IOException, InterruptedException {
+        if (Functions.isWindows()) {
+            System.gc(); // Reduce Windows file busy exceptions cleaning up temp dirs
+        }
+
+        tempAllocator.dispose();
+    }
+
+    /**
+     * Commit fileName to this git repository
+     *
+     * @param fileName name of file to create
+     * @throws GitException
+     * @throws InterruptedException
+     */
+    protected void commitNewFile(final String fileName) throws GitException, InterruptedException {
+        File newFile = new File(testGitDir, fileName);
+        assert !newFile.exists(); // Not expected to use commitNewFile to update existing file
+        PrintWriter writer = null;
+        try {
+            writer = new PrintWriter(newFile, "UTF-8");
+            writer.println("A file named " + fileName);
+            writer.close();
+            testGitClient.add(fileName);
+            testGitClient.commit("Added a file named " + fileName);
+        } catch (FileNotFoundException notFound) {
+            throw new GitException(notFound);
+        } catch (UnsupportedEncodingException unsupported) {
+            throw new GitException(unsupported);
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+
+    /**
+     * Returns list of UserRemoteConfig for this repository.
+     *
+     * @return list of UserRemoteConfig for this repository
+     * @throws IOException
+     */
+    protected List<UserRemoteConfig> remoteConfigs() throws IOException {
+        List<UserRemoteConfig> list = new ArrayList<UserRemoteConfig>();
+        list.add(new UserRemoteConfig(testGitDir.getAbsolutePath(), "origin", "", null));
+        return list;
+    }
+}

--- a/src/test/java/hudson/plugins/git/GitChangeLogParserTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeLogParserTest.java
@@ -1,47 +1,36 @@
 package hudson.plugins.git;
 
-import hudson.Functions;
-import hudson.model.Run;
 import java.io.File;
 import java.io.FileWriter;
-import java.io.IOException;
-
-import org.jvnet.hudson.test.HudsonTestCase;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Unit tests of {@link GitChangeLogParser}
  */
-public class GitChangeLogParserTest extends HudsonTestCase {
+public class GitChangeLogParserTest {
 
-    @Override
-    protected void tearDown() throws Exception
-    {
-        try { //Avoid test failures due to failed cleanup tasks
-            super.tearDown();
-        }
-        catch (Exception e) {
-            if (e instanceof IOException && Functions.isWindows()) {
-                return;
-            }
-            e.printStackTrace();
-        }
-    }
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
 
     /**
      * Test duplicate changes filtered from parsed change set list.
-     * 
+     *
      * @throws Exception
      */
+    @Test
     public void testDuplicatesFiltered() throws Exception {
         GitChangeLogParser parser = new GitChangeLogParser(true);
-        File log = File.createTempFile(getClass().getName(), ".tmp");
+        File log = tmpFolder.newFile();
         FileWriter writer = new FileWriter(log);
         writer.write("commit 123abc456def\n");
         writer.write("    first message\n");
         writer.write("commit 123abc456def\n");
         writer.write("    second message");
         writer.close();
-        GitChangeSetList list = parser.parse((Run) null, null, log);
+        GitChangeSetList list = parser.parse(null, null, log);
         assertNotNull(list);
         assertNotNull(list.getLogs());
         assertEquals(1, list.getLogs().size());

--- a/src/test/java/hudson/plugins/git/GitChangeSetBasicTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetBasicTest.java
@@ -1,0 +1,103 @@
+package hudson.plugins.git;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class GitChangeSetBasicTest {
+
+    private GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat) {
+        return GitChangeSetUtil.genChangeSet(authorOrCommitter, useLegacyFormat, true);
+    }
+
+    private GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat, boolean hasParent) {
+        return GitChangeSetUtil.genChangeSet(authorOrCommitter, useLegacyFormat, hasParent);
+    }
+
+    @Test
+    public void testLegacyChangeSet() {
+        GitChangeSetUtil.assertChangeSet(genChangeSet(false, true));
+    }
+
+    @Test
+    public void testChangeSet() {
+        GitChangeSetUtil.assertChangeSet(genChangeSet(false, false));
+    }
+
+    @Test
+    public void testChangeSetNoParent() {
+        GitChangeSet changeSet = genChangeSet(false, false, false);
+        GitChangeSetUtil.assertChangeSet(changeSet);
+        assertNull(changeSet.getParentCommit());
+    }
+
+    @Test
+    public void testCommitter() {
+        assertEquals(GitChangeSetUtil.COMMITTER_NAME, genChangeSet(false, false).getAuthorName());
+    }
+
+    @Test
+    public void testAuthor() {
+        assertEquals(GitChangeSetUtil.AUTHOR_NAME, genChangeSet(true, false).getAuthorName());
+    }
+
+    @Test
+    public void testIsoDate() {
+
+        GitChangeSet c = new GitChangeSet(Arrays.asList("author John Doe <john.doe@jenkins-ci.org> 2015-03-03T09:22:42-0700"), true);
+        assertEquals("2015-03-03T09:22:42-0700", c.getDate());
+        assertEquals(1425399762000L, c.getTimestamp());
+
+        c = new GitChangeSet(Arrays.asList("author John Doe <john.doe@jenkins-ci.org> 2015-03-03T09:22:42-07:00"), true);
+        assertEquals("2015-03-03T09:22:42-07:00", c.getDate());
+        assertEquals(1425399762000L, c.getTimestamp());
+
+        c = new GitChangeSet(Arrays.asList("author John Doe <john.doe@jenkins-ci.org> 2015-03-03T16:22:42Z"), true);
+        assertEquals("2015-03-03T16:22:42Z", c.getDate());
+        assertEquals(1425399762000L, c.getTimestamp());
+
+        c = new GitChangeSet(Arrays.asList("author John Doe <john.doe@jenkins-ci.org> 1425399762"), true);
+        assertEquals("2015-03-03T16:22:42Z", c.getDate());
+        assertEquals(1425399762000L, c.getTimestamp());
+
+        c = new GitChangeSet(Arrays.asList("author John Doe <john.doe@jenkins-ci.org> 1425374562 -0700"), true);
+        assertEquals("2015-03-03T09:22:42-0700", c.getDate());
+        assertEquals(1425399762000L, c.getTimestamp());
+    }
+
+    private GitChangeSet genChangeSetForSwedCase(boolean authorOrCommitter) {
+        ArrayList<String> lines = new ArrayList<String>();
+        lines.add("commit 1567861636cd854f4dd6fa40bf94c0c657681dd5");
+        lines.add("tree 66236cf9a1ac0c589172b450ed01f019a5697c49");
+        lines.add("parent e74a24e995305bd67a180f0ebc57927e2b8783ce");
+        lines.add("author misterÅ <mister.ahlander@ericsson.com> 1363879004 +0100");
+        lines.add("committer Mister Åhlander <mister.ahlander@ericsson.com> 1364199539 -0400");
+        lines.add("");
+        lines.add("    [task] Updated version.");
+        lines.add("    ");
+        lines.add("    Including earlier updates.");
+        lines.add("    ");
+        lines.add("    Changes in this version:");
+        lines.add("    - Changed to take the gerrit url from gerrit query command.");
+        lines.add("    - Aligned reason information with our new commit hooks");
+        lines.add("    ");
+        lines.add("    Change-Id: Ife96d2abed5b066d9620034bec5f04cf74b8c66d");
+        lines.add("    Reviewed-on: https://gerrit.e.se/12345");
+        lines.add("    Tested-by: Jenkins <jenkins@no-mail.com>");
+        lines.add("    Reviewed-by: Mister Another <mister.another@ericsson.com>");
+        lines.add("");
+        //above lines all on purpose vs specific troublesome case @ericsson.
+        return new GitChangeSet(lines, authorOrCommitter);
+    }
+
+    @Test
+    public void testSwedishCommitterName() {
+        assertEquals("Mister Åhlander", genChangeSetForSwedCase(false).getAuthorName());
+    }
+
+    @Test
+    public void testSwedishAuthorName() {
+        assertEquals("misterÅ", genChangeSetForSwedCase(true).getAuthorName());
+    }
+}

--- a/src/test/java/hudson/plugins/git/GitChangeSetEmptyTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetEmptyTest.java
@@ -90,7 +90,8 @@ public class GitChangeSetEmptyTest {
 
     @Test
     public void testEquals() {
-        assertFalse(changeSet.equals(null));
+        assertEquals(changeSet, changeSet);
+        assertNotEquals(changeSet, GitChangeSetUtil.genChangeSet(true, true));
     }
 
 }

--- a/src/test/java/hudson/plugins/git/GitChangeSetEuroTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetEuroTest.java
@@ -12,7 +12,6 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class GitChangeSetEuroTest {
 
-    private GitChangeSet changeSet = null;
     private final String id = "1567861636cd854f4dd6fa40bf94c0c657681dd5";
     private final String parent = "e74a24e995305bd67a180f0ebc57927e2b8783ce";
     private final String authorName = "Mr. Åhłañder";
@@ -21,7 +20,8 @@ public class GitChangeSetEuroTest {
     private final String comment1 = "Including earlier updates.";
     private final String commentStartText = msg + "\n\n" + comment1 + "\n";
 
-    protected final boolean useAuthorName;
+    private GitChangeSet changeSet = null;
+    private final boolean useAuthorName;
 
     public GitChangeSetEuroTest(String useAuthorName) {
         this.useAuthorName = Boolean.valueOf(useAuthorName);
@@ -131,6 +131,16 @@ public class GitChangeSetEuroTest {
 
     @Test
     public void testEquals() {
-        assertFalse(changeSet.equals(null));
+        assertEquals(changeSet, changeSet);
+
+        assertEquals(GitChangeSetUtil.genChangeSet(false, false), GitChangeSetUtil.genChangeSet(false, false));
+        assertEquals(GitChangeSetUtil.genChangeSet(true, false), GitChangeSetUtil.genChangeSet(true, false));
+        assertEquals(GitChangeSetUtil.genChangeSet(false, true), GitChangeSetUtil.genChangeSet(false, true));
+        assertEquals(GitChangeSetUtil.genChangeSet(true, true), GitChangeSetUtil.genChangeSet(true, true));
+
+        assertNotEquals(changeSet, GitChangeSetUtil.genChangeSet(false, false));
+        assertNotEquals(GitChangeSetUtil.genChangeSet(true, false), changeSet);
+        assertNotEquals(changeSet, GitChangeSetUtil.genChangeSet(false, true));
+        assertNotEquals(GitChangeSetUtil.genChangeSet(true, true), changeSet);
     }
 }

--- a/src/test/java/hudson/plugins/git/GitChangeSetTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTest.java
@@ -1,153 +1,25 @@
 package hudson.plugins.git;
 
-import hudson.Functions;
 import hudson.model.User;
-import hudson.plugins.git.GitChangeSet.Path;
-import hudson.scm.EditType;
 import hudson.tasks.Mailer;
 import hudson.tasks.Mailer.UserProperty;
-import java.io.IOException;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
+public class GitChangeSetTest {
 
-import org.jvnet.hudson.test.HudsonTestCase;
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
-public class GitChangeSetTest extends HudsonTestCase {
-
-    @Override
-    protected void tearDown() throws Exception {
-        try { //Avoid test failures due to failed cleanup tasks
-            super.tearDown();
-        } catch (Exception e) {
-            if (e instanceof IOException && Functions.isWindows()) {
-                return;
-            }
-            e.printStackTrace();
-        }
-    }
-
-    public GitChangeSetTest(String testName) {
-        super(testName);
-    }
-
-    private GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat) {
-        return genChangeSet(authorOrCommitter, useLegacyFormat, true);
-    }
-
-    private GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat, boolean hasParent) {
-        ArrayList<String> lines = new ArrayList<String>();
-        lines.add("Some header junk we should ignore...");
-        lines.add("header line 2");
-        lines.add("commit 123abc456def");
-        lines.add("tree 789ghi012jkl");
-        if (hasParent) {
-            lines.add("parent 345mno678pqr");
-        } else {
-            lines.add("parent ");
-        }
-        lines.add("author John Author <jauthor@nospam.com> 1234567 -0600");
-        lines.add("committer John Committer <jcommitter@nospam.com> 1234567 -0600");
-        lines.add("");
-        lines.add("    Commit title.");
-        lines.add("    Commit extended description.");
-        lines.add("");
-        if (useLegacyFormat) {
-            lines.add("123abc456def");
-            lines.add(" create mode 100644 some/file1");
-            lines.add(" delete mode 100644 other/file2");
-        }
-        lines.add(":000000 123456 0000000000000000000000000000000000000000 123abc456def789abc012def345abc678def901a A\tsrc/test/add.file");
-        lines.add(":123456 000000 123abc456def789abc012def345abc678def901a 0000000000000000000000000000000000000000 D\tsrc/test/deleted.file");
-        lines.add(":123456 789012 123abc456def789abc012def345abc678def901a bc234def567abc890def123abc456def789abc01 M\tsrc/test/modified.file");
-        lines.add(":123456 789012 123abc456def789abc012def345abc678def901a bc234def567abc890def123abc456def789abc01 R012\tsrc/test/renamedFrom.file\tsrc/test/renamedTo.file");
-        lines.add(":000000 123456 bc234def567abc890def123abc456def789abc01 123abc456def789abc012def345abc678def901a C100\tsrc/test/original.file\tsrc/test/copyOf.file");
-
-        return new GitChangeSet(lines, authorOrCommitter);
-    }
-
-    public void testLegacyChangeSet() {
-        GitChangeSet changeSet = genChangeSet(false, true);
-        assertChangeSet(changeSet);
-    }
-
-    public void testChangeSet() {
-        GitChangeSet changeSet = genChangeSet(false, false);
-        assertChangeSet(changeSet);
-    }
-
-    public void testChangeSetNoParent() {
-        GitChangeSet changeSet = genChangeSet(false, false, false);
-        assertChangeSet(changeSet);
-        assertNull(changeSet.getParentCommit());
-    }
-
-    private void assertChangeSet(GitChangeSet changeSet) {
-        assertEquals("123abc456def", changeSet.getId());
-        assertEquals("Commit title.", changeSet.getMsg());
-        assertEquals("Commit title.\nCommit extended description.\n", changeSet.getComment());
-        assertEquals("Commit title.\nCommit extended description.\n".replace("\n", "<br>"), changeSet.getCommentAnnotated());
-        HashSet<String> expectedAffectedPaths = new HashSet<String>(7);
-        expectedAffectedPaths.add("src/test/add.file");
-        expectedAffectedPaths.add("src/test/deleted.file");
-        expectedAffectedPaths.add("src/test/modified.file");
-        expectedAffectedPaths.add("src/test/renamedFrom.file");
-        expectedAffectedPaths.add("src/test/renamedTo.file");
-        expectedAffectedPaths.add("src/test/copyOf.file");
-        assertEquals(expectedAffectedPaths, changeSet.getAffectedPaths());
-
-        Collection<Path> actualPaths = changeSet.getPaths();
-        assertEquals(6, actualPaths.size());
-        for (Path path : actualPaths) {
-            if ("src/test/add.file".equals(path.getPath())) {
-                assertEquals(EditType.ADD, path.getEditType());
-                assertNull(path.getSrc());
-                assertEquals("123abc456def789abc012def345abc678def901a", path.getDst());
-            } else if ("src/test/deleted.file".equals(path.getPath())) {
-                assertEquals(EditType.DELETE, path.getEditType());
-                assertEquals("123abc456def789abc012def345abc678def901a", path.getSrc());
-                assertNull(path.getDst());
-            } else if ("src/test/modified.file".equals(path.getPath())) {
-                assertEquals(EditType.EDIT, path.getEditType());
-                assertEquals("123abc456def789abc012def345abc678def901a", path.getSrc());
-                assertEquals("bc234def567abc890def123abc456def789abc01", path.getDst());
-            } else if ("src/test/renamedFrom.file".equals(path.getPath())) {
-                assertEquals(EditType.DELETE, path.getEditType());
-                assertEquals("123abc456def789abc012def345abc678def901a", path.getSrc());
-                assertEquals("bc234def567abc890def123abc456def789abc01", path.getDst());
-            } else if ("src/test/renamedTo.file".equals(path.getPath())) {
-                assertEquals(EditType.ADD, path.getEditType());
-                assertEquals("123abc456def789abc012def345abc678def901a", path.getSrc());
-                assertEquals("bc234def567abc890def123abc456def789abc01", path.getDst());
-            } else if ("src/test/copyOf.file".equals(path.getPath())) {
-                assertEquals(EditType.ADD, path.getEditType());
-                assertEquals("bc234def567abc890def123abc456def789abc01", path.getSrc());
-                assertEquals("123abc456def789abc012def345abc678def901a", path.getDst());
-            } else {
-                fail("Unrecognized path.");
-            }
-        }
-    }
-
-    public void testAuthorOrCommitter() {
-        GitChangeSet committerCS = genChangeSet(false, false);
-
-        assertEquals("John Committer", committerCS.getAuthorName());
-
-        GitChangeSet authorCS = genChangeSet(true, false);
-
-        assertEquals("John Author", authorCS.getAuthorName());
-    }
-
+    @Test
     public void testFindOrCreateUser() {
-        GitChangeSet committerCS = genChangeSet(false, false);
-        String csAuthor = "John Author";
-        String csAuthorEmail = "jauthor@nospam.com";
-        boolean createAccountBasedOnEmail = true;
+        final GitChangeSet committerCS = GitChangeSetUtil.genChangeSet(false, false);
+        final String email = "jauthor@nospam.com";
+        final boolean createAccountBasedOnEmail = true;
 
-        User user = committerCS.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail);
+        User user = committerCS.findOrCreateUser(GitChangeSetUtil.AUTHOR_NAME, email, createAccountBasedOnEmail);
         assertNotNull(user);
 
         UserProperty property = user.getProperty(Mailer.UserProperty.class);
@@ -155,69 +27,9 @@ public class GitChangeSetTest extends HudsonTestCase {
 
         String address = property.getAddress();
         assertNotNull(address);
-        assertEquals(csAuthorEmail, address);
+        assertEquals(email, address);
 
-        assertEquals(User.getUnknown(), committerCS.findOrCreateUser(null, csAuthorEmail, false));
-        assertEquals(User.getUnknown(), committerCS.findOrCreateUser(null, csAuthorEmail, true));
+        assertEquals(User.getUnknown(), committerCS.findOrCreateUser(null, email, false));
+        assertEquals(User.getUnknown(), committerCS.findOrCreateUser(null, email, true));
     }
-
-    public void testIsoDate() {
-
-        GitChangeSet c = new GitChangeSet(Arrays.asList("author John Doe <john.doe@jenkins-ci.org> 2015-03-03T09:22:42-0700"), true);
-        assertEquals("2015-03-03T09:22:42-0700",c.getDate());
-        assertEquals(1425399762000L, c.getTimestamp());
-
-        c = new GitChangeSet(Arrays.asList("author John Doe <john.doe@jenkins-ci.org> 2015-03-03T09:22:42-07:00"), true);
-        assertEquals("2015-03-03T09:22:42-07:00",c.getDate());
-        assertEquals(1425399762000L,c.getTimestamp());
-
-        c = new GitChangeSet(Arrays.asList("author John Doe <john.doe@jenkins-ci.org> 2015-03-03T16:22:42Z"), true);
-        assertEquals("2015-03-03T16:22:42Z",c.getDate());
-        assertEquals(1425399762000L,c.getTimestamp());
-
-        c = new GitChangeSet(Arrays.asList("author John Doe <john.doe@jenkins-ci.org> 1425399762"), true);
-        assertEquals("2015-03-03T16:22:42Z",c.getDate());
-        assertEquals(1425399762000L,c.getTimestamp());
-
-        c = new GitChangeSet(Arrays.asList("author John Doe <john.doe@jenkins-ci.org> 1425374562 -0700"), true);
-        assertEquals("2015-03-03T09:22:42-0700",c.getDate());
-        assertEquals(1425399762000L,c.getTimestamp());
-    }
-
-
-    private GitChangeSet genChangeSetForSwedCase(boolean authorOrCommitter) {
-        ArrayList<String> lines = new ArrayList<String>();
-        lines.add("commit 1567861636cd854f4dd6fa40bf94c0c657681dd5");
-        lines.add("tree 66236cf9a1ac0c589172b450ed01f019a5697c49");
-        lines.add("parent e74a24e995305bd67a180f0ebc57927e2b8783ce");
-        lines.add("author mistera <mister.ahlander@ericsson.com> 1363879004 +0100");
-        lines.add("committer Mister Åhlander <mister.ahlander@ericsson.com> 1364199539 -0400");
-        lines.add("");
-        lines.add("    [task] Updated version.");
-        lines.add("    ");
-        lines.add("    Including earlier updates.");
-        lines.add("    ");
-        lines.add("    Changes in this version:");
-        lines.add("    - Changed to take the gerrit url from gerrit query command.");
-        lines.add("    - Aligned reason information with our new commit hooks");
-        lines.add("    ");
-        lines.add("    Change-Id: Ife96d2abed5b066d9620034bec5f04cf74b8c66d");
-        lines.add("    Reviewed-on: https://gerrit.e.se/12345");
-        lines.add("    Tested-by: Jenkins <jenkins@no-mail.com>");
-        lines.add("    Reviewed-by: Mister Another <mister.another@ericsson.com>");
-        lines.add("");
-        //above lines all on purpose vs specific troublesome case @ericsson.
-        return new GitChangeSet(lines, authorOrCommitter);
-    }
-
-    public void testAuthorOrCommitterSwedCase() {
-        GitChangeSet committerCS = genChangeSetForSwedCase(false);
-
-        assertEquals("Mister Åhlander", committerCS.getAuthorName());//swedish char on purpose
-
-        GitChangeSet authorCS = genChangeSetForSwedCase(true);
-
-        assertEquals("mistera", authorCS.getAuthorName());
-    }
-
 }

--- a/src/test/java/hudson/plugins/git/GitChangeSetUtil.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetUtil.java
@@ -1,0 +1,99 @@
+package hudson.plugins.git;
+
+import hudson.scm.EditType;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import junit.framework.TestCase;
+
+/** Utility class to support GitChangeSet testing. */
+public class GitChangeSetUtil {
+
+    static final String ID = "123abc456def";
+    static final String PARENT = "345mno678pqr";
+    static final String AUTHOR_NAME = "John Author";
+    static final String COMMITTER_NAME = "John Committer";
+    static final String COMMIT_TITLE = "Commit title.";
+    static final String COMMENT = COMMIT_TITLE + "\n";
+
+    static GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat) {
+        return genChangeSet(authorOrCommitter, useLegacyFormat, true);
+    }
+
+    static GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat, boolean hasParent) {
+        ArrayList<String> lines = new ArrayList<String>();
+        lines.add("Some header junk we should ignore...");
+        lines.add("header line 2");
+        lines.add("commit " + ID);
+        lines.add("tree 789ghi012jkl");
+        if (hasParent) {
+            lines.add("parent " + PARENT);
+        } else {
+            lines.add("parent ");
+        }
+        lines.add("author " + AUTHOR_NAME + " <jauthor@nospam.com> 1234568 -0600");
+        lines.add("committer " + COMMITTER_NAME + " <jcommitter@nospam.com> 1234566 -0600");
+        lines.add("");
+        lines.add("    " + COMMIT_TITLE);
+        lines.add("    Commit extended description.");
+        lines.add("");
+        if (useLegacyFormat) {
+            lines.add("123abc456def");
+            lines.add(" create mode 100644 some/file1");
+            lines.add(" delete mode 100644 other/file2");
+        }
+        lines.add(":000000 123456 0000000000000000000000000000000000000000 123abc456def789abc012def345abc678def901a A\tsrc/test/add.file");
+        lines.add(":123456 000000 123abc456def789abc012def345abc678def901a 0000000000000000000000000000000000000000 D\tsrc/test/deleted.file");
+        lines.add(":123456 789012 123abc456def789abc012def345abc678def901a bc234def567abc890def123abc456def789abc01 M\tsrc/test/modified.file");
+        lines.add(":123456 789012 123abc456def789abc012def345abc678def901a bc234def567abc890def123abc456def789abc01 R012\tsrc/test/renamedFrom.file\tsrc/test/renamedTo.file");
+        lines.add(":000000 123456 bc234def567abc890def123abc456def789abc01 123abc456def789abc012def345abc678def901a C100\tsrc/test/original.file\tsrc/test/copyOf.file");
+        return new GitChangeSet(lines, authorOrCommitter);
+    }
+
+    static void assertChangeSet(GitChangeSet changeSet) {
+        TestCase.assertEquals("123abc456def", changeSet.getId());
+        TestCase.assertEquals("Commit title.", changeSet.getMsg());
+        TestCase.assertEquals("Commit title.\nCommit extended description.\n", changeSet.getComment());
+        TestCase.assertEquals("Commit title.\nCommit extended description.\n".replace("\n", "<br>"), changeSet.getCommentAnnotated());
+        HashSet<String> expectedAffectedPaths = new HashSet<String>(7);
+        expectedAffectedPaths.add("src/test/add.file");
+        expectedAffectedPaths.add("src/test/deleted.file");
+        expectedAffectedPaths.add("src/test/modified.file");
+        expectedAffectedPaths.add("src/test/renamedFrom.file");
+        expectedAffectedPaths.add("src/test/renamedTo.file");
+        expectedAffectedPaths.add("src/test/copyOf.file");
+        TestCase.assertEquals(expectedAffectedPaths, changeSet.getAffectedPaths());
+        Collection<GitChangeSet.Path> actualPaths = changeSet.getPaths();
+        TestCase.assertEquals(6, actualPaths.size());
+        for (GitChangeSet.Path path : actualPaths) {
+            if ("src/test/add.file".equals(path.getPath())) {
+                TestCase.assertEquals(EditType.ADD, path.getEditType());
+                TestCase.assertNull(path.getSrc());
+                TestCase.assertEquals("123abc456def789abc012def345abc678def901a", path.getDst());
+            } else if ("src/test/deleted.file".equals(path.getPath())) {
+                TestCase.assertEquals(EditType.DELETE, path.getEditType());
+                TestCase.assertEquals("123abc456def789abc012def345abc678def901a", path.getSrc());
+                TestCase.assertNull(path.getDst());
+            } else if ("src/test/modified.file".equals(path.getPath())) {
+                TestCase.assertEquals(EditType.EDIT, path.getEditType());
+                TestCase.assertEquals("123abc456def789abc012def345abc678def901a", path.getSrc());
+                TestCase.assertEquals("bc234def567abc890def123abc456def789abc01", path.getDst());
+            } else if ("src/test/renamedFrom.file".equals(path.getPath())) {
+                TestCase.assertEquals(EditType.DELETE, path.getEditType());
+                TestCase.assertEquals("123abc456def789abc012def345abc678def901a", path.getSrc());
+                TestCase.assertEquals("bc234def567abc890def123abc456def789abc01", path.getDst());
+            } else if ("src/test/renamedTo.file".equals(path.getPath())) {
+                TestCase.assertEquals(EditType.ADD, path.getEditType());
+                TestCase.assertEquals("123abc456def789abc012def345abc678def901a", path.getSrc());
+                TestCase.assertEquals("bc234def567abc890def123abc456def789abc01", path.getDst());
+            } else if ("src/test/copyOf.file".equals(path.getPath())) {
+                TestCase.assertEquals(EditType.ADD, path.getEditType());
+                TestCase.assertEquals("bc234def567abc890def123abc456def789abc01", path.getSrc());
+                TestCase.assertEquals("123abc456def789abc012def345abc678def901a", path.getDst());
+            } else {
+                TestCase.fail("Unrecognized path.");
+            }
+        }
+    }
+
+}

--- a/src/test/java/hudson/plugins/git/GitPublisherTest.java
+++ b/src/test/java/hudson/plugins/git/GitPublisherTest.java
@@ -39,10 +39,10 @@ import hudson.plugins.git.extensions.impl.LocalBranch;
 import hudson.plugins.git.extensions.impl.PreBuildMerge;
 import hudson.scm.NullSCM;
 import hudson.tasks.BuildStepDescriptor;
+import hudson.util.StreamTaskListener;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
-import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.Issue;
 
 import java.io.IOException;
@@ -51,22 +51,33 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Tests for {@link GitPublisher}
  * 
  * @author Kohsuke Kawaguchi
  */
-public class GitPublisherTest extends AbstractGitTestCase {
-    @Bug(5005)
+public class GitPublisherTest extends AbstractGitProject {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Issue("JENKINS-5005")
+    @Test
     public void testMatrixBuild() throws Exception {
         final AtomicInteger run = new AtomicInteger(); // count the number of times the perform is called
 
-        commit("a", johnDoe, "commit #1");
+        commitNewFile("a");
 
-        MatrixProject mp = createMatrixProject("xyz");
+        MatrixProject mp = jenkins.createMatrixProject("xyz");
         mp.setAxes(new AxisList(new Axis("VAR","a","b")));
-        mp.setScm(new GitSCM(workDir.getAbsolutePath()));
+        mp.setScm(new GitSCM(testGitDir.getAbsolutePath()));
         mp.getPublishersList().add(new GitPublisher(
                 Collections.singletonList(new TagToPush("origin","foo","message",true, false)),
                 Collections.<BranchToPush>emptyList(),
@@ -92,8 +103,7 @@ public class GitPublisherTest extends AbstractGitTestCase {
             private Object writeReplace() { return new NullSCM(); }
         });
 
-        MatrixBuild b = assertBuildStatusSuccess(mp.scheduleBuild2(0).get());
-        System.out.println(b.getLog());
+        MatrixBuild b = jenkins.assertBuildStatusSuccess(mp.scheduleBuild2(0).get());
 
         assertTrue(existsTag("foo"));
 
@@ -103,11 +113,12 @@ public class GitPublisherTest extends AbstractGitTestCase {
         assertEquals(3,run.get());
     }
 
+    @Test
     public void testMergeAndPush() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");
 
         GitSCM scm = new GitSCM(
-                createRemoteRepositories(),
+                remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
@@ -123,27 +134,28 @@ public class GitPublisherTest extends AbstractGitTestCase {
                 true, true, false));
 
         // create initial commit and then run the build against it:
-        commit("commitFileBase", johnDoe, "Initial Commit");
-        testRepo.git.branch("integration");
+        commitNewFile("commitFileBase");
+        testGitClient.branch("integration");
         build(project, Result.SUCCESS, "commitFileBase");
 
-        testRepo.git.checkout(null, "topic1");
+        testGitClient.checkout(null, "topic1");
         final String commitFile1 = "commitFile1";
-        commit(commitFile1, johnDoe, "Commit number 1");
+        commitNewFile(commitFile1);
         final FreeStyleBuild build1 = build(project, Result.SUCCESS, commitFile1);
         assertTrue(build1.getWorkspace().child(commitFile1).exists());
 
         String sha1 = getHeadRevision(build1, "integration");
-        assertEquals(sha1, testRepo.git.revParse(Constants.HEAD).name());
+        assertEquals(sha1, testGitClient.revParse(Constants.HEAD).name());
 
     }
 
     @Issue("JENKINS-12402")
+    @Test
     public void testMergeAndPushFF() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");
 
         GitSCM scm = new GitSCM(
-                createRemoteRepositories(),
+                remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
@@ -159,21 +171,21 @@ public class GitPublisherTest extends AbstractGitTestCase {
                 true, true, false));
 
         // create initial commit and then run the build against it:
-        commit("commitFileBase", johnDoe, "Initial Commit");
-        testRepo.git.branch("integration");
+        commitNewFile("commitFileBase");
+        testGitClient.branch("integration");
         final FreeStyleBuild build1 = build(project, Result.SUCCESS, "commitFileBase");
         assertTrue(build1.getWorkspace().child("commitFileBase").exists());
         String shaIntegration = getHeadRevision(build1, "integration");
-        assertEquals("the integration branch should be at HEAD",shaIntegration, testRepo.git.revParse(Constants.HEAD).name());
+        assertEquals("the integration branch should be at HEAD", shaIntegration, testGitClient.revParse(Constants.HEAD).name());
 
         // create a new branch and build, this results in a fast-forward merge
-        testRepo.git.checkout("master");
-        ObjectId master = testRepo.git.revParse("HEAD");
-        testRepo.git.branch("branch1");
-        testRepo.git.checkout("branch1");
+        testGitClient.checkout("master");
+        ObjectId master = testGitClient.revParse("HEAD");
+        testGitClient.branch("branch1");
+        testGitClient.checkout("branch1");
         final String commitFile1 = "commitFile1";
-        commit(commitFile1, johnDoe, "Commit number 1");
-        String shaBranch1 = testRepo.git.revParse("branch1").name();
+        commitNewFile(commitFile1);
+        String shaBranch1 = testGitClient.revParse("branch1").name();
         final FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile1);
 
         // Test that the build (including publish) performed as expected.
@@ -184,22 +196,22 @@ public class GitPublisherTest extends AbstractGitTestCase {
         //
         assertTrue(build2.getWorkspace().child("commitFile1").exists());
         shaIntegration = getHeadRevision(build2, "integration");
-        String shaHead = testRepo.git.revParse(Constants.HEAD).name();
+        String shaHead = testGitClient.revParse(Constants.HEAD).name();
         assertEquals("the integration branch and branch1 should line up",shaIntegration, shaBranch1);
         assertEquals("the integration branch should be at HEAD",shaIntegration, shaHead);
         // integration should have master as the parent commit
-        List<ObjectId> revList = testRepo.git.revList("integration^1");
+        List<ObjectId> revList = testGitClient.revList("integration^1");
         ObjectId integrationParent = revList.get(0);
         assertEquals("Fast-forward merge should have had master as a parent",master,integrationParent);
 
         // create a second branch off of master, so as to force a merge commit and to test
         // that --ff gracefully falls back to a merge commit
-        testRepo.git.checkout("master");
-        testRepo.git.branch("branch2");
-        testRepo.git.checkout("branch2");
+        testGitClient.checkout("master");
+        testGitClient.branch("branch2");
+        testGitClient.checkout("branch2");
         final String commitFile2 = "commitFile2";
-        commit(commitFile2, johnDoe, "Commit number 2");
-        String shaBranch2 = testRepo.git.revParse("branch2").name();
+        commitNewFile(commitFile2);
+        String shaBranch2 = testGitClient.revParse("branch2").name();
         final FreeStyleBuild build3 = build(project, Result.SUCCESS, commitFile2);
 
         // Test that the build (including publish) performed as expected
@@ -216,18 +228,19 @@ public class GitPublisherTest extends AbstractGitTestCase {
         assertTrue(build1.getWorkspace().child(commitFile1).exists());
         assertTrue(build1.getWorkspace().child(commitFile2).exists());
         // the integration branch should have branch1 and branch2 as parents
-        revList = testRepo.git.revList("integration^1");
+        revList = testGitClient.revList("integration^1");
         assertEquals("Integration should have branch1 as a parent",revList.get(0).name(),shaBranch1);
-        revList = testRepo.git.revList("integration^2");
+        revList = testGitClient.revList("integration^2");
         assertEquals("Integration should have branch2 as a parent",revList.get(0).name(),shaBranch2);
     }
 
     @Issue("JENKINS-12402")
+    @Test
     public void testMergeAndPushNoFF() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");
 
         GitSCM scm = new GitSCM(
-                createRemoteRepositories(),
+                remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
@@ -243,24 +256,24 @@ public class GitPublisherTest extends AbstractGitTestCase {
                 true, true, false));
 
         // create initial commit and then run the build against it:
-        commit("commitFileBase", johnDoe, "Initial Commit");
-        testRepo.git.branch("integration");
+        commitNewFile("commitFileBase");
+        testGitClient.branch("integration");
         final FreeStyleBuild build1 = build(project, Result.SUCCESS, "commitFileBase");
         assertTrue(build1.getWorkspace().child("commitFileBase").exists());
         String shaIntegration = getHeadRevision(build1, "integration");
-        assertEquals("integration branch should be at HEAD",shaIntegration, testRepo.git.revParse(Constants.HEAD).name());
+        assertEquals("integration branch should be at HEAD", shaIntegration, testGitClient.revParse(Constants.HEAD).name());
 
         // create a new branch and build
         // This would be a fast-forward merge, but we're calling for --no-ff and that should work
-        testRepo.git.checkout("master");
-        ObjectId master = testRepo.git.revParse("HEAD");
-        testRepo.git.branch("branch1");
-        testRepo.git.checkout("branch1");
+        testGitClient.checkout("master");
+        ObjectId master = testGitClient.revParse("HEAD");
+        testGitClient.branch("branch1");
+        testGitClient.checkout("branch1");
         final String commitFile1 = "commitFile1";
-        commit(commitFile1, johnDoe, "Commit number 1");
-        String shaBranch1 = testRepo.git.revParse("branch1").name();
+        commitNewFile(commitFile1);
+        String shaBranch1 = testGitClient.revParse("branch1").name();
         final FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile1);
-        ObjectId mergeCommit = testRepo.git.revParse("integration");
+        ObjectId mergeCommit = testGitClient.revParse("integration");
 
         // Test that the build and publish performed as expected.
         //   - commitFile1 is in the workspace
@@ -272,18 +285,18 @@ public class GitPublisherTest extends AbstractGitTestCase {
         //     * 3066c87 (master) Initial Commit
         //
         assertTrue(build2.getWorkspace().child("commitFile1").exists());
-        List<ObjectId> revList = testRepo.git.revList("integration^1");
+        List<ObjectId> revList = testGitClient.revList("integration^1");
         assertEquals("Integration should have master as a parent",revList.get(0),master);
-        revList = testRepo.git.revList("integration^2");
+        revList = testGitClient.revList("integration^2");
         assertEquals("Integration should have branch1 as a parent",revList.get(0).name(),shaBranch1);
 
         // create a second branch off of master, so as to test that --no-ff is published as expected
-        testRepo.git.checkout("master");
-        testRepo.git.branch("branch2");
-        testRepo.git.checkout("branch2");
+        testGitClient.checkout("master");
+        testGitClient.branch("branch2");
+        testGitClient.checkout("branch2");
         final String commitFile2 = "commitFile2";
-        commit(commitFile2, johnDoe, "Commit number 2");
-        String shaBranch2 = testRepo.git.revParse("branch2").name();
+        commitNewFile(commitFile2);
+        String shaBranch2 = testGitClient.revParse("branch2").name();
         final FreeStyleBuild build3 = build(project, Result.SUCCESS, commitFile2);
 
         // Test that the build performed as expected
@@ -304,18 +317,19 @@ public class GitPublisherTest extends AbstractGitTestCase {
         assertTrue("commitFile1 should exist in the workspace",build1.getWorkspace().child(commitFile1).exists());
         assertTrue("commitFile2 should exist in the workspace",build1.getWorkspace().child(commitFile2).exists());
         // the integration branch should have branch1 and branch2 as parents
-        revList = testRepo.git.revList("integration^1");
+        revList = testGitClient.revList("integration^1");
         assertEquals("Integration should have the first merge commit as a parent",revList.get(0),mergeCommit);
-        revList = testRepo.git.revList("integration^2");
+        revList = testGitClient.revList("integration^2");
         assertEquals("Integration should have branch2 as a parent",revList.get(0).name(),shaBranch2);
     }
 
     @Issue("JENKINS-12402")
+    @Test
     public void testMergeAndPushFFOnly() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");
 
         GitSCM scm = new GitSCM(
-                createRemoteRepositories(),
+                remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
@@ -331,24 +345,24 @@ public class GitPublisherTest extends AbstractGitTestCase {
                 true, true, false));
 
         // create initial commit and then run the build against it:
-        commit("commitFileBase", johnDoe, "Initial Commit");
-        testRepo.git.branch("integration");
+        commitNewFile("commitFileBase");
+        testGitClient.branch("integration");
         final FreeStyleBuild build1 = build(project, Result.SUCCESS, "commitFileBase");
         assertTrue(build1.getWorkspace().child("commitFileBase").exists());
         String shaIntegration = getHeadRevision(build1, "integration");
-        assertEquals("integration should be at HEAD",shaIntegration, testRepo.git.revParse(Constants.HEAD).name());
+        assertEquals("integration should be at HEAD", shaIntegration, testGitClient.revParse(Constants.HEAD).name());
 
         // create a new branch and build
         // This merge can work with --ff-only
-        testRepo.git.checkout("master");
-        ObjectId master = testRepo.git.revParse("HEAD");
-        testRepo.git.branch("branch1");
-        testRepo.git.checkout("branch1");
+        testGitClient.checkout("master");
+        ObjectId master = testGitClient.revParse("HEAD");
+        testGitClient.branch("branch1");
+        testGitClient.checkout("branch1");
         final String commitFile1 = "commitFile1";
-        commit(commitFile1, johnDoe, "Commit number 1");
-        String shaBranch1 = testRepo.git.revParse("branch1").name();
+        commitNewFile(commitFile1);
+        String shaBranch1 = testGitClient.revParse("branch1").name();
         final FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile1);
-        ObjectId mergeCommit = testRepo.git.revParse("integration");
+        ObjectId mergeCommit = testGitClient.revParse("integration");
 
         // Test that the build (including publish) performed as expected.
         //   - commitFile1 is in the workspace
@@ -358,24 +372,23 @@ public class GitPublisherTest extends AbstractGitTestCase {
         //
         assertTrue("commitFile1 should exist in the worksapce",build2.getWorkspace().child("commitFile1").exists());
         shaIntegration = getHeadRevision(build2, "integration");
-        String shaHead = testRepo.git.revParse(Constants.HEAD).name();
+        String shaHead = testGitClient.revParse(Constants.HEAD).name();
         assertEquals("integration and branch1 should line up",shaIntegration, shaBranch1);
         assertEquals("integration and head should line up",shaIntegration, shaHead);
         // integration should have master as the parent commit
-        List<ObjectId> revList = testRepo.git.revList("integration^1");
+        List<ObjectId> revList = testGitClient.revList("integration^1");
         ObjectId integrationParent = revList.get(0);
         assertEquals("Fast-forward merge should have had master as a parent",master,integrationParent);
 
         // create a second branch off of master, so as to force a merge commit
         // but the publish will fail as --ff-only cannot work with a parallel branch
-        testRepo.git.checkout("master");
-        testRepo.git.branch("branch2");
-        testRepo.git.checkout("branch2");
+        testGitClient.checkout("master");
+        testGitClient.branch("branch2");
+        testGitClient.checkout("branch2");
         final String commitFile2 = "commitFile2";
-        commit(commitFile2, johnDoe, "Commit number 2");
-        String shaBranch2 = testRepo.git.revParse("branch2").name();
+        commitNewFile(commitFile2);
+        String shaBranch2 = testGitClient.revParse("branch2").name();
         final FreeStyleBuild build3 = build(project, Result.FAILURE, commitFile2);
-        showRepo(testRepo,"After merge commit build and a failed published");
 
         // Test that the publish did not merge the branches
         //   - The workspace will contain commitFile2, but not branch1's file (commitFile1)
@@ -386,10 +399,10 @@ public class GitPublisherTest extends AbstractGitTestCase {
         //     * ebffeb3 (master) Initial Commit
         assertFalse("commitFile1 should not exist in the worksapce",build2.getWorkspace().child("commitFile1").exists());
         assertTrue("commitFile2 should exist in the worksapce",build2.getWorkspace().child("commitFile2").exists());
-        revList = testRepo.git.revList("branch2^1");
+        revList = testGitClient.revList("branch2^1");
         assertEquals("branch2 should have master as a parent",revList.get(0),master);
         try {
-          revList = testRepo.git.revList("branch2^2");
+          revList = testGitClient.revList("branch2^2");
           assertTrue("branch2 should have no other parent than master",false);
         } catch (java.lang.NullPointerException err) {
           // expected
@@ -397,16 +410,18 @@ public class GitPublisherTest extends AbstractGitTestCase {
     }
 
     @Issue("JENKINS-24786")
+    @Test
     public void testPushEnvVarsInRemoteConfig() throws Exception{
     	FreeStyleProject project = setupSimpleProject("master");
 
-    	// create second (bare) test repository as target
-    	TestGitRepo testTargetRepo = new TestGitRepo("target", this, listener);
+        // create second (bare) test repository as target
+        TaskListener listener = StreamTaskListener.fromStderr();
+        TestGitRepo testTargetRepo = new TestGitRepo("target", tmpFolder.newFolder("push_env_vars"), listener);
     	testTargetRepo.git.init_().workspace(testTargetRepo.gitDir.getAbsolutePath()).bare(true).execute();
-    	testTargetRepo.commit("lostTargetFile", johnDoe, "Initial Target Commit");
+        testTargetRepo.commit("lostTargetFile", new PersonIdent("John Doe", "john@example.com"), "Initial Target Commit");
 
-    	// add second test repository as remote repository with environment variables
-    	List<UserRemoteConfig> remoteRepositories = createRemoteRepositories();
+        // add second test repository as remote repository with environment variables
+        List<UserRemoteConfig> remoteRepositories = remoteConfigs();
     	remoteRepositories.add(new UserRemoteConfig("$TARGET_URL", "$TARGET_NAME", "+refs/heads/$TARGET_BRANCH:refs/remotes/$TARGET_NAME/$TARGET_BRANCH", null));
 
         GitSCM scm = new GitSCM(
@@ -432,24 +447,25 @@ public class GitPublisherTest extends AbstractGitTestCase {
                 Collections.singletonList(new NoteToPush("$TARGET_NAME", note_content, Constants.R_NOTES_COMMITS, false)),
                 true, false, true));
 
-        commit("commitFile", johnDoe, "Initial Commit");
-        testRepo.git.tag(tag_name, "Comment");
-        ObjectId expectedCommit = testRepo.git.revParse("master");
+        commitNewFile("commitFile");
+        testGitClient.tag(tag_name, "Comment");
+        ObjectId expectedCommit = testGitClient.revParse("master");
 
         build(project, Result.SUCCESS, "commitFile");
 
         // check if everything reached target repository
         assertEquals(expectedCommit, testTargetRepo.git.revParse("master"));
-        assertTrue(existsTagInRepo(testTargetRepo, tag_name));
+        assertTrue(existsTagInRepo(testTargetRepo.git, tag_name));
 
     }
 
     @Issue("JENKINS-24082")
+    @Test
     public void testForcePush() throws Exception {
     	FreeStyleProject project = setupSimpleProject("master");
 
         GitSCM scm = new GitSCM(
-                createRemoteRepositories(),
+                remoteConfigs(),
                 Collections.singletonList(new BranchSpec("master")),
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
@@ -462,31 +478,32 @@ public class GitPublisherTest extends AbstractGitTestCase {
                 Collections.<NoteToPush>emptyList(),
                 true, true, true));
 
-        commit("commitFile", johnDoe, "Initial Commit");
+        commitNewFile("commitFile");
 
-        testRepo.git.branch("otherbranch");
-        testRepo.git.checkout("otherbranch");
-        commit("otherCommitFile", johnDoe, "commit lost on force push");
-        
-        testRepo.git.checkout("master");
-        commit("commitFile2", johnDoe, "commit to be pushed");
-        
-        ObjectId expectedCommit = testRepo.git.revParse("master");
-        
+        testGitClient.branch("otherbranch");
+        testGitClient.checkout("otherbranch");
+        commitNewFile("otherCommitFile");
+
+        testGitClient.checkout("master");
+        commitNewFile("commitFile2");
+
+        ObjectId expectedCommit = testGitClient.revParse("master");
+
         build(project, Result.SUCCESS, "commitFile");
 
-        assertEquals(expectedCommit, testRepo.git.revParse("otherbranch"));
+        assertEquals(expectedCommit, testGitClient.revParse("otherbranch"));
     }
 
     /**
      * Fix push to remote when skipTag is enabled
      */
-    @Bug(17769)
+    @Issue("JENKINS-17769")
+    @Test
     public void testMergeAndPushWithSkipTagEnabled() throws Exception {
       FreeStyleProject project = setupSimpleProject("master");
 
         GitSCM scm = new GitSCM(
-                createRemoteRepositories(),
+                remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null, new ArrayList<GitSCMExtension>());
@@ -502,21 +519,22 @@ public class GitPublisherTest extends AbstractGitTestCase {
           true, true, false));
 
       // create initial commit and then run the build against it:
-      commit("commitFileBase", johnDoe, "Initial Commit");
-      testRepo.git.branch("integration");
+      commitNewFile("commitFileBase");
+      testGitClient.branch("integration");
       build(project, Result.SUCCESS, "commitFileBase");
 
-      testRepo.git.checkout(null, "topic1");
+      testGitClient.checkout(null, "topic1");
       final String commitFile1 = "commitFile1";
-      commit(commitFile1, johnDoe, "Commit number 1");
+      commitNewFile(commitFile1);
       final FreeStyleBuild build1 = build(project, Result.SUCCESS, commitFile1);
       assertTrue(build1.getWorkspace().child(commitFile1).exists());
 
       String sha1 = getHeadRevision(build1, "integration");
-      assertEquals(sha1, testRepo.git.revParse(Constants.HEAD).name());
+      assertEquals(sha1, testGitClient.revParse(Constants.HEAD).name());
     }
 
-    @Bug(24786)
+    @Issue("JENKINS-24786")
+    @Test
     public void testMergeAndPushWithCharacteristicEnvVar() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");
 
@@ -534,7 +552,8 @@ public class GitPublisherTest extends AbstractGitTestCase {
         checkEnvVar(project, envName, envValue);
     }
 
-    @Bug(24786)
+    @Issue("JENKINS-24786")
+    @Test
     public void testMergeAndPushWithSystemEnvVar() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");
 
@@ -554,7 +573,7 @@ public class GitPublisherTest extends AbstractGitTestCase {
         scmExtensions.add(new PreBuildMerge(new UserMergeOptions("origin", envReference, null, null)));
         scmExtensions.add(new LocalBranch(envReference));
         GitSCM scm = new GitSCM(
-                createRemoteRepositories(),
+                remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null, scmExtensions);
@@ -579,33 +598,33 @@ public class GitPublisherTest extends AbstractGitTestCase {
         project.getPublishersList().add(publisher);
 
         // create initial commit
-        commit("commitFileBase", johnDoe, "Initial Commit");
-        ObjectId initialCommit = testRepo.git.getHeadRev(testRepo.gitDir.getAbsolutePath(), "master");
-        assertTrue(testRepo.git.isCommitInRepo(initialCommit));
+        commitNewFile("commitFileBase");
+        ObjectId initialCommit = testGitClient.getHeadRev(testGitDir.getAbsolutePath(), "master");
+        assertTrue(testGitClient.isCommitInRepo(initialCommit));
 
         // Create branch in the test repo (pulled into the project workspace at build)
         assertFalse("Test repo has " + envValue + " branch", hasBranch(envValue));
-        testRepo.git.branch(envValue);
+        testGitClient.branch(envValue);
         assertTrue("Test repo missing " + envValue + " branch", hasBranch(envValue));
-        assertFalse(tagNameValue + " in " + testRepo, testRepo.git.tagExists(tagNameValue));
+        assertFalse(tagNameValue + " in " + testGitClient, testGitClient.tagExists(tagNameValue));
 
         // Build the branch
         final FreeStyleBuild build0 = build(project, Result.SUCCESS, "commitFileBase");
 
         String build0HeadBranch = getHeadRevision(build0, envValue);
         assertEquals(build0HeadBranch, initialCommit.getName());
-        assertTrue(tagNameValue + " not in " + testRepo, testRepo.git.tagExists(tagNameValue));
+        assertTrue(tagNameValue + " not in " + testGitClient, testGitClient.tagExists(tagNameValue));
         assertTrue(tagNameValue + " not in build", build0.getWorkspace().child(".git/refs/tags/" + tagNameValue).exists());
 
         // Create a topic branch in the source repository and commit to topic branch
         String topicBranch = envValue + "-topic1";
         assertFalse("Test repo has " + topicBranch + " branch", hasBranch(topicBranch));
-        testRepo.git.checkout(null, topicBranch);
+        testGitClient.checkout(null, topicBranch);
         assertTrue("Test repo has no " + topicBranch + " branch", hasBranch(topicBranch));
         final String commitFile1 = "commitFile1";
-        commit(commitFile1, johnDoe, "Commit number 1");
-        ObjectId topicCommit = testRepo.git.getHeadRev(testRepo.gitDir.getAbsolutePath(), topicBranch);
-        assertTrue(testRepo.git.isCommitInRepo(topicCommit));
+        commitNewFile(commitFile1);
+        ObjectId topicCommit = testGitClient.getHeadRev(testGitDir.getAbsolutePath(), topicBranch);
+        assertTrue(testGitClient.isCommitInRepo(topicCommit));
 
         // Run a build, should be on the topic branch, tagged, and noted
         final FreeStyleBuild build1 = build(project, Result.SUCCESS, commitFile1);
@@ -614,27 +633,27 @@ public class GitPublisherTest extends AbstractGitTestCase {
         assertTrue("Tag " + tagNameValue + " not in build", myWorkspace.child(".git/refs/tags/" + tagNameValue).exists());
 
         String build1Head = getHeadRevision(build1, envValue);
-        assertEquals(build1Head, testRepo.git.revParse(Constants.HEAD).name());
+        assertEquals(build1Head, testGitClient.revParse(Constants.HEAD).name());
         assertEquals("Wrong head commit in build1", topicCommit.getName(), build1Head);
 
     }
 
     private boolean existsTag(String tag) throws InterruptedException {
-        return existsTagInRepo(testRepo, tag);
+        return existsTagInRepo(testGitClient, tag);
     }
 
-    private boolean existsTagInRepo(TestGitRepo gitRepo, String tag) throws InterruptedException {
-        Set<String> tags = gitRepo.git.getTagNames("*");
+    private boolean existsTagInRepo(GitClient gitClient, String tag) throws InterruptedException {
+        Set<String> tags = gitClient.getTagNames("*");
         return tags.contains(tag);
     }
 
     private boolean containsTagMessage(String tag, String str) throws InterruptedException {
-        String msg = git.getTagMessage(tag);
+        String msg = testGitClient.getTagMessage(tag);
         return msg.contains(str);
     }
 
     private boolean hasBranch(String branchName) throws GitException, InterruptedException {
-        Set<Branch> testRepoBranches = testRepo.git.getBranches();
+        Set<Branch> testRepoBranches = testGitClient.getBranches();
         for (Branch branch : testRepoBranches) {
             if (branch.getName().equals(branchName)) {
                 return true;

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -1,73 +1,64 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package hudson.plugins.git;
 
-import hudson.Functions;
 import hudson.model.Action;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.triggers.SCMTrigger;
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.*;
 
 import org.eclipse.jgit.transport.URIish;
-import org.jvnet.hudson.test.HudsonTestCase;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.jvnet.hudson.test.WithoutJenkins;
+
 import javax.servlet.http.HttpServletRequest;
 
-public class GitStatusTest extends HudsonTestCase {
+public class GitStatusTest extends AbstractGitProject {
+
     private GitStatus gitStatus;
     private HttpServletRequest requestWithNoParameter;
     private HttpServletRequest requestWithParameter;
 
-    public GitStatusTest(String testName) {
-        super(testName);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         this.gitStatus = new GitStatus();
         this.requestWithNoParameter = mock(HttpServletRequest.class);
         this.requestWithParameter = mock(HttpServletRequest.class);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        try { //Avoid test failures due to failed cleanup tasks
-            super.tearDown();
-        } catch (Exception e) {
-            if (e instanceof IOException && Functions.isWindows()) {
-                return;
-            }
-            e.printStackTrace();
-        }
-    }
-
+    @WithoutJenkins
+    @Test
     public void testGetDisplayName() {
         assertEquals("Git", this.gitStatus.getDisplayName());
     }
 
+    @WithoutJenkins
+    @Test
     public void testGetSearchUrl() {
         assertEquals("git", this.gitStatus.getSearchUrl());
     }
 
+    @WithoutJenkins
+    @Test
     public void testGetIconFileName() {
         assertNull(this.gitStatus.getIconFileName());
     }
 
+    @WithoutJenkins
+    @Test
     public void testGetUrlName() {
         assertEquals("git", this.gitStatus.getUrlName());
     }
 
+    @Test
     public void testDoNotifyCommitWithNoBranches() throws Exception {
         SCMTrigger aMasterTrigger = setupProject("a", "master", false);
         SCMTrigger aTopicTrigger = setupProject("a", "topic", false);
@@ -81,6 +72,7 @@ public class GitStatusTest extends HudsonTestCase {
         Mockito.verify(bTopicTrigger, Mockito.never()).run();
     }
 
+    @Test
     public void testDoNotifyCommitWithNoMatchingUrl() throws Exception {
         SCMTrigger aMasterTrigger = setupProject("a", "master", false);
         SCMTrigger aTopicTrigger = setupProject("a", "topic", false);
@@ -94,6 +86,7 @@ public class GitStatusTest extends HudsonTestCase {
         Mockito.verify(bTopicTrigger, Mockito.never()).run();
     }
 
+    @Test
     public void testDoNotifyCommitWithOneBranch() throws Exception {
         SCMTrigger aMasterTrigger = setupProject("a", "master", false);
         SCMTrigger aTopicTrigger = setupProject("a", "topic", false);
@@ -107,6 +100,7 @@ public class GitStatusTest extends HudsonTestCase {
         Mockito.verify(bTopicTrigger, Mockito.never()).run();
     }
 
+    @Test
     public void testDoNotifyCommitWithTwoBranches() throws Exception {
         SCMTrigger aMasterTrigger = setupProject("a", "master", false);
         SCMTrigger aTopicTrigger = setupProject("a", "topic", false);
@@ -120,6 +114,7 @@ public class GitStatusTest extends HudsonTestCase {
         Mockito.verify(bTopicTrigger, Mockito.never()).run();
     }
 
+    @Test
     public void testDoNotifyCommitWithNoMatchingBranches() throws Exception {
         SCMTrigger aMasterTrigger = setupProject("a", "master", false);
         SCMTrigger aTopicTrigger = setupProject("a", "topic", false);
@@ -133,6 +128,7 @@ public class GitStatusTest extends HudsonTestCase {
         Mockito.verify(bTopicTrigger, Mockito.never()).run();
     }
 
+    @Test
     public void testDoNotifyCommitWithIgnoredRepository() throws Exception {
         SCMTrigger aMasterTrigger = setupProject("a", "master", true);
 
@@ -140,13 +136,14 @@ public class GitStatusTest extends HudsonTestCase {
         Mockito.verify(aMasterTrigger, Mockito.never()).run();
     }
 
-
+    @Test
     public void testDoNotifyCommitWithNoScmTrigger() throws Exception {
         setupProject("a", "master", null);
         this.gitStatus.doNotifyCommit(requestWithNoParameter, "a", null, "");
         // no expectation here, however we shouldn't have a build triggered, and no exception
     }
 
+    @Test
     public void testDoNotifyCommitWithTwoBranchesAndAdditionalParameter() throws Exception {
         SCMTrigger aMasterTrigger = setupProject("a", "master", false);
         SCMTrigger aTopicTrigger = setupProject("a", "topic", false);
@@ -190,7 +187,7 @@ public class GitStatusTest extends HudsonTestCase {
     }
 
     private void setupProject(String url, String branchString, SCMTrigger trigger) throws Exception {
-        FreeStyleProject project = createFreeStyleProject();
+        FreeStyleProject project = jenkins.createFreeStyleProject();
         GitSCM git = new GitSCM(
                 Collections.singletonList(new UserRemoteConfig(url, null, null, null)),
                 Collections.singletonList(new BranchSpec(branchString)),
@@ -201,7 +198,8 @@ public class GitStatusTest extends HudsonTestCase {
         if (trigger != null) project.addTrigger(trigger);
     }
 
-
+    @WithoutJenkins
+    @Test
     public void testLooseMatch() throws URISyntaxException {
         String[] list = new String[]{
             "https://github.com/jenkinsci/git-plugin.git",
@@ -217,7 +215,7 @@ public class GitStatusTest extends HudsonTestCase {
 
         for (URIish lhs : uris) {
             for (URIish rhs : uris) {
-                assertTrue(lhs+" and "+rhs+" didn't match",new GitStatus().looselyMatches(lhs,rhs));
+                assertTrue(lhs + " and " + rhs + " didn't match", GitStatus.looselyMatches(lhs, rhs));
             }
         }
     }

--- a/src/test/java/hudson/plugins/git/MultipleSCMTest.java
+++ b/src/test/java/hudson/plugins/git/MultipleSCMTest.java
@@ -18,7 +18,6 @@ import org.jenkinsci.plugins.multiplescms.MultiSCM;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import static org.junit.Assert.*;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -46,7 +45,6 @@ public class MultipleSCMTest {
 		repo1 = new TestGitRepo("repo1", tmp.newFolder(), listener);
 	}
 
-    @Ignore("https://github.com/jenkinsci/multiple-scms-plugin/pull/5 broke this; cf. JENKINS-14537")
 	@Test public void basic() throws Exception
 	{
 		FreeStyleProject project = setupBasicProject("master");

--- a/src/test/java/hudson/plugins/git/SCMTriggerTest.java
+++ b/src/test/java/hudson/plugins/git/SCMTriggerTest.java
@@ -10,6 +10,8 @@ import hudson.triggers.SCMTrigger;
 import hudson.util.IOUtils;
 import hudson.util.RunList;
 import hudson.Functions;
+import hudson.model.TaskListener;
+import hudson.util.StreamTaskListener;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -28,9 +30,13 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.apache.commons.io.FileUtils;
+import static org.junit.Assert.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
 
-public abstract class SCMTriggerTest extends AbstractGitTestCase
+public abstract class SCMTriggerTest extends AbstractGitProject
 {
     
     private TemporaryDirectoryAllocator tempAllocator;
@@ -39,11 +45,10 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
     private ExecutorService singleThreadExecutor;
     protected boolean expectChanges = false;
         
-    @Override
-    protected void tearDown() throws Exception
+    @After
+    public void tearDown() throws Exception
     {
         try { //Avoid test failures due to failed cleanup tasks
-            super.tearDown();
             singleThreadExecutor.shutdownNow();
             tempAllocator.dispose();
         }
@@ -55,9 +60,8 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
         }
     }
 
-    @Override
+    @Before
     public void setUp() throws Exception {
-        super.setUp();
         expectChanges = false;
         namespaceRepoZip = new ZipFile("src/test/resources/namespaceBranchRepo.zip");
         namespaceRepoCommits = parseLsRemote(new File("src/test/resources/namespaceBranchRepo.ls-remote"));
@@ -69,6 +73,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
     
     protected abstract boolean isDisableRemotePoll();
 
+    @Test
     public void testNamespaces_with_refsHeadsMaster() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             "refs/heads/master",
@@ -76,6 +81,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
             "origin/master");
     }
 
+    @Test
     public void testNamespaces_with_remotesOriginMaster() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             "remotes/origin/master", 
@@ -83,6 +89,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
             "origin/master");
     }
 
+    @Test
     public void testNamespaces_with_refsRemotesOriginMaster() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             "refs/remotes/origin/master", 
@@ -90,6 +97,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
             "origin/master");
     }
 
+    @Test
     public void testNamespaces_with_master() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             "master",
@@ -97,6 +105,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
             "origin/master");
     }
 
+    @Test
     public void testNamespaces_with_namespace1Master() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             "a_tests/b_namespace1/master",
@@ -104,6 +113,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
             "origin/a_tests/b_namespace1/master");
     }
 
+    @Test
     public void testNamespaces_with_refsHeadsNamespace1Master() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             "refs/heads/a_tests/b_namespace1/master", 
@@ -111,6 +121,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
             "origin/a_tests/b_namespace1/master");
     }
 
+    @Test
     public void testNamespaces_with_namespace2Master() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             "a_tests/b_namespace2/master",
@@ -118,6 +129,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
             "origin/a_tests/b_namespace2/master");
     }
 
+    @Test
     public void testNamespaces_with_refsHeadsNamespace2Master() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             "refs/heads/a_tests/b_namespace2/master", 
@@ -125,6 +137,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
             "origin/a_tests/b_namespace2/master");
     }
 
+    @Test
     public void testNamespaces_with_namespace3_feature3_sha1() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
                 namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace3/feature3"),
@@ -132,6 +145,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
                 "detached");
     }
 
+    @Test
     public void testNamespaces_with_namespace3_feature3_branchName() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
                 "a_tests/b_namespace3/feature3",
@@ -139,6 +153,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
                 "origin/a_tests/b_namespace3/feature3");
     }
 
+    @Test
     public void testNamespaces_with_refsHeadsNamespace3_feature3_sha1() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
                 namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace3/feature3"),
@@ -146,6 +161,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
                 "detached");
     }
 
+    @Test
     public void testNamespaces_with_refsHeadsNamespace3_feature3_branchName() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
                 "refs/heads/a_tests/b_namespace3/feature3",
@@ -153,6 +169,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
                 "origin/a_tests/b_namespace3/feature3");
     }
 
+    @Test
     public void testTags_with_TagA() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             "TagA",
@@ -160,6 +177,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
             "TagA"); //TODO: What do we expect!?
     }
 
+    @Test
     public void testTags_with_TagBAnnotated() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             "TagBAnnotated", 
@@ -167,6 +185,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
             "TagBAnnotated"); //TODO: What do we expect!?
     }
 
+    @Test
     public void testTags_with_refsTagsTagA() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             "refs/tags/TagA",
@@ -174,6 +193,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
             "refs/tags/TagA"); //TODO: What do we expect!?
     }
 
+    @Test
     public void testTags_with_refsTagsTagBAnnotated() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             "refs/tags/TagBAnnotated",
@@ -181,6 +201,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
             "refs/tags/TagBAnnotated");
     }
 
+    @Test
     public void testCommitAsBranchSpec_feature4_sha1() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
                 namespaceRepoCommits.getProperty("refs/heads/b_namespace3/feature4"),
@@ -188,6 +209,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
                 "detached");
     }
 
+    @Test
     public void testCommitAsBranchSpec_feature4_branchName() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
                 "refs/heads/b_namespace3/feature4",
@@ -195,6 +217,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
                 "origin/b_namespace3/feature4");
     }
 
+    @Test
     public void testCommitAsBranchSpec() throws Exception {
         check(namespaceRepoZip, namespaceRepoCommits,
             namespaceRepoCommits.getProperty("refs/heads/b_namespace3/master"), 
@@ -220,6 +243,7 @@ public abstract class SCMTriggerTest extends AbstractGitTestCase
         FreeStyleBuild build1 = waitForBuildFinished(project, 1, 60000);
         assertNotNull("Job has not been triggered", build1);
 
+        TaskListener listener = StreamTaskListener.fromStderr();
         PollingResult poll = project.poll(listener);
         assertEquals("Expected and actual polling results disagree", false, poll.hasChanges());
         

--- a/src/test/java/hudson/plugins/git/TestBranchSpec.java
+++ b/src/test/java/hudson/plugins/git/TestBranchSpec.java
@@ -2,57 +2,59 @@ package hudson.plugins.git;
 
 import hudson.EnvVars;
 import java.util.HashMap;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
 
-public class TestBranchSpec extends TestCase {
+public class TestBranchSpec {
+    @Test
     public void testMatch() {
 
         BranchSpec l = new BranchSpec("master");
-        Assert.assertTrue(l.matches("origin/master"));
-        Assert.assertFalse(l.matches("origin/something/master"));
-        Assert.assertTrue(l.matches("master"));
-        Assert.assertFalse(l.matches("dev"));
+        assertTrue(l.matches("origin/master"));
+        assertFalse(l.matches("origin/something/master"));
+        assertTrue(l.matches("master"));
+        assertFalse(l.matches("dev"));
         
         
         BranchSpec est = new BranchSpec("origin/*/dev");
         
-        Assert.assertFalse(est.matches("origintestdev"));
-        Assert.assertTrue(est.matches("origin/test/dev"));
-        Assert.assertFalse(est.matches("origin/test/release"));
-        Assert.assertFalse(est.matches("origin/test/somthing/release"));
+        assertFalse(est.matches("origintestdev"));
+        assertTrue(est.matches("origin/test/dev"));
+        assertFalse(est.matches("origin/test/release"));
+        assertFalse(est.matches("origin/test/somthing/release"));
         
         BranchSpec s = new BranchSpec("origin/*");
         
-        Assert.assertTrue(s.matches("origin/master"));
+        assertTrue(s.matches("origin/master"));
       
         BranchSpec m = new BranchSpec("**/magnayn/*");
         
-        Assert.assertTrue(m.matches("origin/magnayn/b1"));
-        Assert.assertTrue(m.matches("remote/origin/magnayn/b1"));
-        Assert.assertTrue(m.matches("remotes/origin/magnayn/b1"));
+        assertTrue(m.matches("origin/magnayn/b1"));
+        assertTrue(m.matches("remote/origin/magnayn/b1"));
+        assertTrue(m.matches("remotes/origin/magnayn/b1"));
       
         BranchSpec n = new BranchSpec("*/my.branch/*");
         
-        Assert.assertTrue(n.matches("origin/my.branch/b1"));
-        Assert.assertFalse(n.matches("origin/my-branch/b1"));
-        Assert.assertFalse(n.matches("remote/origin/my.branch/b1"));
-        Assert.assertTrue(n.matches("remotes/origin/my.branch/b1"));
+        assertTrue(n.matches("origin/my.branch/b1"));
+        assertFalse(n.matches("origin/my-branch/b1"));
+        assertFalse(n.matches("remote/origin/my.branch/b1"));
+        assertTrue(n.matches("remotes/origin/my.branch/b1"));
       
         BranchSpec o = new BranchSpec("**");
         
-        Assert.assertTrue(o.matches("origin/my.branch/b1"));
-        Assert.assertTrue(o.matches("origin/my-branch/b1"));
-        Assert.assertTrue(o.matches("remote/origin/my.branch/b1"));
-        Assert.assertTrue(o.matches("remotes/origin/my.branch/b1"));
+        assertTrue(o.matches("origin/my.branch/b1"));
+        assertTrue(o.matches("origin/my-branch/b1"));
+        assertTrue(o.matches("remote/origin/my.branch/b1"));
+        assertTrue(o.matches("remotes/origin/my.branch/b1"));
       
         BranchSpec p = new BranchSpec("*");
 
-        Assert.assertTrue(p.matches("origin/x"));
-        Assert.assertFalse(p.matches("origin/my-branch/b1"));
+        assertTrue(p.matches("origin/x"));
+        assertFalse(p.matches("origin/my-branch/b1"));
     }
     
+    @Test
     public void testMatchEnv() {
         HashMap<String, String> envMap = new HashMap<String, String>();
         envMap.put("master", "master");
@@ -65,51 +67,53 @@ public class TestBranchSpec extends TestCase {
         EnvVars env = new EnvVars(envMap);
 
         BranchSpec l = new BranchSpec("${master}");
-        Assert.assertTrue(l.matches("origin/master", env));
-        Assert.assertFalse(l.matches("origin/something/master", env));
-        Assert.assertTrue(l.matches("master", env));
-        Assert.assertFalse(l.matches("dev", env));
+        assertTrue(l.matches("origin/master", env));
+        assertFalse(l.matches("origin/something/master", env));
+        assertTrue(l.matches("master", env));
+        assertFalse(l.matches("dev", env));
 
 
         BranchSpec est = new BranchSpec("${origin}/*/${dev}");
 
-        Assert.assertFalse(est.matches("origintestdev", env));
-        Assert.assertTrue(est.matches("origin/test/dev", env));
-        Assert.assertFalse(est.matches("origin/test/release", env));
-        Assert.assertFalse(est.matches("origin/test/somthing/release", env));
+        assertFalse(est.matches("origintestdev", env));
+        assertTrue(est.matches("origin/test/dev", env));
+        assertFalse(est.matches("origin/test/release", env));
+        assertFalse(est.matches("origin/test/somthing/release", env));
 
         BranchSpec s = new BranchSpec("${origin}/*");
 
-        Assert.assertTrue(s.matches("origin/master", env));
+        assertTrue(s.matches("origin/master", env));
 
         BranchSpec m = new BranchSpec("**/${magnayn}/*");
 
-        Assert.assertTrue(m.matches("origin/magnayn/b1", env));
-        Assert.assertTrue(m.matches("remote/origin/magnayn/b1", env));
+        assertTrue(m.matches("origin/magnayn/b1", env));
+        assertTrue(m.matches("remote/origin/magnayn/b1", env));
 
         BranchSpec n = new BranchSpec("*/${mybranch}/*");
 
-        Assert.assertTrue(n.matches("origin/my.branch/b1", env));
-        Assert.assertFalse(n.matches("origin/my-branch/b1", env));
-        Assert.assertFalse(n.matches("remote/origin/my.branch/b1", env));
+        assertTrue(n.matches("origin/my.branch/b1", env));
+        assertFalse(n.matches("origin/my-branch/b1", env));
+        assertFalse(n.matches("remote/origin/my.branch/b1", env));
 
         BranchSpec o = new BranchSpec("${anyLong}");
 
-        Assert.assertTrue(o.matches("origin/my.branch/b1", env));
-        Assert.assertTrue(o.matches("origin/my-branch/b1", env));
-        Assert.assertTrue(o.matches("remote/origin/my.branch/b1", env));
+        assertTrue(o.matches("origin/my.branch/b1", env));
+        assertTrue(o.matches("origin/my-branch/b1", env));
+        assertTrue(o.matches("remote/origin/my.branch/b1", env));
 
         BranchSpec p = new BranchSpec("${anyShort}");
 
-        Assert.assertTrue(p.matches("origin/x", env));
-        Assert.assertFalse(p.matches("origin/my-branch/b1", env));
+        assertTrue(p.matches("origin/x", env));
+        assertFalse(p.matches("origin/my-branch/b1", env));
     }
 
+    @Test
     public void testEmptyName() {
     	BranchSpec branchSpec = new BranchSpec("");
     	assertEquals("**",branchSpec.getName());
     }
     
+    @Test
     public void testNullName() {
     	boolean correctExceptionThrown = false;
     	try {
@@ -120,6 +124,7 @@ public class TestBranchSpec extends TestCase {
     	assertTrue(correctExceptionThrown);
     }
     
+    @Test
     public void testNameTrimming() {
     	BranchSpec branchSpec = new BranchSpec(" master ");
     	assertEquals("master",branchSpec.getName());
@@ -127,6 +132,7 @@ public class TestBranchSpec extends TestCase {
     	assertEquals("other",branchSpec.getName());
     }
     
+    @Test
     public void testUsesRefsHeads() {
     	BranchSpec m = new BranchSpec("refs/heads/j*n*");
     	assertTrue(m.matches("refs/heads/jenkins"));
@@ -137,6 +143,7 @@ public class TestBranchSpec extends TestCase {
     	assertFalse(m.matches("remote/origin/jane"));
     }
     
+    @Test
     public void testUsesJavaPatternDirectlyIfPrefixedWithColon() {
     	BranchSpec m = new BranchSpec(":^(?!(origin/prefix)).*");
     	assertTrue(m.matches("origin"));
@@ -148,6 +155,7 @@ public class TestBranchSpec extends TestCase {
     	assertFalse(m.matches("origin/prefix-abc"));
     }
 
+    @Test
     public void testUsesJavaPatternWithRepetition() {
     	// match pattern from JENKINS-26842
     	BranchSpec m = new BranchSpec(":origin/release-\\d{8}");

--- a/src/test/java/hudson/plugins/git/browser/BitbucketWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/BitbucketWebTest.java
@@ -8,26 +8,23 @@ import hudson.model.Run;
 import hudson.plugins.git.GitChangeLogParser;
 import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSet.Path;
-import junit.framework.TestCase;
 import org.xml.sax.SAXException;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 /**
  * @author mattsemar
  *
  */
-public class BitbucketWebTest extends TestCase {
+public class BitbucketWebTest {
 
-    /**
-     *
-     */
     private static final String BITBUCKET_URL = "http://bitbucket.org/USER/REPO";
     private final BitbucketWeb bitbucketWeb = new BitbucketWeb(BITBUCKET_URL);
 
@@ -35,6 +32,7 @@ public class BitbucketWebTest extends TestCase {
      * Test method for {@link BitbucketWeb#getUrl()}.
      * @throws java.net.MalformedURLException
      */
+    @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(bitbucketWeb.getUrl()), BITBUCKET_URL + "/");
     }
@@ -43,6 +41,7 @@ public class BitbucketWebTest extends TestCase {
      * Test method for {@link BitbucketWeb#getUrl()}.
      * @throws java.net.MalformedURLException
      */
+    @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new BitbucketWeb(BITBUCKET_URL + "/").getUrl()), BITBUCKET_URL + "/");
     }
@@ -52,6 +51,7 @@ public class BitbucketWebTest extends TestCase {
      * @throws org.xml.sax.SAXException
      * @throws java.io.IOException
      */
+    @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = bitbucketWeb.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(BITBUCKET_URL + "/commits/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
@@ -62,6 +62,7 @@ public class BitbucketWebTest extends TestCase {
      * @throws org.xml.sax.SAXException
      * @throws java.io.IOException
      */
+    @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final String path1Str = "src/main/java/hudson/plugins/git/browser/GithubWeb.java";
@@ -82,6 +83,7 @@ public class BitbucketWebTest extends TestCase {
      * @throws org.xml.sax.SAXException
      * @throws java.io.IOException
      */
+    @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
         final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -94,6 +96,7 @@ public class BitbucketWebTest extends TestCase {
      * @throws org.xml.sax.SAXException
      * @throws java.io.IOException
      */
+    @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");

--- a/src/test/java/hudson/plugins/git/browser/GitLabTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitLabTest.java
@@ -11,11 +11,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 import org.xml.sax.SAXException;
 
-public class GitLabTest extends TestCase {
+public class GitLabTest {
 
     private static final String GITLAB_URL = "https://SERVER/USER/REPO/";
     private final GitLab gitlab29 = new GitLab(GITLAB_URL, "2.9");
@@ -36,24 +37,28 @@ public class GitLabTest extends TestCase {
     /**
      * Test method for {@link hudson.plugins.git.browser.GitLab#getVersion()}.
      */
+    @Test
     public void testGetVersion() {
-        assertEquals(2.9, gitlab29.getVersion());
-        assertEquals(4.2, gitlab42.getVersion());
-        assertEquals(5.0, gitlab50.getVersion());
-        assertEquals(5.1, gitlab51.getVersion());
-        assertEquals(GitLab.DEFAULT_VERSION, gitlab711.getVersion());
-        assertEquals(GitLab.DEFAULT_VERSION, gitlab7114ee.getVersion());
-        assertEquals(GitLab.DEFAULT_VERSION, gitlabDefault.getVersion());
-        assertEquals(GitLab.DEFAULT_VERSION, gitlabNaN.getVersion());
-        assertEquals(GitLab.DEFAULT_VERSION, gitlabInfinity.getVersion());
-        assertEquals(-1.0, gitlabNegative.getVersion());
-        assertEquals(9999.0, gitlabGreater.getVersion());
+        assertEquals(2.9, gitlab29.getVersion(), .001);
+        assertEquals(4.2, gitlab42.getVersion(), .001);
+        assertEquals(5.0, gitlab50.getVersion(), .001);
+        assertEquals(5.1, gitlab51.getVersion(), .001);
+        assertEquals(GitLab.DEFAULT_VERSION, gitlab711.getVersion(), .001);
+        assertEquals(GitLab.DEFAULT_VERSION, gitlab7114ee.getVersion(), .001);
+        assertEquals(GitLab.DEFAULT_VERSION, gitlabDefault.getVersion(), .001);
+        assertEquals(GitLab.DEFAULT_VERSION, gitlabNaN.getVersion(), .001);
+        assertEquals(GitLab.DEFAULT_VERSION, gitlabInfinity.getVersion(), .001);
+        assertEquals(-1.0, gitlabNegative.getVersion(), .001);
+        assertEquals(9999.0, gitlabGreater.getVersion(), .001);
     }
 
     /**
-     * Test method for {@link hudson.plugins.git.browser.GitLab#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
+     * Test method for
+     * {@link hudson.plugins.git.browser.GitLab#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
+     *
      * @throws IOException
      */
+    @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final GitChangeSet changeSet = createChangeSet("rawchangelog");
         final String expectedURL = GITLAB_URL + "commit/" + SHA1;
@@ -71,9 +76,12 @@ public class GitLabTest extends TestCase {
     }
 
     /**
-     * Test method for {@link hudson.plugins.git.browser.GitLab#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * Test method for
+     * {@link hudson.plugins.git.browser.GitLab#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
+     *
      * @throws IOException
      */
+    @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final Path modified1 = pathMap.get(fileName);
@@ -92,11 +100,14 @@ public class GitLabTest extends TestCase {
     }
 
     /**
-     * Test method for {@link hudson.plugins.git.browser.GitLab#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * Test method for
+     * {@link hudson.plugins.git.browser.GitLab#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
+     *
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
-        final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
+        final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final Path path = pathMap.get(fileName);
         final String expectedURL = GITLAB_URL + "blob/396fc230a3db05c427737aa5c2eb7856ba72b05d/" + fileName;
         final String expectedV29 = expectedURL.replace("blob/", "tree/");
@@ -115,11 +126,14 @@ public class GitLabTest extends TestCase {
     }
 
     /**
-     * Test method for {@link hudson.plugins.git.browser.GitLab#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * Test method for
+     * {@link hudson.plugins.git.browser.GitLab#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
+     *
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
-        final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
+        final HashMap<String, Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");
         final String expectedURL = GITLAB_URL + "commit/fc029da233f161c65eb06d0f1ed4f36ae81d1f4f#bar";
         assertEquals(expectedURL.replace("commit/", "commits/"), gitlab29.getFileLink(path).toString());

--- a/src/test/java/hudson/plugins/git/browser/GitListTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitListTest.java
@@ -8,8 +8,6 @@ import hudson.model.Run;
 import hudson.plugins.git.GitChangeLogParser;
 import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSet.Path;
-import hudson.plugins.git.GitSCM;
-import hudson.scm.RepositoryBrowser;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,7 +17,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 import org.xml.sax.SAXException;
 
@@ -28,11 +27,8 @@ import org.xml.sax.SAXException;
  * @author fauxpark
  *
  */
-public class GitListTest extends TestCase {
+public class GitListTest {
 
-    /**
-     *
-     */
     private static final String GITLIST_URL = "http://gitlist.org/REPO";
     private final GitList gitlist = new GitList(GITLIST_URL);
 
@@ -40,6 +36,7 @@ public class GitListTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.GitList#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(gitlist.getUrl()), GITLIST_URL + "/");
     }
@@ -48,6 +45,7 @@ public class GitListTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.GitList#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new GitList(GITLIST_URL + "/").getUrl()), GITLIST_URL + "/");
     }
@@ -57,6 +55,7 @@ public class GitListTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = gitlist.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(GITLIST_URL + "/commit/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
@@ -67,6 +66,7 @@ public class GitListTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final Path path1 = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -82,6 +82,7 @@ public class GitListTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
         final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -94,6 +95,7 @@ public class GitListTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");

--- a/src/test/java/hudson/plugins/git/browser/GitWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitWebTest.java
@@ -13,16 +13,14 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 import org.xml.sax.SAXException;
 
 
-public class GitWebTest extends TestCase {
+public class GitWebTest {
 
-    /**
-     *
-     */
     private static final String GITWEB_URL = "https://SERVER/gitweb?repo.git";
     private final GitWeb gitwebWeb = new GitWeb(GITWEB_URL);
 
@@ -31,6 +29,7 @@ public class GitWebTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.GitWeb#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(gitwebWeb.getUrl()), GITWEB_URL);
     }
@@ -40,6 +39,7 @@ public class GitWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = gitwebWeb.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(GITWEB_URL + "&a=commit&h=396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
@@ -50,6 +50,7 @@ public class GitWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final Path modified1 = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -61,6 +62,7 @@ public class GitWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
         final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -73,6 +75,7 @@ public class GitWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");

--- a/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
@@ -19,7 +19,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 import org.xml.sax.SAXException;
 
@@ -27,11 +28,8 @@ import org.xml.sax.SAXException;
  * @author mirko
  *
  */
-public class GithubWebTest extends TestCase {
+public class GithubWebTest {
 
-    /**
-     *
-     */
     private static final String GITHUB_URL = "http://github.com/USER/REPO";
     private final GithubWeb githubWeb = new GithubWeb(GITHUB_URL);
 
@@ -39,6 +37,7 @@ public class GithubWebTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.GithubWeb#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(githubWeb.getUrl()), GITHUB_URL  + "/");
     }
@@ -47,15 +46,18 @@ public class GithubWebTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.GithubWeb#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new GithubWeb(GITHUB_URL + "/").getUrl()), GITHUB_URL  + "/");
     }
+
 
     /**
      * Test method for {@link hudson.plugins.git.browser.GithubWeb#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = githubWeb.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(GITHUB_URL + "/commit/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
@@ -66,6 +68,7 @@ public class GithubWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final Path path1 = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -81,6 +84,7 @@ public class GithubWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
         final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -93,6 +97,7 @@ public class GithubWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");
@@ -100,6 +105,7 @@ public class GithubWebTest extends TestCase {
         assertEquals(GITHUB_URL + "/commit/fc029da233f161c65eb06d0f1ed4f36ae81d1f4f#diff-0", String.valueOf(fileLink));
     }
 
+    @Test
     public void testGuessBrowser() {
         assertGuessURL("https://github.com/kohsuke/msv.git", "https://github.com/kohsuke/msv/");
         assertGuessURL("git@github.com:kohsuke/msv.git", "https://github.com/kohsuke/msv/");

--- a/src/test/java/hudson/plugins/git/browser/GitoriousWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitoriousWebTest.java
@@ -13,16 +13,14 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 import org.xml.sax.SAXException;
 
 
-public class GitoriousWebTest extends TestCase {
+public class GitoriousWebTest {
 
-    /**
-     *
-     */
     private static final String GITORIOUS_URL = "https://SERVER/PROJECT";
     private final GitoriousWeb gitoriousWeb = new GitoriousWeb(GITORIOUS_URL);
 
@@ -31,6 +29,7 @@ public class GitoriousWebTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.GitoriousWeb#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(gitoriousWeb.getUrl()), GITORIOUS_URL  + "/");
     }
@@ -39,6 +38,7 @@ public class GitoriousWebTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.GitoriousWeb#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new GitoriousWeb(GITORIOUS_URL + "/").getUrl()), GITORIOUS_URL  + "/");
     }
@@ -48,6 +48,7 @@ public class GitoriousWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = gitoriousWeb.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(GITORIOUS_URL + "/commit/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
@@ -58,6 +59,7 @@ public class GitoriousWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final Path modified1 = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -72,6 +74,7 @@ public class GitoriousWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
         final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -84,6 +87,7 @@ public class GitoriousWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");

--- a/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
+++ b/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
@@ -13,14 +13,15 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 import org.xml.sax.SAXException;
 
 /**
  * @author Chris Klaiber (cklaiber@gmail.com)
  */
-public class KilnGitTest extends TestCase {
+public class KilnGitTest {
 
     private static final String KILN_URL = "http://USER.kilnhg.com/Code/PROJECT/Group/REPO";
     private final KilnGit kilnGit = new KilnGit(KILN_URL);
@@ -30,6 +31,7 @@ public class KilnGitTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.KilnGit#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(kilnGit.getUrl()), KILN_URL  + "/");
     }
@@ -38,6 +40,7 @@ public class KilnGitTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.KilnGit#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new KilnGit(KILN_URL + "/").getUrl()), KILN_URL  + "/");
     }
@@ -47,6 +50,7 @@ public class KilnGitTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = kilnGit.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(KILN_URL + "/History/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
@@ -57,6 +61,7 @@ public class KilnGitTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final Path path1 = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -72,6 +77,7 @@ public class KilnGitTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
         final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -84,6 +90,7 @@ public class KilnGitTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");

--- a/src/test/java/hudson/plugins/git/browser/RedmineWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/RedmineWebTest.java
@@ -12,19 +12,16 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 import org.xml.sax.SAXException;
 
 /**
  * @author mfriedenhagen
  */
-public class RedmineWebTest extends TestCase {
+public class RedmineWebTest {
 
-    /**
-     *
-     */
     private static final String REDMINE_URL = "https://SERVER/PATH/projects/PROJECT/repository";
     private final RedmineWeb redmineWeb = new RedmineWeb(REDMINE_URL);
 
@@ -32,6 +29,7 @@ public class RedmineWebTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.RedmineWeb#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(redmineWeb.getUrl()), REDMINE_URL  + "/");
     }
@@ -40,6 +38,7 @@ public class RedmineWebTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.RedmineWeb#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new RedmineWeb(REDMINE_URL + "/").getUrl()), REDMINE_URL  + "/");
     }
@@ -49,6 +48,7 @@ public class RedmineWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = redmineWeb.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(REDMINE_URL + "/diff?rev=396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
@@ -59,6 +59,7 @@ public class RedmineWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final Path modified1 = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -75,6 +76,7 @@ public class RedmineWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
         final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -87,6 +89,7 @@ public class RedmineWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");

--- a/src/test/java/hudson/plugins/git/browser/RhodeCodeTest.java
+++ b/src/test/java/hudson/plugins/git/browser/RhodeCodeTest.java
@@ -4,6 +4,7 @@ import hudson.model.Run;
 import hudson.plugins.git.GitChangeLogParser;
 import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSet.Path;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -11,15 +12,15 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import junit.framework.TestCase;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
 import org.xml.sax.SAXException;
 
 
-public class RhodeCodeTest extends TestCase {
+public class RhodeCodeTest {
 
-    /**
-     *
-     */
     private static final String RHODECODE_URL = "https://SERVER/r/PROJECT";
     private final RhodeCode rhodecode = new RhodeCode(RHODECODE_URL);
 
@@ -27,6 +28,7 @@ public class RhodeCodeTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.RhodeCode#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(rhodecode.getUrl()), RHODECODE_URL  + "/");
     }
@@ -35,6 +37,7 @@ public class RhodeCodeTest extends TestCase {
      * Test method for {@link hudson.plugins.git.browser.RhodeCode#getUrl()}.
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new RhodeCode(RHODECODE_URL + "/").getUrl()), RHODECODE_URL  + "/");
     }
@@ -44,6 +47,7 @@ public class RhodeCodeTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = rhodecode.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(RHODECODE_URL + "/changeset/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
@@ -54,6 +58,7 @@ public class RhodeCodeTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final Path modified1 = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -68,6 +73,7 @@ public class RhodeCodeTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
         final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -80,6 +86,7 @@ public class RhodeCodeTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");

--- a/src/test/java/hudson/plugins/git/browser/ViewGitWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/ViewGitWebTest.java
@@ -13,14 +13,15 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 import org.xml.sax.SAXException;
 
 /**
  * @author Paul Nyheim (paul.nyheim@gmail.com)
  */
-public class ViewGitWebTest extends TestCase {
+public class ViewGitWebTest {
 
     private static final String VIEWGIT_URL = "http://SERVER/viewgit";
     private static final String PROJECT_NAME = "PROJECT";
@@ -31,6 +32,7 @@ public class ViewGitWebTest extends TestCase {
      * 
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(viewGitWeb.getUrl()), VIEWGIT_URL + "/");
     }
@@ -40,6 +42,7 @@ public class ViewGitWebTest extends TestCase {
      * 
      * @throws MalformedURLException
      */
+    @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new ViewGitWeb(VIEWGIT_URL + "/", PROJECT_NAME).getUrl()), VIEWGIT_URL + "/");
     }
@@ -52,6 +55,7 @@ public class ViewGitWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = viewGitWeb.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals("http://SERVER/viewgit/?p=PROJECT&a=commit&h=396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
@@ -65,6 +69,7 @@ public class ViewGitWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final Path path1 = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -83,6 +88,7 @@ public class ViewGitWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
@@ -91,6 +97,7 @@ public class ViewGitWebTest extends TestCase {
                 String.valueOf(fileLink));
     }
     
+    @Test
     public void testGetDiffLinkForDeletedFile() throws Exception{
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");
@@ -106,6 +113,7 @@ public class ViewGitWebTest extends TestCase {
      * @throws SAXException
      * @throws IOException
      */
+    @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");

--- a/src/test/java/hudson/plugins/git/util/BuildDataTest.java
+++ b/src/test/java/hudson/plugins/git/util/BuildDataTest.java
@@ -1,24 +1,20 @@
 package hudson.plugins.git.util;
 
-import hudson.plugins.git.AbstractGitTestCase;
-
-import hudson.plugins.git.util.BuildData;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 /**
  * @author Mark Waite
  */
-public class BuildDataTest extends AbstractGitTestCase {
-    /**
-     * Verifies that the display name is "Git Build Data".
-     */
+public class BuildDataTest {
+
+    @Test
     public void testDisplayNameWithoutSCM() throws Exception {
         final BuildData data = new BuildData();
         assertEquals(data.getDisplayName(), "Git Build Data");
     }
 
-    /**
-     * Verifies that the display name is "Git Build Data:scmName".
-     */
+    @Test
     public void testDisplayNameWithSCM() throws Exception {
         final String scmName = "testSCM";
         final BuildData data = new BuildData(scmName);

--- a/src/test/java/hudson/plugins/git/util/CommitTimeComparatorTest.java
+++ b/src/test/java/hudson/plugins/git/util/CommitTimeComparatorTest.java
@@ -1,6 +1,6 @@
 package hudson.plugins.git.util;
 
-import hudson.plugins.git.AbstractGitTestCase;
+import hudson.plugins.git.AbstractGitRepository;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.Revision;
 
@@ -9,14 +9,18 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class CommitTimeComparatorTest extends AbstractGitTestCase {
+public class CommitTimeComparatorTest extends AbstractGitRepository {
+
     /**
      * Verifies that the sort is old to new.
      */
+    @Test
     public void testSort() throws Exception {
         boolean first = true;
         // create repository with three commits
@@ -25,13 +29,13 @@ public class CommitTimeComparatorTest extends AbstractGitTestCase {
             if (first)      first = false;
             else            Thread.sleep(1000);
 
-            commit("file" + i, johnDoe, "Commit #" + i);
-            git.branch("branch" + i);
+            commitNewFile("file" + i);
+            testGitClient.branch("branch" + i);
         }
 
         Map<Revision,Branch> branches = new HashMap<Revision,Branch>();
         List<Revision> revs = new ArrayList<Revision>();
-        for (Branch b : git.getBranches()) {
+        for (Branch b : testGitClient.getBranches()) {
             if (!b.getName().startsWith("branch"))  continue;
             Revision r = new Revision(b.getSHA1());
             revs.add(r);
@@ -42,7 +46,7 @@ public class CommitTimeComparatorTest extends AbstractGitTestCase {
         for (int i=0; i<16; i++) {
             // shuffle, then sort.
             Collections.shuffle(revs);
-            Collections.sort(revs, new CommitTimeComparator(git.getRepository()));
+            Collections.sort(revs, new CommitTimeComparator(testGitClient.getRepository()));
 
             // it should be always branch1, branch2, branch3
             for (int j=0; j<3; j++)

--- a/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
@@ -1,36 +1,40 @@
 package hudson.plugins.git.util;
 
+import hudson.plugins.git.AbstractGitRepository;
 import java.util.Collection;
 
-import hudson.plugins.git.AbstractGitTestCase;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
+import static org.junit.Assert.*;
+import org.junit.Test;
 
 /**
  * @author Arnout Engelen
  */
-public class DefaultBuildChooserTest extends AbstractGitTestCase {
+public class DefaultBuildChooserTest extends AbstractGitRepository {
+    @Test
     public void testChooseGitRevisionToBuildByShaHash() throws Exception {
-        git.commit("Commit 1");
-        String shaHashCommit1 = git.getBranches().iterator().next().getSHA1String();
-        git.commit("Commit 2");
-        String shaHashCommit2 = git.getBranches().iterator().next().getSHA1String();
+        testGitClient.commit("Commit 1");
+        String shaHashCommit1 = testGitClient.getBranches().iterator().next().getSHA1String();
+        testGitClient.commit("Commit 2");
+        String shaHashCommit2 = testGitClient.getBranches().iterator().next().getSHA1String();
         assertNotSame(shaHashCommit1, shaHashCommit2);
 
         DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
 
-        Collection<Revision> candidateRevisions = buildChooser.getCandidateRevisions(false, shaHashCommit1, git, null, null, null);
+        Collection<Revision> candidateRevisions = buildChooser.getCandidateRevisions(false, shaHashCommit1, testGitClient, null, null, null);
 
         assertEquals(1, candidateRevisions.size());
         assertEquals(shaHashCommit1, candidateRevisions.iterator().next().getSha1String());
 
-        candidateRevisions = buildChooser.getCandidateRevisions(false, "aaa" + shaHashCommit1.substring(3), git, null, null, null);
+        candidateRevisions = buildChooser.getCandidateRevisions(false, "aaa" + shaHashCommit1.substring(3), testGitClient, null, null, null);
         assertTrue(candidateRevisions.isEmpty());
     }
     /**
      * RegExp patterns prefixed with : should pass through to DefaultBuildChooser.getAdvancedCandidateRevisions
      * @throws Exception
      */
+    @Test
     public void testIsAdvancedSpec() throws Exception {
         DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
 


### PR DESCRIPTION
Switch most of the tests from JUnit 3 to JUnit 4.  For most tests, the conversion is simple and no performance improvement is detected.

Several of the tests were using HudsonTestCase (JUnit 3) or JenkinsRule (JUnit 4) when it was not needed.  That caused those tests to run longer than necessary.  Changing the tests to JUnit 4 allows the use of the WithoutJenkins annotation for those tests which are inside a JenkinsRule based test, but don't actually need a Jenkins instance.

The largest (and longest) tests still need to be converted from JUnit 3 to JUnit 4.  That will take more time, so I wanted to have this set of proposed changes reviewed by @ndeloof or @kohsuke in case I've missed something important while trying to reduce test execution time.