### PR TITLE
GitPublisher fix for JENKINS-20393

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -239,7 +239,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         listener.getLogger().println("Pushing HEAD to branch " + mergeTarget + " of " + remote.getName() + " repository");
 
                         remoteURI = remote.getURIs().get(0);
-                        PushCommand push = git.push().to(remoteURI).ref("HEAD:" + mergeTarget);
+                        PushCommand push = git.push().to(remoteURI).ref("refs/heads/" + mergeTarget + ":refs/heads/" + mergeTarget);
                         if (forcePush) {
                           push.force();
                         }
@@ -335,7 +335,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         listener.getLogger().println("Pushing HEAD to branch " + branchName + " at repo "
                                                      + targetRepo);
                         remoteURI = remote.getURIs().get(0);
-                        PushCommand push = git.push().to(remoteURI).ref("HEAD:" + branchName);
+                        PushCommand push = git.push().to(remoteURI).ref("refs/heads/" + branchName + ":refs/heads/" + branchName);
                         if (forcePush) {
                           push.force();
                         }


### PR DESCRIPTION
As discussed, I think this would be a potential quick-win fix for [JENKINS-20393](https://issues.jenkins-ci.org/browse/JENKINS-20393), at least until JGit decides to implement a DWIMery-way of parsing RefSpecs.