### PR TITLE
Fix a bug where the tip filtering removes all tipCandidates

### DIFF
--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -155,6 +155,10 @@ public class GitUtils implements Serializable {
                             walk.reset();
                             RevCommit head = walk.parseCommit(r.getSha1());
 
+                            if (visited.contains(head)) {
+                              continue;
+                            }
+
                             tipCandidates.put(head, r);
 
                             walk.markStart(head);

--- a/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
@@ -1,12 +1,26 @@
 package hudson.plugins.git.util;
 
+import hudson.EnvVars;
+import hudson.Launcher;
+import hudson.model.TaskListener;
 import hudson.plugins.git.AbstractGitRepository;
 import java.util.Collection;
 
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
+import hudson.util.StreamTaskListener;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.jenkinsci.plugins.gitclient.Git;
+import org.jenkinsci.plugins.gitclient.GitClient;
 import static org.junit.Assert.*;
 import org.junit.Test;
+import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
+import org.mockito.Mockito;
 
 /**
  * @author Arnout Engelen
@@ -30,6 +44,59 @@ public class DefaultBuildChooserTest extends AbstractGitRepository {
         candidateRevisions = buildChooser.getCandidateRevisions(false, "aaa" + shaHashCommit1.substring(3), testGitClient, null, null, null);
         assertTrue(candidateRevisions.isEmpty());
     }
+
+    /**
+     * Regression test for a bug that accidentally resulted in empty build candidates.
+     *
+     * This test creates two repositories, one fake-remote repository in temporary directory "dir".
+     * A second repository in temporary directory "dir2".
+     * We create the following commit graph with 2 commits and 3 tags in "dir":
+     * commit1(tag/a)---commit2(tag/b, tag/c)
+     * We then clone this repository into "dir2" and fetch the remote tags as refs with the given refspec.
+     * This is necessary to make the GitClient recognize the tags via getRemoteBranches.
+     *
+     * Expected output if only tag/a has previously been build:
+     * The candidates should only include the commit pointed to by tag/b or tag/c.
+     */
+    @Test
+    public void testChooseWithMultipleTag() throws Exception {
+        TemporaryDirectoryAllocator temporaryDirectoryAllocator = new TemporaryDirectoryAllocator();
+        File dir = temporaryDirectoryAllocator.allocate();
+        File dir2 = temporaryDirectoryAllocator.allocate();
+        String repo2path = dir2.getAbsolutePath() + "/repo2";
+
+        runGitCommand(Arrays.asList("init"), dir);
+
+        runGitCommand(Arrays.asList("commit", "--allow-empty", "-m", "commit1"), dir);
+        runGitCommand(Arrays.asList("tag", "-a", "-m", "tag/a", "tag/a"), dir);
+        runGitCommand(Arrays.asList("commit", "--allow-empty", "-m", "commit2"), dir);
+        runGitCommand(Arrays.asList("tag", "-a", "-m", "tag/b", "tag/b"), dir);
+        runGitCommand(Arrays.asList("tag", "-a", "-m", "tag/c", "tag/c"), dir);
+
+        runGitCommand(Arrays.asList("clone", dir.getAbsolutePath(), "."), dir2);
+        runGitCommand(Arrays.asList("fetch", "--tags", "origin", "+refs/tags/tag/*:refs/remotes/origin/tags/tag/*"), dir2);
+
+        TaskListener listener = StreamTaskListener.fromStderr();
+        GitClient client = Git.with(listener, new EnvVars()).in(dir2).getClient();
+        client.init();
+        String shaHashCommit1 = client.getBranches().iterator().next().getSHA1String();
+
+        DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM(dir.getAbsolutePath()).getBuildChooser();
+
+        BuildData buildData = Mockito.mock(BuildData.class);
+        Mockito.when(buildData.hasBeenBuilt(client.revParse("tag/a"))).thenReturn(true);
+        Mockito.when(buildData.hasBeenBuilt(client.revParse("tag/b"))).thenReturn(false);
+        Mockito.when(buildData.hasBeenBuilt(client.revParse("tag/c"))).thenReturn(false);
+
+        BuildChooserContext context = Mockito.mock(BuildChooserContext.class);
+        Mockito.when(context.getEnvironment()).thenReturn(new EnvVars());
+
+        Collection<Revision> candidateRevisions = buildChooser.getCandidateRevisions(false, "tag/*", client, null, buildData, context);
+        assertEquals(1, candidateRevisions.size());
+        String name = candidateRevisions.iterator().next().getBranches().iterator().next().getName();
+        assertTrue(name.equals("origin/tags/tag/c") || name.equals("origin/tags/tag/b"));
+    }
+
     /**
      * RegExp patterns prefixed with : should pass through to DefaultBuildChooser.getAdvancedCandidateRevisions
      * @throws Exception
@@ -44,5 +111,17 @@ public class DefaultBuildChooserTest extends AbstractGitRepository {
         // regexp use case
         assertTrue(buildChooser.isAdvancedSpec(":origin/master"));
         assertTrue(buildChooser.isAdvancedSpec(":origin/master-\\d{*}"));
+    }
+
+    private void runGitCommand(List<String> commands, File dir) throws IOException, InterruptedException {
+        TaskListener listener = StreamTaskListener.fromStderr();
+        ArrayList<String> gitCommand = new ArrayList<String>(commands);
+        gitCommand.add(0, "git");
+        int returnCode = new Launcher.LocalLauncher(listener).launch().cmds(
+            gitCommand
+        ).pwd(dir.getCanonicalPath()).join();
+        if (returnCode != 0) {
+            throw new IOException("git command did not return status 0");
+        }
     }
 }


### PR DESCRIPTION
This bug occurs when there are multiple matching tags on the same commit.
The existing logic removed the tipCandidate if the commit was already visited.
If there are two revisions on the same commit, the following happens:
The first run places itself in the tipCandidates and marks the commit as visited.
The second run (via the second revision) then places the same commit with another
revision in the tipCandidates but removes it right after because the commit is
already marked as visited.

This patch skips this misbehavior and just keeps the the first revision of a commit.