### PR TITLE
[JENKINS-29689] always try to reuse last environment

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -568,9 +568,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         final String singleBranch = getSingleBranch(pollEnv);
 
-        if (!requiresWorkspaceForPolling(pollEnv)) {
+        final EnvVars environment = project instanceof AbstractProject ? GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener) : new EnvVars();
 
-            final EnvVars environment = project instanceof AbstractProject ? GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener, false) : new EnvVars();
+        if (!requiresWorkspaceForPolling(pollEnv)) {
 
             GitClient git = createClient(listener, environment, project, Jenkins.getInstance(), null);
 
@@ -633,8 +633,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
             return NO_CHANGES;
         }
-
-        final EnvVars environment = project instanceof AbstractProject ? GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener) : new EnvVars();
 
         FilePath workingDirectory = workingDirectory(project,workspace,environment,listener);
 


### PR DESCRIPTION
Otherwise the environment may not contain important variables such as JOB_NAME.

I'm pretty sure this change is covered by existing test cases. I've also tested the change with new and existing projects, with and without "force workspace" and it looks to be working fine.