### PR TITLE
Consider tags when checking which branches to build

### DIFF
--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -11,6 +11,7 @@ import hudson.plugins.git.GitException;
 import hudson.plugins.git.Revision;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.NodeProperty;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -51,6 +52,16 @@ public class GitUtils implements Serializable {
                 revisions.put(b.getSHA1(), r);
             }
             r.getBranches().add(b);
+        }
+        for (String tag : git.getTagNames(null)) {
+            String tagRef = Constants.R_TAGS + tag;
+            ObjectId objectId = git.revParse(tagRef);
+            Revision r = revisions.get(objectId);
+            if (r == null) {
+                r = new Revision(objectId);
+                revisions.put(objectId, r);
+            }
+            r.getBranches().add(new Branch(tagRef, objectId));
         }
         return revisions.values();
     }

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -700,6 +700,39 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertFalse("scm polling should not detect any more changes after last build", project.poll(listener).hasChanges());
     }
 
+    public void testMultipleBranchesWithTags() throws Exception {
+        List<BranchSpec> branchSpecs = Arrays.asList(
+                new BranchSpec("refs/tags/v*"),
+                new BranchSpec("refs/remotes/origin/non-existent"));
+        FreeStyleProject project = setupProject(branchSpecs, false, null, null, janeDoe.getName(), null, false, null);
+
+        // create initial commit and then run the build against it:
+        // Here the changelog is by default empty (because changelog for first commit is always empty
+        commit("commitFileBase", johnDoe, "Initial Commit");
+
+        // there are no branches to be build
+        FreeStyleBuild freeStyleBuild = build(project, Result.FAILURE);
+
+        final String v1 = "v1";
+
+        git.tag(v1, "version 1");
+        assertTrue("v1 tag exists", git.tagExists(v1));
+
+        freeStyleBuild = build(project, Result.SUCCESS);
+        assertTrue("change set is empty", freeStyleBuild.getChangeSet().isEmptySet());
+
+        commit("file1", johnDoe, "change to file1");
+        git.tag("none", "latest");
+
+        freeStyleBuild = build(project, Result.SUCCESS);
+
+        ObjectId tag = git.revParse(Constants.R_TAGS + v1);
+        GitSCM scm = (GitSCM)project.getScm();
+        BuildData buildData = scm.getBuildData(freeStyleBuild);
+
+        assertEquals("last build matches the v1 tag revision", tag, buildData.lastBuild.getSHA1());
+    }
+
     @Issue("JENKINS-19037")
     @SuppressWarnings("ResultOfObjectAllocationIgnored")
     public void testBlankRepositoryName() throws Exception {


### PR DESCRIPTION
When using multiple branch specifiers, the git plugin uses an advanced
selection mechanism as defined in `getAdvancedCandidateRevisons` which
does not consider tags from the repository, only normal branches.

E.g. when using the following Branch specifiers:
- refs/remotes/origin/${B}
- refs/tags/${B}

where B is a build parameter having a default value of "master" never
causes any tag to be build, regardless of what the user chooses.

Include the tags to complete the list of valid branches to find the best
matching ref for the current build.
