### PR TITLE
add support for specifying credentials for submodule URLs

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/Credentials.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/Credentials.java
@@ -1,0 +1,160 @@
+package hudson.plugins.git.extensions.impl;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.GitTool;
+import hudson.plugins.git.Messages;
+import hudson.security.ACL;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.regex.Pattern;
+import org.jenkinsci.plugins.gitclient.Git;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.gitclient.GitURIRequirementsBuilder;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import static hudson.Util.*;
+
+/**
+ * Definition of a credential for a given URL.
+ *
+ * @author Jacob Keller
+ */
+public class Credentials extends AbstractDescribableImpl<Credentials> {
+    private String url;
+    private String credentialsId;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getCredentialsId() {
+        return credentialsId;
+    }
+
+    @DataBoundConstructor
+    public Credentials(String url, String credentialsId) {
+        this.url = fixEmptyAndTrim(url);
+        this.credentialsId = credentialsId;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<Credentials> {
+        @Override
+        public String getDisplayName() {
+            return "Add credentials";
+        }
+
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item project,
+                                                     @QueryParameter String url) {
+            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
+                return new StandardListBoxModel();
+            }
+            return new StandardListBoxModel()
+                    .withEmptySelection()
+                    .withMatching(
+                            GitClient.CREDENTIALS_MATCHER,
+                            CredentialsProvider.lookupCredentials(StandardCredentials.class,
+                                    project,
+                                    ACL.SYSTEM,
+                                    GitURIRequirementsBuilder.fromUri(url).build())
+                    );
+        }
+
+        public FormValidation doCheckCredentialsId(@AncestorInPath Item project,
+                                                   @QueryParameter String url,
+                                                   @QueryParameter String value) {
+            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
+                return FormValidation.ok();
+            }
+
+            value = Util.fixEmptyAndTrim(value);
+            if (value == null) {
+                return FormValidation.ok();
+            }
+
+            url = Util.fixEmptyAndTrim(url);
+            if (url == null)
+            // not set, can't check
+            {
+                return FormValidation.ok();
+            }
+
+            if (url.indexOf('$') >= 0)
+            // set by variable, can't check
+            {
+                return FormValidation.ok();
+            }
+
+            StandardCredentials credentials = lookupCredentials(project, value, url);
+
+            if (credentials == null) {
+                // no credentials available, can't check
+                return FormValidation.warning("Cannot find any credentials with id " + value);
+            }
+
+            // TODO check if this type of credential is acceptable to the Git client or does it merit warning the user
+
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckUrl(@AncestorInPath Item project,
+                                         @QueryParameter String credentialsId,
+                                         @QueryParameter String value) throws IOException, InterruptedException {
+
+            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
+                return FormValidation.ok();
+            }
+
+            String url = Util.fixEmptyAndTrim(value);
+            if (url == null)
+                return FormValidation.error("Please enter Git repository.");
+
+            if (url.indexOf('$') >= 0)
+                // set by variable, can't validate
+                return FormValidation.ok();
+
+            // get git executable on master
+            final EnvVars environment = new EnvVars(System.getenv()); // GitUtils.getPollEnvironment(project, null, launcher, TaskListener.NULL, false);
+
+            GitClient git = Git.with(TaskListener.NULL, environment)
+                    .using(GitTool.getDefaultInstallation().getGitExe())
+                    .getClient();
+            git.addDefaultCredentials(lookupCredentials(project, credentialsId, url));
+
+            // attempt to connect the provided URL
+            try {
+                git.getHeadRev(url, "HEAD");
+            } catch (GitException e) {
+                return FormValidation.error(Messages.UserRemoteConfig_FailedToConnect(e.getMessage()));
+            }
+
+            return FormValidation.ok();
+        }
+
+        private static StandardCredentials lookupCredentials(Item project, String credentialId, String uri) {
+            return (credentialId == null) ? null : CredentialsMatchers.firstOrNull(
+                        CredentialsProvider.lookupCredentials(StandardCredentials.class, project, ACL.SYSTEM,
+                                GitURIRequirementsBuilder.fromUri(uri).build()),
+                        CredentialsMatchers.withId(credentialId));
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -1,18 +1,28 @@
 package hudson.plugins.git.extensions.impl;
 
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import hudson.Extension;
 import hudson.model.Run;
+import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.SubmoduleCombinator;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import hudson.plugins.git.extensions.impl.Credentials;
 import hudson.plugins.git.util.BuildData;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
+import hudson.security.ACL;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  * Further tweak the behaviour of git-submodule.
@@ -40,13 +50,26 @@ public class SubmoduleOption extends GitSCMExtension {
     private boolean recursiveSubmodules;
     private boolean trackingSubmodules;
     private Integer timeout;
+    List<Credentials> credentials;
 
     @DataBoundConstructor
+    public SubmoduleOption(boolean disableSubmodules, boolean recursiveSubmodules, boolean trackingSubmodules, Integer timeout, List<Credentials> credentials) {
+        this.disableSubmodules = disableSubmodules;
+        this.recursiveSubmodules = recursiveSubmodules;
+        this.trackingSubmodules = trackingSubmodules;
+        this.timeout = timeout;
+        if (credentials == null)
+            this.credentials = new ArrayList<Credentials>();
+        else
+            this.credentials = credentials;
+    }
+
     public SubmoduleOption(boolean disableSubmodules, boolean recursiveSubmodules, boolean trackingSubmodules, Integer timeout) {
         this.disableSubmodules = disableSubmodules;
         this.recursiveSubmodules = recursiveSubmodules;
         this.trackingSubmodules = trackingSubmodules;
         this.timeout = timeout;
+        this.credentials = new ArrayList<Credentials>();
     }
 
     public boolean isDisableSubmodules() {
@@ -70,6 +93,24 @@ public class SubmoduleOption extends GitSCMExtension {
         if (!disableSubmodules && git.hasGitModules()) {
             git.submoduleClean(recursiveSubmodules);
         }
+    }
+
+    @Override
+    public GitClient decorate(GitSCM scm, GitClient git) throws IOException, InterruptedException, GitException {
+        for (Credentials creds : credentials) {
+            StandardCredentials credentials = CredentialsMatchers
+                .firstOrNull(CredentialsProvider.lookupCredentials(StandardCredentials.class,
+                            (Item) null,
+                            ACL.SYSTEM,
+                            URIRequirementBuilder.fromUri(creds.getUrl()).build()),
+                        CredentialsMatchers.allOf(CredentialsMatchers.withId(creds.getCredentialsId()),
+                            GitClient.CREDENTIALS_MATCHER));
+            if (credentials != null) {
+                git.addCredentials(creds.getUrl(), credentials);
+            }
+        }
+
+        return git;
     }
 
     @Override

--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -35,7 +35,7 @@
 
     <f:entry title="${%Additional Behaviours}">
         <!-- TODO: switch to <f:repeatableHeteroList field="extensions"> -->
-        <f:hetero-list name="extensions" items="${instance.extensions}" descriptors="${descriptor.getExtensionDescriptors()}"
+       <f:hetero-list name="extensions" items="${instance.extensions}" descriptors="${descriptor.getExtensionDescriptors()}"
                        hasHeader="true" />
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/Credentials/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/Credentials/config.groovy
@@ -1,0 +1,24 @@
+package hudson.plugins.git.extensions.impl.Credentials;
+
+def f = namespace(lib.FormTagLib);
+def c = namespace(lib.CredentialsTagLib)
+
+f.entry(title:_("URL"), field:"url") {
+    f.textbox()
+}
+
+f.entry(title:_("Credentials"), field:"credentialsId") {
+    c.select(onchange="""{
+            var self = this.targetElement ? this.targetElement : this;
+            var r = findPreviousFormItem(self,'url');
+            r.onchange(r);
+            self = null;
+            r = null;
+    }""" /* workaround for JENKINS-19124 */)
+}
+
+f.entry {
+    div(align:"right") {
+        input (type:"button", value:_("Delete"), class:"repeatable-delete")
+    }
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/Credentials/help-credentials.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/Credentials/help-credentials.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Credentials to be provided for authentication with the given URL</p>
+</div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/Credentials/help-url.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/Credentials/help-url.html
@@ -1,0 +1,3 @@
+<div>
+  <p>The URL for which the provided credentials will be used.</p>
+</div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
@@ -14,6 +14,9 @@ f.entry(title:_("Update tracking submodules to tip of branch"), field:"trackingS
 f.entry(title:_("Timeout (in minutes) for submodules operations"), field:"timeout") {
     f.textbox()
 }
+f.entry(title:_("Submodule Credentials")) {
+    f.repeatableProperty(field:"credentials", noAddButton:"false")
+}
 
 /*
   This needs more thought


### PR DESCRIPTION
Credentials are associated with a specific URL, and the credentials
provided for each remote do not have the same URL. Add credentials boxes
to the SubmoduleOptions extensions. These will allow users to specify
credentials which match the URL of the submodule.