### PR TITLE
Provide GIT_DESCRIBE token

### DIFF
--- a/src/main/java/hudson/plugins/git/GitDescribeTokenMacro.java
+++ b/src/main/java/hudson/plugins/git/GitDescribeTokenMacro.java
@@ -1,0 +1,37 @@
+package hudson.plugins.git;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.TaskListener;
+import hudson.plugins.git.util.BuildData;
+import hudson.scm.SCM;
+import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+
+import java.io.IOException;
+
+/**
+ * {@code GIT_DESCRIBE} token that expands to the description of a commit using the most recent tag reachable from it.
+ *
+ * @author Szymon Sasin
+ */
+@Extension(optional = true)
+public class GitDescribeTokenMacro extends DataBoundTokenMacro {
+
+    @Override
+    public boolean acceptsMacroName(String macroName) {
+        return "GIT_DESCRIBE".equals(macroName);
+    }
+
+    @Override
+    public String evaluate(AbstractBuild<?, ?> ctx, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException {
+
+        SCM scm = ctx.getProject().getScm();
+        if (!(scm instanceof GitSCM)) {
+            return "error: not a git";
+        }
+        return ((GitSCM) scm).readGitDescribe(ctx, listener);
+    }
+
+}
+

--- a/src/main/java/hudson/plugins/git/GitDescribeTokenMacro.java
+++ b/src/main/java/hudson/plugins/git/GitDescribeTokenMacro.java
@@ -3,12 +3,13 @@ package hudson.plugins.git;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
-import hudson.plugins.git.util.BuildData;
 import hudson.scm.SCM;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * {@code GIT_DESCRIBE} token that expands to the description of a commit using the most recent tag reachable from it.
@@ -17,6 +18,34 @@ import java.io.IOException;
  */
 @Extension(optional = true)
 public class GitDescribeTokenMacro extends DataBoundTokenMacro {
+
+    /**
+     * Include tag part (default=true)
+     */
+    @Parameter
+    public boolean tag = true;
+
+    /**
+     * Include distance to a tag part (default=true)
+     */
+    @Parameter
+    public boolean distance = true;
+
+    /**
+     * Include revision part (default=true)
+     */
+    @Parameter()
+    public boolean revision = true;
+
+    public GitDescribeTokenMacro() {
+
+    }
+
+    GitDescribeTokenMacro(boolean tag, boolean distance, boolean revision) {
+        this.tag = tag;
+        this.distance = distance;
+        this.revision = revision;
+    }
 
     @Override
     public boolean acceptsMacroName(String macroName) {
@@ -30,7 +59,41 @@ public class GitDescribeTokenMacro extends DataBoundTokenMacro {
         if (!(scm instanceof GitSCM)) {
             return "error: not a git";
         }
-        return ((GitSCM) scm).readGitDescribe(ctx, listener);
+        String gitDescribe = ((GitSCM) scm).readGitDescribe(ctx, listener);
+
+        return parse(gitDescribe);
+    }
+
+    private String parse(String gitDescribe) {
+        if (tag && distance && revision) {
+            return gitDescribe;
+        }
+
+        Pattern p = Pattern.compile("(.+)-(\\d+)-g(.*)");
+        Matcher matcher = p.matcher(gitDescribe);
+        if (matcher.find()) {
+
+            StringBuilder gitDesc = new StringBuilder();
+            if (tag) {
+                gitDesc.append(matcher.group(1));
+            }
+            if (distance) {
+                if (gitDesc.length() != 0) gitDesc.append('-');
+                gitDesc.append(matcher.group(2));
+            }
+            if (revision) {
+                if (gitDesc.length() != 0) gitDesc.append("-g");
+                gitDesc.append(matcher.group(3));
+            }
+
+            return gitDesc.toString();
+        }
+
+        if (tag){
+            return gitDescribe;
+        } else {
+            return "";
+        }
     }
 
 }

--- a/src/main/resources/hudson/plugins/git/GitDescribeTokenMacro/help.html
+++ b/src/main/resources/hudson/plugins/git/GitDescribeTokenMacro/help.html
@@ -1,6 +1,0 @@
-<div>
-  <dt>$${GIT_DESCRIBE}</dt>
-  <dd>
-    Expands to the description of a commit using the most recent tag reachable from it.
-  </dd>
-</div>

--- a/src/main/resources/hudson/plugins/git/GitDescribeTokenMacro/help.html
+++ b/src/main/resources/hudson/plugins/git/GitDescribeTokenMacro/help.html
@@ -1,0 +1,6 @@
+<div>
+  <dt>$${GIT_DESCRIBE}</dt>
+  <dd>
+    Expands to the description of a commit using the most recent tag reachable from it.
+  </dd>
+</div>

--- a/src/main/resources/hudson/plugins/git/GitDescribeTokenMacro/help.jelly
+++ b/src/main/resources/hudson/plugins/git/GitDescribeTokenMacro/help.jelly
@@ -1,0 +1,23 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <dt>$${GIT_DESCRIBE}</dt>
+  <dd>
+    Expands to the description of a commit using the most recent tag reachable from it: 'git describe'.
+  </dd>
+
+  <h3>Parameters</h3>
+  <dl>
+    <dt>tag (default to true)</dt>
+    <dd>
+      Include tag part
+    </dd>
+    <dt>distance (default to true)</dt>
+    <dd>
+      Include distance part
+    </dd>
+    <dt>revision (default to true)</dt>
+    <dd>
+      Include revision part
+    </dd>
+  </dl>
+</j:jelly>

--- a/src/test/java/hudson/plugins/git/GitDescribeTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/git/GitDescribeTokenMacroTest.java
@@ -1,0 +1,49 @@
+package hudson.plugins.git;
+
+import hudson.model.AbstractBuild;
+import hudson.model.TaskListener;
+import hudson.scm.SCM;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class GitDescribeTokenMacroTest {
+
+    @Test
+    public void acceptsMacroName() throws Exception {
+        GitDescribeTokenMacro gitDescribeTokenMacro = new GitDescribeTokenMacro();
+
+        assertFalse(gitDescribeTokenMacro.acceptsMacroName("dupa"));
+        assertFalse(gitDescribeTokenMacro.acceptsMacroName(""));
+        assertFalse(gitDescribeTokenMacro.acceptsMacroName(null));
+
+        assertTrue(gitDescribeTokenMacro.acceptsMacroName("GIT_DESCRIBE"));
+    }
+
+    @Test
+    public void evaluate() throws Exception {
+        GitDescribeTokenMacro gitDescribeTokenMacro = new GitDescribeTokenMacro();
+
+        GitSCM gitSCM = mock(GitSCM.class);
+        when(gitSCM.readGitDescribe(any(AbstractBuild.class), any(TaskListener.class))).thenReturn("2.4.1-12-gabcdef01");
+
+        AbstractBuild build = mock(AbstractBuild.class, RETURNS_DEEP_STUBS);
+        when(build.getProject().getScm()).thenReturn(gitSCM);
+
+        assertEquals("2.4.1-12-gabcdef01", gitDescribeTokenMacro.evaluate(build, null, null));
+
+    }
+
+    @Test
+    public void evaluate_notAGitSCM() throws Exception {
+        GitDescribeTokenMacro gitDescribeTokenMacro = new GitDescribeTokenMacro();
+
+        AbstractBuild build = mock(AbstractBuild.class, RETURNS_DEEP_STUBS);
+        when(build.getProject().getScm()).thenReturn(mock(SCM.class));
+
+        assertThat(gitDescribeTokenMacro.evaluate(build, null, null), CoreMatchers.startsWith("error:"));
+    }
+}

--- a/src/test/java/hudson/plugins/git/GitDescribeTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/git/GitDescribeTokenMacroTest.java
@@ -6,6 +6,8 @@ import hudson.scm.SCM;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
@@ -24,17 +26,30 @@ public class GitDescribeTokenMacroTest {
     }
 
     @Test
-    public void evaluate() throws Exception {
-        GitDescribeTokenMacro gitDescribeTokenMacro = new GitDescribeTokenMacro();
+    public void evaluate_defaultParameters() throws Exception {
+        GitDescribeTokenMacro tokenMacro = new GitDescribeTokenMacro();
 
-        GitSCM gitSCM = mock(GitSCM.class);
-        when(gitSCM.readGitDescribe(any(AbstractBuild.class), any(TaskListener.class))).thenReturn("2.4.1-12-gabcdef01");
+        assertEquals("2.4.1-12-gabcdef01", tokenMacro.evaluate(mockBuild("2.4.1-12-gabcdef01"), null, null));
+    }
 
-        AbstractBuild build = mock(AbstractBuild.class, RETURNS_DEEP_STUBS);
-        when(build.getProject().getScm()).thenReturn(gitSCM);
+    @Test
+    public void evaluate_withParameters() throws Exception {
+        assertEquals("2.4.1", new GitDescribeTokenMacro(true, false, false).evaluate(mockBuild("2.4.1-12-gabcdef01"), null, null));
+        assertEquals("2.4.1-12", new GitDescribeTokenMacro(true, false, false).evaluate(mockBuild("2.4.1-12"), null, null));
+        assertEquals("2.4.1", new GitDescribeTokenMacro(true, false, false).evaluate(mockBuild("2.4.1"), null, null));
+        assertEquals("tag-111-gaaa", new GitDescribeTokenMacro(true, false, false).evaluate(mockBuild("tag-111-gaaa-12-gabcdef01"), null, null));
 
-        assertEquals("2.4.1-12-gabcdef01", gitDescribeTokenMacro.evaluate(build, null, null));
+        assertEquals("12-gabcdef01", new GitDescribeTokenMacro(false, true, true).evaluate(mockBuild("2.4.1-12-gabcdef01"), null, null));
+        assertEquals("12-gabcdef01", new GitDescribeTokenMacro(false, true, true).evaluate(mockBuild("tag-111-gaaa-12-gabcdef01"), null, null));
+        assertEquals("", new GitDescribeTokenMacro(false, true, true).evaluate(mockBuild("2.4.1"), null, null));
 
+        assertEquals("abcdef01", new GitDescribeTokenMacro(false, false, true).evaluate(mockBuild("2.4.1-12-gabcdef01"), null, null));
+        assertEquals("abcdef01", new GitDescribeTokenMacro(false, false, true).evaluate(mockBuild("tag-111-gaaa-12-gabcdef01"), null, null));
+        assertEquals("", new GitDescribeTokenMacro(false, false, true).evaluate(mockBuild("2.4.1"), null, null));
+
+        assertEquals("2.4.1-gabcdef01", new GitDescribeTokenMacro(true, false, true).evaluate(mockBuild("2.4.1-12-gabcdef01"), null, null));
+        assertEquals("2.4.1-12", new GitDescribeTokenMacro(true, true, false).evaluate(mockBuild("2.4.1-12-gabcdef01"), null, null));
+        assertEquals("2.4.1", new GitDescribeTokenMacro(true, false, true).evaluate(mockBuild("2.4.1"), null, null));
     }
 
     @Test
@@ -45,5 +60,14 @@ public class GitDescribeTokenMacroTest {
         when(build.getProject().getScm()).thenReturn(mock(SCM.class));
 
         assertThat(gitDescribeTokenMacro.evaluate(build, null, null), CoreMatchers.startsWith("error:"));
+    }
+
+    private AbstractBuild mockBuild(String gitDescribe) throws IOException, InterruptedException {
+        GitSCM gitSCM = mock(GitSCM.class);
+        when(gitSCM.readGitDescribe(any(AbstractBuild.class), any(TaskListener.class))).thenReturn(gitDescribe);
+
+        AbstractBuild build = mock(AbstractBuild.class, RETURNS_DEEP_STUBS);
+        when(build.getProject().getScm()).thenReturn(gitSCM);
+        return build;
     }
 }


### PR DESCRIPTION
Provides result of 'git describe' as a token macro `GIT_DESCRIBE` with parameters:
- `tag`: includes tag part
- `distance`: includes distance part
- `revision`: includes revision part

For example:
`${GIT_DESCRIBE}` will give: `some-tag-32-gabcdef1234`
`${GIT_DESCRIBE, tag=false}` will give: `32-gabcdef1234`
`${GIT_DESCRIBE, revision=false}` will give: `some-tag-32`
