### PR TITLE
fix for JENKINS-29603

### DIFF
--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -263,7 +263,7 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
                                         parametrizedBranchSpec = true;
                                     } else {
                                         for (String branch : branches) {
-                                            if (branchSpec.matches(repository.getName() + "/" + branch)) {
+                                            if (branchSpec.matches(branch)) {
                                                 if (LOGGER.isLoggable(Level.FINE)) {
                                                     LOGGER.fine("Branch Spec " + branchSpec + " matches modified branch " + branch + " for " + project.getFullDisplayName() + ". ");
                                                 }


### PR DESCRIPTION
Can you please review and integrate the patch? I use it already in production and so far it works for different tags, branches etc.. It makes life so much easier if the Git branch / tag in the job definition is unique (using ref/heads/.. or ref/tags/..). With the patch, the branch parameter of notifyCommit must match the branch parameter in the job definition, that's it! This is quite robust and you get no mysterious behaviour.
