### PR TITLE
Improvements to online help regarding default global git operation timeout.

### DIFF
--- a/src/main/resources/hudson/plugins/git/extensions/impl/CheckoutOption/help-timeout.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CheckoutOption/help-timeout.html
@@ -2,4 +2,5 @@
   Specify a timeout (in minutes) for checkout.<br/>
   This option overrides the default timeout of 10 minutes. <br/>
   You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-11286" target="_blank">JENKINS-11286</a>).
+  Note that property should be set on both master and slave to have effect (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-22547" target="_blank">JENKINS-22547</a>).
 </div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CheckoutOption/help-timeout.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CheckoutOption/help-timeout.html
@@ -1,5 +1,5 @@
 <div>
   Specify a timeout (in minutes) for checkout.<br/>
   This option overrides the default timeout of 10 minutes. <br/>
-  You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeout (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-11286" target="_blank">JENKINS-11286</a>).
+  You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-11286" target="_blank">JENKINS-11286</a>).
 </div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-timeout.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-timeout.html
@@ -2,4 +2,5 @@
   Specify a timeout (in minutes) for clone and fetch operations.<br/>
   This option overrides the default timeout of 10 minutes. <br/>
   You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-11286" target="_blank">JENKINS-11286</a>).
+  Note that property should be set on both master and slave to have effect (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-22547" target="_blank">JENKINS-22547</a>).
 </div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-timeout.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-timeout.html
@@ -1,5 +1,5 @@
 <div>
   Specify a timeout (in minutes) for clone and fetch operations.<br/>
   This option overrides the default timeout of 10 minutes. <br/>
-  You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeout (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-11286" target="_blank">JENKINS-11286</a>).
+  You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-11286" target="_blank">JENKINS-11286</a>).
 </div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/help-timeout.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/help-timeout.html
@@ -2,4 +2,5 @@
   Specify a timeout (in minutes) for submodules operations.<br/>
   This option overrides the default timeout of 10 minutes. <br/>
   You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-11286" target="_blank">JENKINS-11286</a>).
+  Note that property should be set on both master and slave to have effect (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-22547" target="_blank">JENKINS-22547</a>).
 </div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/help-timeout.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/help-timeout.html
@@ -1,5 +1,5 @@
 <div>
   Specify a timeout (in minutes) for submodules operations.<br/>
   This option overrides the default timeout of 10 minutes. <br/>
-  You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeout (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-11286" target="_blank">JENKINS-11286</a>).
+  You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-11286" target="_blank">JENKINS-11286</a>).
 </div>


### PR DESCRIPTION
It took us some trial and error to make this work, hopefully it will be much easier with the updated help.
