### PR TITLE
[FIXED JENKINS-30178] Add default parameters defined in the job

### DIFF
--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -25,7 +25,6 @@ import jenkins.triggers.SCMTriggerItem;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.lang.StringUtils;
-
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;

--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -339,12 +339,6 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
 
             } else {
                 defValues = new ArrayList<ParameterValue>();
-            }
-
-            /*
-             * This check is made ONLY if someone will call this method even if isParametrized() is false.
-             */
-            if (paramDefProp == null) {
                 return defValues;
             }
 

--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -341,16 +341,16 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
          * Get the default parameters values from a job
          *
          */
-        private List<ParameterValue> getDefaultParametersValues(Job job) {
+        private ArrayList<ParameterValue> getDefaultParametersValues(Job<?,?> job) {
             ArrayList<ParameterValue> defValues;
-            ParametersDefinitionProperty paramDefProp = ((Job<?,?>)job).getProperty(ParametersDefinitionProperty.class);
+            ParametersDefinitionProperty paramDefProp = job.getProperty(ParametersDefinitionProperty.class);
 
             if (paramDefProp != null) {
                 List <ParameterDefinition> parameterDefinition = paramDefProp.getParameterDefinitions();
                 defValues = new ArrayList<ParameterValue>(parameterDefinition.size());
 
             } else {
-                defValues = new ArrayList<ParameterValue>(0);
+                defValues = new ArrayList<ParameterValue>();
             }
 
             /*

--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -342,8 +342,16 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
          *
          */
         private List<ParameterValue> getDefaultParametersValues(Job job) {
-            ParametersDefinitionProperty paramDefProp = (ParametersDefinitionProperty) job.getProperty(ParametersDefinitionProperty.class);
-            ArrayList<ParameterValue> defValues = new ArrayList<ParameterValue>();
+            ArrayList<ParameterValue> defValues;
+            ParametersDefinitionProperty paramDefProp = ((Job<?,?>)job).getProperty(ParametersDefinitionProperty.class);
+
+            if (paramDefProp != null) {
+                List <ParameterDefinition> parameterDefinition = paramDefProp.getParameterDefinitions();
+                defValues = new ArrayList<ParameterValue>(parameterDefinition.size());
+
+            } else {
+                defValues = new ArrayList<ParameterValue>(0);
+            }
 
             /*
              * This check is made ONLY if someone will call this method even if isParametrized() is false.

--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -281,13 +281,17 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
 
                             if (!(project instanceof AbstractProject && ((AbstractProject) project).isDisabled())) {
                                 //JENKINS-30178 Add default parameters defined in the job
-                                List<JobProperty> jobProperties = ((Job) project).getAllProperties();
-                                for (JobProperty jobProperty : jobProperties) {
-                                    if(jobProperty instanceof ParametersDefinitionProperty) {
-                                        ParametersDefinitionProperty parametersDefinitionProperty = (ParametersDefinitionProperty) jobProperty;
-                                        for (ParameterDefinition parameterDefinition : parametersDefinitionProperty.getParameterDefinitions()) {
-                                            parameterDefinition.getDefaultParameterValue();
-                                            buildParameters.add(parameterDefinition.getDefaultParameterValue());
+                                if (project instanceof Job) {
+                                    List<JobProperty> jobProperties = ((Job) project).getAllProperties();
+                                    for (JobProperty jobProperty : jobProperties) {
+                                        if (jobProperty instanceof ParametersDefinitionProperty) {
+                                            ParametersDefinitionProperty parametersDefinitionProperty = (ParametersDefinitionProperty) jobProperty;
+                                            for (ParameterDefinition parameterDefinition : parametersDefinitionProperty.getParameterDefinitions()) {
+                                                ParameterValue parameterValue = parameterDefinition.getDefaultParameterValue();
+                                                if (parameterValue != null) {
+                                                    buildParameters.add(parameterValue);
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -282,8 +282,8 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
                                 //JENKINS-30178 Add default parameters defined in the job
                                 if (project instanceof Job) {
                                     Set<String> buildParametersNames = new HashSet<String>();
-                                    for (ParameterValue val: allBuildParameters) {
-                                        buildParametersNames.add(val.getName());
+                                    for (ParameterValue parameterValue: allBuildParameters) {
+                                        buildParametersNames.add(parameterValue.getName());
                                     }
 
                                     List<ParameterValue> jobParametersValues = getDefaultParametersValues((Job) project);

--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -280,6 +280,17 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
                             urlFound = true;
 
                             if (!(project instanceof AbstractProject && ((AbstractProject) project).isDisabled())) {
+                                //JENKINS-30178 Add default parameters defined in the job
+                                List<JobProperty> jobProperties = ((Job) project).getAllProperties();
+                                for (JobProperty jobProperty : jobProperties) {
+                                    if(jobProperty instanceof ParametersDefinitionProperty) {
+                                        ParametersDefinitionProperty parametersDefinitionProperty = (ParametersDefinitionProperty) jobProperty;
+                                        for (ParameterDefinition parameterDefinition : parametersDefinitionProperty.getParameterDefinitions()) {
+                                            parameterDefinition.getDefaultParameterValue();
+                                            buildParameters.add(parameterDefinition.getDefaultParameterValue());
+                                        }
+                                    }
+                                }
                                 if (!parametrizedBranchSpec && isNotEmpty(sha1)) {
                                     LOGGER.info("Scheduling " + project.getFullDisplayName() + " to build commit " + sha1);
                                     scmTriggerItem.scheduleBuild2(scmTriggerItem.getQuietPeriod(),


### PR DESCRIPTION
Jenkins doesn't set configured environment variables with default values in the "This build is parameterized" section on commit notification from SCM using `/git/notifyCommit` request. However it works properly when build is manually triggered with "Build with parameters" button.

https://issues.jenkins-ci.org/browse/JENKINS-30178

@reviewbybees @ndeloof @oleg-nenashev 