### PR TITLE
Do not trigger build on empty changeset

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
@@ -93,7 +93,7 @@ public class PathRestriction extends GitSCMExtension {
     public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener, BuildData buildData) {
         Collection<String> paths = commit.getAffectedPaths();
         if (paths.isEmpty()) {// nothing modified, so no need to compute any of this
-            return null;
+            return true;
         }
 
         List<Pattern> included = getIncludedPatterns();

--- a/src/test/java/hudson/plugins/git/extensions/impl/PathRestrictionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/PathRestrictionTest.java
@@ -88,7 +88,7 @@ public class PathRestrictionTest {
         @Test
         public void test() throws Exception {
             GitChangeSet commit = new FakePathGitChangeSet(new HashSet<String>());
-            assertNull(getExtension().isRevExcluded((hudson.plugins.git.GitSCM) project.getScm(), repo.git, commit, listener, mockBuildData));
+            assertTrue(getExtension().isRevExcluded((hudson.plugins.git.GitSCM) project.getScm(), repo.git, commit, listener, mockBuildData));
         }
     }
 


### PR DESCRIPTION
1) If I create a commit and revert it(we have 2 commits) in one pull request and then merge it - polling will be triggered jenkins job with empty merge commit even if the changes in excluded path.
2) If I create a commit and triggered jenkins job manually the next polling will be triggered jenkins job with no changes, but shouldn't.