### PR TITLE
git-plugin: support use of parent credentials in submodules

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
+++ b/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
@@ -204,7 +204,7 @@ public abstract class GitSCMBackwardCompatibility extends SCM implements Seriali
                 skipTag = null;
             }
             if (disableSubmodules || recursiveSubmodules || trackingSubmodules) {
-                addIfMissing(new SubmoduleOption(disableSubmodules, recursiveSubmodules, trackingSubmodules, null));
+                addIfMissing(new SubmoduleOption(disableSubmodules, recursiveSubmodules, trackingSubmodules, false, null));
             }
             if (isNotBlank(gitConfigName) || isNotBlank(gitConfigEmail)) {
                 addIfMissing(new UserIdentity(gitConfigName,gitConfigEmail));

--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -39,13 +39,15 @@ public class SubmoduleOption extends GitSCMExtension {
     private boolean disableSubmodules;
     private boolean recursiveSubmodules;
     private boolean trackingSubmodules;
+    private boolean parentCredentials;
     private Integer timeout;
 
     @DataBoundConstructor
-    public SubmoduleOption(boolean disableSubmodules, boolean recursiveSubmodules, boolean trackingSubmodules, Integer timeout) {
+    public SubmoduleOption(boolean disableSubmodules, boolean recursiveSubmodules, boolean trackingSubmodules, boolean parentCredentials, Integer timeout) {
         this.disableSubmodules = disableSubmodules;
         this.recursiveSubmodules = recursiveSubmodules;
         this.trackingSubmodules = trackingSubmodules;
+        this.parentCredentials = parentCredentials;
         this.timeout = timeout;
     }
 
@@ -59,6 +61,10 @@ public class SubmoduleOption extends GitSCMExtension {
 
     public boolean isTrackingSubmodules() {
         return trackingSubmodules;
+    }
+
+    public boolean isParentCredentials() {
+        return parentCredentials;
     }
 
     public Integer getTimeout() {
@@ -83,6 +89,7 @@ public class SubmoduleOption extends GitSCMExtension {
             git.submoduleUpdate()
                 .recursive(recursiveSubmodules)
                 .remoteTracking(trackingSubmodules)
+                .parentCredentials(parentCredentials)
                 .timeout(timeout)
                 .execute();
         }

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
@@ -11,6 +11,9 @@ f.entry(title:_("Recursively update submodules"), field:"recursiveSubmodules") {
 f.entry(title:_("Update tracking submodules to tip of branch"), field:"trackingSubmodules") {
     f.checkbox()
 }
+f.entry(title:_("Use credentials from default remote of parent repository"), field:"parentCredentials") {
+    f.checkbox()
+}
 f.entry(title:_("Timeout (in minutes) for submodules operations"), field:"timeout") {
     f.textbox()
 }

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/help-parentCredentials.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/help-parentCredentials.html
@@ -1,0 +1,3 @@
+<div>
+  Use credentials from the default remote of the parent project.
+</div>


### PR DESCRIPTION
Extend the advanced submodules behavior plugin to support additional
change of enabling "submodulesUseParentCreds" feature. This is a new
feature that enables the simple method of allowing submodules to use
their parent repository credentials instead of having to provide
individual credentials per each submodule URL.

This request depends on the feature being available in the git-client plugin, but I'm not quite sure how to indicate that in the maven file here.