### PR TITLE
Fix FileNotFound when running tests in directory with spaces

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeLogParser.java
+++ b/src/main/java/hudson/plugins/git/GitChangeLogParser.java
@@ -5,12 +5,14 @@ import hudson.scm.ChangeLogParser;
 import hudson.scm.RepositoryBrowser;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.xml.sax.SAXException;
 
 import javax.annotation.Nonnull;
 
 import java.io.File;
+import java.io.InputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -29,6 +31,10 @@ public class GitChangeLogParser extends ChangeLogParser {
     public GitChangeLogParser(boolean authorOrCommitter) {
         super();
         this.authorOrCommitter = authorOrCommitter;
+    }
+    
+    public List<GitChangeSet> parse(@Nonnull InputStream changelog) throws IOException {
+        return parse(IOUtils.readLines(changelog, "UTF-8"));
     }
 
     public List<GitChangeSet> parse(@Nonnull List<String> changelog) {

--- a/src/test/java/hudson/plugins/git/browser/BitbucketWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/BitbucketWebTest.java
@@ -13,7 +13,6 @@ import org.xml.sax.SAXException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -106,9 +105,8 @@ public class BitbucketWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
-        final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
+        final List<GitChangeSet> changeSetList = logParser.parse(BitbucketWebTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }
 

--- a/src/test/java/hudson/plugins/git/browser/BitbucketWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/BitbucketWebTest.java
@@ -106,7 +106,7 @@ public class BitbucketWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
+        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/BitbucketWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/BitbucketWebTest.java
@@ -13,6 +13,7 @@ import org.xml.sax.SAXException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -105,7 +106,7 @@ public class BitbucketWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(BitbucketWebTest.class.getResource(rawchangelogpath).getFile());
+        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/GitLabTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitLabTest.java
@@ -7,6 +7,7 @@ import hudson.plugins.git.GitChangeSet.Path;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -150,7 +151,7 @@ public class GitLabTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(GitLabTest.class.getResource(rawchangelogpath).getFile());
+        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/GitLabTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitLabTest.java
@@ -151,7 +151,7 @@ public class GitLabTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
+        final File rawchangelog = new File(URLDecoder.decode(GitLabTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/GitLabTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitLabTest.java
@@ -7,7 +7,6 @@ import hudson.plugins.git.GitChangeSet.Path;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -151,9 +150,8 @@ public class GitLabTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(GitLabTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
-        final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
+        final List<GitChangeSet> changeSetList = logParser.parse(GitLabTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }
 

--- a/src/test/java/hudson/plugins/git/browser/GitListTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitListTest.java
@@ -105,7 +105,7 @@ public class GitListTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
+        final File rawchangelog = new File(URLDecoder.decode(GitListTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/GitListTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitListTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -104,7 +105,7 @@ public class GitListTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(GitListTest.class.getResource(rawchangelogpath).getFile());
+        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/GitListTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitListTest.java
@@ -13,7 +13,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -105,9 +104,8 @@ public class GitListTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(GitListTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
-        final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
+        final List<GitChangeSet> changeSetList = logParser.parse(GitListTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }
 

--- a/src/test/java/hudson/plugins/git/browser/GitWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitWebTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -84,7 +85,7 @@ public class GitWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(GitWebTest.class.getResource(rawchangelogpath).getFile());
+        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/GitWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitWebTest.java
@@ -85,7 +85,7 @@ public class GitWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
+        final File rawchangelog = new File(URLDecoder.decode(GitWebTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/GitWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitWebTest.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -85,9 +84,8 @@ public class GitWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(GitWebTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
-        final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
+        final List<GitChangeSet> changeSetList = logParser.parse(GitWebTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }
 

--- a/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -118,7 +119,7 @@ public class GithubWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(GithubWebTest.class.getResource(rawchangelogpath).getFile());
+        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
@@ -15,7 +15,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -119,9 +118,8 @@ public class GithubWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(GithubWebTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
-        final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
+        final List<GitChangeSet> changeSetList = logParser.parse(GithubWebTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }
 

--- a/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
@@ -119,7 +119,7 @@ public class GithubWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
+        final File rawchangelog = new File(URLDecoder.decode(GithubWebTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/GitoriousWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitoriousWebTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -96,7 +97,7 @@ public class GitoriousWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(GitoriousWebTest.class.getResource(rawchangelogpath).getFile());
+        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/GitoriousWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitoriousWebTest.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -97,9 +96,8 @@ public class GitoriousWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(GitoriousWebTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
-        final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
+        final List<GitChangeSet> changeSetList = logParser.parse(GitoriousWebTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }
 

--- a/src/test/java/hudson/plugins/git/browser/GitoriousWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitoriousWebTest.java
@@ -97,7 +97,7 @@ public class GitoriousWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
+        final File rawchangelog = new File(URLDecoder.decode(GitoriousWebTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
+++ b/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
@@ -100,7 +100,7 @@ public class KilnGitTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
+        final File rawchangelog = new File(URLDecoder.decode(KilnGitTest.class.getResource(rawchangelogpath).getFile()), "utf-8");
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
+++ b/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -100,9 +99,8 @@ public class KilnGitTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(KilnGitTest.class.getResource(rawchangelogpath).getFile()), "utf-8");
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
-        final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
+        final List<GitChangeSet> changeSetList = logParser.parse(KilnGitTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }
 

--- a/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
+++ b/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -99,7 +100,7 @@ public class KilnGitTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(KilnGitTest.class.getResource(rawchangelogpath).getFile());
+        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/RedmineWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/RedmineWebTest.java
@@ -99,7 +99,7 @@ public class RedmineWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
+        final File rawchangelog = new File(URLDecoder.decode(RedmineWebTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/RedmineWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/RedmineWebTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -98,7 +99,7 @@ public class RedmineWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(RedmineWebTest.class.getResource(rawchangelogpath).getFile());
+        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/RedmineWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/RedmineWebTest.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -99,9 +98,8 @@ public class RedmineWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(RedmineWebTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
-        final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
+        final List<GitChangeSet> changeSetList = logParser.parse(RedmineWebTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }
 

--- a/src/test/java/hudson/plugins/git/browser/RhodeCodeTest.java
+++ b/src/test/java/hudson/plugins/git/browser/RhodeCodeTest.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -96,9 +95,8 @@ public class RhodeCodeTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(RhodeCodeTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
-        final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
+        final List<GitChangeSet> changeSetList = logParser.parse(RhodeCodeTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }
 

--- a/src/test/java/hudson/plugins/git/browser/RhodeCodeTest.java
+++ b/src/test/java/hudson/plugins/git/browser/RhodeCodeTest.java
@@ -96,7 +96,7 @@ public class RhodeCodeTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
+        final File rawchangelog = new File(URLDecoder.decode(RhodeCodeTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/RhodeCodeTest.java
+++ b/src/test/java/hudson/plugins/git/browser/RhodeCodeTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -95,7 +96,7 @@ public class RhodeCodeTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(RhodeCodeTest.class.getResource(rawchangelogpath).getFile());
+        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/ViewGitWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/ViewGitWebTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -122,7 +123,7 @@ public class ViewGitWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(ViewGitWebTest.class.getResource(rawchangelogpath).getFile());
+        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/ViewGitWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/ViewGitWebTest.java
@@ -123,7 +123,7 @@ public class ViewGitWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(BitbucketWebTest.class.getResource(rawchangelogpath), "utf-8").getFile());
+        final File rawchangelog = new File(URLDecoder.decode(ViewGitWebTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
         final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
         return changeSetList.get(0);

--- a/src/test/java/hudson/plugins/git/browser/ViewGitWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/ViewGitWebTest.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -123,9 +122,8 @@ public class ViewGitWebTest {
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
-        final File rawchangelog = new File(URLDecoder.decode(ViewGitWebTest.class.getResource(rawchangelogpath).getFile(), "utf-8"));
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
-        final List<GitChangeSet> changeSetList = logParser.parse((Run) null, null, rawchangelog).getLogs();
+        final List<GitChangeSet> changeSetList = logParser.parse(ViewGitWebTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }
 


### PR DESCRIPTION
When tests are run in a directory with spaces, they will fail the file lookup because the way URL encodes spaces.  I modified the tests to decode the filename before it tries to open the file.
@reviewbybees 