### PR TITLE
Add support for SCM Name environment variables for multi-scm builds

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1179,7 +1179,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         // Set environment variable and namespace variable as well.
         env.put(propertyName, value);
-        if (scmNameEnvPrefix != "") {
+        if (!scmNameEnvPrefix.equals("")) {
             env.put(scmNameEnvPrefix + propertyName, value);
         }
     }

--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -1,6 +1,10 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
+    <j:set var="scmd" value="${null}"/>
+    <j:if test="${instance != null}">
+      <j:set var="scm" value="${instance}"/>
+    </j:if>
     <script><![CDATA[
     function encodeAllInputs(sep, form, field) {
         var inputs = Form.getInputs(form, null, field);

--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -1,10 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-    <j:set var="scmd" value="${null}"/>
-    <j:if test="${instance != null}">
-      <j:set var="scm" value="${instance}"/>
-    </j:if>
     <script><![CDATA[
     function encodeAllInputs(sep, form, field) {
         var inputs = Form.getInputs(form, null, field);

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -688,6 +688,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         rule.assertLogContains(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build1);
     }
 
+    @Test
     public void testEnvVarsAvailableBySCMName() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");
 
@@ -707,9 +708,9 @@ public class GitSCMTest extends AbstractGitTestCase {
 
         // Non-SCM namespaced variables
         assertEquals("origin/master", env1.get(GitSCM.GIT_BRANCH));
-        assertLogContains(env1.get(GitSCM.GIT_BRANCH), build1);
+        rule.assertLogContains(env1.get(GitSCM.GIT_BRANCH), build1);
 
-        assertLogContains(checkoutString(project, GitSCM.GIT_COMMIT), build1);
+        rule.assertLogContains(checkoutString(project, GitSCM.GIT_COMMIT), build1);
 
         // SCM namespaced variables
         assertEquals("origin/master", env1.get(scmNameString1Prefix + GitSCM.GIT_BRANCH));
@@ -723,11 +724,11 @@ public class GitSCMTest extends AbstractGitTestCase {
         EnvVars env2 = getEnvVars(project);
 
         // Non-SCM namespaced variables
-        assertLogNotContains(checkoutString(project, GitSCM.GIT_PREVIOUS_COMMIT), build2);
-        assertLogContains(checkoutString(project, GitSCM.GIT_PREVIOUS_COMMIT), build1);
+        rule.assertLogNotContains(checkoutString(project, GitSCM.GIT_PREVIOUS_COMMIT), build2);
+        rule.assertLogContains(checkoutString(project, GitSCM.GIT_PREVIOUS_COMMIT), build1);
 
-        assertLogNotContains(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build2);
-        assertLogContains(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build1);
+        rule.assertLogNotContains(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build2);
+        rule.assertLogContains(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build1);
 
         // SCM namespaced variables
         assertEquals(env2.get(GitSCM.GIT_PREVIOUS_COMMIT), env2.get(scmNameString1Prefix + GitSCM.GIT_PREVIOUS_COMMIT));

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -597,7 +597,10 @@ public class GitSCMTest extends AbstractGitTestCase {
     public void testEnvVarsAvailableBySCMName() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");
 
-        final String scmNameString1 = "ScmName1";
+        // SCM Names need to be made environment variable name safe.
+        final String scmNameString1 = "Scm Name 1";
+        final String scmNameString1Prefix = "Scm_Name_1_";
+
         GitSCM git1 = (GitSCM) project.getScm();
         git1.getExtensions().replace(new ScmName(scmNameString1));
 
@@ -615,8 +618,8 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertLogContains(checkoutString(project, GitSCM.GIT_COMMIT), build1);
 
         // SCM namespaced variables
-        assertEquals("origin/master", env1.get(scmNameString1 + "_" + GitSCM.GIT_BRANCH));
-        assertEquals(env1.get(GitSCM.GIT_COMMIT), env1.get(scmNameString1 + "_" + GitSCM.GIT_COMMIT));
+        assertEquals("origin/master", env1.get(scmNameString1Prefix + GitSCM.GIT_BRANCH));
+        assertEquals(env1.get(GitSCM.GIT_COMMIT), env1.get(scmNameString1Prefix + GitSCM.GIT_COMMIT));
 
         // Second commit for clean repo.
         final String commitFile2 = "commitFile2";
@@ -633,10 +636,10 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertLogContains(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build1);
 
         // SCM namespaced variables
-        assertEquals(env2.get(GitSCM.GIT_PREVIOUS_COMMIT), env2.get(scmNameString1 + "_" + GitSCM.GIT_PREVIOUS_COMMIT));
-        assertEquals(env2.get(GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), env2.get(scmNameString1 + "_" + GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT));
+        assertEquals(env2.get(GitSCM.GIT_PREVIOUS_COMMIT), env2.get(scmNameString1Prefix + GitSCM.GIT_PREVIOUS_COMMIT));
+        assertEquals(env2.get(GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), env2.get(scmNameString1Prefix + GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT));
 
-        assertEquals(env1.get(GitSCM.GIT_COMMIT), env2.get(scmNameString1 + "_" + GitSCM.GIT_PREVIOUS_COMMIT));
+        assertEquals(env1.get(GitSCM.GIT_COMMIT), env2.get(scmNameString1Prefix + GitSCM.GIT_PREVIOUS_COMMIT));
     }
 
     // For HUDSON-7411


### PR DESCRIPTION
One of the difficulties of using the Git plugin in a Multi-SCM environment is it uses the same variables names for each SCM added in a multi-SCM Jenkins build context. To alleviate this issue without altering current behavior of allowing overwrites, an additional environmental variable will be set prefixed/namespaced by the SCM Name set for the repository. This should allow the decoding the state of multiple repositories easier. If no SCM Name is set, no additional variables are set.

In addition to the environment variable change, there is a change to the plugin configuration templates to work-around the issue that the SCMD parameter is being set incorrectly in when derived via the Multi-SCM plugin.
