### PR TITLE
Change plugin configuration template to workaround multiscm repository browser issues.

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -1,6 +1,14 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
+    <j:if test="${scmd != null}">
+        <j:if test="${scmd.getClass().getName().equals(&quot;org.jenkinsci.plugins.multiplescms.MultiSCM$DescriptorImpl&quot;)}">
+            <j:set var="scmd" value="${null}"/>
+            <j:if test="${instance != null}">
+                <j:set var="scm" value="${instance}"/>
+            </j:if>
+        </j:if>
+    </j:if>
     <script><![CDATA[
     function encodeAllInputs(sep, form, field) {
         var inputs = Form.getInputs(form, null, field);


### PR DESCRIPTION
When the Git Plugin is called via the Multi-SCM Plugin  Configuration templates, the template variables are in a mixed state using Multi-SCM configuration values and Git Plugin Configuration values. The template variables affected are:
  * scmd
  * scm
  * instance

The template changes proposed should identify this confused state and attempts to normalize it in backwards compatible with other SCM plugins.

A brief description of how the GIT config template renders under the Multi-SCM plugin follows.

The SCM Configuration templates start in:
  * jenkins/core/src/main/resources/lib/hudson/project/config-scm.jelly

This template sets the *scmd*, *scm*, *instance* template variables for the Multi-SCM plugin and renders its config template.

The Multi-SCM plugin config template calls the jenkins hetero-list macro to configure multiple SCMs.
  * multiple-scms-plugin/src/main/resources/org/jenkinsci/plugins/multiplescms/MultiSCM

The hetero-list macro partially overrides the template variables by setting *instance* to "real" SCM being selected by the hetero-list, in the case of the Git Plugin, the Git Plugin DescriptorImpl. The *scmd* and *scm* template variables are unchanged.
  * jenkins/core/src/main/resources/lib/form/hetero-list.jelly

At this point we enter the Git Plugin Config template with the template variables set as:
  * *scmd* = org.jenkinsci.plugins.multiplescms.MultiSCM$DescriptorImpl@xxxx
  * *scm* = org.jenkinsci.plugins.multiplescms.MultiSCM@xxxx
  * *instance* = hudson.plugins.git.GitSCM@xxxx
