### PR TITLE
JENKINS-31108 Allow publishing from shallow clone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>1.19.0</version>
+      <version>1.19.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -190,11 +190,6 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
 
         final GitSCM gitSCM = (GitSCM) scm;
 
-        if(gitSCM.getUseShallowClone()) {
-        	listener.getLogger().println("GitPublisher disabled while using shallow clone.");
-        	return true;
-    	}
-        
         final String projectName = build.getProject().getName();
         final int buildNumber = build.getNumber();
         final Result buildResult = build.getResult();


### PR DESCRIPTION
Previously this operation was forbidden in versions of Git CLI < 1.9.0
(see http://stackoverflow.com/q/6900103 for more details).

Now this operation will succeed using newer client version, but it will
fail when using an old version due to
https://github.com/jenkinsci/git-client-plugin/pull/192