### PR TITLE
git-plugin: add support to ignore errors from GitPublisher

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -52,6 +52,7 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
     private boolean pushMerge;
     private boolean pushOnlyIfSuccess;
     private boolean forcePush;
+    private boolean ignoreGitErrors;
     
     private List<TagToPush> tagsToPush;
     // Pushes HEAD to these locations
@@ -65,13 +66,15 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         List<NoteToPush> notesToPush,
                         boolean pushOnlyIfSuccess,
                         boolean pushMerge,
-                        boolean forcePush) {
+                        boolean forcePush,
+                        boolean ignoreGitErrors) {
         this.tagsToPush = tagsToPush;
         this.branchesToPush = branchesToPush;
         this.notesToPush = notesToPush;
         this.pushMerge = pushMerge;
         this.pushOnlyIfSuccess = pushOnlyIfSuccess;
         this.forcePush = forcePush;
+        this.ignoreGitErrors = ignoreGitErrors;
         this.configVersion = 2L;
     }
 
@@ -85,6 +88,10 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
 
     public boolean isForcePush() {
         return forcePush;
+    }
+
+    public boolean isIgnoreGitErrors() {
+        return ignoreGitErrors;
     }
 
     public boolean isPushTags() {
@@ -253,7 +260,8 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                     return false;
                 } catch (GitException e) {
                     e.printStackTrace(listener.error("Failed to push merge to origin repository"));
-                    return false;
+                    if (!ignoreGitErrors)
+                        return false;
                 }
             }
 
@@ -306,7 +314,8 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         push.execute();
                     } catch (GitException e) {
                         e.printStackTrace(listener.error("Failed to push tag " + tagName + " to " + targetRepo));
-                        return false;
+                        if (!ignoreGitErrors)
+                            return false;
                     }
                 }
             }
@@ -342,7 +351,8 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         push.execute();
                     } catch (GitException e) {
                         e.printStackTrace(listener.error("Failed to push branch " + branchName + " to " + targetRepo));
-                        return false;
+                        if (!ignoreGitErrors)
+                            return false;
                     }
                 }
             }
@@ -386,7 +396,8 @@ public class GitPublisher extends Recorder implements Serializable, MatrixAggreg
                         push.execute();
                     } catch (GitException e) {
                         e.printStackTrace(listener.error("Failed to add note: \n" + noteMsg  + "\n******"));
-                        return false;
+                        if (!ignoreGitErrors)
+                            return false;
                     }
                 }
             }

--- a/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
@@ -29,6 +29,11 @@
              description="${%Add force option to git push}">
       <f:checkbox />
     </f:entry>
+    <f:entry field="ignoreGitErrors"
+             title="${%Ignore Git Errors}"
+             description="${%Ignore failure from git commands}">
+      <f:checkbox />
+    </f:entry>
     <f:entry field="tagsToPush"
              title="${%Tags}"
              description="${%Tags to push to remote repositories}">

--- a/src/main/resources/hudson/plugins/git/GitPublisher/help-ignoreGitErrors.html
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/help-ignoreGitErrors.html
@@ -1,0 +1,7 @@
+<div>
+  Ignore errors from git push and other git commands run by the Git Publisher.
+  The errors will still be logged in the console output but will not
+  cause the build to fail. This is primarily useful if pushing to a
+  gerrit server which will return error code when there are no references
+  to update.
+</div>


### PR DESCRIPTION
Primarily to allow the usecase of ignoring the failure when pushing to a
gerrit refspec without pushing new changes, add an option
"ignoreGitErrors" to the GitPublisher which will enable creation of a
publisher that will simply keep going when receiving errors from git
commands. Other errors not the result of a GitException will still be
handled. In addition, the stack trace will still appear on the logs but
won't fail the builds.

Add a test for the same based on force push, that ensures the build
succeeds but does not actually result in a completed push.
