### PR TITLE
Override the right onNotifyCommit method of the GitStatus.Listener

### DIFF
--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -120,7 +120,7 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
     }
 
     /**
-     * Contributes to a {@link #doNotifyCommit(String, String, String)} response.
+     * Contributes to a {@link #doNotifyCommit(HttpServletRequest, String, String, String)} response.
      *
      * @since 1.4.1
      */
@@ -182,9 +182,7 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
             return onNotifyCommit(uri, sha1, buildParameters, branches);
         }
 
-        public List<ResponseContributor> onNotifyCommit(URIish uri, @Nullable String sha1, List<ParameterValue> buildParameters, String... branches) {
-            return Collections.EMPTY_LIST;
-        }
+        public abstract List<ResponseContributor> onNotifyCommit(URIish uri, @Nullable String sha1, List<ParameterValue> buildParameters, String... branches);
 
 
     }

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -27,8 +27,10 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
 import hudson.model.Item;
+import hudson.model.ParameterValue;
 import hudson.plugins.git.GitStatus;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
@@ -146,7 +148,7 @@ public class GitSCMSource extends AbstractGitSCMSource {
     public static class ListenerImpl extends GitStatus.Listener {
 
         @Override
-        public List<GitStatus.ResponseContributor> onNotifyCommit(URIish uri, String sha1, String... branches) {
+        public List<GitStatus.ResponseContributor> onNotifyCommit(URIish uri, @Nullable String sha1, List<ParameterValue> buildParameters, String... branches) {
             List<GitStatus.ResponseContributor> result = new ArrayList<GitStatus.ResponseContributor>();
             boolean notified = false;
             // run in high privilege to see all the projects anonymous users don't see.

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
@@ -1,0 +1,58 @@
+package jenkins.plugins.git;
+
+import hudson.model.Item;
+import hudson.model.TopLevelItem;
+import hudson.plugins.git.GitStatus;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceOwner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Robin Müller
+ */
+public class GitSCMSourceTest {
+
+    public static final String REMOTE = "git@remote:test/project.git";
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    private GitStatus gitStatus;
+
+    @Before
+    public void setup() {
+        gitStatus = new GitStatus();
+    }
+
+    @Test
+    public void testSourceOwnerTriggeredByDoNotifyCommit() throws ServletException, IOException {
+        GitSCMSource gitSCMSource = new GitSCMSource("id", REMOTE, "", "*", "", false);
+        GitSCMSourceOwner scmSourceOwner = setupGitSCMSourceOwner(gitSCMSource);
+        jenkins.getInstance().add(scmSourceOwner, "gitSourceOwner");
+
+        gitStatus.doNotifyCommit(mock(HttpServletRequest.class), REMOTE, "master", "");
+
+        verify(scmSourceOwner).onSCMSourceUpdated(gitSCMSource);
+    }
+
+    private GitSCMSourceOwner setupGitSCMSourceOwner(GitSCMSource gitSCMSource) {
+        GitSCMSourceOwner owner = mock(GitSCMSourceOwner.class);
+        when(owner.getSCMSources()).thenReturn(Collections.<SCMSource>singletonList(gitSCMSource));
+        when(owner.hasPermission(Item.READ)).thenReturn(true);
+        return owner;
+    }
+
+    private interface GitSCMSourceOwner extends TopLevelItem, SCMSourceOwner {}
+}


### PR DESCRIPTION
At the moment no SCMSourceOwner that owns GitSCMSources gets informed about source updates if the doNotifyCommit gets called. The reason for this is that the ListenerImpl in the GitSCMSource class overrides the wrong onNotifyCommit method. This pull request fixes this and makes the onNotifyCommit method of the GitStatus.Listener with the "complete" signature abstract (instead of returning EMPTY_LIST). This ensures that any further implementation of this listener will implement/override the correct onNotifyCommit method.