### PR TITLE
[JENKINS-29603] Fix notifyCommit for branches that contain slashes

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -545,7 +545,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return j;
     }
 
-    public static final Pattern GIT_REF = Pattern.compile("(refs/[^/]+)/.*");
+    public static final Pattern GIT_REF = Pattern.compile("(refs/[^/]+)/(.*)");
 
     private PollingResult compareRemoteRevisionWithImpl(Job<?, ?> project, Launcher launcher, FilePath workspace, final TaskListener listener) throws IOException, InterruptedException {
         // Poll for changes. Are there any unbuilt revisions that Hudson ought to build ?

--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -265,7 +265,7 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
                                         parametrizedBranchSpec = true;
                                     } else {
                                         for (String branch : branches) {
-                                            if (branchSpec.matches(repository.getName() + "/" + branch)) {
+                                            if (branchSpec.matchesRepositoryBranch(repository.getName(), branch)) {
                                                 if (LOGGER.isLoggable(Level.FINE)) {
                                                     LOGGER.fine("Branch Spec " + branchSpec + " matches modified branch " + branch + " for " + project.getFullDisplayName() + ". ");
                                                 }

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -6,7 +6,6 @@ import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.triggers.SCMTrigger;
-
 import java.net.URISyntaxException;
 import java.util.*;
 import org.eclipse.jgit.transport.URIish;
@@ -194,7 +193,7 @@ public class GitStatusTest extends AbstractGitProject {
     };
 
     @Theory
-    public void testDoNotifyBranchWithSlash(@FromDataPoints("branchSpecPrefixes") String branchSpecPrefix) throws Exception {
+    public void testDoNotifyCommitBranchWithSlash(@FromDataPoints("branchSpecPrefixes") String branchSpecPrefix) throws Exception {
         SCMTrigger trigger = setupProject("remote", branchSpecPrefix + "feature/awesome-feature", false);
         this.gitStatus.doNotifyCommit(requestWithNoParameter, "remote", "feature/awesome-feature", null);
 
@@ -202,7 +201,7 @@ public class GitStatusTest extends AbstractGitProject {
     }
 
     @Theory
-    public void testDoNotifyBranchWithoutSlash(@FromDataPoints("branchSpecPrefixes") String branchSpecPrefix) throws Exception {
+    public void testDoNotifyCommitBranchWithoutSlash(@FromDataPoints("branchSpecPrefixes") String branchSpecPrefix) throws Exception {
         SCMTrigger trigger = setupProject("remote", branchSpecPrefix + "awesome-feature", false);
         this.gitStatus.doNotifyCommit(requestWithNoParameter, "remote", "awesome-feature", null);
 
@@ -210,7 +209,7 @@ public class GitStatusTest extends AbstractGitProject {
     }
 
     @Theory
-    public void testDoNotifyBranchByBranchRef(@FromDataPoints("branchSpecPrefixes") String branchSpecPrefix) throws Exception {
+    public void testDoNotifyCommitBranchByBranchRef(@FromDataPoints("branchSpecPrefixes") String branchSpecPrefix) throws Exception {
         SCMTrigger trigger = setupProject("remote", branchSpecPrefix + "awesome-feature", false);
         this.gitStatus.doNotifyCommit(requestWithNoParameter, "remote", "refs/heads/awesome-feature", null);
 
@@ -218,7 +217,7 @@ public class GitStatusTest extends AbstractGitProject {
     }
 
     @Test
-    public void testDoNotifyBranchWithRegex() throws Exception {
+    public void testDoNotifyCommitBranchWithRegex() throws Exception {
         SCMTrigger trigger = setupProject("remote", ":[^/]*/awesome-feature", false);
         this.gitStatus.doNotifyCommit(requestWithNoParameter, "remote", "feature/awesome-feature", null);
 

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -225,6 +225,14 @@ public class GitStatusTest extends AbstractGitProject {
         Mockito.verify(trigger).run();
     }
 
+    @Test
+    public void testDoNotifyCommitBranchWithWildcard() throws Exception {
+        SCMTrigger trigger = setupProject("remote", "origin/feature/*", false);
+        this.gitStatus.doNotifyCommit(requestWithNoParameter, "remote", "feature/awesome-feature", null);
+
+        Mockito.verify(trigger).run();
+    }
+
     private void assertAdditionalParameters(Collection<? extends Action> actions) {
         for (Action action: actions) {
             if (action instanceof ParametersAction) {

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -198,7 +198,7 @@ public class GitStatusTest extends AbstractGitProject {
     }
 
     @DataPoints("branchSpecPrefixes")
-    public static String[] branchSpecPrefixes = new String[] {
+    public static final String[] BRANCH_SPEC_PREFIXES = new String[] {
             "",
             "refs/remotes/",
             "refs/heads/",


### PR DESCRIPTION
[JENKINS-29603](https://issues.jenkins-ci.org/browse/JENKINS-29603)

The current implementation tries to solve 2 issues (does the BranchSpec match a given branch reference from the local git repository/repositories, does the BranchSpec match a given repository branch name from the outer world) with one method. IMHO this isn't a good idea. Therefore this pull-request adds the new method matchesRepositoryBranch to the BranchSpec. This method takes 2 parameters (repository name, branch name). With those 2 parameters it's quite easy to determine whether a BranchSpec matches the given branch name from the outer world no matter if this contains a slash or not.
I hope the added test cases cover all possibilities for specifying branches.
