### PR TITLE
User/bjacklyn/add functionality to ancestry build chooser

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -23,6 +23,7 @@ import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.plugins.git.extensions.impl.AuthorInChangelog;
 import hudson.plugins.git.extensions.impl.BuildChooserSetting;
 import hudson.plugins.git.extensions.impl.ChangelogToBranch;
+import hudson.plugins.git.extensions.impl.DoNotFilterTipRevisions;
 import hudson.plugins.git.extensions.impl.PreBuildMerge;
 import hudson.plugins.git.opt.PreBuildMergeOptions;
 import hudson.plugins.git.util.Build;
@@ -659,8 +660,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
             listener.getLogger().println("Polling for changes in");
 
+            boolean filterTipRevisions = getExtensions().get(DoNotFilterTipRevisions.class) == null ? true : false;
+
             Collection<Revision> candidates = getBuildChooser().getCandidateRevisions(
-                    true, singleBranch, git, listener, buildData, new BuildChooserContextImpl(project, null, environment));
+                    true, singleBranch, filterTipRevisions, git, listener, buildData, new BuildChooserContextImpl(project, null, environment));
 
             for (Revision c : candidates) {
                 if (!isRevExcluded(git, c, listener, buildData)) {
@@ -948,8 +951,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         if (candidates.isEmpty() ) {
             final String singleBranch = environment.expand( getSingleBranch(environment) );
 
+            boolean filterTipRevisions = getExtensions().get(DoNotFilterTipRevisions.class) == null ? true : false;
+
             candidates = getBuildChooser().getCandidateRevisions(
-                    false, singleBranch, git, listener, buildData, context);
+                    false, singleBranch, filterTipRevisions, git, listener, buildData, context);
         }
 
         if (candidates.isEmpty()) {

--- a/src/main/java/hudson/plugins/git/extensions/impl/DoNotFilterTipRevisions.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/DoNotFilterTipRevisions.java
@@ -1,0 +1,21 @@
+package hudson.plugins.git.extensions.impl;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+
+public class DoNotFilterTipRevisions extends GitSCMExtension {
+
+    @DataBoundConstructor
+    public DoNotFilterTipRevisions() { }
+    
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Don't filter branches that are an ancestor of another branch";
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/git/util/AncestryBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/AncestryBuildChooser.java
@@ -88,13 +88,13 @@ public class AncestryBuildChooser extends BuildChooser {
     }
 
     @Override
-    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String branchSpec, GitClient git, final TaskListener listener, BuildData data, BuildChooserContext context)
-            throws GitException, IOException, InterruptedException {
+    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String branchSpec, boolean filterTipRevisions, GitClient git,
+            final TaskListener listener, BuildData data, BuildChooserContext context) throws GitException, IOException, InterruptedException {
 
         // this BuildChooser's gitSCM exists, but the BuildChooser's gitSCM in the constructor doesn't
         buildChooser.gitSCM = gitSCM;
 
-        final Collection<Revision> candidates = buildChooser.getCandidateRevisions(isPollCall, branchSpec, git, listener, data, context);
+        final Collection<Revision> candidates = buildChooser.getCandidateRevisions(isPollCall, branchSpec, filterTipRevisions, git, listener, data, context);
 
         // filter candidates based on branch age and ancestry
         final List<Revision> filteredCandidates = git.withRepository(new RepositoryCallback<List<Revision>>() {

--- a/src/main/java/hudson/plugins/git/util/AncestryBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/AncestryBuildChooser.java
@@ -2,9 +2,13 @@ package hudson.plugins.git.util;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -20,9 +24,11 @@ import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import hudson.Extension;
 import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.Messages;
 import hudson.plugins.git.Revision;
@@ -34,41 +40,67 @@ public class AncestryBuildChooser extends BuildChooser {
     private BuildChooser buildChooser;
     private final Integer maximumAgeInDays;
     private final String ancestorCommitSha1;
+    private final String prioritizedBranches;
 
     @DataBoundConstructor
-    public AncestryBuildChooser(BuildChooser buildChooser, Integer maximumAgeInDays, String ancestorCommitSha1) {
+    public AncestryBuildChooser(BuildChooser buildChooser, Integer maximumAgeInDays, String ancestorCommitSha1, String prioritizedBranches) {
         this.buildChooser = buildChooser;
         this.maximumAgeInDays = maximumAgeInDays;
         this.ancestorCommitSha1 = ancestorCommitSha1;
+        this.prioritizedBranches = prioritizedBranches;
     }
-    
+
     public BuildChooser getBuildChooser() {
         return buildChooser;
     }
-    
+
     public Integer getMaximumAgeInDays() {
         return maximumAgeInDays;
     }
-    
+
     public String getAncestorCommitSha1() {
         return ancestorCommitSha1;
     }
 
+    public String getPrioritizedBranches() {
+        return prioritizedBranches;
+    }
+
+    public List<String> getPrioritizedBranchesAsList() {
+        return normalize(prioritizedBranches);
+    }
+
+    private List<String> normalize(String s) {
+        if (StringUtils.isBlank(s)) {
+            return Lists.newArrayList();
+        } else {
+            String lines[] = s.split("[\\r\\n]+");
+            List<String> trimmedLines = Lists.newArrayListWithCapacity(lines.length);
+            for (String line : lines) {
+                String trimmedLine = line.trim();
+                if (!StringUtils.isBlank(trimmedLine)) {
+                    trimmedLines.add(trimmedLine);
+                }
+            }
+
+            return trimmedLines;
+        }
+    }
+
     @Override
-    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String branchSpec,
-                GitClient git, final TaskListener listener, BuildData data, BuildChooserContext context)
-                throws GitException, IOException, InterruptedException {
-        
+    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String branchSpec, GitClient git, final TaskListener listener, BuildData data, BuildChooserContext context)
+            throws GitException, IOException, InterruptedException {
+
         // this BuildChooser's gitSCM exists, but the BuildChooser's gitSCM in the constructor doesn't
         buildChooser.gitSCM = gitSCM;
 
         final Collection<Revision> candidates = buildChooser.getCandidateRevisions(isPollCall, branchSpec, git, listener, data, context);
-        
+
         // filter candidates based on branch age and ancestry
-        return git.withRepository(new RepositoryCallback<List<Revision>>() {
+        final List<Revision> filteredCandidates = git.withRepository(new RepositoryCallback<List<Revision>>() {
             public List<Revision> invoke(Repository repository, VirtualChannel channel) throws IOException {
                 RevWalk walk = new RevWalk(repository);
-                
+
                 RevCommit ancestor = null;
                 if (!Strings.isNullOrEmpty(ancestorCommitSha1)) {
                     try {
@@ -77,101 +109,151 @@ public class AncestryBuildChooser extends BuildChooser {
                         throw new GitException(e);
                     }
                 }
-                
+
                 final CommitAgeFilter ageFilter = new CommitAgeFilter(maximumAgeInDays);
                 final AncestryFilter ancestryFilter = new AncestryFilter(walk, ancestor);
-                
+
                 final List<Revision> filteredCandidates = Lists.newArrayList();
-                
+
                 try {
                     for (Revision currentRevision : candidates) {
                         RevCommit currentRev = walk.parseCommit(ObjectId.fromString(currentRevision.getSha1String()));
-                        
+
                         if (ageFilter.isEnabled() && !ageFilter.apply(currentRev)) {
                             continue;
                         }
-                        
+
                         if (ancestryFilter.isEnabled() && !ancestryFilter.apply(currentRev)) {
                             continue;
                         }
-                        
+
                         filteredCandidates.add(currentRevision);
                     }
                 } catch (Throwable e) {
-                    
+
                     // if a wrapped IOException was thrown, unwrap before throwing it
                     Iterator<IOException> ioeIter = Iterables.filter(Throwables.getCausalChain(e), IOException.class).iterator();
-                    if (ioeIter.hasNext()) 
+                    if (ioeIter.hasNext())
                         throw ioeIter.next();
                     else
                         throw Throwables.propagate(e);
                 }
-                
+
                 return filteredCandidates;
             }
         });
+
+        // sort candidate revisions by priority branches
+        List<String> prioritizedBranches = getPrioritizedBranchesAsList();
+        if (prioritizedBranches.size() > 0) {
+            Collections.sort(filteredCandidates, new PrioritizedBranchesComparator(prioritizedBranches));
+        }
+
+        return filteredCandidates;
     }
-    
+
+    private static class PrioritizedBranchesComparator implements Comparator<Revision> {
+
+        final List<String> prioritizedBranches;
+        final Map<String, Integer> cachedRevisionPriorities;
+
+        public PrioritizedBranchesComparator(List<String> prioritizedBranches) {
+            this.prioritizedBranches = prioritizedBranches;
+            this.cachedRevisionPriorities = Maps.newHashMap();
+        }
+
+        public int compare(Revision rev1, Revision rev2) {
+            return getPriorityForRevision(rev1) - getPriorityForRevision(rev2);
+        }
+
+        /*
+         * If the revision matches any priority branches, returns priority
+         * corresponding to matching index. Else returns Integer.MAX_VALUE
+         * (lowest priority).
+         */
+        private Integer getPriorityForRevision(Revision rev) {
+            if (cachedRevisionPriorities.containsKey(rev.getSha1String())) {
+                return cachedRevisionPriorities.get(rev.getSha1String());
+            } else {
+                Integer priority = 0;
+                Collection<Branch> branches = rev.getBranches();
+
+                for (String prioritizedBranch : prioritizedBranches) {
+                    for (Branch branch : branches) {
+                        if (branch.getName().contains(prioritizedBranch)) {
+                            cachedRevisionPriorities.put(branch.getSHA1String(), priority);
+                            return priority;
+                        }
+                    }
+                    priority++;
+                }
+
+                // no revision branches match any prioritized branches
+                cachedRevisionPriorities.put(rev.getSha1String(), Integer.MAX_VALUE);
+                return Integer.MAX_VALUE;
+            }
+        }
+    }
+
     private static class CommitAgeFilter implements Predicate<RevCommit> {
-        
+
         private DateTime oldestAllowableCommitDate = null;
-        
+
         public CommitAgeFilter(Integer oldestAllowableAgeInDays) {
             if (oldestAllowableAgeInDays != null && oldestAllowableAgeInDays >= 0) {
                 this.oldestAllowableCommitDate = new LocalDate().toDateTimeAtStartOfDay().minusDays(oldestAllowableAgeInDays);
             }
         }
-        
+
         public boolean apply(RevCommit rev) {
             return new DateTime(rev.getCommitterIdent().getWhen()).isAfter(this.oldestAllowableCommitDate);
         }
-        
+
         public boolean isEnabled() {
             return oldestAllowableCommitDate != null;
         }
     }
-    
+
     private static class AncestryFilter implements Predicate<RevCommit> {
-        
+
         RevWalk revwalk;
         RevCommit ancestor;
-        
+
         public AncestryFilter(RevWalk revwalk, RevCommit ancestor) {
             this.revwalk = revwalk;
             this.ancestor = ancestor;
         }
-        
+
         public boolean apply(RevCommit rev) {
             try {
                 return revwalk.isMergedInto(ancestor, rev);
 
-            // wrap IOException so it can propagate
             } catch (IOException e) {
+                // wrap IOException so it can propagate
                 throw Throwables.propagate(e);
             }
         }
-        
+
         public boolean isEnabled() {
             return (revwalk != null) && (ancestor != null);
         }
     }
-    
+
     @Extension
     public static final class DescriptorImpl extends BuildChooserDescriptor {
         @Override
         public String getDisplayName() {
             return Messages.BuildChooser_Ancestry();
         }
-        
+
         public List<BuildChooserDescriptor> getBuildChooserDescriptors() {
             Jenkins jenkins = Jenkins.getInstance();
 
             return Lists.newArrayList(
-                (BuildChooserDescriptor) jenkins.getDescriptor(DefaultBuildChooser.class),
-                (BuildChooserDescriptor) jenkins.getDescriptor(InverseBuildChooser.class)
-            );
+                    (BuildChooserDescriptor) jenkins.getDescriptor(DefaultBuildChooser.class),
+                    (BuildChooserDescriptor) jenkins.getDescriptor(InverseBuildChooser.class));
         }
     }
-    
+
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/hudson/plugins/git/util/BuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooser.java
@@ -70,7 +70,7 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
      * @throws IOException
      * @throws GitException
      */
-    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch,
+    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch, boolean filterTipRevisions,
                                                       GitClient git, TaskListener listener, BuildData buildData, BuildChooserContext context) throws GitException, IOException, InterruptedException {
         // fallback to the previous signature
         return getCandidateRevisions(isPollCall, singleBranch, (IGitAPI) git, listener, buildData, context);

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -41,7 +41,7 @@ public class DefaultBuildChooser extends BuildChooser {
      * @throws GitException
      */
     @Override
-    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String branchSpec,
+    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String branchSpec, boolean filterTipRevisions,
                                                       GitClient git, TaskListener listener, BuildData data, BuildChooserContext context)
             throws GitException, IOException, InterruptedException {
 
@@ -50,7 +50,7 @@ public class DefaultBuildChooser extends BuildChooser {
         // if the branch name contains more wildcards then the simple usecase
         // does not apply and we need to skip to the advanced usecase
         if (isAdvancedSpec(branchSpec))
-            return getAdvancedCandidateRevisions(isPollCall,listener,new GitUtils(listener,git),data, context);
+            return getAdvancedCandidateRevisions(isPollCall,listener,filterTipRevisions,new GitUtils(listener,git),data, context);
 
         // check if we're trying to build a specific commit
         // this only makes sense for a build, there is no
@@ -196,7 +196,8 @@ public class DefaultBuildChooser extends BuildChooser {
      * @throws IOException
      * @throws GitException
      */
-    private List<Revision> getAdvancedCandidateRevisions(boolean isPollCall, TaskListener listener, GitUtils utils, BuildData data, BuildChooserContext context) throws GitException, IOException, InterruptedException {
+    private List<Revision> getAdvancedCandidateRevisions(boolean isPollCall, TaskListener listener, boolean filterTipRevisions,
+            GitUtils utils, BuildData data, BuildChooserContext context) throws GitException, IOException, InterruptedException {
 
         EnvVars env = context.getEnvironment();
 
@@ -246,8 +247,10 @@ public class DefaultBuildChooser extends BuildChooser {
         verbose(listener, "After branch filtering: {0}", revs);
 
         // 3. We only want 'tip' revisions
-        revs = utils.filterTipBranches(revs);
-        verbose(listener, "After non-tip filtering: {0}", revs);
+        if (filterTipRevisions) {
+            revs = utils.filterTipBranches(revs);
+            verbose(listener, "After non-tip filtering: {0}", revs);
+        }
 
         // 4. Finally, remove any revisions that have already been built.
         verbose(listener, "Removing what''s already been built: {0}", data.getBuildsByBranchName());

--- a/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java
@@ -39,7 +39,7 @@ public class InverseBuildChooser extends BuildChooser {
 
     @Override
     public Collection<Revision> getCandidateRevisions(boolean isPollCall,
-            String singleBranch, GitClient git, TaskListener listener,
+            String singleBranch, boolean filterTipRevisions, GitClient git, TaskListener listener,
             BuildData buildData, BuildChooserContext context) throws GitException, IOException, InterruptedException {
 
         EnvVars env = context.getEnvironment();
@@ -72,7 +72,9 @@ public class InverseBuildChooser extends BuildChooser {
         }
 
         // Filter out branch revisions that aren't leaves
-        branchRevs = utils.filterTipBranches(branchRevs);
+        if (filterTipRevisions) {
+            branchRevs = utils.filterTipBranches(branchRevs);
+        }
 
         // Warn the user that they've done something crazy such as excluding all branches
         if (branchRevs.isEmpty()) {

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -382,8 +382,8 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         }
 
         @Override
-        public Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch, GitClient git,
-                                                          TaskListener listener, BuildData buildData,
+        public Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch, boolean filterTipRevisions,
+                                                          GitClient git, TaskListener listener, BuildData buildData,
                                                           BuildChooserContext context)
                 throws GitException, IOException, InterruptedException {
             return Collections.singleton(revision);

--- a/src/main/resources/hudson/plugins/git/extensions/impl/DoNotFilterTipRevisions/help.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/DoNotFilterTipRevisions/help.html
@@ -1,0 +1,14 @@
+<div>
+       By default if two branches are seen by the git-plugin; <i>feature</i>, and <i>master</i>, where feature points to a commit that is an <b>ancestor</b> of master 
+       then only master will be built. This option prevents feature from being filtered. This functionality is desired when teams are working on
+       a branch that is contained within another branch, and would like their commits built regardless.
+       <pre>
+       
+       With Filtering:                               Without Filtering:
+       o <-- master (buildable)                      o <-- master (buildable)
+       |\                                            |\
+       | o <-- feature (filtered)                    | o <-- feature (buildable)
+       |/                                            |/
+       o                                             o
+       </pre>
+</div>

--- a/src/main/resources/hudson/plugins/git/util/AncestryBuildChooser/config.groovy
+++ b/src/main/resources/hudson/plugins/git/util/AncestryBuildChooser/config.groovy
@@ -2,6 +2,11 @@ package hudson.plugins.git.util.AncestryBuildChooser;
 
 def f = namespace(lib.FormTagLib);
 
+f.entry() {
+    f.dropdownDescriptorSelector(title:_("Strategy"), field:"buildChooser",
+            descriptors: descriptor.getBuildChooserDescriptors())
+}
+
 f.description {
     raw(_("maximum_age_of_commit_blurb"))
 }

--- a/src/main/resources/hudson/plugins/git/util/AncestryBuildChooser/config.groovy
+++ b/src/main/resources/hudson/plugins/git/util/AncestryBuildChooser/config.groovy
@@ -22,3 +22,11 @@ f.description {
 f.entry(title:_("Commit in Ancestry"), field:"ancestorCommitSha1") {
     f.textbox()
 }
+
+f.description {
+    raw(_("prioritized_branches_blurb"))
+}
+
+f.entry(title:_("Prioritized Branches"), field:"prioritizedBranches") {
+    f.expandableTextbox()
+}

--- a/src/main/resources/hudson/plugins/git/util/AncestryBuildChooser/config.properties
+++ b/src/main/resources/hudson/plugins/git/util/AncestryBuildChooser/config.properties
@@ -1,2 +1,3 @@
 maximum_age_of_commit_blurb=The maximum age of a commit (in days) for it to be built. This uses the GIT_COMMITTER_DATE, not GIT_AUTHOR_DATE.
 commit_in_ancestry_blurb=If an ancestor commit (sha1) is provided, only branches with this commit in their history will be built.
+prioritized_branches_blurb=Matching branches jump ahead of other buildable branches when the next build is scheduled.

--- a/src/main/resources/hudson/plugins/git/util/AncestryBuildChooser/help-prioritizedBranches.html
+++ b/src/main/resources/hudson/plugins/git/util/AncestryBuildChooser/help-prioritizedBranches.html
@@ -1,0 +1,15 @@
+<div>
+  Prioritized branches use substring to match repository branches. This can be useful if branch names containing 'CRITICAL' need to jump ahead of other user builds.
+  <p/>
+  <pre>This example illustrates the build order when CRITICAL and RELEASE are specified:
+	Commit order:
+		feature/my-other-feature
+		user/CRITICAL/my-critical-feature
+		RELEASE/0.0.1
+	Build order:
+		user/CRITICAL/my-critical-feature
+		RELEASE/0.0.1
+		feature/my-other-feature
+  </pre>
+  Multiple branch priority names must be separated by a new line, and leaving the textbox empty means no branch priority sorting is done.
+</div>

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -892,7 +892,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         for (RemoteConfig remoteConfig : gitSCM.getRepositories()) {
             git.fetch_().from(remoteConfig.getURIs().get(0), remoteConfig.getFetchRefSpecs());
         }
-        Collection<Revision> candidateRevisions = ((DefaultBuildChooser) (gitSCM).getBuildChooser()).getCandidateRevisions(false, "origin/master", git, listener, project.getLastBuild().getAction(BuildData.class), null);
+        Collection<Revision> candidateRevisions = ((DefaultBuildChooser) (gitSCM).getBuildChooser()).getCandidateRevisions(false, "origin/master", true, git, listener, project.getLastBuild().getAction(BuildData.class), null);
         assertEquals(1, candidateRevisions.size());
     }
 

--- a/src/test/java/hudson/plugins/git/util/AncestryBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/AncestryBuildChooserTest.java
@@ -38,18 +38,24 @@ import hudson.plugins.git.Revision;
 import hudson.plugins.git.extensions.impl.BuildChooserSetting;
 
 public class AncestryBuildChooserTest extends AbstractGitRepository {
-    
+
     private String rootCommit = null;
     private String ancestorCommit = null;
     private String fiveDaysAgoCommit = null;
     private String tenDaysAgoCommit = null;
     private String twentyDaysAgoCommit = null;
-    
+
     private final DateTime fiveDaysAgo = new LocalDate().toDateTimeAtStartOfDay().minusDays(5);
     private final DateTime tenDaysAgo = new LocalDate().toDateTimeAtStartOfDay().minusDays(10);
     private final DateTime twentyDaysAgo = new LocalDate().toDateTimeAtStartOfDay().minusDays(20);
     
     private final PersonIdent johnDoe = new PersonIdent("John Doe", "john@example.com");
+    
+    private static final String DEFAULT_PRIORITIZED_BRANCHES = "";
+    
+    private static final BuildChooser DEFAULT_BUILD_CHOOSER = new DefaultBuildChooser();
+    private static final BuildChooser INVERSE_BUILD_CHOOSER = new InverseBuildChooser();
+    
 
     /*
      * 20 days old ->  O O    <- 10 days old
@@ -63,54 +69,62 @@ public class AncestryBuildChooserTest extends AbstractGitRepository {
     @Before
     public void setUp() throws Exception {
         Set<String> prevBranches = stringifyBranches(testGitClient.getBranches());
-        
+
         testGitClient.commit("Root Commit");
         rootCommit = getLastCommitSha1(prevBranches);
-        
+
         testGitClient.commit("Ancestor Commit");
         ancestorCommit = getLastCommitSha1(prevBranches);
-        
+
         testGitClient.branch("20-days-old-branch");
         testGitClient.checkoutBranch("20-days-old-branch", ancestorCommit);
         this.commit("20 days ago commit message", new PersonIdent(johnDoe, twentyDaysAgo.toDate()), new PersonIdent(johnDoe, twentyDaysAgo.toDate()));
         twentyDaysAgoCommit = getLastCommitSha1(prevBranches);
-        
+
         testGitClient.checkout().ref(ancestorCommit).execute();
         testGitClient.checkoutBranch("10-days-old-branch", ancestorCommit);
         this.commit("10 days ago commit message", new PersonIdent(johnDoe, tenDaysAgo.toDate()), new PersonIdent(johnDoe, tenDaysAgo.toDate()));
         tenDaysAgoCommit = getLastCommitSha1(prevBranches);
-        
+
+        // create a RELEASE branch for tenDaysAgoCommit
+        testGitClient.checkout().ref(tenDaysAgoCommit).execute();
+        testGitClient.checkoutBranch("RELEASE/10-days-old-branch", tenDaysAgoCommit);
+
         testGitClient.checkout().ref(rootCommit).execute();
         testGitClient.checkoutBranch("5-days-old-branch", rootCommit);
         this.commit("5 days ago commit message", new PersonIdent(johnDoe, fiveDaysAgo.toDate()), new PersonIdent(johnDoe, fiveDaysAgo.toDate()));
         fiveDaysAgoCommit = getLastCommitSha1(prevBranches);
+
+        // create a CRITICAL and RELEASE branch for fiveDaysAgoCommit
+        testGitClient.checkout().ref(fiveDaysAgoCommit).execute();
+        testGitClient.checkoutBranch("CRITICAL/RELEASE/5-days-old-branch", fiveDaysAgoCommit);
     }
-    
+
     private Set<String> stringifyBranches(Set<Branch> original) {
-        Set<String> result = new TreeSet<String>(); 
-        
-        for (Iterator<Branch> iter = original.iterator(); iter.hasNext(); ) {
+        Set<String> result = new TreeSet<String>();
+
+        for (Iterator<Branch> iter = original.iterator(); iter.hasNext();) {
             result.add(iter.next().getSHA1String());
         }
-        
+
         return result;
     }
-    
+
     private String getLastCommitSha1(Set<String> prevBranches) throws Exception {
         Set<String> newBranches = stringifyBranches(testGitClient.getBranches());
-        
+
         SetView<String> difference = Sets.difference(newBranches, prevBranches);
-        
+
         assertEquals(1, difference.size());
-        
+
         String result = difference.iterator().next();
-        
+
         prevBranches.clear();
         prevBranches.addAll(newBranches);
-        
+
         return result;
     }
-    
+
     // Git Client implementation throws away committer date info so we have to do this manually..
     // Copied from JGitAPIImpl.commit(String message)
     private void commit(String message, PersonIdent author, PersonIdent committer) {
@@ -127,139 +141,249 @@ public class AncestryBuildChooserTest extends AbstractGitRepository {
         } catch (GitAPIException e) {
             throw new GitException(e);
         } finally {
-            if (repo != null) repo.close();
+            if (repo != null)
+                repo.close();
         }
     }
-    
-    private List<String> getFilteredTestCandidates(Integer maxAgeInDays, String ancestorCommitSha1) throws Exception {
-        return getFilteredTestCandidates(new DefaultBuildChooser(), maxAgeInDays, ancestorCommitSha1);
+
+    private List<String> getTestCandidates(Integer maxAgeInDays, String ancestorCommitSha1) throws Exception {
+        return getTestCandidates(DEFAULT_BUILD_CHOOSER, maxAgeInDays, ancestorCommitSha1);
     }
-    
-    private List<String> getFilteredTestCandidates(BuildChooser buildChooser, Integer maxAgeInDays, String ancestorCommitSha1) throws Exception {
+
+    private List<String> getTestCandidates(BuildChooser buildChooser, Integer maxAgeInDays, String ancestorCommitSha1) throws Exception {
+        return getTestCandidates(buildChooser, maxAgeInDays, ancestorCommitSha1, DEFAULT_PRIORITIZED_BRANCHES);
+    }
+
+    private List<String> getTestCandidates(BuildChooser buildChooser, Integer maxAgeInDays, String ancestorCommitSha1, String prioritizedBranches) throws Exception {
         GitSCM gitSCM = new GitSCM("foo");
-        AncestryBuildChooser chooser = new AncestryBuildChooser(new DefaultBuildChooser(), maxAgeInDays, ancestorCommitSha1);
+        AncestryBuildChooser chooser = new AncestryBuildChooser(buildChooser, maxAgeInDays, ancestorCommitSha1, prioritizedBranches);
         gitSCM.getExtensions().add(new BuildChooserSetting(chooser));
         assertEquals(maxAgeInDays, chooser.getMaximumAgeInDays());
         assertEquals(ancestorCommitSha1, chooser.getAncestorCommitSha1());
-        
+
         // mock necessary objects
         GitClient git = Mockito.spy(this.testGitClient);
         Mockito.when(git.getRemoteBranches()).thenReturn(this.testGitClient.getBranches());
-        
+
         BuildData buildData = Mockito.mock(BuildData.class);
         Mockito.when(buildData.hasBeenBuilt(git.revParse(rootCommit))).thenReturn(false);
-        
+
         BuildChooserContext context = Mockito.mock(BuildChooserContext.class);
         Mockito.when(context.getEnvironment()).thenReturn(new EnvVars());
-        
+
         TaskListener listener = TaskListener.NULL;
-        
+
         // get filtered candidates
         Collection<Revision> candidateRevisions = gitSCM.getBuildChooser().getCandidateRevisions(true, "**-days-old-branch", git, listener, buildData, context);
-        
+
         // transform revision candidates to sha1 strings
         List<String> candidateSha1s = Lists.newArrayList(Iterables.transform(candidateRevisions, new Function<Revision, String>() {
             public String apply(Revision rev) {
                 return rev.getSha1String();
             }
         }));
-        
+
         return candidateSha1s;
     }
-    
+
     @Test
     public void testFilterRevisionsNoRestriction() throws Exception {
         final Integer maxAgeInDays = null;
         final String ancestorCommitSha1 = null;
-        
-        List<String> candidateSha1s = getFilteredTestCandidates(maxAgeInDays, ancestorCommitSha1);
-        
+
+        List<String> candidateSha1s = getTestCandidates(maxAgeInDays, ancestorCommitSha1);
+
         assertEquals(3, candidateSha1s.size());
         assertTrue(candidateSha1s.contains(fiveDaysAgoCommit));
         assertTrue(candidateSha1s.contains(tenDaysAgoCommit));
         assertTrue(candidateSha1s.contains(twentyDaysAgoCommit));
     }
-    
+
     @Test
     public void testFilterRevisionsZeroDate() throws Exception {
         final Integer maxAgeInDays = 0;
         final String ancestorCommitSha1 = null;
-        
-        List<String> candidateSha1s = getFilteredTestCandidates(maxAgeInDays, ancestorCommitSha1);
-        
+
+        List<String> candidateSha1s = getTestCandidates(maxAgeInDays, ancestorCommitSha1);
+
         assertEquals(0, candidateSha1s.size());
     }
-    
+
     @Test
     public void testFilterRevisionsTenDays() throws Exception {
         final Integer maxAgeInDays = 10;
         final String ancestorCommitSha1 = null;
-        
-        List<String> candidateSha1s = getFilteredTestCandidates(maxAgeInDays, ancestorCommitSha1);
-        
+
+        List<String> candidateSha1s = getTestCandidates(maxAgeInDays, ancestorCommitSha1);
+
         assertEquals(1, candidateSha1s.size());
         assertTrue(candidateSha1s.contains(fiveDaysAgoCommit));
     }
-    
+
     @Test
     public void testFilterRevisionsThirtyDays() throws Exception {
         final Integer maxAgeInDays = 30;
         final String ancestorCommitSha1 = null;
-        
-        List<String> candidateSha1s = getFilteredTestCandidates(maxAgeInDays, ancestorCommitSha1);
-        
+
+        List<String> candidateSha1s = getTestCandidates(maxAgeInDays, ancestorCommitSha1);
+
         assertEquals(3, candidateSha1s.size());
         assertTrue(candidateSha1s.contains(fiveDaysAgoCommit));
         assertTrue(candidateSha1s.contains(tenDaysAgoCommit));
         assertTrue(candidateSha1s.contains(twentyDaysAgoCommit));
     }
-    
+
     @Test
     public void testFilterRevisionsBlankAncestor() throws Exception {
         final Integer maxAgeInDays = null;
         final String ancestorCommitSha1 = "";
-        
-        List<String> candidateSha1s = getFilteredTestCandidates(maxAgeInDays, ancestorCommitSha1);
-        
+
+        List<String> candidateSha1s = getTestCandidates(maxAgeInDays, ancestorCommitSha1);
+
         assertEquals(3, candidateSha1s.size());
         assertTrue(candidateSha1s.contains(fiveDaysAgoCommit));
         assertTrue(candidateSha1s.contains(tenDaysAgoCommit));
         assertTrue(candidateSha1s.contains(twentyDaysAgoCommit));
     }
-    
+
     @Test
     public void testFilterRevisionsNonExistingAncestor() throws Exception {
         final Integer maxAgeInDays = null;
         final String ancestorCommitSha1 = "This commit sha1 does not exist.";
-        
+
         try {
-            List<String> candidateSha1s = getFilteredTestCandidates(maxAgeInDays, ancestorCommitSha1);
+            List<String> candidateSha1s = getTestCandidates(maxAgeInDays, ancestorCommitSha1);
             fail("Invalid sha1 should throw GitException.");
         } catch (GitException e) {
             return;
         }
     }
-    
+
     @Test
     public void testFilterRevisionsExistingAncestor() throws Exception {
         final Integer maxAgeInDays = null;
         final String ancestorCommitSha1 = ancestorCommit;
-        
-        List<String> candidateSha1s = getFilteredTestCandidates(maxAgeInDays, ancestorCommitSha1);
-        
+
+        List<String> candidateSha1s = getTestCandidates(maxAgeInDays, ancestorCommitSha1);
+
         assertEquals(2, candidateSha1s.size());
         assertTrue(candidateSha1s.contains(tenDaysAgoCommit));
         assertTrue(candidateSha1s.contains(twentyDaysAgoCommit));
     }
-    
+
     @Test
-    public void testFilteringWithInverseBuildChooser() throws Exception {
-        final Integer maxAgeInDays = 15;
-        final String ancestorCommitSha1 = ancestorCommit;
-        
-        List<String> candidateSha1s = getFilteredTestCandidates(new InverseBuildChooser(), maxAgeInDays, ancestorCommitSha1);
-        
-        assertEquals(1, candidateSha1s.size());
-        assertTrue(candidateSha1s.contains(tenDaysAgoCommit));
+    public void testUsingInverseBuildChooser() throws Exception {
+        final Integer maxAgeInDays = null;
+        final String ancestorCommitSha1 = null;
+
+        List<String> candidateSha1s = getTestCandidates(INVERSE_BUILD_CHOOSER, maxAgeInDays, ancestorCommitSha1);
+
+        // no branch spec means everything is excluded by InverseBuildChooser
+        assertEquals(0, candidateSha1s.size());
+    }
+
+    @Test
+    public void testSortingByNullPriorityBranches() throws Exception {
+        final Integer maxAgeInDays = null;
+        final String ancestorCommitSha1 = null;
+        final String priorityBranches = null;
+
+        List<String> candidateSha1s = getTestCandidates(DEFAULT_BUILD_CHOOSER, maxAgeInDays, ancestorCommitSha1, priorityBranches);
+
+        assertEquals(3, candidateSha1s.size());
+
+        // no priority branches; sort order should be by oldest commit first
+        assertEquals(candidateSha1s.get(0), twentyDaysAgoCommit);
+        assertEquals(candidateSha1s.get(1), tenDaysAgoCommit);
+        assertEquals(candidateSha1s.get(2), fiveDaysAgoCommit);
+    }
+
+    @Test
+    public void testSortingByEmptyPriorityBranches() throws Exception {
+        final Integer maxAgeInDays = null;
+        final String ancestorCommitSha1 = null;
+        final String priorityBranches = "";
+
+        List<String> candidateSha1s = getTestCandidates(DEFAULT_BUILD_CHOOSER, maxAgeInDays, ancestorCommitSha1, priorityBranches);
+
+        assertEquals(3, candidateSha1s.size());
+
+        // no priority branches; sort order should be oldest commits first
+        assertEquals(twentyDaysAgoCommit, candidateSha1s.get(0));
+        assertEquals(tenDaysAgoCommit, candidateSha1s.get(1));
+        assertEquals(fiveDaysAgoCommit, candidateSha1s.get(2));
+    }
+
+    @Test
+    public void testSortingByCriticalPriorityBranch() throws Exception {
+        final Integer maxAgeInDays = null;
+        final String ancestorCommitSha1 = null;
+        final String priorityBranches = "CRITICAL";
+
+        List<String> candidateSha1s = getTestCandidates(DEFAULT_BUILD_CHOOSER, maxAgeInDays, ancestorCommitSha1, priorityBranches);
+
+        assertEquals(3, candidateSha1s.size());
+
+        // fiveDaysAgoCommit should be first as it has a CRITICAL priority
+        // branch
+        assertEquals(fiveDaysAgoCommit, candidateSha1s.get(0));
+        assertEquals(twentyDaysAgoCommit, candidateSha1s.get(1));
+        assertEquals(tenDaysAgoCommit, candidateSha1s.get(2));
+    }
+
+    @Test
+    public void testSortingByMultiplePriorityBranches() throws Exception {
+        final Integer maxAgeInDays = null;
+        final String ancestorCommitSha1 = null;
+        final String priorityBranches = "CRITICAL\nRELEASE";
+
+        List<String> candidateSha1s = getTestCandidates(DEFAULT_BUILD_CHOOSER, maxAgeInDays, ancestorCommitSha1, priorityBranches);
+
+        assertEquals(3, candidateSha1s.size());
+
+        // fiveDaysAgoCommit should be first as it has a CRITICAL priority
+        // branch, and tenDaysAgoCommit second as it has a RELEASE priority
+        // branch
+        assertEquals(fiveDaysAgoCommit, candidateSha1s.get(0));
+        assertEquals(tenDaysAgoCommit, candidateSha1s.get(1));
+        assertEquals(twentyDaysAgoCommit, candidateSha1s.get(2));
+    }
+
+    @Test
+    public void testGetPriorityBranchesWithVariousInputs() throws Exception {
+        // linux line-ending
+        AncestryBuildChooser chooser = new AncestryBuildChooser(DEFAULT_BUILD_CHOOSER, null, null, "a\nb");
+        List<String> parsedPriorityBranches = chooser.getPrioritizedBranchesAsList();
+        assertEquals(2, parsedPriorityBranches.size());
+        assertTrue(parsedPriorityBranches.contains("a"));
+        assertTrue(parsedPriorityBranches.contains("b"));
+
+        // mac line-ending
+        chooser = new AncestryBuildChooser(DEFAULT_BUILD_CHOOSER, null, null, "a\rb");
+        parsedPriorityBranches = chooser.getPrioritizedBranchesAsList();
+        assertEquals(2, parsedPriorityBranches.size());
+        assertTrue(parsedPriorityBranches.contains("a"));
+        assertTrue(parsedPriorityBranches.contains("b"));
+
+        // windows line-ending
+        chooser = new AncestryBuildChooser(DEFAULT_BUILD_CHOOSER, null, null, "a\r\nb");
+        parsedPriorityBranches = chooser.getPrioritizedBranchesAsList();
+        assertEquals(2, parsedPriorityBranches.size());
+        assertTrue(parsedPriorityBranches.contains("a"));
+        assertTrue(parsedPriorityBranches.contains("b"));
+
+        // tabs and spaces
+        chooser = new AncestryBuildChooser(DEFAULT_BUILD_CHOOSER, null, null, " \ta\r\nb \t");
+        parsedPriorityBranches = chooser.getPrioritizedBranchesAsList();
+        assertEquals(2, parsedPriorityBranches.size());
+        assertTrue(parsedPriorityBranches.contains("a"));
+        assertTrue(parsedPriorityBranches.contains("b"));
+
+        // empty lines and multiple line-endings
+        chooser = new AncestryBuildChooser(DEFAULT_BUILD_CHOOSER, null, null, "\n\t a\r\nb \t\r\n");
+        parsedPriorityBranches = chooser.getPrioritizedBranchesAsList();
+        assertEquals(2, parsedPriorityBranches.size());
+        assertTrue(parsedPriorityBranches.contains("a"));
+        assertTrue(parsedPriorityBranches.contains("b"));
     }
 }

--- a/src/test/java/hudson/plugins/git/util/AncestryBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/AncestryBuildChooserTest.java
@@ -174,7 +174,7 @@ public class AncestryBuildChooserTest extends AbstractGitRepository {
         TaskListener listener = TaskListener.NULL;
 
         // get filtered candidates
-        Collection<Revision> candidateRevisions = gitSCM.getBuildChooser().getCandidateRevisions(true, "**-days-old-branch", git, listener, buildData, context);
+        Collection<Revision> candidateRevisions = gitSCM.getBuildChooser().getCandidateRevisions(true, "**-days-old-branch", true, git, listener, buildData, context);
 
         // transform revision candidates to sha1 strings
         List<String> candidateSha1s = Lists.newArrayList(Iterables.transform(candidateRevisions, new Function<Revision, String>() {

--- a/src/test/java/hudson/plugins/git/util/CandidateRevisionsTest.java
+++ b/src/test/java/hudson/plugins/git/util/CandidateRevisionsTest.java
@@ -117,7 +117,7 @@ public class CandidateRevisionsTest extends AbstractGitRepository {
         BuildChooserContext context = Mockito.mock(BuildChooserContext.class);
         Mockito.when(context.getEnvironment()).thenReturn(new EnvVars());
 
-        Collection<Revision> candidateRevisions = buildChooser.getCandidateRevisions(false, "tag/*", testGitClient2, null, buildData, context);
+        Collection<Revision> candidateRevisions = buildChooser.getCandidateRevisions(false, "tag/*", true, testGitClient2, null, buildData, context);
         assertEquals(1, candidateRevisions.size());
         String name = candidateRevisions.iterator().next().getBranches().iterator().next().getName();
         assertTrue("Wrong name: '" + name + "'", name.equals("origin/tags/tag/c") || name.equals("origin/tags/tag/b"));

--- a/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
@@ -22,12 +22,12 @@ public class DefaultBuildChooserTest extends AbstractGitRepository {
 
         DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
 
-        Collection<Revision> candidateRevisions = buildChooser.getCandidateRevisions(false, shaHashCommit1, testGitClient, null, null, null);
+        Collection<Revision> candidateRevisions = buildChooser.getCandidateRevisions(false, shaHashCommit1, true, testGitClient, null, null, null);
 
         assertEquals(1, candidateRevisions.size());
         assertEquals(shaHashCommit1, candidateRevisions.iterator().next().getSha1String());
 
-        candidateRevisions = buildChooser.getCandidateRevisions(false, "aaa" + shaHashCommit1.substring(3), testGitClient, null, null, null);
+        candidateRevisions = buildChooser.getCandidateRevisions(false, "aaa" + shaHashCommit1.substring(3), true, testGitClient, null, null, null);
         assertTrue(candidateRevisions.isEmpty());
     }
     /**


### PR DESCRIPTION
This is still a work-in-progress, but I've gotten to the point where I'd like some feedback. It also might be easier to evaluate this pull request by looking at each commit rather than the entire thing at once.

1: AncestryBuildChooser can now use either DefaultBuildChooser or InverseBuildChooser.
2: AncestryBuildChooser can specify prioritized branches. For example, if there are two buildable branches, but one of them contains "CRITICAL" in its name then it will be built next even if it was committed after the first branch. This helps when machines are clogged up and something needs to jump the queue and get built immediately.
3: Added an extension to not filter tip revisions. My organization's workflow has teams working on branches which automerge downstream into other branches (and eventually into master). This results in master being the only thing built as the other branches are filtered out.

TODO: create tests for filtering of tip revisions, and add some logging.
