### PR TITLE
[JENKINS-29326] Don't add duplicate BuildData

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1053,6 +1053,13 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         retrieveChanges(build, git, listener);
         Build revToBuild = determineRevisionToBuild(build, buildData, environment, git, listener);
 
+        boolean buildDataAlreadyPresent = true;
+
+        if (!build.getActions(BuildData.class).contains(buildData)) {
+            build.addAction(buildData);
+            buildDataAlreadyPresent = false;
+        }
+
         environment.put(GIT_COMMIT, revToBuild.revision.getSha1String());
         Branch branch = Iterables.getFirst(revToBuild.revision.getBranches(),null);
         if (branch != null && branch.getName() != null) { // null for a detached HEAD
@@ -1074,8 +1081,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         // Don't add the tag and changelog if we've already processed this BuildData before.
-        if (!build.getActions(BuildData.class).contains(buildData)) {
-            build.addAction(buildData);
+        if (!buildDataAlreadyPresent) {
             build.addAction(new GitTagAction(build, workspace, revToBuild.revision));
 
             if (changelogFile != null) {

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1055,14 +1055,13 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         // Track whether we're trying to add a duplicate BuildData, now that it's been updated with
         // revision info for this build etc. The default assumption is that it's a duplicate.
-        boolean buildDataAlreadyPresent = true;
+        boolean buildDataAlreadyPresent = build.getActions(BuildData.class).contains(buildData);
 
         // If the BuildData is not already attached to this build, add it to the build and mark that
         // it wasn't already present, so that we add the GitTagAction and changelog after the checkout
         // finishes.
-        if (!build.getActions(BuildData.class).contains(buildData)) {
+        if (!buildDataAlreadyPresent) {
             build.addAction(buildData);
-            buildDataAlreadyPresent = false;
         }
 
         environment.put(GIT_COMMIT, revToBuild.revision.getSha1String());

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1053,8 +1053,13 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         retrieveChanges(build, git, listener);
         Build revToBuild = determineRevisionToBuild(build, buildData, environment, git, listener);
 
+        // Track whether we're trying to add a duplicate BuildData, now that it's been updated with
+        // revision info for this build etc. The default assumption is that it's a duplicate.
         boolean buildDataAlreadyPresent = true;
 
+        // If the BuildData is not already attached to this build, add it to the build and mark that
+        // it wasn't already present, so that we add the GitTagAction and changelog after the checkout
+        // finishes.
         if (!build.getActions(BuildData.class).contains(buildData)) {
             build.addAction(buildData);
             buildDataAlreadyPresent = false;

--- a/src/main/java/hudson/plugins/git/util/Build.java
+++ b/src/main/java/hudson/plugins/git/util/Build.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git.util;
 
+import com.google.common.base.Objects;
 import hudson.model.Result;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
@@ -98,8 +99,8 @@ public class Build implements Serializable, Cloneable {
         } else {
             Build otherBuild = (Build) o;
             if (otherBuild.hudsonBuildNumber == this.hudsonBuildNumber
-                    && otherBuild.revision == this.revision
-                    && otherBuild.marked == this.marked) {
+                    && Objects.equal(otherBuild.revision, this.revision)
+                    && Objects.equal(otherBuild.marked, this.marked)) {
                 return true;
             } else {
                 return false;

--- a/src/main/java/hudson/plugins/git/util/Build.java
+++ b/src/main/java/hudson/plugins/git/util/Build.java
@@ -92,6 +92,21 @@ public class Build implements Serializable, Cloneable {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Build)) {
+            return false;
+        } else {
+            Build otherBuild = (Build) o;
+            if (otherBuild.hudsonBuildNumber == this.hudsonBuildNumber
+                    && otherBuild.revision.equals(this.revision)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    @Override
     public Build clone() {
         Build clone;
         try {

--- a/src/main/java/hudson/plugins/git/util/Build.java
+++ b/src/main/java/hudson/plugins/git/util/Build.java
@@ -98,7 +98,8 @@ public class Build implements Serializable, Cloneable {
         } else {
             Build otherBuild = (Build) o;
             if (otherBuild.hudsonBuildNumber == this.hudsonBuildNumber
-                    && otherBuild.revision.equals(this.revision)) {
+                    && otherBuild.revision == this.revision
+                    && otherBuild.marked == this.marked) {
                 return true;
             } else {
                 return false;

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -16,7 +16,6 @@ import java.io.Serializable;
 import java.util.*;
 
 import static hudson.Util.fixNull;
-
 /**
  * Captures the Git related information for a build.
  *
@@ -243,6 +242,23 @@ public class BuildData implements Action, Serializable, Cloneable {
                 ",remoteUrls="+remoteUrls+
                 ",buildsByBranchName="+buildsByBranchName+
                 ",lastBuild="+lastBuild+"]";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof BuildData)) {
+            return false;
+        } else {
+            BuildData otherBuildData = (BuildData) o;
+
+            if (otherBuildData.remoteUrls.equals(this.remoteUrls)
+                    && otherBuildData.buildsByBranchName.equals(this.buildsByBranchName)
+                    && otherBuildData.lastBuild.equals(this.lastBuild)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
[JENKINS-29326](https://issues.jenkins-ci.org/browse/JENKINS-29326)

Added equals methods to BuildData and Build, and check if we already
have an equivalent BuildData on a build before we add it, the git tag
action and changelog, so that we avoid duplicate records of all these things.

NOTE - this probably still needs some tests, most likely to end up in workflow-multibranch.

cc @reviewbybees 