### PR TITLE
New cherry pick sensitive ChangelogToBranch extension option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580</version>
+    <version>1.609</version>
   </parent>
   
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>1.19.0</version>
+      <version>1.19.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/ChangelogToBranchOptions.java
+++ b/src/main/java/hudson/plugins/git/ChangelogToBranchOptions.java
@@ -13,17 +13,20 @@ import hudson.model.Descriptor;
  * @author <a href="mailto:dirk.reske@t-systems.com">Dirk Reske (dirk.reske@t-systems.com)</a>
  */
 public class ChangelogToBranchOptions extends AbstractDescribableImpl<ChangelogToBranchOptions> implements Serializable {
-    private String compareRemote;
+    
+	private String compareRemote;
     private String compareTarget;
+    private Boolean cherryPick;
 
     @DataBoundConstructor
-    public ChangelogToBranchOptions(String compareRemote, String compareTarget) {
+    public ChangelogToBranchOptions(String compareRemote, String compareTarget, Boolean cherryPick) {
         this.compareRemote = compareRemote;
         this.compareTarget = compareTarget;
+        this.cherryPick = cherryPick;
     }
 
     public ChangelogToBranchOptions(ChangelogToBranchOptions options) {
-        this(options.getCompareRemote(), options.getCompareTarget());
+        this(options.getCompareRemote(), options.getCompareTarget(), options.getCherryPick());
     }
 
     public String getCompareRemote() {
@@ -37,8 +40,16 @@ public class ChangelogToBranchOptions extends AbstractDescribableImpl<ChangelogT
     public String getRef() {
         return compareRemote + "/" + compareTarget;
     }
+    
+    public Boolean getCherryPick() {
+		return cherryPick;
+	}
+    
+    public boolean isCherryPick() {
+    	return cherryPick != null && cherryPick.booleanValue();
+    }
 
-    @Extension
+	@Extension
     public static class DescriptorImpl extends Descriptor<ChangelogToBranchOptions> {
 
         @Override

--- a/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/config.jelly
+++ b/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/config.jelly
@@ -10,4 +10,7 @@
   <f:entry title="Name of branch" field="compareTarget">
     <f:textbox id="git.compareTarget" clazz="required"/>
   </f:entry>
+  <f:entry field="cherryPick" title="Exclude cherry picks">
+      <f:checkbox />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/help-cherryPick.html
+++ b/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/help-cherryPick.html
@@ -1,0 +1,5 @@
+<div>
+    Use git log with parameters --cherry-pick --right-only --no-merges to exclude already cherry picked commits from changelog.
+    <p>
+    This function only works with cli git implementation!
+</div>

--- a/src/test/java/hudson/plugins/git/AbstractGitProject.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitProject.java
@@ -54,6 +54,7 @@ import org.eclipse.jgit.lib.ObjectId;
 
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.JGitTool;
+import org.jenkinsci.remoting.RoleChecker;
 
 import static org.junit.Assert.*;
 import org.junit.Rule;
@@ -246,6 +247,9 @@ public class AbstractGitProject extends AbstractGitRepository {
                     throw new RuntimeException(e);
                 }
             }
+
+			public void checkRoles(RoleChecker checker) throws SecurityException {				
+			}
         });
     }
 

--- a/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
@@ -40,6 +40,7 @@ import org.eclipse.jgit.lib.PersonIdent;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.JGitTool;
+import org.jenkinsci.remoting.RoleChecker;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 
@@ -285,6 +286,9 @@ public abstract class AbstractGitTestCase extends HudsonTestCase {
                         throw new RuntimeException(e);
                     }
                 }
+
+				public void checkRoles(RoleChecker checker) throws SecurityException {
+				}
             });
     }
 

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -47,6 +47,7 @@ import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.jenkinsci.plugins.gitclient.*;
+import org.jenkinsci.remoting.RoleChecker;
 import org.jvnet.hudson.test.TestExtension;
 
 import java.io.File;
@@ -787,6 +788,9 @@ public class GitSCMTest extends AbstractGitTestCase {
                 throw new IOException2(e);
             }
         }
+
+		public void checkRoles(RoleChecker checker) throws SecurityException {
+		}
     }
 
     // eg: "jane doe and john doe should be the culprits", culprits, [johnDoe, janeDoe])


### PR DESCRIPTION
New option in ChangelogToBranch extension that enable branches comparsion without already cherry picked commits.

It's very important for jenkins to use in our projects - it is only way to show correct changelog between our release branches, because we havily use cherry picking where preparing release candidates to build. Without this, jenkins show much false positives commits in build changelog. We currently very depends on this modified plugins in our jenkins installation, other plugins that build on top of changelog are important for us (for example jira plugin).

! It depends on pull request 197 into git client plugin https://github.com/jenkinsci/git-client-plugin/pull/197. !
## Using the version that makes "mvn hpi:run" work.

I also in this pull request upgrade parent pom version of this plugin maven project to 1.609, because this plugin is currently impossible to development as someone change version of matrix plugin to 1.6, now we can't test anymore! I change version of parent pom to 1.609 to match the matrix plugin used.
