### PR TITLE
[FIXED JENKINS-32544] fix commit message rendering

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -155,9 +155,9 @@ public class GitChangeSet extends ChangeLogSet.Entry {
         StringBuilder message = new StringBuilder();
 
         for (String line : lines) {
-            if( line.length() < 1)
-                continue;
-            if (line.startsWith("commit ")) {
+            if (line.isEmpty()) {
+                message.append('\n');
+            } else if (line.startsWith("commit ")) {
                 String[] split = line.split(" ");
                 if (split.length > 1) this.id = split[1];
                 else throw new IllegalArgumentException("Commit has no ID" + lines);
@@ -224,7 +224,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
             }
         }
 
-        this.comment = message.toString();
+        this.comment = message.toString().trim();
 
         int endOfFirstLine = this.comment.indexOf('\n');
         if (endOfFirstLine == -1) {

--- a/src/test/java/hudson/plugins/git/GitChangeSetSimpleTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetSimpleTest.java
@@ -50,7 +50,7 @@ public class GitChangeSetSimpleTest {
     public void testChangeSetDetails() {
         assertEquals(GitChangeSetUtil.ID, changeSet.getId());
         assertEquals(GitChangeSetUtil.COMMIT_TITLE, changeSet.getMsg());
-        assertEquals("Commit title.\nCommit extended description.\n", changeSet.getComment());
+        assertEquals("Commit title.\nCommit extended description.", changeSet.getComment());
         HashSet<String> expectedAffectedPaths = new HashSet<>(7);
         expectedAffectedPaths.add("src/test/add.file");
         expectedAffectedPaths.add("src/test/deleted.file");

--- a/src/test/java/hudson/plugins/git/GitChangeSetUtil.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetUtil.java
@@ -71,8 +71,8 @@ public class GitChangeSetUtil {
     static void assertChangeSet(GitChangeSet changeSet) {
         TestCase.assertEquals("123abc456def", changeSet.getId());
         TestCase.assertEquals("Commit title.", changeSet.getMsg());
-        TestCase.assertEquals("Commit title.\nCommit extended description.\n", changeSet.getComment());
-        TestCase.assertEquals("Commit title.\nCommit extended description.\n".replace("\n", "<br>"), changeSet.getCommentAnnotated());
+        TestCase.assertEquals("Commit title.\nCommit extended description.", changeSet.getComment());
+        TestCase.assertEquals("Commit title.\nCommit extended description.".replace("\n", "<br>"), changeSet.getCommentAnnotated());
         HashSet<String> expectedAffectedPaths = new HashSet<>(7);
         expectedAffectedPaths.add("src/test/add.file");
         expectedAffectedPaths.add("src/test/deleted.file");


### PR DESCRIPTION
When viewing the Changes page of a build that is linked to a Git repository, the existing logic strips out newlines from the commit messages, causing them to be rendered incorrectly.  This change fixes this issue.

Details, including a before/after screen shot, are at the following URL:

https://issues.jenkins-ci.org/browse/JENKINS-32544
