### PR TITLE
Added two extensions, [ExcludeMatrixParent] and [ExcludeMatrixChild].…

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1049,6 +1049,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         for (GitSCMExtension ext : extensions) {
             ext.beforeCheckout(this, build, git, listener);
         }
+        
+        for (GitSCMExtension ext : extensions) {
+        	if(!(ext.doCheckout(this, build, git, listener))){
+        		return;
+        	}
+        }
 
         retrieveChanges(build, git, listener);
         Build revToBuild = determineRevisionToBuild(build, buildData, environment, git, listener);

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -130,6 +130,13 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
             return rev;
         }
     }
+    
+     /**
+     * Called before the checkout activity (including fetch and checkout) starts, will skip whole Checkout if returned false.
+     */
+    public boolean doCheckout(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener) throws IOException, InterruptedException, GitException {
+    	return true;
+    }
 
     /**
      * Called before the checkout activity (including fetch and checkout) starts.

--- a/src/main/java/hudson/plugins/git/extensions/impl/ExcludeMatrixChilds.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/ExcludeMatrixChilds.java
@@ -1,0 +1,56 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.model.Run;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixRun;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+
+import org.jenkinsci.plugins.gitclient.CloneCommand;
+import org.jenkinsci.plugins.gitclient.FetchCommand;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+/**
+ * Git SCM skip checkout on Matrix configuration child jobs
+ *
+ */
+public class ExcludeMatrixChilds extends GitSCMExtension {
+    @DataBoundConstructor
+    public ExcludeMatrixChilds() {
+    }
+    
+    @Override
+    public boolean doCheckout(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener) throws IOException, InterruptedException, GitException {
+        
+        boolean doCheckout = true;
+        
+        // Checkout should not be done for Matrix child jobs
+        if (build instanceof MatrixRun) {
+			listener.getLogger().println("[ExcludeMatrixChilds] Build is a Matrix child job, skipping checkout...");
+			doCheckout = false;
+		} else {
+			listener.getLogger().println("[ExcludeMatrixChilds] Build is a Matrix parent job, executing as normal...");
+		}
+		
+		return doCheckout;
+    }
+    
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Exclude Matrix Childs";
+        }
+    }
+}
+

--- a/src/main/java/hudson/plugins/git/extensions/impl/ExcludeMatrixParent.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/ExcludeMatrixParent.java
@@ -1,0 +1,57 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.model.Run;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixRun;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+
+import org.jenkinsci.plugins.gitclient.CloneCommand;
+import org.jenkinsci.plugins.gitclient.FetchCommand;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+/**
+ * Git SCM skip checkout on a Matrix configuration parent job
+ *
+ */
+public class ExcludeMatrixParent extends GitSCMExtension {
+    @DataBoundConstructor
+    public ExcludeMatrixParent() {
+    }
+    
+    @Override
+    public boolean doCheckout(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener) throws IOException, InterruptedException, GitException {
+        
+        boolean doCheckout = true;
+        
+        // Checkout should not be done for Matrix parent jobs
+		if (build instanceof MatrixBuild) {
+			if (!(build instanceof MatrixRun)) {
+				listener.getLogger().println("[ExcludeMatrixParent] Build is a Matrix parent job, skipping checkout...");
+				doCheckout = false;
+			} else {
+				listener.getLogger().println("[ExcludeMatrixParent] Build is a Matrix child job, executing as normal...");
+			}
+		}
+		
+		return doCheckout;
+    }
+    
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Exclude Matrix Parent";
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/ExcludeMatrixChilds/help.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/ExcludeMatrixChilds/help.html
@@ -1,0 +1,1 @@
+This options makes Git SCM skip checkout on a Matrix configuration child jobs. Still executes as normal on Matrix parent job.

--- a/src/main/resources/hudson/plugins/git/extensions/impl/ExcludeMatrixParent/help.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/ExcludeMatrixParent/help.html
@@ -1,0 +1,1 @@
+This options makes Git SCM skip checkout on a Matrix configuration parent job. Still executes as normal on Matrix child spawns.


### PR DESCRIPTION
… These options allows the checkout process to be excluded when running Matrix parent or child jobs.

**[ExcludeMatrixChild]**
This is useful for scenarios when only the Parent job does the git cloning, and all child runs uses that same workspace, without doing the actual git clone themselves. This scenario of course assumes that the child configuration only makes read operations, since write operation can corrupt the Git repository.

**[ExcludeMatrixParent]**
Another scenario is when there is no need for the Parent job to clone the repository, since that workspace will not be used by the children and they need to clone themselves in unique workspace. This scenario is write operation safe if the workspaces are unique.
