### PR TITLE
AuthorInChangelog does not require a workspace for polling

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/AuthorInChangelog.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/AuthorInChangelog.java
@@ -19,7 +19,7 @@ public class AuthorInChangelog extends FakeGitSCMExtension {
 
     @Override
     public boolean requiresWorkspaceForPolling() {
-        return true;
+        return false;
     }
 
     @Extension


### PR DESCRIPTION
I couldn't find a single reason why the AuthorInChangelog extension is marked as requiring a workspace during polling. Ultimately, this extension only decides if the parsed author or parsed committer information is used.