### PR TITLE
AuthorInChangelog does not require a workspace for polling

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/AuthorInChangelog.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/AuthorInChangelog.java
@@ -19,7 +19,7 @@ public class AuthorInChangelog extends FakeGitSCMExtension {
 
     @Override
     public boolean requiresWorkspaceForPolling() {
-        return true;
+        return false;
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/extensions/impl/AuthorInChangelog.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/AuthorInChangelog.java
@@ -17,11 +17,6 @@ public class AuthorInChangelog extends FakeGitSCMExtension {
     public AuthorInChangelog() {
     }
 
-    @Override
-    public boolean requiresWorkspaceForPolling() {
-        return false;
-    }
-
     @Extension
     public static class DescriptorImpl extends GitSCMExtensionDescriptor {
         @Override

--- a/src/main/java/hudson/plugins/git/extensions/impl/CheckoutOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CheckoutOption.java
@@ -31,11 +31,6 @@ public class CheckoutOption extends FakeGitSCMExtension {
     }
 
     @Override
-    public boolean requiresWorkspaceForPolling() {
-        return false;
-    }
-
-    @Override
     public void decorateCheckoutCommand(GitSCM scm, AbstractBuild<?, ?> build, GitClient git, BuildListener listener, CheckoutCommand cmd) throws IOException, InterruptedException, GitException {
         cmd.timeout(timeout);
     }

--- a/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
@@ -13,7 +13,6 @@ import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -48,6 +47,10 @@ public abstract class GitSCMExtensionTest {
 	}
 
 	protected FreeStyleProject setupBasicProject(TestGitRepo repo) throws Exception {
+		return setupBasicProject(repo, Collections.<GitSCMExtension>emptyList());
+	}
+
+	protected FreeStyleProject setupBasicProject(TestGitRepo repo, List<GitSCMExtension> additionalExtensions) throws Exception {
 		GitSCMExtension extension = getExtension();
 		FreeStyleProject project = j.createFreeStyleProject(extension.getClass() + "Project");
 		List<BranchSpec> branches = Collections.singletonList(new BranchSpec("master"));
@@ -58,8 +61,10 @@ public abstract class GitSCMExtensionTest {
 				null, null,
 				Collections.<GitSCMExtension>emptyList());
 		scm.getExtensions().add(extension);
+		scm.getExtensions().addAll(additionalExtensions);
 		project.setScm(scm);
 		project.getBuildersList().add(new CaptureEnvironmentBuilder());
 		return project;
 	}
+
 }

--- a/src/test/java/hudson/plugins/git/extensions/impl/AuthorInChangelogTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/AuthorInChangelogTest.java
@@ -1,0 +1,64 @@
+package hudson.plugins.git.extensions.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.jgit.lib.PersonIdent;
+import org.junit.Test;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.plugins.git.GitChangeSet;
+import hudson.plugins.git.TestGitRepo;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionTest;
+
+public class AuthorInChangelogTest extends GitSCMExtensionTest {
+
+	final PersonIdent peterPan = new PersonIdent("Peter Pan", "peter@pan.com");
+
+	FreeStyleProject project;
+	TestGitRepo repo;
+
+	@Override
+	public void before() throws Exception {
+		repo = new TestGitRepo("repo", tmp.newFolder(), listener);
+	}
+
+	@Override
+	protected GitSCMExtension getExtension() {
+		return new AuthorInChangelog();
+	}
+
+	@Test
+	public void useAuthorForChangeLogUser() throws Exception {
+		project = setupBasicProject(repo);
+
+		repo.commit("repo-init", repo.janeDoe, repo.johnDoe, "repo0 initial commit");
+
+		FreeStyleBuild build1 = build(project, Result.SUCCESS);
+
+		assertTrue("initial build should not contain any changes", build1.getChangeSet().isEmptySet());
+
+		repo.commit("A", repo.janeDoe, repo.johnDoe, "#1 change by author jane");
+		repo.commit("B", repo.johnDoe, repo.janeDoe, "#2 change by author john");
+		repo.commit("C", repo.janeDoe, peterPan, "#3 change by author jane");
+		repo.commit("D", peterPan, repo.janeDoe, "#4 change by author peter");
+
+		FreeStyleBuild build2 = build(project, Result.SUCCESS);
+
+		assertEquals("further build should contain four changes", 4, build2.getChangeSet().getItems().length);
+		assertTrue("First change should have user jane", checkChangeSetUser(build2.getChangeSet().getItems()[0], repo.janeDoe));
+		assertTrue("Second change should have user john", checkChangeSetUser(build2.getChangeSet().getItems()[1], repo.johnDoe));
+		assertTrue("Third change should have user jane", checkChangeSetUser(build2.getChangeSet().getItems()[2], repo.janeDoe));
+		assertTrue("Fourth change should have user peter", checkChangeSetUser(build2.getChangeSet().getItems()[3], peterPan));
+
+	}
+
+	public boolean checkChangeSetUser(Object changeSetItem, PersonIdent expectedUser) {
+		GitChangeSet changeSet = (GitChangeSet) changeSetItem;
+		return expectedUser.getName().equals(changeSet.getAuthorName());
+	}
+
+}

--- a/src/test/java/hudson/plugins/git/extensions/impl/UserExclusionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/UserExclusionTest.java
@@ -1,11 +1,12 @@
 package hudson.plugins.git.extensions.impl;
 
+import java.util.Arrays;
+
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.plugins.git.TestGitRepo;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionTest;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -22,7 +23,6 @@ public class UserExclusionTest extends GitSCMExtensionTest{
 	@Override
 	public void before() throws Exception {
 		repo = new TestGitRepo("repo", tmp.newFolder(), listener);
-		project = setupBasicProject(repo);
 	}
 
 	@Override
@@ -32,6 +32,7 @@ public class UserExclusionTest extends GitSCMExtensionTest{
 
 	@Test
 	public void test() throws Exception {
+		project = setupBasicProject(repo);
 
 		repo.commit("repo-init", repo.johnDoe, "repo0 initial commit");
 
@@ -43,13 +44,36 @@ public class UserExclusionTest extends GitSCMExtensionTest{
 
 		repo.commit("repo-init", repo.janeDoe, "excluded user commit");
 
-		assertFalse("scm polling should ignore excluded user", project.poll(listener).hasChanges());
+		assertFalse("scm polling should ignore excluded committer user", project.poll(listener).hasChanges());
 
 		// should be enough, but let's test more
 
 		build(project, Result.SUCCESS);
 
 		assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
-
 	}
+
+	@Test
+	public void testInConcertWithAuthorInChangelog() throws Exception {
+		project = setupBasicProject(repo, Arrays.<GitSCMExtension>asList(new AuthorInChangelog()));
+
+		repo.commit("repo-init", repo.johnDoe, repo.janeDoe, "repo0 initial commit");
+
+		assertTrue("scm polling should detect a change after initial commit", project.poll(listener).hasChanges());
+
+		build(project, Result.SUCCESS);
+
+		assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+
+		repo.commit("repo-init", repo.janeDoe, repo.johnDoe, "excluded user commit");
+
+		assertFalse("scm polling should ignore excluded author user", project.poll(listener).hasChanges());
+
+		// should be enough, but let's test more
+
+		build(project, Result.SUCCESS);
+
+		assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+	}
+
 }


### PR DESCRIPTION
The AuthorInChangelog extension is only used to decide if the author or the committer name/email should parsed during change log calculation.

Yes, the "changelog" is also parsed during polling with the UserExclusion extension. But requiring a workspace is not a trait of the AuthorInChangelog extension itself.

I added tests to ensure that both extensions use the correct author name if AuthorInChangelog is used.
