### PR TITLE
git: add support for --force option for submodule update

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
+++ b/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
@@ -204,7 +204,7 @@ public abstract class GitSCMBackwardCompatibility extends SCM implements Seriali
                 skipTag = null;
             }
             if (disableSubmodules || recursiveSubmodules || trackingSubmodules) {
-                addIfMissing(new SubmoduleOption(disableSubmodules, recursiveSubmodules, trackingSubmodules, null, null));
+                addIfMissing(new SubmoduleOption(disableSubmodules, recursiveSubmodules, false, trackingSubmodules, null, null));
             }
             if (isNotBlank(gitConfigName) || isNotBlank(gitConfigEmail)) {
                 addIfMissing(new UserIdentity(gitConfigName,gitConfigEmail));

--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -39,14 +39,16 @@ public class SubmoduleOption extends GitSCMExtension {
      */
     private boolean disableSubmodules;
     private boolean recursiveSubmodules;
+    private boolean forceSubmodules;
     private boolean trackingSubmodules;
     private String reference;
     private Integer timeout;
 
     @DataBoundConstructor
-    public SubmoduleOption(boolean disableSubmodules, boolean recursiveSubmodules, boolean trackingSubmodules, String reference, Integer timeout) {
+    public SubmoduleOption(boolean disableSubmodules, boolean recursiveSubmodules, boolean forceSubmodules, boolean trackingSubmodules, String reference, Integer timeout) {
         this.disableSubmodules = disableSubmodules;
         this.recursiveSubmodules = recursiveSubmodules;
+        this.forceSubmodules = forceSubmodules;
         this.trackingSubmodules = trackingSubmodules;
         this.reference = reference;
         this.timeout = timeout;
@@ -58,6 +60,10 @@ public class SubmoduleOption extends GitSCMExtension {
 
     public boolean isRecursiveSubmodules() {
         return recursiveSubmodules;
+    }
+
+    public boolean isForceSubmodules() {
+        return forceSubmodules;
     }
 
     public boolean isTrackingSubmodules() {
@@ -89,6 +95,7 @@ public class SubmoduleOption extends GitSCMExtension {
             git.setupSubmoduleUrls(revToBuild.lastBuild.getRevision(), listener);
             git.submoduleUpdate()
                 .recursive(recursiveSubmodules)
+                .force(forceSubmodules)
                 .remoteTracking(trackingSubmodules)
                 .ref(build.getEnvironment(listener).expand(reference))
                 .timeout(timeout)

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
@@ -8,6 +8,9 @@ f.entry(title:_("Disable submodules processing"), field:"disableSubmodules") {
 f.entry(title:_("Recursively update submodules"), field:"recursiveSubmodules") {
     f.checkbox()
 }
+f.entry(title:_("Force update of submodules"), field:"forceSubmodules") {
+    f.checkbox()
+}
 f.entry(title:_("Update tracking submodules to tip of branch"), field:"trackingSubmodules") {
     f.checkbox()
 }


### PR DESCRIPTION
Takes advantage of the addition of --force support in the git client plugin. See that PR to determine the value of the additional option.

Signed-off-by: Jacob Keller jacob.e.keller@intel.com
