### PR TITLE
LocalBranch "**" checks out to local branch using remote branch name.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <findbugs-maven-plugin.version>3.0.3</findbugs-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.7.4.201502262128</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.7.6.201602180812</jacoco-maven-plugin.version>
     <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
     <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
     <maven-hpi-plugin.version>1.115</maven-hpi-plugin.version>
@@ -350,5 +350,6 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>
+
+</project>  
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -439,38 +439,40 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     }
     
     /**
-     * Derives a local branch name from the remote branch name by removing the name of the remote
-     * from the remote branch name.
+     * Derives a local branch name from the remote branch name by removing the
+     * name of the remote from the remote branch name.
      * <p>
      * Ex. origin/master becomes master
      * <p>
-     * Cycles through the list of user remotes looking for a match allowing user to configure an
-     * alternalte (not origin) name for the remote.
+     * Cycles through the list of user remotes looking for a match allowing user
+     * to configure an alternalte (not origin) name for the remote.
+     * 
      * @param remoteBranchName
-     * @return a local branch name derived by stripping the remote repository name from the
-     * {@code remoteBranchName} parameter.  If a matching remote is not found, the original
-     * {@code remoteBranchName} will be returned.
+     * @return a local branch name derived by stripping the remote repository
+     *         name from the {@code remoteBranchName} parameter. If a matching
+     *         remote is not found, the original {@code remoteBranchName} will
+     *         be returned.
      */
     public String deriveLocalBranchName(String remoteBranchName) {
-       // default remoteName is 'origin' used if list of user remote configs is empty.
-       String remoteName = "origin";
-       
-       for (final UserRemoteConfig remote : getUserRemoteConfigs()) {
-          remoteName = remote.getName();
-          if (remoteName == null || remoteName.isEmpty()) {
-              remoteName = "origin";
-          }
-          if (remoteBranchName.startsWith(remoteName + "/")) {
-             // found the remote config associated with remoteBranchName
-             LOGGER.log(Level.INFO, "Matched remote name: " + remoteName);
-             break;
-          }
-       }
+        // default remoteName is 'origin' used if list of user remote configs is empty.
+        String remoteName = "origin";
 
-       // now strip the remote name and return the resulting local branch name.
-       LOGGER.log(Level.INFO, "Local branch name in checkout replacing '^" + remoteName + "/'");
-       String localBranchName = remoteBranchName.replaceFirst("^" + remoteName + "/", "");
-       return localBranchName;
+        for (final UserRemoteConfig remote : getUserRemoteConfigs()) {
+            remoteName = remote.getName();
+            if (remoteName == null || remoteName.isEmpty()) {
+                remoteName = "origin";
+            }
+            if (remoteBranchName.startsWith(remoteName + "/")) {
+                // found the remote config associated with remoteBranchName
+                LOGGER.log(Level.INFO, "Matched remote name: " + remoteName);
+                break;
+            }
+        }
+
+        // now strip the remote name and return the resulting local branch name.
+        LOGGER.log(Level.INFO, "Local branch name in checkout replacing '^" + remoteName + "/'");
+        String localBranchName = remoteBranchName.replaceFirst("^" + remoteName + "/", "");
+        return localBranchName;
     }
 
     public String getGitTool() {

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -469,6 +469,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         // now strip the remote name and return the resulting local branch name.
+        String localBranchName = remoteBranchName.replaceFirst("^" + remoteName + "/", "");
         return localBranchName;
     }
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -464,14 +464,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
             if (remoteBranchName.startsWith(remoteName + "/")) {
                 // found the remote config associated with remoteBranchName
-                LOGGER.log(Level.INFO, "Matched remote name: " + remoteName);
                 break;
             }
         }
 
         // now strip the remote name and return the resulting local branch name.
-        LOGGER.log(Level.INFO, "Local branch name in checkout replacing '^" + remoteName + "/'");
-        String localBranchName = remoteBranchName.replaceFirst("^" + remoteName + "/", "");
         return localBranchName;
     }
 
@@ -1116,7 +1113,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                   // local branch is configured with empty value or "**" so use remote branch name for checkout
                   localBranchName = deriveLocalBranchName(remoteBranchName);
                }
-               LOGGER.log(Level.INFO, "Local branch name in checkout is '" + localBranchName + "'");
                environment.put(GIT_LOCAL_BRANCH, localBranchName);
             }
         }
@@ -1247,7 +1243,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                       // local branch is configured with empty value or "**" so use remote branch name for checkout
                       localBranchName = deriveLocalBranchName(remoteBranchName);
                    }
-                   LOGGER.log(Level.INFO, "Local branch name in build env vars is '" + localBranchName + "'");
                    env.put(GIT_LOCAL_BRANCH, localBranchName);
                 }
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/LocalBranch.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/LocalBranch.java
@@ -7,8 +7,12 @@ import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- *
- *
+ * The Git plugin checks code out to a detached head.  Configure
+ * LocalBranch to force checkout to a specific local branch.
+ * Configure this extension as null or as "**" to signify that
+ * the local branch name should be the same as the remote branch
+ * name sans the remote repository prefix (origin for example).
+ * 
  * @author Kohsuke Kawaguchi
  */
 public class LocalBranch extends FakeGitSCMExtension {
@@ -27,7 +31,7 @@ public class LocalBranch extends FakeGitSCMExtension {
     public static class DescriptorImpl extends GitSCMExtensionDescriptor {
         @Override
         public String getDisplayName() {
-            return "Check out to specific local branch";
+            return "Check out to specific local branch, null to use remote branch name.";
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/extensions/impl/LocalBranch.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/LocalBranch.java
@@ -31,7 +31,7 @@ public class LocalBranch extends FakeGitSCMExtension {
     public static class DescriptorImpl extends GitSCMExtensionDescriptor {
         @Override
         public String getDisplayName() {
-            return "Check out to specific local branch, null to use remote branch name.";
+            return "Check out to specific local branch";
         }
     }
 }


### PR DESCRIPTION
Maven SCM support for branches relies on the local branch name being the
same as the remote branch name.  Tools such as the Maven release plugin
will push changes using the same local and remote branch names as
explained at https://maven.apache.org/scm/git.html

Ex. git push pushUrl currentBranch:currentBranch

To facilitate this requirement, LocalBranch values of "**" or null will
result in using the remote branch name.