### PR TITLE
Updated display name of TFS browser

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
@@ -24,7 +24,7 @@ import java.net.URL;
 import java.util.regex.Pattern;
 
 /**
- * Browser for TFS 2013
+ * Browser for TFS 2013 and higher versions using the same format.
  */
 public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
 
@@ -82,7 +82,7 @@ public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
     public static class TFS2013GitRepositoryBrowserDescriptor extends Descriptor<RepositoryBrowser<?>> {
 
         public String getDisplayName() {
-            return "Microsoft TFS 2013";
+            return "Microsoft Team Foundation Server";
         }
 
         @Override


### PR DESCRIPTION
In one deployment we found that users are confused about the fact that you have to select Microsoft TFS 2013 ... when in fact some 2015 release is installed.

The format of these versions is the same and as such I think it would be useful to change to the generic terms implemented in this PR.

