### PR TITLE
TFS repository browser relabel and fix

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
@@ -24,7 +24,8 @@ import java.net.URL;
 import java.util.regex.Pattern;
 
 /**
- * Browser for TFS 2013 and higher versions using the same format.
+ * Browser for Git repositories on Microsoft Team Foundaation Server (TFS) 2013 and higher versions using the 
+ * same format. This includes Git repositories hosted with the Visual Studio Team Services.
  */
 public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
 
@@ -81,8 +82,9 @@ public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
     @Extension
     public static class TFS2013GitRepositoryBrowserDescriptor extends Descriptor<RepositoryBrowser<?>> {
 
+        private static final String REPOSITORY_BROWSER_LABEL = "Microsoft Team Foundation Server / Visual Studio Team Services";
         public String getDisplayName() {
-            return "Microsoft Team Foundation Server";
+            return REPOSITORY_BROWSER_LABEL;
         }
 
         @Override
@@ -128,7 +130,7 @@ public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
                 @Override
                 protected FormValidation check() throws IOException, ServletException {
                     try {
-                        if (findText(open(new URL(finalValue)), "Team Foundation Server 2013")) {
+                        if (findText(open(new URL(finalValue)), REPOSITORY_BROWSER_LABEL)) {
                             return FormValidation.ok();
                         } else {
                             return FormValidation.error("This is a valid URL but it doesn't look like Microsoft TFS 2013");

--- a/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
@@ -24,7 +24,7 @@ import java.net.URL;
 import java.util.regex.Pattern;
 
 /**
- * Browser for Git repositories on Microsoft Team Foundaation Server (TFS) 2013 and higher versions using the 
+ * Browser for Git repositories on Microsoft Team Foundation Server (TFS) 2013 and higher versions using the
  * same format. This includes Git repositories hosted with the Visual Studio Team Services.
  */
 public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
@@ -82,7 +82,7 @@ public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
     @Extension
     public static class TFS2013GitRepositoryBrowserDescriptor extends Descriptor<RepositoryBrowser<?>> {
 
-        private static final String REPOSITORY_BROWSER_LABEL = "Microsoft Team Foundation Server / Visual Studio Team Services";
+        private static final String REPOSITORY_BROWSER_LABEL = "Microsoft Team Foundation Server/Visual Studio Team Services";
         public String getDisplayName() {
             return REPOSITORY_BROWSER_LABEL;
         }


### PR DESCRIPTION
This updates the label as discussed in https://github.com/jenkinsci/git-plugin/pull/382

It also fixes the test and removes the trap of using a string twice by introducing a static.

Here is what it looks like:

![git-mstfs-vsts](https://cloud.githubusercontent.com/assets/145658/13928410/baf62f1e-ef52-11e5-8433-4c4a339472ec.png)

Functionality in terms of links is not changed. 

I tested this on a local jenkins server just for rendering as well as a large deployment with TFS.

I did NOT test this with VSTS since I dont have an account or repo. @olivierdagenais mentioned that he would test this against VSTS.

@MarkEWaite sorry this did not come in time for the release you just cut. Potentially there are issues with the TFS browser since the two strings are different in the current release. 