### PR TITLE
[JENKINS-29326] Restore lost BuildData.equals override

### DIFF
--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -243,4 +243,22 @@ public class BuildData implements Action, Serializable, Cloneable {
                 ",buildsByBranchName="+buildsByBranchName+
                 ",lastBuild="+lastBuild+"]";
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof BuildData)) {
+            return false;
+        } else {
+            BuildData otherBuildData = (BuildData) o;
+
+            if (otherBuildData.remoteUrls.equals(this.remoteUrls)
+                    && otherBuildData.buildsByBranchName.equals(this.buildsByBranchName)
+                    && otherBuildData.lastBuild.equals(this.lastBuild)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
https://github.com/jenkinsci/git-plugin/commit/336c1787c7b967e4220c4d459092397fda29892a by @MarkEWaite purported to merely be reverting https://github.com/jenkinsci/git-plugin/commit/c1872d038cc2f584bafbc375744deb54a1dbe316 but in fact it also deleted an unrelated method introduced in https://github.com/jenkinsci/git-plugin/pull/372. Thus the tested added in https://github.com/jenkinsci/workflow-plugin/pull/271 passes against 2.4.1, starts failing against 2.4.2, and is fixed by this patch.

@reviewbybees esp. @abayer