### PR TITLE
Fix `BuildDataTest#testAddRemoteUrl`

### DIFF
--- a/src/test/java/hudson/plugins/git/util/BuildDataTest.java
+++ b/src/test/java/hudson/plugins/git/util/BuildDataTest.java
@@ -118,7 +118,7 @@ public class BuildDataTest {
         String remoteUrl2 = "https://github.com/jenkinsci/git-plugin.git/";
         data.addRemoteUrl(remoteUrl2);
         assertFalse(data.getRemoteUrls().isEmpty());
-        assertEquals(remoteUrl2, data.getRemoteUrls().toArray()[1]);
+        assertTrue(data.getRemoteUrls().contains(remoteUrl2));
         assertEquals(2, data.getRemoteUrls().size());
     }
 


### PR DESCRIPTION
`remoteUrls` is a `Set`, which unless guaranteed by the specific implementation (which is not the case here) does not provide a specific iteration order, so the test cannot depend on it.

@reviewbybees 