### PR TITLE
AbstractGitSCMSource.getPattern bug

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -323,14 +323,12 @@ public abstract class AbstractGitSCMSource extends SCMSource {
       StringBuilder quotedBranches = new StringBuilder();
       for (String wildcard : branches.split(" ")){
         StringBuilder quotedBranch = new StringBuilder();
-        for(String branch : wildcard.split("\\*")){
-          if (wildcard.startsWith("*") || quotedBranches.length()>0) {
+        for(String branch : wildcard.split("(?=[*])|(?<=[*])")){
+          if (branch.equals("*")) {
             quotedBranch.append(".*");
+          } else if (!branch.isEmpty()) {
+            quotedBranch.append(Pattern.quote(branch));
           }
-          quotedBranch.append(Pattern.quote(branch));
-        }
-        if (wildcard.endsWith("*")){
-          quotedBranch.append(".*");
         }
         if (quotedBranches.length()>0) {
           quotedBranches.append("|");

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -36,6 +36,13 @@ public class AbstractGitSCMSourceTest {
     assertTrue(abstractGitSCMSource.isExcluded("bugfix"));
     assertTrue(abstractGitSCMSource.isExcluded("bugfix/test"));
     assertTrue(abstractGitSCMSource.isExcluded("test"));
+
+    when(abstractGitSCMSource.getIncludes()).thenReturn("master feature/*");
+    when(abstractGitSCMSource.getExcludes()).thenReturn("feature/*/private");
+    assertFalse(abstractGitSCMSource.isExcluded("master"));
+    assertTrue(abstractGitSCMSource.isExcluded("devel"));
+    assertFalse(abstractGitSCMSource.isExcluded("feature/spiffy"));
+    assertTrue(abstractGitSCMSource.isExcluded("feature/spiffy/private"));
   }
 
 }


### PR DESCRIPTION
[Tip](http://stackoverflow.com/a/2848147/12916)

#227 was translating `feature/*/private` to `\Qfeature/\E\Q/private\E` rather than `\Qfeature/\E.*\Q/private\E` as you would expect.

@reviewbybees esp. @Vlatombe