### PR TITLE
Fix JENKINS-34070 NoStaplerConstructorException on UserMergeOptions.mergeStrategy

### DIFF
--- a/src/main/java/hudson/plugins/git/UserMergeOptions.java
+++ b/src/main/java/hudson/plugins/git/UserMergeOptions.java
@@ -7,6 +7,7 @@ import hudson.plugins.git.opt.PreBuildMergeOptions;
 import hudson.util.ListBoxModel;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.Serializable;
 
@@ -19,7 +20,7 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
 
     private String mergeRemote;
     private String mergeTarget;
-    private String mergeStrategy;
+    private MergeCommand.Strategy mergeStrategy;
     private MergeCommand.GitPluginFastForwardMode fastForwardMode;
 
     /**
@@ -27,20 +28,52 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
      */
     @Deprecated
     public UserMergeOptions(String mergeRemote, String mergeTarget, String mergeStrategy) {
-        this(mergeRemote, mergeTarget, mergeStrategy, MergeCommand.GitPluginFastForwardMode.FF);
+        this(mergeTarget);
+        setMergeRemote(mergeRemote);
+        setMergeStrategy(mergeStrategy);
+        setFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF);
+    }
+
+    /**
+     * @Deprecated use the new @DataBoundConstructor where you only need to supply the necessary information.
+     */
+    @Deprecated
+    public UserMergeOptions(String mergeRemote, String mergeTarget, String mergeStrategy, MergeCommand.GitPluginFastForwardMode fastForwardMode) {
+        this(mergeTarget);
+        setMergeRemote(mergeRemote);
+        setMergeStrategy(mergeStrategy);
+        setFastForwardMode(fastForwardMode);
     }
 
     @DataBoundConstructor
-    public UserMergeOptions(String mergeRemote, String mergeTarget, String mergeStrategy,
-            MergeCommand.GitPluginFastForwardMode fastForwardMode) {
-        this.mergeRemote = mergeRemote;
+    public UserMergeOptions(String mergeTarget) {
         this.mergeTarget = mergeTarget;
+    }
+
+    @DataBoundSetter
+    public void setMergeRemote(String mergeRemote) {
+        this.mergeRemote = mergeRemote;
+    }
+
+    @DataBoundSetter
+    public void setMergeStrategy(MergeCommand.Strategy mergeStrategy) {
         this.mergeStrategy = mergeStrategy;
+    }
+
+    @DataBoundSetter
+    public void setFastForwardMode(MergeCommand.GitPluginFastForwardMode fastForwardMode) {
         this.fastForwardMode = fastForwardMode;
     }
 
+    private void setMergeStrategy(String mergeStrategy) {
+        this.mergeStrategy = (mergeStrategy == null ? null : MergeCommand.Strategy.valueOf(mergeStrategy.toUpperCase()));
+    }
+
     public UserMergeOptions(PreBuildMergeOptions pbm) {
-        this(pbm.getRemoteBranchName(), pbm.getMergeTarget(), pbm.getMergeStrategy().toString(), pbm.getFastForwardMode());
+        this(pbm.getMergeTarget());
+        this.mergeRemote = pbm.getRemoteBranchName();
+        this.mergeStrategy = pbm.getMergeStrategy();
+        this.fastForwardMode = pbm.getFastForwardMode();
     }
 
     /**
@@ -64,7 +97,7 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
 
     public MergeCommand.Strategy getMergeStrategy() {
         for (MergeCommand.Strategy strategy: MergeCommand.Strategy.values())
-            if (strategy.toString().equals(mergeStrategy))
+            if (strategy.equals(mergeStrategy))
                 return strategy;
         return MergeCommand.Strategy.DEFAULT;
     }
@@ -128,11 +161,5 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
             return "";
         }
 
-        public ListBoxModel doFillMergeStrategyItems() {
-            ListBoxModel m = new ListBoxModel();
-            for (MergeCommand.Strategy strategy: MergeCommand.Strategy.values())
-                m.add(strategy.toString(), strategy.toString());
-            return m;
-        }
     }
 }

--- a/src/main/java/hudson/plugins/git/opt/PreBuildMergeOptions.java
+++ b/src/main/java/hudson/plugins/git/opt/PreBuildMergeOptions.java
@@ -29,7 +29,7 @@ public class PreBuildMergeOptions implements Serializable {
     /**
      * Merge strategy.
      */
-    public String mergeStrategy = MergeCommand.Strategy.DEFAULT.toString();
+    public MergeCommand.Strategy mergeStrategy = MergeCommand.Strategy.DEFAULT;
 
     public MergeCommand.GitPluginFastForwardMode fastForwardMode = MergeCommand.GitPluginFastForwardMode.FF;
 
@@ -53,13 +53,13 @@ public class PreBuildMergeOptions implements Serializable {
     @Exported
     public MergeCommand.Strategy getMergeStrategy() {
         for (MergeCommand.Strategy strategy: MergeCommand.Strategy.values())
-            if (strategy.toString().equals(mergeStrategy))
+            if (strategy.equals(mergeStrategy))
                 return strategy;
         return MergeCommand.Strategy.DEFAULT;
     }
 
     public void setMergeStrategy(MergeCommand.Strategy mergeStrategy) {
-        this.mergeStrategy = mergeStrategy.toString();
+        this.mergeStrategy = mergeStrategy;
     }
 
     @Exported

--- a/src/main/resources/hudson/plugins/git/UserMergeOptions/config.jelly
+++ b/src/main/resources/hudson/plugins/git/UserMergeOptions/config.jelly
@@ -1,17 +1,19 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="Name of repository" field="mergeRemote">
-    <f:textbox id="git.mergeRemote" />
+    <f:textbox />
     <!-- TODO add the check url. Note that we cannot rely on the repo.name tag to be at the root of the form -->
     <!--		             checkUrl="'${rootURL}/scm/GitSCM/gitRemoteNameCheck?isMerge=true&amp;value='+escape(this.value)
                      +encodeAllInputs('&amp;', this.form, 'repo.name')
                      +encodeAllInputs('&amp;', this.form, 'repo.url')"/ -->
   </f:entry>
   <f:entry title="${%Branch to merge to}" field="mergeTarget">
-    <f:textbox id="git.mergeTarget" clazz="required"/>
+    <f:textbox clazz="required"/>
   </f:entry>
   <f:entry title="Merge strategy" field="mergeStrategy">
-      <f:select />
+      <f:enum>
+          ${it.toString()}
+      </f:enum>
   </f:entry>
   <f:entry title="Fast-forward mode" field="fastForwardMode">
       <f:enum>

--- a/src/test/java/hudson/plugins/git/GitPublisherTest.java
+++ b/src/test/java/hudson/plugins/git/GitPublisherTest.java
@@ -122,7 +122,9 @@ public class GitPublisherTest extends AbstractGitProject {
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
+        UserMergeOptions userMergeOptions = new UserMergeOptions("integration");
+        userMergeOptions.setMergeRemote("origin");
+        scm.getExtensions().add(new PreBuildMerge(userMergeOptions));
         scm.getExtensions().add(new LocalBranch("integration"));
         project.setScm(scm);
 
@@ -159,7 +161,10 @@ public class GitPublisherTest extends AbstractGitProject {
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, MergeCommand.GitPluginFastForwardMode.FF)));
+        UserMergeOptions userMergeOptions = new UserMergeOptions("integration");
+        userMergeOptions.setMergeRemote("origin");
+        userMergeOptions.setFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF);
+        scm.getExtensions().add(new PreBuildMerge(userMergeOptions));
         scm.getExtensions().add(new LocalBranch("integration"));
         project.setScm(scm);
 
@@ -244,7 +249,10 @@ public class GitPublisherTest extends AbstractGitProject {
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, MergeCommand.GitPluginFastForwardMode.NO_FF)));
+        UserMergeOptions userMergeOptions = new UserMergeOptions("integration");
+        userMergeOptions.setMergeRemote("origin");
+        userMergeOptions.setFastForwardMode(MergeCommand.GitPluginFastForwardMode.NO_FF);
+        scm.getExtensions().add(new PreBuildMerge(userMergeOptions));
         scm.getExtensions().add(new LocalBranch("integration"));
         project.setScm(scm);
 
@@ -333,7 +341,10 @@ public class GitPublisherTest extends AbstractGitProject {
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, MergeCommand.GitPluginFastForwardMode.FF_ONLY)));
+        UserMergeOptions userMergeOptions = new UserMergeOptions("integration");
+        userMergeOptions.setMergeRemote("origin");
+        userMergeOptions.setFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF_ONLY);
+        scm.getExtensions().add(new PreBuildMerge(userMergeOptions));
         scm.getExtensions().add(new LocalBranch("integration"));
         project.setScm(scm);
 
@@ -565,7 +576,9 @@ public class GitPublisherTest extends AbstractGitProject {
                 Collections.singletonList(new BranchSpec("*")),
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null, new ArrayList<GitSCMExtension>());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
+        UserMergeOptions userMergeOptions = new UserMergeOptions("integration");
+        userMergeOptions.setMergeRemote("origin");
+        scm.getExtensions().add(new PreBuildMerge(userMergeOptions));
         scm.getExtensions().add(new LocalBranch("integration"));
         project.setScm(scm);
 
@@ -628,7 +641,9 @@ public class GitPublisherTest extends AbstractGitProject {
         String envReference = "${" + envName + "}";
 
         List<GitSCMExtension> scmExtensions = new ArrayList<GitSCMExtension>();
-        scmExtensions.add(new PreBuildMerge(new UserMergeOptions("origin", envReference, null, null)));
+        UserMergeOptions userMergeOptions = new UserMergeOptions(envReference);
+        userMergeOptions.setMergeRemote("origin");
+        scmExtensions.add(new PreBuildMerge(userMergeOptions));
         scmExtensions.add(new LocalBranch(envReference));
         GitSCM scm = new GitSCM(
                 remoteConfigs(),

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -907,7 +907,11 @@ public class GitSCMTest extends AbstractGitTestCase {
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", "default", MergeCommand.GitPluginFastForwardMode.FF)));
+        UserMergeOptions userMergeOptions = new UserMergeOptions("integration");
+        userMergeOptions.setMergeRemote("origin");
+        userMergeOptions.setMergeStrategy(MergeCommand.Strategy.DEFAULT);
+        userMergeOptions.setFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF);
+        scm.getExtensions().add(new PreBuildMerge(userMergeOptions));
         project.setScm(scm);
 
         // create initial commit and then run the build against it:
@@ -946,7 +950,11 @@ public class GitSCMTest extends AbstractGitTestCase {
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", "default", MergeCommand.GitPluginFastForwardMode.FF)));
+        UserMergeOptions userMergeOptions = new UserMergeOptions("integration");
+        userMergeOptions.setMergeRemote("origin");
+        userMergeOptions.setMergeStrategy(MergeCommand.Strategy.DEFAULT);
+        userMergeOptions.setFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF);
+        scm.getExtensions().add(new PreBuildMerge(userMergeOptions));
         project.setScm(scm);
 
         // create initial commit and then run the build against it:
@@ -980,7 +988,9 @@ public class GitSCMTest extends AbstractGitTestCase {
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
+        UserMergeOptions userMergeOptions = new UserMergeOptions("integration");
+        userMergeOptions.setMergeRemote("origin");
+        scm.getExtensions().add(new PreBuildMerge(userMergeOptions));
         project.setScm(scm);
 
         // create initial commit and then run the build against it:
@@ -1019,7 +1029,11 @@ public class GitSCMTest extends AbstractGitTestCase {
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(scm);
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", "", MergeCommand.GitPluginFastForwardMode.FF)));
+        UserMergeOptions userMergeOptions = new UserMergeOptions("integration");
+        userMergeOptions.setMergeRemote("origin");
+        userMergeOptions.setMergeStrategy(MergeCommand.Strategy.DEFAULT);
+        userMergeOptions.setFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF);
+        scm.getExtensions().add(new PreBuildMerge(userMergeOptions));
 
         // create initial commit and then run the build against it:
         commit("commitFileBase", johnDoe, "Initial Commit");
@@ -1056,8 +1070,16 @@ public class GitSCMTest extends AbstractGitTestCase {
     			null, null,
     			Collections.<GitSCMExtension>emptyList());
     	project.setScm(scm);
-	scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration1", "", MergeCommand.GitPluginFastForwardMode.FF)));
-	scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration2", "", MergeCommand.GitPluginFastForwardMode.FF)));
+        UserMergeOptions userMergeOptions1 = new UserMergeOptions("integration1");
+        userMergeOptions1.setMergeRemote("origin");
+        userMergeOptions1.setMergeStrategy(MergeCommand.Strategy.DEFAULT);
+        userMergeOptions1.setFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF);
+	scm.getExtensions().add(new PreBuildMerge(userMergeOptions1));
+        UserMergeOptions userMergeOptions2 = new UserMergeOptions("integration2");
+        userMergeOptions2.setMergeRemote("origin");
+        userMergeOptions2.setMergeStrategy(MergeCommand.Strategy.DEFAULT);
+        userMergeOptions2.setFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF);
+	scm.getExtensions().add(new PreBuildMerge(userMergeOptions2));
     	
     	commit("dummyFile", johnDoe, "Initial Commit");
     	testRepo.git.branch("integration1");
@@ -1086,7 +1108,9 @@ public class GitSCMTest extends AbstractGitTestCase {
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
+        UserMergeOptions userMergeOptions = new UserMergeOptions("integration");
+        userMergeOptions.setMergeRemote("origin");
+        scm.getExtensions().add(new PreBuildMerge(userMergeOptions));
         project.setScm(scm);
 
         // create initial commit and then run the build against it:
@@ -1126,7 +1150,9 @@ public class GitSCMTest extends AbstractGitTestCase {
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
+        UserMergeOptions userMergeOptions = new UserMergeOptions("integration");
+        userMergeOptions.setMergeRemote("origin");
+        scm.getExtensions().add(new PreBuildMerge(userMergeOptions));
         project.setScm(scm);
 
         // create initial commit and then run the build against it:

--- a/src/test/java/hudson/plugins/git/opt/PreBuildMergeOptionsTest.java
+++ b/src/test/java/hudson/plugins/git/opt/PreBuildMergeOptionsTest.java
@@ -44,7 +44,11 @@ public class PreBuildMergeOptionsTest {
     @Issue("JENKINS-9843")
     @Test public void exporting() throws Exception {
         FreeStyleProject p = r.createFreeStyleProject();
-        p.setScm(new GitSCM(Collections.singletonList(new UserRemoteConfig("http://wherever/thing.git", "repo", null, null)), null, null, null, null, null, Collections.<GitSCMExtension>singletonList(new PreBuildMerge(new UserMergeOptions("repo", "master", MergeCommand.Strategy.DEFAULT.name(), MergeCommand.GitPluginFastForwardMode.FF)))));
+        UserMergeOptions userMergeOptions = new UserMergeOptions("master");
+        userMergeOptions.setMergeRemote("repo");
+        userMergeOptions.setMergeStrategy(MergeCommand.Strategy.DEFAULT);
+        userMergeOptions.setFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF);
+        p.setScm(new GitSCM(Collections.singletonList(new UserRemoteConfig("http://wherever/thing.git", "repo", null, null)), null, null, null, null, null, Collections.<GitSCMExtension>singletonList(new PreBuildMerge(userMergeOptions))));
         r.createWebClient().goToXml(p.getUrl() + "api/xml?depth=2");
     }
 


### PR DESCRIPTION
Fixing [JENKINS-34070](https://issues.jenkins-ci.org/browse/JENKINS-34070)

I implemented all recommendations in that bug report, and I checked that the GUI still works locally. The code snippet generator for the **Merge before build** option looks much better which this change.

I tried to convert all tests to use the new `@DataBoundConstructor`, except I did not know what to do with `UserMergeOptionsTest.java`. Please let me know. Thanks.
