### PR TITLE
Fix for error when job is configured with multiple remotes and branch spec is set to commit SHA1

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -473,16 +473,13 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         			break;
         		}
         	}
-        	if (repository == null) {
-        		return null;
-        	}
         } else {
         	repository = getRepositories().get(0).getName();
         }
 
 
         // replace repository wildcard with repository name
-        if (branch.startsWith("*/")) {
+        if (branch.startsWith("*/") && repository != null) {
             branch = repository + branch.substring(1);
         }
 

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -867,6 +867,32 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
+    @Issue("JENKINS-26268")
+    public void testBranchSpecAsSHA1WithMultipleRepositories() throws Exception {
+        FreeStyleProject project = setupSimpleProject("master");
+
+        TestGitRepo secondTestRepo = new TestGitRepo("second", this, listener);
+        List<UserRemoteConfig> remotes = new ArrayList<UserRemoteConfig>();
+        remotes.addAll(testRepo.remoteConfigs());
+        remotes.addAll(secondTestRepo.remoteConfigs());
+
+        // create initial commit
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit number 1");
+
+        String sha1 = testRepo.git.revParse("HEAD").getName();
+
+        project.setScm(new GitSCM(
+                remotes,
+                Collections.singletonList(new BranchSpec(sha1)),
+                false, Collections.<SubmoduleConfig>emptyList(),
+                null, null,
+                Collections.<GitSCMExtension>emptyList()));
+
+        final FreeStyleBuild build = build(project, Result.SUCCESS, commitFile1);
+        assertBuildStatusSuccess(build);
+    }
+
     @Issue("JENKINS-25639")
     public void testCommitDetectedOnlyOnceInMultipleRepositories() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");


### PR DESCRIPTION
Steps to reproduce:
1. create a job and add git scm, with two remotes:
/source/repo1.git
/source/repo2.git
2. set branch to commit SHA1 from one of the two repos
3. build

Expected: Successful build
Actual: Failed build with error: 
`ERROR: Couldn't find any revision to build. Verify the repository and branch configuration for this job.`