### PR TITLE
fix logging "Failed mkdirs of /var/jenkins_home/caches" when the directory already exists

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -257,8 +257,11 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             return null;
         }
         File cacheDir = new File(new File(jenkins.getRootDir(), "caches"), cacheEntry);
-        boolean ok = cacheDir.getParentFile().mkdirs();
-        if (!ok) LOGGER.info("Failed mkdirs of " + cacheDir.getParent());
+        File parentDir = cacheDir.getParentFile();
+        if (!parentDir.isDirectory()) {
+            boolean ok = parentDir.mkdirs();
+            if (!ok) LOGGER.info("Failed mkdirs of " + parentDir.getPath());
+        }
         return cacheDir;
     }
 


### PR DESCRIPTION
File.mkdirs() returns false when it fails to create the directories and even when they already exist.