### PR TITLE
Support for browsing  gogs and gitlab >= 8.0

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/GitLab.java
+++ b/src/main/java/hudson/plugins/git/browser/GitLab.java
@@ -8,12 +8,15 @@ import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.net.URL;
+
 import javax.servlet.ServletException;
+
 import org.kohsuke.stapler.QueryParameter;
 
 /**
@@ -73,7 +76,8 @@ public class GitLab extends GitRepositoryBrowser {
      * Creates a link to the commit diff.
      *
      * v &lt; 3.0: [GitLab URL]/commits/[Hash]#[File path]
-     * else:       [GitLab URL]/commit/[Hash]#[File path]
+     * v &lt; 8.0: [GitLab URL]/commit/[Hash]#[File path]
+     * else:       [GitLab URL]/commit/[Hash]#diff-[index]
      *
      * @param path
      * @return diff link
@@ -82,7 +86,14 @@ public class GitLab extends GitRepositoryBrowser {
     @Override
     public URL getDiffLink(Path path) throws IOException {
         final GitChangeSet changeSet = path.getChangeSet();
-        return new URL(getUrl(), calculatePrefix() + changeSet.getId() + "#" + path.getPath());
+        String filelink = null;
+        if(getVersion() < 8.0) {
+        	filelink = "#" + path.getPath().toString();
+        } else
+        {
+        	filelink = "#diff-" + String.valueOf(getIndexOfPath(path));
+        }
+        return new URL(getUrl(), calculatePrefix() + changeSet.getId() + filelink);
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/browser/GitList.java
+++ b/src/main/java/hudson/plugins/git/browser/GitList.java
@@ -13,6 +13,7 @@ import hudson.plugins.git.GitChangeSet.Path;
 import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import net.sf.json.JSONObject;
+
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -66,13 +67,8 @@ public class GitList extends GitRepositoryBrowser {
      * @throws IOException
      */
     private URL getDiffLinkRegardlessOfEditType(Path path) throws IOException {
-        final GitChangeSet changeSet = path.getChangeSet();
-        final ArrayList<String> affectedPaths = new ArrayList<String>(changeSet.getAffectedPaths());
-        Collections.sort(affectedPaths);
-        final String pathAsString = path.getPath();
-        final int i = Collections.binarySearch(affectedPaths, pathAsString);
-        assert i >= 0;
-        return new URL(getChangeSetLink(changeSet), "#" + String.valueOf(i + 1)); //GitList diff indices begin at 1
+    	//GitList diff indices begin at 1
+        return new URL(getChangeSetLink(path.getChangeSet()), "#" + String.valueOf(getIndexOfPath(path) + 1));
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -4,7 +4,9 @@ import hudson.EnvVars;
 import hudson.model.Job;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitChangeSet;
+import hudson.plugins.git.GitChangeSet.Path;
 import hudson.scm.RepositoryBrowser;
+
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -82,6 +84,30 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
     protected boolean getNormalizeUrl() {
 		return true;
 	}
+    
+    /**
+     * Calculate the index of the given path in a
+     * sorted list of affected files
+     *
+     * @param path affected file path
+     * @return The index in the lexicographical sorted filelist
+     */
+    protected int getIndexOfPath(Path path) throws IOException {
+    	final String pathAsString = path.getPath();
+    	final GitChangeSet changeSet = path.getChangeSet();
+    	int i = 0;
+    	boolean found = false;
+    	for (String affected : changeSet.getAffectedPaths())
+    	{
+    		int res = affected.compareTo(pathAsString);
+    		if (res == 0)
+    			found = true;
+    		else if (res < 0)
+    			i++;
+    	}
+    	assert found;
+    	return found ? i : -1;
+    }
 
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/hudson/plugins/git/browser/GithubWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GithubWeb.java
@@ -13,6 +13,7 @@ import hudson.plugins.git.GitChangeSet.Path;
 import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import net.sf.json.JSONObject;
+
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -66,14 +67,8 @@ public class GithubWeb extends GitRepositoryBrowser {
      * @throws IOException
      */
     private URL getDiffLinkRegardlessOfEditType(Path path) throws IOException {
-        final GitChangeSet changeSet = path.getChangeSet();
-        final ArrayList<String> affectedPaths = new ArrayList<String>(changeSet.getAffectedPaths());
-        // Github seems to sort the output alphabetically by the path.
-        Collections.sort(affectedPaths);
-        final String pathAsString = path.getPath();
-        final int i = Collections.binarySearch(affectedPaths, pathAsString);
-        assert i >= 0;
-        return new URL(getChangeSetLink(changeSet), "#diff-" + String.valueOf(i));
+    	// Github seems to sort the output alphabetically by the path.
+        return new URL(getChangeSetLink(path.getChangeSet()), "#diff-" + String.valueOf(getIndexOfPath(path)));
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/browser/GogsGit.java
+++ b/src/main/java/hudson/plugins/git/browser/GogsGit.java
@@ -1,0 +1,115 @@
+package hudson.plugins.git.browser;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.plugins.git.GitChangeSet;
+import hudson.plugins.git.GitChangeSet.Path;
+import hudson.scm.EditType;
+import hudson.scm.RepositoryBrowser;
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * @author Norbert Lange (nolange79@gmail.com)
+ */
+public class GogsGit extends GitRepositoryBrowser {
+
+    private static final long serialVersionUID = 1L;
+
+    @DataBoundConstructor
+    public GogsGit(String repoUrl) {
+        super(repoUrl);
+    }
+
+    /**
+     * Creates a link to the change set
+     * http://[GogsGit URL]/commit/[commit]
+     *
+     * @param changeSet commit hash
+     * @return change set link
+     * @throws IOException
+     */
+    @Override
+    public URL getChangeSetLink(GitChangeSet changeSet) throws IOException {
+        URL url = getUrl();
+        return new URL(url, url.getPath() + "commit/" + changeSet.getId().toString());
+    }
+
+    /**
+     * Creates a link to the file diff.
+     * http://[GogsGit URL]/commit/[commit]#diff-N
+     *
+     * @param path affected file path
+     * @return diff link
+     * @throws IOException
+     */
+    @Override
+    public URL getDiffLink(Path path) throws IOException {
+        if (path.getEditType() != EditType.EDIT || path.getSrc() == null || path.getDst() == null
+                || path.getChangeSet().getParentCommit() == null) {
+            return null;
+        }
+        return getDiffLinkRegardlessOfEditType(path);
+    }
+
+    /**
+     * Return a diff link regardless of the edit type by appending the index of the pathname in the changeset.
+     *
+     * @param path
+     * @return url for differences
+     * @throws IOException
+     */
+    private URL getDiffLinkRegardlessOfEditType(Path path) throws IOException {
+    	final String pathAsString = path.getPath();
+    	final GitChangeSet changeSet = path.getChangeSet();
+    	int i = 0;
+    	boolean found = false;
+    	for (String affected : changeSet.getAffectedPaths())
+    	{
+    		int res = affected.compareTo(pathAsString);
+    		if (res == 0)
+    			found = true;
+    		else if (res < 0)
+    			i++;
+    	}
+    	assert found;
+        // Gogs diff indices begin at 1.
+        return new URL(getChangeSetLink(changeSet), "#diff-" + String.valueOf(i + 1));
+    }
+
+    /**
+     * Creates a link to the file.
+     * http://[GogsGit URL]/src/[commit]/[path]
+     * Deleted Files link to the parent version. No easy way to find it
+     *
+     * @param path affected file path
+     * @return diff link
+     * @throws IOException
+     */
+    @Override
+    public URL getFileLink(Path path) throws IOException {
+        if (path.getEditType().equals(EditType.DELETE)) {
+            return getDiffLinkRegardlessOfEditType(path);
+        } else {
+            URL url = getUrl();
+            return new URL(url, url.getPath() + "src/" + path.getChangeSet().getId().toString() + "/" + path.getPath());
+        }
+    }
+
+    @Extension
+    public static class GogsGitDescriptor extends Descriptor<RepositoryBrowser<?>> {
+        public String getDisplayName() {
+            return "gogs";
+        }
+
+        @Override
+        public GogsGit newInstance(StaplerRequest req, JSONObject jsonObject) throws FormException {
+            return req.bindJSON(GogsGit.class, jsonObject);
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/git/browser/GogsGit.java
+++ b/src/main/java/hudson/plugins/git/browser/GogsGit.java
@@ -65,21 +65,8 @@ public class GogsGit extends GitRepositoryBrowser {
      * @throws IOException
      */
     private URL getDiffLinkRegardlessOfEditType(Path path) throws IOException {
-    	final String pathAsString = path.getPath();
-    	final GitChangeSet changeSet = path.getChangeSet();
-    	int i = 0;
-    	boolean found = false;
-    	for (String affected : changeSet.getAffectedPaths())
-    	{
-    		int res = affected.compareTo(pathAsString);
-    		if (res == 0)
-    			found = true;
-    		else if (res < 0)
-    			i++;
-    	}
-    	assert found;
         // Gogs diff indices begin at 1.
-        return new URL(getChangeSetLink(changeSet), "#diff-" + String.valueOf(i + 1));
+        return new URL(getChangeSetLink(path.getChangeSet()), "#diff-" + String.valueOf(getIndexOfPath(path) + 1));
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/browser/KilnGit.java
+++ b/src/main/java/hudson/plugins/git/browser/KilnGit.java
@@ -8,6 +8,7 @@ import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import hudson.scm.browsers.QueryBuilder;
 import net.sf.json.JSONObject;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -72,11 +73,7 @@ public class KilnGit extends GitRepositoryBrowser {
      */
     private URL getDiffLinkRegardlessOfEditType(Path path) throws IOException {
         final GitChangeSet changeSet = path.getChangeSet();
-        final ArrayList<String> affectedPaths = new ArrayList<String>(changeSet.getAffectedPaths());
-        // Kiln seems to sort the output alphabetically by the path.
-        Collections.sort(affectedPaths);
-        final String pathAsString = path.getPath();
-        final int i = Collections.binarySearch(affectedPaths, pathAsString);
+        final int i = getIndexOfPath(path);
         if (i >= 0) {
             // Kiln diff indices begin at 1.
             URL url = getUrl();

--- a/src/test/java/hudson/plugins/git/browser/GitLabTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitLabTest.java
@@ -25,6 +25,7 @@ public class GitLabTest {
     private final GitLab gitlab51 = new GitLab(GITLAB_URL, "5.1");
     private final GitLab gitlab711 = new GitLab(GITLAB_URL, "7.11");
     private final GitLab gitlab7114ee = new GitLab(GITLAB_URL, "7.11.4.ee");
+    private final GitLab gitlab80 = new GitLab(GITLAB_URL, "8.0");
     private final GitLab gitlabDefault = new GitLab(GITLAB_URL, "");
     private final GitLab gitlabNaN = new GitLab(GITLAB_URL, "NaN");
     private final GitLab gitlabInfinity = new GitLab(GITLAB_URL, "Infinity");
@@ -85,18 +86,23 @@ public class GitLabTest {
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
         final Path modified1 = pathMap.get(fileName);
-        final String expectedURL = GITLAB_URL + "commit/" + SHA1 + "#" + fileName;
-        assertEquals(expectedURL.replace("commit/", "commits/"), gitlab29.getDiffLink(modified1).toString());
-        assertEquals(expectedURL, gitlab42.getDiffLink(modified1).toString());
-        assertEquals(expectedURL, gitlab50.getDiffLink(modified1).toString());
-        assertEquals(expectedURL, gitlab51.getDiffLink(modified1).toString());
-        assertEquals(expectedURL, gitlab711.getDiffLink(modified1).toString());
-        assertEquals(expectedURL, gitlab7114ee.getDiffLink(modified1).toString());
-        assertEquals(expectedURL, gitlabDefault.getDiffLink(modified1).toString());
-        assertEquals(expectedURL, gitlabNaN.getDiffLink(modified1).toString());
-        assertEquals(expectedURL, gitlabInfinity.getDiffLink(modified1).toString());
-        assertEquals(expectedURL.replace("commit/", "commits/"), gitlabNegative.getDiffLink(modified1).toString());
+        final String expectedPre30 = GITLAB_URL + "commits/" + SHA1 + "#" + fileName;
+        final String expectedPre80 = GITLAB_URL + "commit/" + SHA1 + "#" + fileName;
+        final String expectedURL = GITLAB_URL + "commit/" + SHA1 + "#" + "diff-0";
+        final String expectedDefault = expectedPre80;
+        assertEquals(expectedPre30, gitlabNegative.getDiffLink(modified1).toString());
+        assertEquals(expectedPre30, gitlab29.getDiffLink(modified1).toString());
+        assertEquals(expectedPre80, gitlab42.getDiffLink(modified1).toString());
+        assertEquals(expectedPre80, gitlab50.getDiffLink(modified1).toString());
+        assertEquals(expectedPre80, gitlab51.getDiffLink(modified1).toString());
+        assertEquals(expectedPre80, gitlab711.getDiffLink(modified1).toString());
+        assertEquals(expectedPre80, gitlab7114ee.getDiffLink(modified1).toString());
+        assertEquals(expectedURL, gitlab80.getDiffLink(modified1).toString());
         assertEquals(expectedURL, gitlabGreater.getDiffLink(modified1).toString());
+        
+        assertEquals(expectedDefault, gitlabDefault.getDiffLink(modified1).toString());
+        assertEquals(expectedDefault, gitlabNaN.getDiffLink(modified1).toString());
+        assertEquals(expectedDefault, gitlabInfinity.getDiffLink(modified1).toString());
     }
 
     /**
@@ -112,6 +118,7 @@ public class GitLabTest {
         final String expectedURL = GITLAB_URL + "blob/396fc230a3db05c427737aa5c2eb7856ba72b05d/" + fileName;
         final String expectedV29 = expectedURL.replace("blob/", "tree/");
         final String expectedV50 = GITLAB_URL + "396fc230a3db05c427737aa5c2eb7856ba72b05d/tree/" + fileName;
+        assertEquals(expectedV29, gitlabNegative.getFileLink(path).toString());
         assertEquals(expectedV29, gitlab29.getFileLink(path).toString());
         assertEquals(expectedV29, gitlab42.getFileLink(path).toString());
         assertEquals(expectedV50, gitlab50.getFileLink(path).toString());
@@ -121,7 +128,6 @@ public class GitLabTest {
         assertEquals(expectedURL, gitlabDefault.getFileLink(path).toString());
         assertEquals(expectedURL, gitlabNaN.getFileLink(path).toString());
         assertEquals(expectedURL, gitlabInfinity.getFileLink(path).toString());
-        assertEquals(expectedV29, gitlabNegative.getFileLink(path).toString());
         assertEquals(expectedURL, gitlabGreater.getFileLink(path).toString());
     }
 
@@ -134,19 +140,28 @@ public class GitLabTest {
     @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
-        final Path path = pathMap.get("bar");
-        final String expectedURL = GITLAB_URL + "commit/fc029da233f161c65eb06d0f1ed4f36ae81d1f4f#bar";
-        assertEquals(expectedURL.replace("commit/", "commits/"), gitlab29.getFileLink(path).toString());
-        assertEquals(expectedURL, gitlab42.getFileLink(path).toString());
-        assertEquals(expectedURL, gitlab50.getFileLink(path).toString());
-        assertEquals(expectedURL, gitlab51.getFileLink(path).toString());
-        assertEquals(expectedURL, gitlab711.getFileLink(path).toString());
-        assertEquals(expectedURL, gitlab7114ee.getFileLink(path).toString());
-        assertEquals(expectedURL, gitlabDefault.getFileLink(path).toString());
-        assertEquals(expectedURL, gitlabNaN.getFileLink(path).toString());
-        assertEquals(expectedURL, gitlabInfinity.getFileLink(path).toString());
-        assertEquals(expectedURL.replace("commit/", "commits/"), gitlabNegative.getFileLink(path).toString());
+        final String fileName = "bar";
+        final Path path = pathMap.get(fileName);
+        final String SHA1 = "fc029da233f161c65eb06d0f1ed4f36ae81d1f4f";
+        final String expectedPre30 = GITLAB_URL + "commits/" + SHA1 + "#" + fileName;
+        final String expectedPre80 = GITLAB_URL + "commit/" + SHA1 + "#" + fileName;
+        final String expectedURL = GITLAB_URL + "commit/" + SHA1 + "#" + "diff-0";
+        final String expectedDefault = expectedPre80;
+ 
+        assertEquals(expectedPre30, gitlabNegative.getFileLink(path).toString());
+        assertEquals(expectedPre30, gitlab29.getFileLink(path).toString());
+        assertEquals(expectedPre80, gitlab42.getFileLink(path).toString());
+        assertEquals(expectedPre80, gitlab50.getFileLink(path).toString());
+        assertEquals(expectedPre80, gitlab51.getFileLink(path).toString());
+        assertEquals(expectedPre80, gitlab711.getFileLink(path).toString());
+        assertEquals(expectedPre80, gitlab7114ee.getFileLink(path).toString());
+        assertEquals(expectedURL, gitlab80.getFileLink(path).toString());
         assertEquals(expectedURL, gitlabGreater.getFileLink(path).toString());
+        
+        assertEquals(expectedDefault, gitlabDefault.getFileLink(path).toString());
+        assertEquals(expectedDefault, gitlabNaN.getFileLink(path).toString());
+        assertEquals(expectedDefault, gitlabInfinity.getFileLink(path).toString());
+
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {

--- a/src/test/java/hudson/plugins/git/browser/GogsGitTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GogsGitTest.java
@@ -1,0 +1,123 @@
+package hudson.plugins.git.browser;
+
+import hudson.model.Run;
+import hudson.plugins.git.GitChangeLogParser;
+import hudson.plugins.git.GitChangeSet;
+import hudson.plugins.git.GitChangeSet.Path;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import org.xml.sax.SAXException;
+
+/**
+ * @author Norbert Lange (nolange79@gmail.com)
+ */
+public class GogsGitTest {
+
+    private static final String GOGS_URL = "http://USER.kilnhg.com/Code/PROJECT/Group/REPO";
+    private final GogsGit GogsGit = new GogsGit(GOGS_URL);
+
+
+    /**
+     * Test method for {@link hudson.plugins.git.browser.GogsGit#getUrl()}.
+     * @throws MalformedURLException
+     */
+    @Test
+    public void testGetUrl() throws IOException {
+        assertEquals(String.valueOf(GogsGit.getUrl()), GOGS_URL  + "/");
+    }
+
+    /**
+     * Test method for {@link hudson.plugins.git.browser.GogsGit#getUrl()}.
+     * @throws MalformedURLException
+     */
+    @Test
+    public void testGetUrlForRepoWithTrailingSlash() throws IOException {
+        assertEquals(String.valueOf(new GogsGit(GOGS_URL + "/").getUrl()), GOGS_URL  + "/");
+    }
+
+    /**
+     * Test method for {@link hudson.plugins.git.browser.GogsGit#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
+     * @throws SAXException
+     * @throws IOException
+     */
+    @Test
+    public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
+        final URL changeSetLink = GogsGit.getChangeSetLink(createChangeSet("rawchangelog"));
+        assertEquals(GOGS_URL + "/commit/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
+    }
+
+    /**
+     * Test method for {@link hudson.plugins.git.browser.GogsGit#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * @throws SAXException
+     * @throws IOException
+     */
+    @Test
+    public void testGetDiffLinkPath() throws IOException, SAXException {
+        final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
+        final Path path1 = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
+        assertEquals(GOGS_URL + "/commit/396fc230a3db05c427737aa5c2eb7856ba72b05d#diff-1", GogsGit.getDiffLink(path1).toString());
+        final Path path2 = pathMap.get("src/test/java/hudson/plugins/git/browser/GithubWebTest.java");
+        assertEquals(GOGS_URL + "/commit/396fc230a3db05c427737aa5c2eb7856ba72b05d#diff-2", GogsGit.getDiffLink(path2).toString());
+        final Path path3 = pathMap.get("src/test/resources/hudson/plugins/git/browser/rawchangelog-with-deleted-file");
+        assertNull("Do not return a diff link for added files.", GogsGit.getDiffLink(path3));
+    }
+
+    /**
+     * Test method for {@link hudson.plugins.git.browser.GogsGit#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * @throws SAXException
+     * @throws IOException
+     */
+    @Test
+    public void testGetFileLinkPath() throws IOException, SAXException {
+        final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
+        final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
+        final URL fileLink = GogsGit.getFileLink(path);
+        assertEquals(GOGS_URL  + "/src/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/main/java/hudson/plugins/git/browser/GithubWeb.java", String.valueOf(fileLink));
+    }
+
+    /**
+     * Test method for {@link hudson.plugins.git.browser.GogsGit#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * @throws SAXException
+     * @throws IOException
+     */
+    @Test
+    public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
+        final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
+        final Path path = pathMap.get("bar");
+        final URL fileLink = GogsGit.getFileLink(path);
+        assertEquals(GOGS_URL + "/commit/fc029da233f161c65eb06d0f1ed4f36ae81d1f4f#diff-1", String.valueOf(fileLink));
+    }
+
+    private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
+        final GitChangeLogParser logParser = new GitChangeLogParser(false);
+        final List<GitChangeSet> changeSetList = logParser.parse(GogsGitTest.class.getResourceAsStream(rawchangelogpath));
+        return changeSetList.get(0);
+    }
+
+    /**
+     * @param changelog
+     * @return
+     * @throws IOException
+     * @throws SAXException
+     */
+    private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
+        final HashMap<String, Path> pathMap = new HashMap<String, Path>();
+        final Collection<Path> changeSet = createChangeSet(changelog).getPaths();
+        for (final Path path : changeSet) {
+            pathMap.put(path.getPath(), path);
+        }
+        return pathMap;
+    }
+
+
+}


### PR DESCRIPTION
Hello,

these commits add support for gogs (https://gogs.io), also they fix the diff links for current Gitlab versions. I assume 8.0 introduced the change, but I only verified this with 8.0... the change might actually have happened earlier.

Also, shouldnt the default version be increased to a supported version? I already modified the Tests so this change could be done easily