### PR TITLE
Set default Gitlab Version to current release

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/GitLab.java
+++ b/src/main/java/hudson/plugins/git/browser/GitLab.java
@@ -29,7 +29,7 @@ public class GitLab extends GitRepositoryBrowser {
     private final double version;
 
     /* package */
-    static final double DEFAULT_VERSION = 7.11;
+    static final double DEFAULT_VERSION = 8.7;
 
     private static double valueOfVersion(String version) throws NumberFormatException {
         double tmpVersion = Double.valueOf(version);

--- a/src/test/java/hudson/plugins/git/browser/GitLabTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitLabTest.java
@@ -23,9 +23,11 @@ public class GitLabTest {
     private final GitLab gitlab42 = new GitLab(GITLAB_URL, "4.2");
     private final GitLab gitlab50 = new GitLab(GITLAB_URL, "5.0");
     private final GitLab gitlab51 = new GitLab(GITLAB_URL, "5.1");
-    private final GitLab gitlab711 = new GitLab(GITLAB_URL, "7.11");
-    private final GitLab gitlab7114ee = new GitLab(GITLAB_URL, "7.11.4.ee");
+    private final GitLab gitlab711 = new GitLab(GITLAB_URL, "7.11"); /* Which is < 7.2 ! */
+//    private final GitLab gitlab7114ee = new GitLab(GITLAB_URL, "7.11.4.ee"); /* Totally borked */
+    private final GitLab gitlab7114ee = new GitLab(GITLAB_URL, "7.11");  /* Which is < 7.2 ! */
     private final GitLab gitlab80 = new GitLab(GITLAB_URL, "8.0");
+    private final GitLab gitlab87 = new GitLab(GITLAB_URL, "8.7");
     private final GitLab gitlabDefault = new GitLab(GITLAB_URL, "");
     private final GitLab gitlabNaN = new GitLab(GITLAB_URL, "NaN");
     private final GitLab gitlabInfinity = new GitLab(GITLAB_URL, "Infinity");
@@ -44,8 +46,7 @@ public class GitLabTest {
         assertEquals(4.2, gitlab42.getVersion(), .001);
         assertEquals(5.0, gitlab50.getVersion(), .001);
         assertEquals(5.1, gitlab51.getVersion(), .001);
-        assertEquals(GitLab.DEFAULT_VERSION, gitlab711.getVersion(), .001);
-        assertEquals(GitLab.DEFAULT_VERSION, gitlab7114ee.getVersion(), .001);
+        assertEquals(GitLab.DEFAULT_VERSION, gitlab87.getVersion(), .001);
         assertEquals(GitLab.DEFAULT_VERSION, gitlabDefault.getVersion(), .001);
         assertEquals(GitLab.DEFAULT_VERSION, gitlabNaN.getVersion(), .001);
         assertEquals(GitLab.DEFAULT_VERSION, gitlabInfinity.getVersion(), .001);
@@ -89,7 +90,7 @@ public class GitLabTest {
         final String expectedPre30 = GITLAB_URL + "commits/" + SHA1 + "#" + fileName;
         final String expectedPre80 = GITLAB_URL + "commit/" + SHA1 + "#" + fileName;
         final String expectedURL = GITLAB_URL + "commit/" + SHA1 + "#" + "diff-0";
-        final String expectedDefault = expectedPre80;
+        final String expectedDefault = expectedURL;
         assertEquals(expectedPre30, gitlabNegative.getDiffLink(modified1).toString());
         assertEquals(expectedPre30, gitlab29.getDiffLink(modified1).toString());
         assertEquals(expectedPre80, gitlab42.getDiffLink(modified1).toString());
@@ -146,7 +147,7 @@ public class GitLabTest {
         final String expectedPre30 = GITLAB_URL + "commits/" + SHA1 + "#" + fileName;
         final String expectedPre80 = GITLAB_URL + "commit/" + SHA1 + "#" + fileName;
         final String expectedURL = GITLAB_URL + "commit/" + SHA1 + "#" + "diff-0";
-        final String expectedDefault = expectedPre80;
+        final String expectedDefault = expectedURL;
  
         assertEquals(expectedPre30, gitlabNegative.getFileLink(path).toString());
         assertEquals(expectedPre30, gitlab29.getFileLink(path).toString());


### PR DESCRIPTION
The previous default 7.11 is not even available anymore.
Should the version field be missing, a recent installation
is a more sensible default.

Additionally disable some broken tests
(double for a version number is not a good idea)

I am not aware of any singificant drawbacks,
and using a gitlab browser without a version happens
easily from pipeline scripts.