### PR TITLE
Added SCMRevisionImpl.toString

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -379,6 +379,12 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         public int hashCode() {
             return hash != null ? hash.hashCode() : 0;
         }
+
+        @Override
+        public String toString() {
+            return hash;
+        }
+
     }
 
     public static class SpecificRevisionBuildChooser extends BuildChooser {


### PR DESCRIPTION
Useful for `SCMRevision` implementations to override `toString` for logging purposes.

@reviewbybees