### PR TITLE
Deleting obsolete encodeAllInputs function

### DIFF
--- a/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/config.jelly
+++ b/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/config.jelly
@@ -2,10 +2,6 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="Name of repository" field="compareRemote">
     <f:textbox id="git.compareRemote" clazz="required" />
-    <!-- TODO add the check url. Note that we cannot rely on the repo.name tag to be at the root of the form -->
-    <!--		             checkUrl="'${rootURL}/scm/GitSCM/gitRemoteNameCheck?isMerge=true&amp;value='+escape(this.value)
-                     +encodeAllInputs('&amp;', this.form, 'repo.name')
-                     +encodeAllInputs('&amp;', this.form, 'repo.url')"/ -->
   </f:entry>
   <f:entry title="Name of branch" field="compareTarget">
     <f:textbox id="git.compareTarget" clazz="required"/>

--- a/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
@@ -1,20 +1,5 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <script><![CDATA[
-    function encodeAllInputs(sep, form, field) {
-        var inputs = Form.getInputs(form, null, field);
-        if (inputs.length == 0)
-            return "";
-
-        var rv = sep;
-        for (var i = 0; i < inputs.length; ++i) {
-            if (i != 0)
-                rv += "&";
-            rv += field+"="+encode(inputs[i].value);
-        }
-        return rv;
-    }
-    ]]></script>
     <f:entry field="pushOnlyIfSuccess"
              title="${%Push Only If Build Succeeds}">
       <f:checkbox />

--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -1,22 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-    <script><![CDATA[
-    function encodeAllInputs(sep, form, field) {
-        var inputs = Form.getInputs(form, null, field);
-        if (inputs.length == 0)
-            return "";
-
-        var rv = sep;
-        for (var i = 0; i < inputs.length; ++i) {
-            if (i != 0)
-                rv += "&";
-            rv += field+"="+encode(inputs[i].value);
-        }
-        return rv;
-    }
-    ]]></script>
-
     <f:entry title="Repositories" field="userRemoteConfigs" >
         <f:repeatableProperty field="userRemoteConfigs" minimum="1" noAddButton="true"/>
     </f:entry>

--- a/src/main/resources/hudson/plugins/git/UserMergeOptions/config.jelly
+++ b/src/main/resources/hudson/plugins/git/UserMergeOptions/config.jelly
@@ -2,10 +2,6 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="Name of repository" field="mergeRemote">
     <f:textbox id="git.mergeRemote" />
-    <!-- TODO add the check url. Note that we cannot rely on the repo.name tag to be at the root of the form -->
-    <!--		             checkUrl="'${rootURL}/scm/GitSCM/gitRemoteNameCheck?isMerge=true&amp;value='+escape(this.value)
-                     +encodeAllInputs('&amp;', this.form, 'repo.name')
-                     +encodeAllInputs('&amp;', this.form, 'repo.url')"/ -->
   </f:entry>
   <f:entry title="${%Branch to merge to}" field="mergeTarget">
     <f:textbox id="git.mergeTarget" clazz="required"/>


### PR DESCRIPTION
As demonstrated in https://github.com/jenkinsci/workflow-cps-plugin/pull/7, newer versions of HtmlUnit (which the 2.x plugin POM will pick up; cf. #390) will go berserk if they encounter a `<script>` directly inside `<table>` (i.e., between `<tr>`s). Always keep script inside `<td>` if you need it. This patch allows some `configRoundtrip` calls to succeed when using `GitSCM`.

In this case, the `encodeAllInputs` function seems to have not been used since 2.0: 61bd032828366df80589dd2f2aa22f0709c8915a and 2d37646c7fbac1687779ad62ffd4f1a8b0aae304 deleted some usages but not the function itself. Anyway modern form binding does not require plugins to write JavaScript hacks like this. Just use `field` attributes, `FormValidation` with `@QueryParameter` and `@RelativePath`.

@reviewbybees