### PR TITLE
Check EXTENDED_READ, not CONFIGURE, on a context

### DIFF
--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -131,7 +131,9 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
                                          @QueryParameter String credentialsId,
                                          @QueryParameter String value) throws IOException, InterruptedException {
 
-            if (project == null || !project.hasPermission(Item.EXTENDED_READ)) {
+            // Normally this permission is hidden and implied by Item.CONFIGURE, so from a view-only form you will not be able to use this check.
+            // (Under certain circumstances being granted only USE_OWN might suffice, though this presumes a fix of JENKINS-31870.)
+            if (project == null || !project.hasPermission(CredentialsProvider.USE_ITEM)) {
                 return FormValidation.ok();
             }
 

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -76,7 +76,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
 
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item project,
                                                      @QueryParameter String url) {
-            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
+            if (project == null || !project.hasPermission(Item.EXTENDED_READ)) {
                 return new StandardListBoxModel();
             }
             return new StandardListBoxModel()
@@ -93,7 +93,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
         public FormValidation doCheckCredentialsId(@AncestorInPath Item project,
                                                    @QueryParameter String url,
                                                    @QueryParameter String value) {
-            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
+            if (project == null || !project.hasPermission(Item.EXTENDED_READ)) {
                 return FormValidation.ok();
             }
 
@@ -131,7 +131,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
                                          @QueryParameter String credentialsId,
                                          @QueryParameter String value) throws IOException, InterruptedException {
 
-            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
+            if (project == null || !project.hasPermission(Item.EXTENDED_READ)) {
                 return FormValidation.ok();
             }
 

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -134,7 +134,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
                                          @QueryParameter String value) throws IOException, InterruptedException {
 
             // Normally this permission is hidden and implied by Item.CONFIGURE, so from a view-only form you will not be able to use this check.
-            // (Under certain circumstances being granted only USE_OWN might suffice, though this presumes a fix of JENKINS-31870.)
+            // (TODO under certain circumstances being granted only USE_OWN might suffice, though this presumes a fix of JENKINS-31870.)
             if (item == null || !item.hasPermission(CredentialsProvider.USE_ITEM)) {
                 return FormValidation.ok();
             }

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -124,7 +124,7 @@ public class GitSCMSource extends AbstractGitSCMSource {
 
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath SCMSourceOwner context,
                                                      @QueryParameter String remote) {
-            if (context == null || !context.hasPermission(Item.CONFIGURE)) {
+            if (context == null || !context.hasPermission(Item.EXTENDED_READ)) {
                 return new ListBoxModel();
             }
             StandardListBoxModel result = new StandardListBoxModel();


### PR DESCRIPTION
Needed for https://github.com/jenkinsci/workflow-cps-plugin/pull/12 to work well with multibranch, where the branch project is view-only but you may still want to work with configuration forms. The symptom is that _Credentials_ pulldowns are empty even when there are valid credentials available for the branch project.

@reviewbybees esp. @stephenc