### PR TITLE
[Jenkins 33445] Allow tags & remote branches

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -358,6 +358,16 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return (gitDescriptor != null && gitDescriptor.isCreateAccountBasedOnEmail());
     }
 
+    public boolean isShowRemoteBranches() {
+        DescriptorImpl gitDescriptor = getDescriptor();
+        return (gitDescriptor != null && gitDescriptor.isShowRemoteBranches());
+    }
+
+    public boolean isShowTags() {
+        DescriptorImpl gitDescriptor = getDescriptor();
+        return (gitDescriptor != null && gitDescriptor.isShowTags());
+    }
+
     public BuildChooser getBuildChooser() {
         BuildChooser bc;
 
@@ -1343,6 +1353,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         private String globalConfigName;
         private String globalConfigEmail;
         private boolean createAccountBasedOnEmail;
+        private boolean showRemoteBranches;
+        private boolean showTags;
 //        private GitClientType defaultClientType = GitClientType.GITCLI;
 
         public DescriptorImpl() {
@@ -1432,6 +1444,22 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         public void setCreateAccountBasedOnEmail(boolean createAccountBasedOnEmail) {
             this.createAccountBasedOnEmail = createAccountBasedOnEmail;
+        }
+
+        public boolean isShowRemoteBranches() {
+            return showRemoteBranches;
+        }
+
+        public void setShowRemoteBranches(boolean showRemoteBranches) {
+            this.showRemoteBranches = showRemoteBranches;
+        }
+
+        public boolean isShowTags() {
+            return showTags;
+        }
+
+        public void setShowTags(boolean showTags) {
+            this.showTags = showTags;
         }
 
         /**

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -303,7 +303,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                         }
 
                         if (gitObject instanceof Tag) {
-                            ObjectId commit = client.revList(gitObject.getName()).get(0);
+                            ObjectId commit = client.revList(gitObject.getName(), 1).get(0);
                             String temp = commit.toString();
                             String sha1 = temp.substring(temp.indexOf("[") + 1, temp.indexOf("]"));
                             /* Recreate the Tag with the commit

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -34,6 +34,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.model.Descriptor;
 import hudson.model.ParameterValue;
@@ -41,6 +42,7 @@ import hudson.model.Queue;
 import hudson.model.queue.Tasks;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.GitSCM.DescriptorImpl;
 import hudson.plugins.git.browser.GitRepositoryBrowser;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.plugins.git.extensions.GitSCMExtension;
@@ -82,6 +84,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.LinkedList;
 import java.util.logging.Logger;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -218,6 +221,16 @@ public class GitSCMSource extends AbstractGitSCMSource {
 
         for (String rawRefSpec : rawRefSpecs.split(" ")) {
             refSpecs.add(new RefSpec(rawRefSpec));
+        }
+
+        Hudson hudson = Hudson.getInstance();
+        if (hudson == null) {
+            return refSpecs;
+        }
+
+        hudson.plugins.git.GitSCM.DescriptorImpl descriptor = (hudson.plugins.git.GitSCM.DescriptorImpl) hudson.getDescriptor(GitSCM.class);
+        if (descriptor.isShowRemoteBranches()) {
+            refSpecs.add(new RefSpec("+refs/remotes/*:refs/remotes/*"));
         }
 
         return refSpecs;

--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -11,6 +11,12 @@
     <f:entry title="${%Create new accounts base on author/committer's email}" field="createAccountBasedOnEmail">
            <f:checkbox name="createAccountBasedOnEmail" checked="${descriptor.createAccountBasedOnEmail}"/>
     </f:entry>
+    <f:entry title="Show remote branches in SCMSource" field="showRemoteBranches">
+           <f:checkbox name="showRemoteBranches" checked="${descriptor.showRemoteBranches}"/>
+    </f:entry>
+    <f:entry title="Show tags in SCMSource" field="showTags">
+           <f:checkbox name="showTags" checked="${descriptor.showTags}"/>
+    </f:entry>
     <!--
     <f:entry title="${%Default git client implementation}" field="defaultClientType">
         <select>


### PR DESCRIPTION
This pull request adds support for optionally returning tags and remote branches from the specified repository, in addition to the local branches.

This allows an aggregate repository to be created, with remotes pointing to a number of other repositories, and have each branch under them made available for testing within a single (multibranch) job.

This behavior is off by default, and configurable via the Git global settings.


Use case:
A single Jenkins job that feeds from an aggregate repository with remotes for upstream & local development repositories. Upstream releases & stable branches need to be built & tested, as do all local development branches.