### PR TITLE
[JENKINS-34540] Add build parameters to environment variables to allow checkout specified tag

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1088,6 +1088,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         EnvVars environment = build.getEnvironment(listener);
+        for (ParametersAction action : build.getActions(ParametersAction.class)) {
+            for (ParameterValue param: action.getParameters()) {
+                param.buildEnvironment(build, environment);
+            }
+        }
+
         GitClient git = createClient(listener, environment, build, workspace);
 
         for (GitSCMExtension ext : extensions) {


### PR DESCRIPTION
I try to create a "Pipeline" with string parameter "TAG_NAME" and "Pipeline script from SCM" with "Branch Specifier" = "refs/tags/${TAG_NAME}" (I attached job file to this issue).
But this don't work (looks like TAG_NAME is not pass to environment variable) with error like:
```
Started by user Artem V. Navrotskiy
 > git rev-parse --is-inside-work-tree # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url https://github.com/bozaro/octobuild.git # timeout=10
Fetching upstream changes from https://github.com/bozaro/octobuild.git
 > git --version # timeout=10
using .gitcredentials to set credentials
 > git config --local credential.username bozaro # timeout=10
 > git config --local credential.helper store --file=/tmp/git5054038889952082299.credentials # timeout=10
 > git -c core.askpass=true fetch --tags --progress https://github.com/bozaro/octobuild.git +refs/heads/*:refs/remotes/origin/*
 > git config --local --remove-section credential # timeout=10
 > git rev-parse refs/tags/${TAG_NAME}^{commit} # timeout=10
 > git rev-parse refs/remotes/origin/refs/tags/${TAG_NAME}^{commit} # timeout=10
 > git rev-parse refs/tags/${TAG_NAME}^{commit} # timeout=10
ERROR: Couldn't find any revision to build. Verify the repository and branch configuration for this job.
Finished: FAILURE
```

But on old-style "Freestyle Build Job" I can use parameters in branch specifier.
Also, this issue can not be work around by Jenkinsfile content.