### PR TITLE
Fix environment contributors not firing during polling + Test (and fix FindBugs where it triggered on the files)

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -625,7 +625,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
             EnvVars environment = new EnvVars();
             if (project instanceof AbstractProject) {
-                GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener, false);
+                environment = GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener, false);
             } else {
                 try {
                     environment = project.getEnvironment(null, listener);

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -911,7 +911,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return null;
     }
 
-    @SuppressFBWarnings(value="SE_BAD_FIELD", justification = "If your project or run aren't serializable you've got bigger problems")
+    @SuppressFBWarnings(value="SE_BAD_FIELD",
+            justification = "If your project or run can't at least be marshalled by XStream then you've got bigger problems.")
     /*package*/ static class BuildChooserContextImpl implements BuildChooserContext, Serializable {
         final Job project;
         final Run build;

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -691,7 +691,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         final EnvVars environment = project instanceof AbstractProject ? GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener) : new EnvVars();
-        FilePath workingDirectory = workingDirectory(project, workspace, environment, listener);
+        FilePath workingDirectory = workingDirectory(project,workspace,environment,listener);
 
         // (Re)build if the working directory doesn't exist
         if (workingDirectory == null || !workingDirectory.exists()) {

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -623,7 +623,16 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         if (!requiresWorkspaceForPolling(pollEnv)) {
 
-            final EnvVars environment = project instanceof AbstractProject ? GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener, false) : project.getEnvironment(null, listener);;
+            EnvVars environment = new EnvVars();
+            if (project instanceof AbstractProject) {
+                GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener, false);
+            } else {
+                try {
+                    environment = project.getEnvironment(null, listener);
+                } catch (Exception ex) {
+                    LOGGER.log(Level.WARNING, "Exception in getting polling environment", ex);
+                }
+            }
 
             GitClient git = createClient(listener, environment, project, Jenkins.getInstance(), null);
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -6,8 +6,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.google.common.collect.Iterables;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.*;
 import hudson.*;
 import hudson.init.Initializer;
 import hudson.matrix.MatrixBuild;
@@ -125,6 +124,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     /**
      * All the configured extensions attached to this.
      */
+    @SuppressFBWarnings(value = "SE_BAD_FIELD",
+            justification = "DescribableList extends PersistedList, if we can't marshall that, we are in trouble.")
     private DescribableList<GitSCMExtension,GitSCMExtensionDescriptor> extensions;
 
     public Collection<SubmoduleConfig> getSubmoduleCfg() {
@@ -848,9 +849,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
     }
 
+    @SuppressFBWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Plugin depends on git-client which always provides implementations")
     public GitTool resolveGitTool(TaskListener listener) {
         if (gitTool == null) return GitTool.getDefaultInstallation();
-        GitTool git =  Jenkins.getInstance().getDescriptorByType(GitTool.DescriptorImpl.class).getInstallation(gitTool);
+        GitTool git =  Jenkins.getActiveInstance().getDescriptorByType(GitTool.DescriptorImpl.class).getInstallation(gitTool);
         if (git == null) {
             listener.getLogger().println("selected Git installation does not exists. Using Default");
             git = GitTool.getDefaultInstallation();
@@ -909,6 +911,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return null;
     }
 
+    @SuppressFBWarnings(value="SE_BAD_FIELD", justification = "If your project or run aren't serializable you've got bigger problems")
     /*package*/ static class BuildChooserContextImpl implements BuildChooserContext, Serializable {
         final Job project;
         final Run build;
@@ -1375,16 +1378,18 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             return GitSCMExtensionDescriptor.all();
         }
 
+        @SuppressFBWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Plugin depends on git-client which always provides implementations")
         public boolean showGitToolOptions() {
-            return Jenkins.getInstance().getDescriptorByType(GitTool.DescriptorImpl.class).getInstallations().length>1;
+            return Jenkins.getActiveInstance().getDescriptorByType(GitTool.DescriptorImpl.class).getInstallations().length>1;
         }
 
         /**
          * Lists available toolinstallations.
          * @return  list of available git tools
          */
+        @SuppressFBWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Plugin depends on git-client which always provides implementations")
         public List<GitTool> getGitTools() {
-            GitTool[] gitToolInstallations = Hudson.getInstance().getDescriptorByType(GitTool.DescriptorImpl.class).getInstallations();
+            GitTool[] gitToolInstallations = Hudson.getActiveInstance().getDescriptorByType(GitTool.DescriptorImpl.class).getInstallations();
             return Arrays.asList(gitToolInstallations);
         }
 
@@ -1771,6 +1776,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
      * Set to true to enable more logging to build's {@link TaskListener}.
      * Used by various classes in this package.
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Helpful to set at runtime")
     public static boolean VERBOSE = Boolean.getBoolean(GitSCM.class.getName() + ".verbose");
 
     /**

--- a/src/main/java/hudson/plugins/git/SubmoduleCombinator.java
+++ b/src/main/java/hudson/plugins/git/SubmoduleCombinator.java
@@ -170,8 +170,11 @@ public class SubmoduleCombinator {
 
         for (IndexEntry entry : entries) {
             Revision b = null;
-            for (IndexEntry e : item.keySet()) {
-                if (e.getFile().equals(entry.getFile())) b = item.get(e);
+            for (Map.Entry<IndexEntry, Revision> revisionEntry : item.entrySet()) {
+                IndexEntry e = revisionEntry.getKey();
+                if (e.getFile().equals(entry.getFile())) {
+                    b = revisionEntry.getValue();
+                }
             }
 
             if (b == null) return -1;

--- a/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
@@ -90,7 +90,7 @@ public class FisheyeGitRepositoryBrowser extends GitRepositoryBrowser {
 				return FormValidation.errorWithMarkup("The URL should end like <tt>.../browse/foobar/</tt>");
 
 			// Connect to URL and check content only if we have admin permission
-			if (!Hudson.getInstance().hasPermission(Hudson.ADMINISTER))
+			if (!Hudson.getActiveInstance().hasPermission(Hudson.ADMINISTER))
 				return FormValidation.ok();
 
 			final String finalValue = value;

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git.browser;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.model.Job;
 import hudson.model.TaskListener;
@@ -92,6 +93,7 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
      * @param path affected file path
      * @return The index in the lexicographical sorted filelist
      */
+    @SuppressFBWarnings(value="UC_USELESS_CONDITION", justification = "Assertion may be turned off by cmdline flag")
     protected int getIndexOfPath(Path path) throws IOException {
     	final String pathAsString = path.getPath();
     	final GitChangeSet changeSet = path.getChangeSet();

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -21,6 +21,7 @@ import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Map;
 import org.jenkinsci.plugins.gitclient.CheckoutCommand;
 import org.jenkinsci.plugins.gitclient.CloneCommand;
@@ -34,7 +35,7 @@ import org.jenkinsci.plugins.gitclient.MergeCommand;
  * @author Kohsuke Kawaguchi
  * @since 2.0.0
  */
-public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExtension> {
+public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExtension> implements Serializable {
 
     /**
      * @return <code>true</code> when this extension has a requirement to get a workspace during polling,

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -35,7 +35,7 @@ import org.jenkinsci.plugins.gitclient.MergeCommand;
  * @author Kohsuke Kawaguchi
  * @since 2.0.0
  */
-public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExtension> implements Serializable {
+public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExtension> {
 
     /**
      * @return <code>true</code> when this extension has a requirement to get a workspace during polling,

--- a/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
@@ -23,6 +23,9 @@ import java.util.regex.PatternSyntaxException;
  * @author Kanstantsin Shautsou
  */
 public class MessageExclusion extends GitSCMExtension {
+
+	private static final long serialVersionUID = 1L;
+
 	/**
 	 * Java Pattern for matching messages to be ignored.
 	 */

--- a/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
@@ -24,8 +24,6 @@ import java.util.regex.PatternSyntaxException;
  */
 public class MessageExclusion extends GitSCMExtension {
 
-	private static final long serialVersionUID = 1L;
-
 	/**
 	 * Java Pattern for matching messages to be ignored.
 	 */

--- a/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
@@ -23,7 +23,6 @@ import java.util.regex.PatternSyntaxException;
  * @author Kanstantsin Shautsou
  */
 public class MessageExclusion extends GitSCMExtension {
-
 	/**
 	 * Java Pattern for matching messages to be ignored.
 	 */

--- a/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
@@ -26,6 +26,8 @@ import java.util.regex.Pattern;
  * @author Kohsuke Kawaguchi
  */
 public class PathRestriction extends GitSCMExtension {
+    private static final long serialVersionUID = 1L;
+
     private final String includedRegions;
     private final String excludedRegions;
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
  * @author Kohsuke Kawaguchi
  */
 public class PathRestriction extends GitSCMExtension {
-    private static final long serialVersionUID = 1L;
 
     private final String includedRegions;
     private final String excludedRegions;

--- a/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPath.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPath.java
@@ -55,7 +55,7 @@ public class SparseCheckoutPath extends AbstractDescribableImpl<SparseCheckoutPa
 
     public Descriptor<SparseCheckoutPath> getDescriptor()
     {
-        return Hudson.getInstance().getDescriptor(getClass());
+        return Hudson.getActiveInstance().getDescriptor(getClass());
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/util/BuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooser.java
@@ -139,14 +139,14 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
     }
 
     public BuildChooserDescriptor getDescriptor() {
-        return (BuildChooserDescriptor)Hudson.getInstance().getDescriptorOrDie(getClass());
+        return (BuildChooserDescriptor)Hudson.getActiveInstance().getDescriptorOrDie(getClass());
     }
 
     /**
      * All the registered build choosers.
      */
     public static DescriptorExtensionList<BuildChooser,BuildChooserDescriptor> all() {
-        return Hudson.getInstance()
+        return Hudson.getActiveInstance()
                .<BuildChooser,BuildChooserDescriptor>getDescriptorList(BuildChooser.class);
     }
 

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -1,6 +1,7 @@
 package hudson.plugins.git.util;
 
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -27,6 +28,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class GitUtils implements Serializable {
+    @SuppressFBWarnings(value="SE_BAD_FIELD",
+            justification = "The concrete GitClient implementations are serializable")
     GitClient git;
     TaskListener listener;
 

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -260,8 +260,17 @@ public class GitUtils implements Serializable {
         // add env contributing actions' values from last build to environment - fixes JENKINS-22009
         addEnvironmentContributingActionsValues(env, b);
 
-        EnvVars.resolve(env);
+        // Just use environment contributors
 
+        try {  // Getting environment may trigger remoting in some cases which can throw errors.
+            for (EnvironmentContributor ec : EnvironmentContributor.all().reverseView())
+                ec.buildEnvironmentFor(p, env, listener);
+        } catch (IOException ioe) {
+            LOGGER.log(Level.WARNING, "Error getting polling environment", ioe);
+        } catch (InterruptedException ie) {
+            LOGGER.log(Level.WARNING, "Error getting polling environment", ie);
+        }
+        EnvVars.resolve(env);
         return env;
     }
 

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1201,8 +1201,10 @@ public class GitSCMTest extends AbstractGitTestCase {
 
     @Test
     public void testEnvironmentVariableExpansion() throws Exception {
+        // First we test environment expansion with just the repo, using an EnvironmentContributor
         FreeStyleProject project = createFreeStyleProject();
-        project.setScm(new GitSCM("${CAT}" + testRepo.gitDir.getPath()));
+        String repoUrl = "${CAT}";
+        project.setScm(new GitSCM(repoUrl + testRepo.gitDir.getPath()));
 
         // create initial commit and then run the build against it:
         commit("a.txt", johnDoe, "Initial Commit");
@@ -1219,13 +1221,12 @@ public class GitSCMTest extends AbstractGitTestCase {
 
         build(project, Result.SUCCESS, "b.txt");
 
-        // Test branch expansion with environment contributors
+        // Next we try expansion with both a repo an a branch
         FreeStyleProject project2 = createFreeStyleProject();
-        String url = "${CAT}";
         git.branch("cheese");
         commit("a.txt", johnDoe, "Initial Commit");
-        GitRepositoryBrowser browser = new GithubWeb(url);
-        GitSCM scm = new GitSCM(createRepoList("${CAT}"),
+        GitRepositoryBrowser browser = new GithubWeb(repoUrl);
+        GitSCM scm = new GitSCM(createRepoList(repoUrl),
                 Collections.singletonList(new BranchSpec("${cheese}")),
                 false, Collections.<SubmoduleConfig>emptyList(),
                 browser, null, null);

--- a/src/test/java/hudson/plugins/git/TestBranchSpec.java
+++ b/src/test/java/hudson/plugins/git/TestBranchSpec.java
@@ -2,18 +2,11 @@ package hudson.plugins.git;
 
 import hudson.EnvVars;
 
-import java.io.IOException;
 import java.util.HashMap;
 import static org.junit.Assert.*;
 
-import hudson.model.EnvironmentContributor;
-import hudson.model.Job;
-import hudson.model.TaskListener;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.TestExtension;
-
-import javax.annotation.Nonnull;
 
 
 public class TestBranchSpec {

--- a/src/test/java/hudson/plugins/git/TestBranchSpec.java
+++ b/src/test/java/hudson/plugins/git/TestBranchSpec.java
@@ -1,10 +1,19 @@
 package hudson.plugins.git;
 
 import hudson.EnvVars;
+
+import java.io.IOException;
 import java.util.HashMap;
 import static org.junit.Assert.*;
+
+import hudson.model.EnvironmentContributor;
+import hudson.model.Job;
+import hudson.model.TaskListener;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.TestExtension;
+
+import javax.annotation.Nonnull;
 
 
 public class TestBranchSpec {


### PR DESCRIPTION
Resolves issues with environment contributor not firing during polling, causing issues with an environment contributor setting the branch name used in polling.

Specific use case:
- AbstractProject (usually a FreestyleProject) using git polling for the build
- Branch for the project is set using an environment variable
- Environment variable for branch is set using an EnvironmentContributor (any of them, it doesn't matter)
- Polling will fail to trigger a build because the EnvironmentContributor is not fired when polling (especially visible when polling without a workspace). 

@reviewbybees
