### PR TITLE
Dont rely on System.getEnv()

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -570,21 +570,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
     }
 
-    private static Node workspaceToNode(FilePath workspace) { // TODO https://trello.com/c/doFFMdUm/46-filepath-getcomputer
-        Jenkins j = Jenkins.getInstance();
-        if (workspace != null && workspace.isRemote()) {
-            for (Computer c : j.getComputers()) {
-                if (c.getChannel() == workspace.getChannel()) {
-                    Node n = c.getNode();
-                    if (n != null) {
-                        return n;
-                    }
-                }
-            }
-        }
-        return j;
-    }
-
     public static final Pattern GIT_REF = Pattern.compile("(refs/[^/]+)/.*");
 
     private PollingResult compareRemoteRevisionWithImpl(Job<?, ?> project, Launcher launcher, FilePath workspace, final TaskListener listener) throws IOException, InterruptedException {
@@ -677,7 +662,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             return NO_CHANGES;
         }
 
-        final EnvVars environment = project instanceof AbstractProject ? GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener) : new EnvVars();
+        final Node node = GitUtils.workspaceToNode(workspace);
+        final EnvVars environment = project instanceof AbstractProject ? GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener) : project.getEnvironment(node, listener);
 
         FilePath workingDirectory = workingDirectory(project,workspace,environment,listener);
 
@@ -686,7 +672,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             return BUILD_NOW;
         }
 
-        GitClient git = createClient(listener, environment, project, workspaceToNode(workspace), workingDirectory);
+        GitClient git = createClient(listener, environment, project, node, workingDirectory);
 
         if (git.hasGitRepo()) {
             // Repo is there - do a fetch
@@ -737,7 +723,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         if (ws != null) {
             ws.mkdirs(); // ensure it exists
         }
-        return createClient(listener,environment, build.getParent(), workspaceToNode(workspace), ws);
+        return createClient(listener,environment, build.getParent(), GitUtils.workspaceToNode(workspace), ws);
     }
 
     /*package*/ GitClient createClient(TaskListener listener, EnvVars environment, Job project, Node n, FilePath ws) throws IOException, InterruptedException {

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -10,10 +10,12 @@ import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.Item;
+import hudson.model.Job;
 import hudson.model.TaskListener;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.GitURIRequirementsBuilder;
@@ -127,7 +129,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
             return FormValidation.ok();
         }
 
-        public FormValidation doCheckUrl(@AncestorInPath Item project,
+        public FormValidation doCheckUrl(@AncestorInPath Job project,
                                          @QueryParameter String credentialsId,
                                          @QueryParameter String value) throws IOException, InterruptedException {
 
@@ -144,7 +146,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
                 return FormValidation.ok();
 
             // get git executable on master
-            final EnvVars environment = new EnvVars(System.getenv()); // GitUtils.getPollEnvironment(project, null, launcher, TaskListener.NULL, false);
+            final EnvVars environment = project.getEnvironment(Jenkins.getActiveInstance(), TaskListener.NULL);
 
             GitClient git = Git.with(TaskListener.NULL, environment)
                     .using(GitTool.getDefaultInstallation().getGitExe())

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -152,7 +152,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
             if (item instanceof Job) {
                 environment = ((Job) item).getEnvironment(jenkins, TaskListener.NULL);
             } else {
-                environment = jenkins.getComputer("(master)").buildEnvironment(TaskListener.NULL);
+                environment = jenkins.toComputer().buildEnvironment(TaskListener.NULL);
             }
 
             GitClient git = Git.with(TaskListener.NULL, environment)

--- a/src/main/java/jenkins/plugins/git/GitStep.java
+++ b/src/main/java/jenkins/plugins/git/GitStep.java
@@ -28,6 +28,7 @@ import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Item;
+import hudson.model.Job;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.SubmoduleConfig;
@@ -97,7 +98,7 @@ public final class GitStep extends SCMStep {
             return delegate.doFillCredentialsIdItems(project, url);
         }
 
-        public FormValidation doCheckUrl(@AncestorInPath Item project,
+        public FormValidation doCheckUrl(@AncestorInPath Job project,
                                          @QueryParameter String credentialsId,
                                          @QueryParameter String value) throws IOException, InterruptedException {
             return delegate.doCheckUrl(project, credentialsId, value);

--- a/src/main/java/jenkins/plugins/git/GitStep.java
+++ b/src/main/java/jenkins/plugins/git/GitStep.java
@@ -98,10 +98,10 @@ public final class GitStep extends SCMStep {
             return delegate.doFillCredentialsIdItems(project, url);
         }
 
-        public FormValidation doCheckUrl(@AncestorInPath Job project,
+        public FormValidation doCheckUrl(@AncestorInPath Item item,
                                          @QueryParameter String credentialsId,
                                          @QueryParameter String value) throws IOException, InterruptedException {
-            return delegate.doCheckUrl(project, credentialsId, value);
+            return delegate.doCheckUrl(item, credentialsId, value);
         }
 
         @Override


### PR DESCRIPTION
use `project.getEnvironment()` to ensure all environment contributors get involved and can populate environment for polling or checking git URL
