### PR TITLE
Pointless to call the deprecated GitSCM.getUserMergeOptions when we have the options field

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
@@ -58,7 +58,7 @@ public class PreBuildMerge extends GitSCMExtension {
             return rev;
 
         // Only merge if there's a branch to merge that isn't us..
-        listener.getLogger().println("Merging " + rev + " to " + remoteBranchRef + ", " + scm.getUserMergeOptions().toString());
+        listener.getLogger().println("Merging " + rev + " to " + remoteBranchRef + ", " + options);
 
         // checkout origin/blah
         ObjectId target = git.revParse(remoteBranchRef);
@@ -98,9 +98,10 @@ public class PreBuildMerge extends GitSCMExtension {
 
     @Override
     public void decorateMergeCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, MergeCommand cmd) throws IOException, InterruptedException, GitException {
-        if (scm.getUserMergeOptions().getMergeStrategy() != null)
-            cmd.setStrategy(scm.getUserMergeOptions().getMergeStrategy());
-        cmd.setGitPluginFastForwardMode(scm.getUserMergeOptions().getFastForwardMode());
+        if (options.getMergeStrategy() != null) {
+            cmd.setStrategy(options.getMergeStrategy());
+        }
+        cmd.setGitPluginFastForwardMode(options.getFastForwardMode());
     }
 
     @Override


### PR DESCRIPTION
https://github.com/jenkinsci/git-plugin/pull/170 introduced a call to a deprecated method, which https://github.com/jenkinsci/git-plugin/commit/3d67ef2019cb8d1bb639575744a94ccea949a55c copied. Breaks encapsulation: the extension should be using its own configuration, not going back to the owning SCM to look itself up.

@reviewbybees