### PR TITLE
[JENKINS-36141] Add regex branch specifier help

### DIFF
--- a/src/main/resources/hudson/plugins/git/BranchSpec/help-name.html
+++ b/src/main/resources/hudson/plugins/git/BranchSpec/help-name.html
@@ -53,7 +53,25 @@
            The syntax is of the form: <tt>:regexp</tt>.
            Regular expression syntax in branches to build will only
            build those branches whose names match the regular
-           expression.
+           expression.</br>
+           Examples:<br/>
+            <ul>
+                <li><tt>:^(?!(origin/prefix)).*</tt></li>
+                <ul>
+                    <li>matches: <tt>origin</tt> or <tt>origin/master</tt> or <tt>origin/feature</tt></li>
+                    <li>does not match: <tt>origin/prefix</tt> or <tt>origin/prefix_123</tt> or <tt>origin/prefix-abc</tt></li>
+                </ul>
+                <li><tt>:origin/release-\d{8}</tt></li>
+                <ul>
+                    <li>matches: <tt>origin/release-20150101</tt></li>
+                    <li>does not match: <tt>origin/release-2015010</tt> or <tt>origin/release-201501011</tt> or <tt>origin/release-20150101-something</tt></li>
+                </ul>
+                <li><tt>:^(?!origin/master$|origin/develop$).*</tt></li>
+                <ul>
+                    <li>matches: <tt>origin/branch1</tt> or <tt>origin/branch-2</tt> or <tt>origin/master123</tt> or <tt>origin/develop-123</tt></li>
+                    <li>does not match: <tt>origin/master</tt> or <tt>origin/develop</tt></li>
+                </ul>
+            </ul>
     </ul>
   </p>
 </div>

--- a/src/test/java/hudson/plugins/git/BranchSpecTest.java
+++ b/src/test/java/hudson/plugins/git/BranchSpecTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 
-public class TestBranchSpec {
+public class BranchSpecTest {
     @Test
     public void testMatch() {
 
@@ -171,6 +171,17 @@ public class TestBranchSpec {
     	assertFalse(m.matches("origin/release-2015010"));
     	assertFalse(m.matches("origin/release-201501011"));
     	assertFalse(m.matches("origin/release-20150101-something"));
+    }
+
+    @Test
+    public void testUsesJavaPatternToExcludeMultipleBranches() {
+        BranchSpec m = new BranchSpec(":^(?!origin/master$|origin/develop$).*");
+        assertTrue(m.matches("origin/branch1"));
+        assertTrue(m.matches("origin/branch-2"));
+        assertTrue(m.matches("origin/master123"));
+        assertTrue(m.matches("origin/develop-123"));
+        assertFalse(m.matches("origin/master"));
+        assertFalse(m.matches("origin/develop"));
     }
 
     private EnvVars createEnvMap(String key, String value) {


### PR DESCRIPTION
Additional help when 'Branch Specifier' question mark button
clicked in jenkins job configuration ([JENKINS-36141](https://issues.jenkins-ci.org/browse/JENKINS-36141)).

- Renamed `TestBranchSpec.java` test file to
  `BranchSpecTest.java` to conform to junit test naming
  conventions and also to be enable intellij to recognize and run
  this file as a junit test file.
- Added additional branch specifier test that shows how to
  exclude multiple branches from build