### PR TITLE
[FIXED JENKINS-36419] - Resolve Binary compatibility issue in 2.5.1

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -113,7 +113,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     private List<BranchSpec> branches;
     private boolean doGenerateSubmoduleConfigurations;
 
+    @CheckForNull
     public String gitTool = null;
+    @CheckForNull
     private GitRepositoryBrowser browser;
     private Collection<SubmoduleConfig> submoduleCfg;
     public static final String GIT_BRANCH = "GIT_BRANCH";
@@ -162,9 +164,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             List<BranchSpec> branches,
             Boolean doGenerateSubmoduleConfigurations,
             Collection<SubmoduleConfig> submoduleCfg,
-            GitRepositoryBrowser browser,
-            String gitTool,
-            List<GitSCMExtension> extensions) {
+            @CheckForNull GitRepositoryBrowser browser,
+            @CheckForNull String gitTool,
+            @NonNull List<GitSCMExtension> extensions) {
 
         // moved from createBranches
         this.branches = isEmpty(branches) ? newArrayList(new BranchSpec("*/master")) : branches;
@@ -483,6 +485,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return localBranchName;
     }
 
+    @CheckForNull
     public String getGitTool() {
         return gitTool;
     }

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -111,17 +111,37 @@ public abstract class AbstractGitSCMSource extends SCMSource {
 
     public abstract String getExcludes();
 
-    public abstract GitRepositoryBrowser getBrowser();
+    /**
+     * Gets {@link GitRepositoryBrowser} to be used with this SCMSource.
+     * @return Repository browser or {@code null} if the default tool should be used.
+     * @since 2.5.1
+     */
+    public GitRepositoryBrowser getBrowser() {
+        // Always return null by default
+        return null;
+    }
 
-    public abstract void setBrowser(GitRepositoryBrowser browser);
+    /**
+     * Gets Git tool to be used for this SCM Source.
+     * @return Git Tool or {@code null} if the default tool should be used.
+     * @since 2.5.1
+     */
+    @CheckForNull
+    public String getGitTool() {
+        // Always return null by default
+        return null;
+    }
 
-    public abstract String getGitTool();
-
-    public abstract void setGitTool(String gitTool);
-
-    public abstract List<GitSCMExtension> getExtensions();
-
-    public abstract void setExtensions(List<GitSCMExtension> extensions);
+    /**
+     * Gets list of extensions, which should be used with this branch source.
+     * @return List of Extensions to be used. May be empty
+     * @since 2.5.1
+     */
+    @NonNull
+    public List<GitSCMExtension> getExtensions() {
+        // Always return empty list
+        return Collections.emptyList();
+    }
 
     public String getRemoteName() {
       return "origin";

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -116,6 +116,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
      * @return Repository browser or {@code null} if the default tool should be used.
      * @since 2.5.1
      */
+    @CheckForNull
     public GitRepositoryBrowser getBrowser() {
         // Always return null by default
         return null;

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -66,6 +66,7 @@ import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 import org.kohsuke.accmod.Restricted;
@@ -134,15 +135,15 @@ public class GitSCMSource extends AbstractGitSCMSource {
     @Restricted(NoExternalUse.class)
     @DataBoundSetter
     public void setGitTool(String gitTool) {
-        this.gitTool = gitTool;
+        this.gitTool = Util.fixEmptyAndTrim(gitTool);
     }
 
     @Override
     public List<GitSCMExtension> getExtensions() {
         if (extensions == null) {
-            extensions = new ArrayList<GitSCMExtension>();
+            return Collections.emptyList();
         }
-        return extensions;
+        return Collections.unmodifiableList(new ArrayList<GitSCMExtension>(extensions));
     }
 
     // For Stapler only

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -27,6 +27,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import hudson.Extension;
 import hudson.Util;
@@ -67,6 +68,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author Stephen Connolly
@@ -88,8 +91,10 @@ public class GitSCMSource extends AbstractGitSCMSource {
 
     private final boolean ignoreOnPushNotifications;
 
+    @CheckForNull
     private GitRepositoryBrowser browser;
 
+    @CheckForNull
     private String gitTool;
 
     private List<GitSCMExtension> extensions;
@@ -113,7 +118,8 @@ public class GitSCMSource extends AbstractGitSCMSource {
         return browser;
     }
 
-    @Override
+    // For Stapler only
+    @Restricted(NoExternalUse.class)
     @DataBoundSetter
     public void setBrowser(GitRepositoryBrowser browser) {
         this.browser = browser;
@@ -124,7 +130,8 @@ public class GitSCMSource extends AbstractGitSCMSource {
         return gitTool;
     }
 
-    @Override
+    // For Stapler only
+    @Restricted(NoExternalUse.class)
     @DataBoundSetter
     public void setGitTool(String gitTool) {
         this.gitTool = gitTool;
@@ -138,7 +145,8 @@ public class GitSCMSource extends AbstractGitSCMSource {
         return extensions;
     }
 
-    @Override
+    // For Stapler only
+    @Restricted(NoExternalUse.class)
     @DataBoundSetter
     public void setExtensions(List<GitSCMExtension> extensions) {
         this.extensions = Util.fixNull(extensions);

--- a/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
@@ -181,27 +181,6 @@ public class GithubWebTest {
             }
             return result;
         }
-        @Override
-        public GitRepositoryBrowser getBrowser() {
-            return null;
-        }
-        @Override
-        public void setBrowser(GitRepositoryBrowser browser) {
-        }
-        @Override
-        public String getGitTool() {
-            return null;
-        }
-        @Override
-        public void setGitTool(String gitTool) {
-        }
-        @Override
-        public List<GitSCMExtension> getExtensions() {
-            return new ArrayList<GitSCMExtension>();
-        }
-        @Override
-        public void setExtensions(List<GitSCMExtension> extensions) {
-        }
     }
 
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTrivialTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTrivialTest.java
@@ -143,33 +143,6 @@ public class AbstractGitSCMSourceTrivialTest {
         public List<RefSpec> getRefSpecs() {
             return expectedRefSpecs;
         }
-
-        @Override
-        public GitRepositoryBrowser getBrowser() {
-            return null;
-        }
-
-        @Override
-        public void setBrowser(GitRepositoryBrowser browser) {
-        }
-
-        @Override
-        public String getGitTool() {
-            return null;
-        }
-
-        @Override
-        public void setGitTool(String gitTool) {
-        }
-
-        @Override
-        public List<GitSCMExtension> getExtensions() {
-            return new ArrayList<GitSCMExtension>();
-        }
-
-        @Override
-        public void setExtensions(List<GitSCMExtension> extensions) {
-        }
     }
 
     private class SCMRevisionImpl extends SCMRevision {


### PR DESCRIPTION
Fixes binary compatibility issue introduced in https://github.com/jenkinsci/git-plugin/pull/350

- [x] Get rid of setter methods. Breaks the compatibility against 2.5.1, but it's intentional
- [x] Add default implementations and Javadoc to getter methods
- [x] Code annotations
- [x] Fix implementation issues introduced in https://github.com/jenkinsci/git-plugin/pull/350

https://issues.jenkins-ci.org/browse/JENKINS-36419

@MarkEWaite @reviewbybees @aheritier 