### PR TITLE
[JENKINS-36507] Move refspec control of initial clone to CloneOption

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1039,7 +1039,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
             RemoteConfig rc = repos.get(0);
             try {
-                CloneCommand cmd = git.clone_().url(rc.getURIs().get(0).toPrivateString()).repositoryName(rc.getName()).refspecs(rc.getFetchRefSpecs());
+                CloneCommand cmd = git.clone_().url(rc.getURIs().get(0).toPrivateString()).repositoryName(rc.getName());
                 for (GitSCMExtension ext : extensions) {
                     ext.decorateCloneCommand(this, build, git, listener, cmd);
                 }

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
@@ -11,6 +11,9 @@ f.entry(title:_("Shallow clone depth"), field:"depth") {
 f.entry(title:_("Do not fetch tags"), field:"noTags") {
 	f.checkbox()
 }
+f.entry(title:_("Honor refspec on initial clone"), field:"honorRefspec") {
+	f.checkbox()
+}
 f.entry(title:_("Path of the reference repo to use during clone"), field:"reference") {
     f.textbox()
 }

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-honorRefspec.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-honorRefspec.html
@@ -1,0 +1,5 @@
+<div>
+  Perform initial clone using the refspec defined for the repository.
+  This can save time, data transfer and disk space when you only need
+  to access the references specified by the refspec.
+</div>

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -142,8 +142,55 @@ public class GitSCMTest extends AbstractGitTestCase {
         build(projectMasterBranch, Result.SUCCESS, commitFile1);
     }
 
+    /**
+     * This test and testSpecificRefspecsWithoutCloneOption confirm behaviors of
+     * refspecs on initial clone. Without the CloneOption to honor refspec, all
+     * references are cloned, even if they will be later ignored due to the
+     * refspec.  With the CloneOption to ignore refspec, the initial clone also
+     * honors the refspec and only retrieves references per the refspec.
+     * @throws Exception on error
+     */
     @Test
+    @Issue("JENKINS-31393")
     public void testSpecificRefspecs() throws Exception {
+        List<UserRemoteConfig> repos = new ArrayList<UserRemoteConfig>();
+        repos.add(new UserRemoteConfig(testRepo.gitDir.getAbsolutePath(), "origin", "+refs/heads/foo:refs/remotes/foo", null));
+
+        /* Set CloneOption to honor refspec on initial clone */
+        FreeStyleProject projectWithMaster = setupProject(repos, Collections.singletonList(new BranchSpec("master")), null, false, null);
+        CloneOption cloneOptionMaster = new CloneOption(false, null, null);
+        cloneOptionMaster.setHonorRefspec(true);
+        ((GitSCM)projectWithMaster.getScm()).getExtensions().add(cloneOptionMaster);
+
+        /* Set CloneOption to honor refspec on initial clone */
+        FreeStyleProject projectWithFoo = setupProject(repos, Collections.singletonList(new BranchSpec("foo")), null, false, null);
+        CloneOption cloneOptionFoo = new CloneOption(false, null, null);
+        cloneOptionFoo.setHonorRefspec(true);
+        ((GitSCM)projectWithMaster.getScm()).getExtensions().add(cloneOptionFoo);
+
+        // create initial commit
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit in master");
+        // create branch and make initial commit
+        git.branch("foo");
+        git.checkout().branch("foo");
+        commit(commitFile1, johnDoe, "Commit in foo");
+
+        build(projectWithMaster, Result.FAILURE);
+        build(projectWithFoo, Result.SUCCESS, commitFile1);
+    }
+
+    /**
+     * This test and testSpecificRefspecs confirm behaviors of
+     * refspecs on initial clone. Without the CloneOption to honor refspec, all
+     * references are cloned, even if they will be later ignored due to the
+     * refspec.  With the CloneOption to ignore refspec, the initial clone also
+     * honors the refspec and only retrieves references per the refspec.
+     * @throws Exception on error
+     */
+    @Test
+    @Issue("JENKINS-36507")
+    public void testSpecificRefspecsWithoutCloneOption() throws Exception {
         List<UserRemoteConfig> repos = new ArrayList<UserRemoteConfig>();
         repos.add(new UserRemoteConfig(testRepo.gitDir.getAbsolutePath(), "origin", "+refs/heads/foo:refs/remotes/foo", null));
         FreeStyleProject projectWithMaster = setupProject(repos, Collections.singletonList(new BranchSpec("master")), null, false, null);
@@ -157,7 +204,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         git.checkout().branch("foo");
         commit(commitFile1, johnDoe, "Commit in foo");
 
-        build(projectWithMaster, Result.FAILURE);
+        build(projectWithMaster, Result.SUCCESS); /* If clone refspec had been honored, this would fail */
         build(projectWithFoo, Result.SUCCESS, commitFile1);
     }
 


### PR DESCRIPTION
The decision if the refspec should be honored during clone is now
part of the CloneOption additional behaviour.  The user can control
the setting per job, and the default setting remains compatible with
the git plugin 2.5.0 (and prior) cloning of all references initially,
then later honoring the refspec in other operations.

Prior to git plugin 2.5.1, JENKINS-31393 caused the user provided
refspec to be ignored during the initial clone. It was honored in
later fetch operations, but not in the first clone. That meant the
initial clone had to fetch all the branches and their references from
the remote repository, even if those branches were later ignored due
to the refspec.

The fix for JENKINS-31393 exposed JENKINS-36507 which indicates that
the Gerrit Plugin assumes all references are fetched, even though it
only passes the refspec for one branch. The git plugin shouldn't
require a code change in the gerrit plugin, so each job must choose if
JENKINS-31393 will affect that job or not.

Most jobs that are significantly affected by JENKINS-31393 will likely
need to make other changes in the "Advanced clone options" (like using
a reference repository, or disabling the cloning of tags, or enabling
shallow clone).

Added CloneOption tests for JENKINS-36507 using the same basic test as
was earlier submitted for JENKINS-31393.

The testSpecificRefspecs and testSpecificRefspecsWithoutCloneOption
methods confirm behaviors of refspecs on initial clone. Without the
CloneOption to honor refspec, all references are cloned, even if they
will be later ignored due to the refspec.  With the CloneOption to ignore
refspec, the initial clone also honors the refspec and only retrieves
references per the refspec.