### PR TITLE
Use abstract decorateCheckoutCommand

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/CheckoutOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CheckoutOption.java
@@ -1,8 +1,8 @@
 package hudson.plugins.git.extensions.impl;
 
 import hudson.Extension;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.FakeGitSCMExtension;
@@ -36,7 +36,7 @@ public class CheckoutOption extends FakeGitSCMExtension {
     }
 
     @Override
-    public void decorateCheckoutCommand(GitSCM scm, AbstractBuild<?, ?> build, GitClient git, BuildListener listener, CheckoutCommand cmd) throws IOException, InterruptedException, GitException {
+    public void decorateCheckoutCommand(GitSCM scm, Run<?, ?> run, GitClient git, TaskListener listener, CheckoutCommand cmd) throws IOException, InterruptedException, GitException {
         cmd.timeout(timeout);
     }
 

--- a/src/test/java/jenkins/plugins/git/GitStepTest.java
+++ b/src/test/java/jenkins/plugins/git/GitStepTest.java
@@ -253,4 +253,18 @@ public class GitStepTest {
         r.assertLogContains("+edited by build", b);
     }
 
+    @Test
+    public void checkoutTimeout() throws Exception {
+        sampleRepo.init();
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+            "node {\n" +
+            "  checkout(\n" +
+            "    [$class: 'GitSCM', extensions: [[$class: 'CheckoutOption', timeout: 1234]],\n" +
+            "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]]\n" +
+            "  )" +
+            "}"));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("# timeout=1234", b);
+    }
 }


### PR DESCRIPTION
Allows CheckoutOption to work with e.g. Pipeline tasks

I'm not sure about the test.  It's not actually testing GitStep, but it's very similar to the existing tests.  Should it be in a new class?