### PR TITLE
[JENKINS-22547] Honor checkout timeout setting

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/CheckoutOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CheckoutOption.java
@@ -3,6 +3,8 @@ package hudson.plugins.git.extensions.impl;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.FakeGitSCMExtension;
@@ -36,6 +38,12 @@ public class CheckoutOption extends FakeGitSCMExtension {
     }
 
     @Override
+    public void decorateCheckoutCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, CheckoutCommand cmd) throws IOException, InterruptedException, GitException {
+        cmd.timeout(timeout);
+    }
+
+    @Override
+    @Deprecated
     public void decorateCheckoutCommand(GitSCM scm, AbstractBuild<?, ?> build, GitClient git, BuildListener listener, CheckoutCommand cmd) throws IOException, InterruptedException, GitException {
         cmd.timeout(timeout);
     }

--- a/src/test/java/hudson/plugins/git/extensions/impl/CheckoutOptionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CheckoutOptionTest.java
@@ -1,0 +1,103 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.GitTool;
+import hudson.plugins.git.SubmoduleConfig;
+import hudson.plugins.git.UserRemoteConfig;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jenkinsci.plugins.gitclient.CheckoutCommand;
+import org.jenkinsci.plugins.gitclient.Git;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class CheckoutOptionTest {
+
+    private CheckoutOption option;
+    private static final int INITIAL_TIMEOUT = 10;
+
+    public CheckoutOptionTest() {
+    }
+
+    @Before
+    public void setUp() {
+        option = new CheckoutOption(INITIAL_TIMEOUT);
+    }
+
+    @Test
+    public void testGetTimeout() {
+        assertEquals(INITIAL_TIMEOUT, (int) option.getTimeout());
+    }
+
+    @Test
+    public void testRequiresWorkspaceForPolling() {
+        assertFalse(option.requiresWorkspaceForPolling());
+    }
+
+    @Test
+    public void testDecorateCheckoutCommand() throws Exception {
+        final int NEW_TIMEOUT = 13;
+
+        CheckoutCommandImpl cmd = new CheckoutCommandImpl();
+        assertEquals(INITIAL_TIMEOUT, cmd.getTimeout());
+
+        GitSCM scm = null;
+        Run build = null;
+        TaskListener listener = null;
+        GitClient git = null;
+
+        option = new CheckoutOption(NEW_TIMEOUT);
+        option.decorateCheckoutCommand(scm, build, git, listener, cmd);
+        assertEquals(NEW_TIMEOUT, cmd.getTimeout());
+    }
+
+    public class CheckoutCommandImpl implements CheckoutCommand {
+
+        private int timeout = INITIAL_TIMEOUT;
+
+        public int getTimeout() {
+            return timeout;
+        }
+
+        @Override
+        public CheckoutCommand timeout(Integer timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        @Override
+        public CheckoutCommand ref(String ref) {
+            throw new UnsupportedOperationException("Don't call me");
+        }
+
+        @Override
+        public CheckoutCommand branch(String branch) {
+            throw new UnsupportedOperationException("Don't call me");
+        }
+
+        @Override
+        public CheckoutCommand deleteBranchIfExist(boolean deleteBranch) {
+            throw new UnsupportedOperationException("Don't call me");
+        }
+
+        @Override
+        public CheckoutCommand sparseCheckoutPaths(List<String> sparseCheckoutPaths) {
+            throw new UnsupportedOperationException("Don't call me");
+        }
+
+        @Override
+        public void execute() throws GitException, InterruptedException {
+            throw new UnsupportedOperationException("Don't call me");
+        }
+    }
+}

--- a/src/test/java/hudson/plugins/git/extensions/impl/CheckoutOptionWorkflowTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CheckoutOptionWorkflowTest.java
@@ -1,0 +1,32 @@
+package hudson.plugins.git.extensions.impl;
+
+import jenkins.plugins.git.GitSampleRepoRule;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class CheckoutOptionWorkflowTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+    @Test
+    public void checkoutTimeout() throws Exception {
+        sampleRepo.init();
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                + "  checkout(\n"
+                + "    [$class: 'GitSCM', extensions: [[$class: 'CheckoutOption', timeout: 1234]],\n"
+                + "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]]\n"
+                + "  )"
+                + "}"));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("# timeout=1234", b);
+    }
+}


### PR DESCRIPTION
Previously implemented a deprecated version of decorateCheckoutCommand
in CheckoutOption but called the non-deprecated version.  That caused
the job's checkout timeout setting to be ignored.