### PR TITLE
[JENKINS-33983] Using correct git installation when fetching heads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,8 @@
     <java.level>6</java.level>
     <!-- Use the same configuration than before. -->
     <concurrency>2</concurrency>
+    <permgen.size>128m</permgen.size>
+    <argLine>-XX:MaxPermSize=${permgen.size}</argLine>
     <!-- TODO: Ongoing work on https://github.com/MarkEWaite/git-plugin/tree/master-findbugs-fixes. -->
     <findbugs.failOnError>false</findbugs.failOnError>
     <workflow.version>1.14.2</workflow.version>
@@ -173,6 +175,18 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.6.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>1.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -39,6 +39,7 @@ import hudson.plugins.git.Branch;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.GitTool;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.SubmoduleConfig;
 import hudson.plugins.git.UserRemoteConfig;
@@ -149,6 +150,16 @@ public abstract class AbstractGitSCMSource extends SCMSource {
     }
 
     @CheckForNull
+    protected GitTool resolveGitTool() {
+        GitTool tool = Jenkins.getInstance().getDescriptorByType(GitTool.DescriptorImpl.class)
+            .getInstallation(getGitTool());
+        if (getGitTool() == null) {
+            tool = GitTool.getDefaultInstallation();
+        }
+        return tool;
+    }
+
+    @CheckForNull
     @Override
     protected SCMRevision retrieve(@NonNull SCMHead head, @NonNull TaskListener listener)
             throws IOException, InterruptedException {
@@ -157,7 +168,8 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         cacheLock.lock();
         try {
             File cacheDir = getCacheDir(cacheEntry);
-            Git git = Git.with(listener, new EnvVars(EnvVars.masterEnvVars)).in(cacheDir);
+            GitTool tool = resolveGitTool();
+            Git git = Git.with(listener, new EnvVars(EnvVars.masterEnvVars)).using(tool.getGitExe()).in(cacheDir);
             GitClient client = git.getClient();
             client.addDefaultCredentials(getCredentials());
             if (!client.hasGitRepo()) {
@@ -193,7 +205,8 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         cacheLock.lock();
         try {
             File cacheDir = getCacheDir(cacheEntry);
-            Git git = Git.with(listener, new EnvVars(EnvVars.masterEnvVars)).in(cacheDir);
+            GitTool tool = resolveGitTool();
+            Git git = Git.with(listener, new EnvVars(EnvVars.masterEnvVars)).using(tool.getGitExe()).in(cacheDir);
             GitClient client = git.getClient();
             client.addDefaultCredentials(getCredentials());
             if (!client.hasGitRepo()) {

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceRetrieveHeadsTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceRetrieveHeadsTest.java
@@ -1,0 +1,129 @@
+package jenkins.plugins.git;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitTool;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadObserver;
+import org.eclipse.jgit.transport.RefSpec;
+import org.jenkinsci.plugins.gitclient.Git;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * Tests for {@link AbstractGitSCMSource}
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Git.class)
+public class AbstractGitSCMSourceRetrieveHeadsTest {
+
+    public static final String EXPECTED_GIT_EXE = "git-custom";
+
+    private AbstractGitSCMSource gitSCMSource;
+
+    @Before
+    public void setup() throws Exception {
+        // Mock GitTool
+        GitTool mockedTool = PowerMockito.mock(GitTool.class, Mockito.RETURNS_DEFAULTS);
+        PowerMockito.doReturn(EXPECTED_GIT_EXE).when(mockedTool).getGitExe();
+
+        // Mock git implementation
+        Git git = Mockito.mock(Git.class, Mockito.CALLS_REAL_METHODS);
+        PowerMockito.doThrow(new GitToolSpecified()).when(git).using(EXPECTED_GIT_EXE);
+        PowerMockito.doThrow(new GitToolNotSpecified()).when(git).getClient();
+        PowerMockito.doReturn(git).when(git).in(Mockito.any(File.class));
+        PowerMockito.doReturn(git).when(git).in(Mockito.any(FilePath.class));
+
+        // mock static factory to return our git mock
+        PowerMockito.mockStatic(Git.class, Mockito.CALLS_REAL_METHODS);
+        PowerMockito.doReturn(git).when(Git.class, "with", Mockito.any(), Mockito.any());
+
+        // Partial mock our AbstractGitSCMSourceImpl
+        gitSCMSource = PowerMockito.spy(new AbstractGitSCMSourceImpl());
+        // Always resolve to mocked GitTool
+        PowerMockito.doReturn(mockedTool).when(gitSCMSource).resolveGitTool();
+    }
+
+    /**
+     *  Validate that the correct git installation is used when fetching latest heads.
+     *  That means {@link Git#using(String)} is called properly.
+     */
+    @Test(expected = GitToolSpecified.class)
+    public void correctGitToolIsUsed() throws Exception {
+        try {
+            // Should throw exception confirming that Git#using was used correctly
+            gitSCMSource.retrieve(new SCMHead("master"), TaskListener.NULL);
+        } catch (GitToolNotSpecified e) {
+            Assert.fail("Git client was constructed wirth arbitrary git tool");
+        }
+    }
+
+    /**
+     *  Validate that the correct git installation is used when fetching latest heads.
+     *  That means {@link Git#using(String)} is called properly.
+     */
+    @Test(expected = GitToolSpecified.class)
+    public void correctGitToolIsUsed2() throws Exception {
+        try {
+            // Should throw exception confirming that Git#using was used correctly
+            gitSCMSource.retrieve(PowerMockito.mock(SCMHeadObserver.class), TaskListener.NULL);
+        } catch (GitToolNotSpecified e) {
+            Assert.fail("Git client was constructed with arbitrary git tool");
+        }
+    }
+
+    public static class GitToolSpecified extends RuntimeException {
+
+    }
+
+    public static class GitToolNotSpecified extends RuntimeException {
+
+    }
+
+    public static class AbstractGitSCMSourceImpl extends AbstractGitSCMSource {
+
+        public AbstractGitSCMSourceImpl() {
+            super("AbstractGitSCMSourceImpl-id");
+        }
+
+        @Override
+        public String getGitTool() {
+            return "EXPECTED_GIT_EXE";
+        }
+
+        @Override
+        public String getCredentialsId() {
+            return "";
+        }
+
+        @Override
+        public String getRemote() {
+            return "";
+        }
+
+        @Override
+        public String getIncludes() {
+            return "";
+        }
+
+        @Override
+        public String getExcludes() {
+            return "";
+        }
+
+        @Override
+        protected List<RefSpec> getRefSpecs() {
+            return Collections.emptyList();
+        }
+    }
+}


### PR DESCRIPTION
Fix for [JENKINS-33983](https://issues.jenkins-ci.org/browse/JENKINS-33983).
A correct  git client (for either selected git tool installation or global default installation) is now created when fetching git heads instead of always using jGit. 


