### PR TITLE
[JENKINS-36507] Move refspec control of initial clone into CloneOption

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1039,7 +1039,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
             RemoteConfig rc = repos.get(0);
             try {
-                CloneCommand cmd = git.clone_().url(rc.getURIs().get(0).toPrivateString()).repositoryName(rc.getName()).refspecs(rc.getFetchRefSpecs());
+                CloneCommand cmd = git.clone_().url(rc.getURIs().get(0).toPrivateString()).repositoryName(rc.getName());
                 for (GitSCMExtension ext : extensions) {
                     ext.decorateCloneCommand(this, build, git, listener, cmd);
                 }

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -16,6 +16,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.IOException;
+import java.util.List;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.RemoteConfig;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -26,6 +29,7 @@ public class CloneOption extends GitSCMExtension {
     private final String reference;
     private final Integer timeout;
     private int depth = 1;
+    private boolean honorRefspec = false;
 
     public CloneOption(boolean shallow, String reference, Integer timeout) {
         this(shallow, false, reference, timeout);
@@ -37,6 +41,7 @@ public class CloneOption extends GitSCMExtension {
         this.noTags = noTags;
         this.reference = reference;
         this.timeout = timeout;
+        this.honorRefspec = false;
     }
 
     public boolean isShallow() {
@@ -45,6 +50,48 @@ public class CloneOption extends GitSCMExtension {
 
     public boolean isNoTags() {
         return noTags;
+    }
+
+    /**
+     * This setting allows the job definition to control whether the refspec
+     * will be honored during the first clone or not.
+     *
+     * Prior to git plugin 2.5.1, JENKINS-31393 caused the user provided refspec
+     * to be ignored during the initial clone. It was honored in later fetch
+     * operations, but not in the first clone. That meant the initial clone had
+     * to fetch all the branches and their references from the remote
+     * repository, even if those branches were later ignored due to the refspec.
+     *
+     * The fix for JENKINS-31393 exposed JENKINS-36507 which suggests that
+     * the Gerrit Plugin assumes all references are fetched, even though it only
+     * passes the refspec for one branch.
+     *
+     * @param honorRefspec
+     */
+    @DataBoundSetter
+    public void setHonorRefspec(boolean honorRefspec) {
+        this.honorRefspec = honorRefspec;
+    }
+
+    /**
+     * Returns true if the job should clone only the items which match the
+     * refspec, or if all references are cloned, then the refspec should be used
+     * in later operations.
+     *
+     * Prior to git plugin 2.5.1, JENKINS-31393 caused the user provided refspec
+     * to be ignored during the initial clone. It was honored in later fetch
+     * operations, but not in the first clone. That meant the initial clone had
+     * to fetch all the branches and their references from the remote
+     * repository, even if those branches were later ignored due to the refspec.
+     *
+     * The fix for JENKINS-31393 exposed JENKINS-36507 which seems to show that
+     * the Gerrit Plugin assumes all references are fetched, even though it only
+     * passes the refspec for one branch.
+     *
+     * @return true if initial clone will honor the user defined refspec
+     */
+    public boolean isHonorRefspec() {
+        return honorRefspec;
     }
 
     public String getReference() {
@@ -78,6 +125,19 @@ public class CloneOption extends GitSCMExtension {
             listener.getLogger().println("Avoid fetching tags");
             cmd.tags(false);
         }
+        if (honorRefspec) {
+            listener.getLogger().println("Honoring refspec on initial clone");
+            // Read refspec configuration from the first configured repository.
+            // Same technique is used in GitSCM.
+            // Assumes the passed in scm represents a single repository, or if
+            // multiple repositories are in use, the first repository in the
+            // configuration is treated as authoritative.
+            // Git plugin does not support multiple independent repositories
+            // in a single job definition.
+            RemoteConfig rc = scm.getRepositories().get(0);
+            List<RefSpec> refspecs = rc.getFetchRefSpecs();
+            cmd.refspecs(refspecs);
+        }
         cmd.timeout(timeout);
         cmd.reference(build.getEnvironment(listener).expand(reference));
     }
@@ -89,6 +149,11 @@ public class CloneOption extends GitSCMExtension {
 	    cmd.depth(depth);
         }
         cmd.tags(!noTags);
+        /* cmd.refspecs() not required.
+         * FetchCommand already requires list of refspecs through its
+         * from(remote, refspecs) method, no need to adjust refspecs
+         * here on initial clone
+         */
         cmd.timeout(timeout);
     }
 

--- a/src/main/java/jenkins/plugins/git/GitStep.java
+++ b/src/main/java/jenkins/plugins/git/GitStep.java
@@ -28,7 +28,6 @@ import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Item;
-import hudson.model.Job;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.SubmoduleConfig;

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
@@ -11,6 +11,9 @@ f.entry(title:_("Shallow clone depth"), field:"depth") {
 f.entry(title:_("Do not fetch tags"), field:"noTags") {
 	f.checkbox()
 }
+f.entry(title:_("Honor refspec on initial clone"), field:"honorRefspec") {
+	f.checkbox()
+}
 f.entry(title:_("Path of the reference repo to use during clone"), field:"reference") {
     f.textbox()
 }

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-honorRefspec.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-honorRefspec.html
@@ -1,0 +1,5 @@
+<div>
+  Perform initial clone using the refspec defined for the repository.
+  This can save time, data transfer and disk space when you only need
+  to access the references specified by the refspec.
+</div>

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -142,8 +142,55 @@ public class GitSCMTest extends AbstractGitTestCase {
         build(projectMasterBranch, Result.SUCCESS, commitFile1);
     }
 
+    /**
+     * This test and testSpecificRefspecsWithoutCloneOption confirm behaviors of
+     * refspecs on initial clone. Without the CloneOption to honor refspec, all
+     * references are cloned, even if they will be later ignored due to the
+     * refspec.  With the CloneOption to ignore refspec, the initial clone also
+     * honors the refspec and only retrieves references per the refspec.
+     * @throws Exception on error
+     */
     @Test
+    @Issue("JENKINS-31393")
     public void testSpecificRefspecs() throws Exception {
+        List<UserRemoteConfig> repos = new ArrayList<UserRemoteConfig>();
+        repos.add(new UserRemoteConfig(testRepo.gitDir.getAbsolutePath(), "origin", "+refs/heads/foo:refs/remotes/foo", null));
+
+        /* Set CloneOption to honor refspec on initial clone */
+        FreeStyleProject projectWithMaster = setupProject(repos, Collections.singletonList(new BranchSpec("master")), null, false, null);
+        CloneOption cloneOptionMaster = new CloneOption(false, null, null);
+        cloneOptionMaster.setHonorRefspec(true);
+        ((GitSCM)projectWithMaster.getScm()).getExtensions().add(cloneOptionMaster);
+
+        /* Set CloneOption to honor refspec on initial clone */
+        FreeStyleProject projectWithFoo = setupProject(repos, Collections.singletonList(new BranchSpec("foo")), null, false, null);
+        CloneOption cloneOptionFoo = new CloneOption(false, null, null);
+        cloneOptionFoo.setHonorRefspec(true);
+        ((GitSCM)projectWithMaster.getScm()).getExtensions().add(cloneOptionFoo);
+
+        // create initial commit
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit in master");
+        // create branch and make initial commit
+        git.branch("foo");
+        git.checkout().branch("foo");
+        commit(commitFile1, johnDoe, "Commit in foo");
+
+        build(projectWithMaster, Result.FAILURE);
+        build(projectWithFoo, Result.SUCCESS, commitFile1);
+    }
+
+    /**
+     * This test and testSpecificRefspecs confirm behaviors of
+     * refspecs on initial clone. Without the CloneOption to honor refspec, all
+     * references are cloned, even if they will be later ignored due to the
+     * refspec.  With the CloneOption to ignore refspec, the initial clone also
+     * honors the refspec and only retrieves references per the refspec.
+     * @throws Exception on error
+     */
+    @Test
+    @Issue("JENKINS-36507")
+    public void testSpecificRefspecsWithoutCloneOption() throws Exception {
         List<UserRemoteConfig> repos = new ArrayList<UserRemoteConfig>();
         repos.add(new UserRemoteConfig(testRepo.gitDir.getAbsolutePath(), "origin", "+refs/heads/foo:refs/remotes/foo", null));
         FreeStyleProject projectWithMaster = setupProject(repos, Collections.singletonList(new BranchSpec("master")), null, false, null);
@@ -157,7 +204,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         git.checkout().branch("foo");
         commit(commitFile1, johnDoe, "Commit in foo");
 
-        build(projectWithMaster, Result.FAILURE);
+        build(projectWithMaster, Result.SUCCESS); /* If clone refspec had been honored, this would fail */
         build(projectWithFoo, Result.SUCCESS, commitFile1);
     }
 


### PR DESCRIPTION
The decision if the refspec should be honored during clone is now
part of the CloneOption additional behaviour.  The user can control
the setting per job, and the default setting remains compatible with
the git plugin 2.5.0 (and prior) cloning of all references initially,
then later honoring the refspec in other operations.

Prior to git plugin 2.5.1, JENKINS-31393 caused the user provided
refspec to be ignored during the initial clone. It was honored in
later fetch operations, but not in the first clone. That meant the
initial clone had to fetch all the branches and their references from
the remote repository, even if those branches were later ignored due
to the refspec.

The fix for JENKINS-31393 exposed JENKINS-36507 which indicates that
the Gerrit Plugin assumes all references are fetched, even though it
only passes the refspec for one branch. The git plugin shouldn't
require a code change in the gerrit plugin, so each job must choose if
JENKINS-31393 will affect that job or not.

Most jobs that are significantly affected by JENKINS-31393 will likely
need to make other changes in the "Advanced clone options" (like using
a reference repository, or disabling the cloning of tags, or enabling
shallow clone).

Added CloneOption tests for JENKINS-36507 using the same basic test as
was earlier submitted for JENKINS-31393.

The testSpecificRefspecs and testSpecificRefspecsWithoutCloneOption
methods confirm behaviors of refspecs on initial clone. Without the
CloneOption to honor refspec, all references are cloned, even if they
will be later ignored due to the refspec.  With the CloneOption to ignore
refspec, the initial clone also honors the refspec and only retrieves
references per the refspec.