### PR TITLE
Call JGit 4 close method if JGit 3 release method not found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <!-- TODO: Ongoing work on https://github.com/MarkEWaite/git-plugin/tree/master-findbugs-fixes. -->
     <findbugs.failOnError>false</findbugs.failOnError>
     <workflow.version>1.14.2</workflow.version>
+    <permgen.size>160m</permgen.size>
   </properties>
 
   <build>
@@ -92,6 +93,12 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-XX:MaxPermSize=${permgen.size} -Djava.awt.headless=true</argLine>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -59,20 +59,20 @@ public class GitUtils implements Serializable {
         try {
             closeMethod = walk.getClass().getDeclaredMethod("close");
         } catch (NoSuchMethodException ex) {
-            LOGGER.log(Level.SEVERE, "Finding RevWalk close method exception {0}", ex);
+            LOGGER.log(Level.SEVERE, "Exception finding walker close method: {0}", ex);
             return;
         } catch (SecurityException ex) {
-            LOGGER.log(Level.SEVERE, "Finding RevWalk close method exception {0}", ex);
+            LOGGER.log(Level.SEVERE, "Exception finding walker close method: {0}", ex);
             return;
         }
         try {
             closeMethod.invoke(walk);
         } catch (IllegalAccessException ex) {
-            LOGGER.log(Level.SEVERE, "Calling RevWalk close method exception {0}", ex);
+            LOGGER.log(Level.SEVERE, "Exception calling walker close method: {0}", ex);
         } catch (IllegalArgumentException ex) {
-            LOGGER.log(Level.SEVERE, "Calling RevWalk close method exception {0}", ex);
+            LOGGER.log(Level.SEVERE, "Exception calling walker close method: {0}", ex);
         } catch (InvocationTargetException ex) {
-            LOGGER.log(Level.SEVERE, "Calling RevWalk close method exception {0}", ex);
+            LOGGER.log(Level.SEVERE, "Exception calling walker close method: {0}", ex);
         }
     }
 

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -19,6 +19,8 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.RepositoryCallback;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
@@ -52,7 +54,7 @@ public class GitUtils implements Serializable {
         return j;
     }
 
-    private static void _close(RevWalk walk) {
+    private static void _close(@NonNull RevWalk walk) {
         LOGGER.info("Calling RevWalk close");
         java.lang.reflect.Method closeMethod;
         try {
@@ -79,11 +81,14 @@ public class GitUtils implements Serializable {
     /**
      * Call release method on walk.  JGit 3 uses release(), JGit 4 uses close() to
      * release resources.
-     * 
+     *
      * This method should be removed once the code depends on git client 2.0.0.
      * @param walk object whose close or release method will be called
      */
     private static void _release(RevWalk walk) throws IOException {
+        if (walk == null) {
+            return;
+        }
         try {
             LOGGER.info("Calling RevWalk release");
             walk.release(); // JGit 3

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -55,7 +55,6 @@ public class GitUtils implements Serializable {
     }
 
     private static void _close(@NonNull RevWalk walk) {
-        LOGGER.info("Calling RevWalk close");
         java.lang.reflect.Method closeMethod;
         try {
             closeMethod = walk.getClass().getDeclaredMethod("close");
@@ -75,7 +74,6 @@ public class GitUtils implements Serializable {
         } catch (InvocationTargetException ex) {
             LOGGER.log(Level.SEVERE, "Calling RevWalk close method exception {0}", ex);
         }
-        LOGGER.info("RevWalk close called");
     }
 
     /**
@@ -90,9 +88,7 @@ public class GitUtils implements Serializable {
             return;
         }
         try {
-            LOGGER.info("Calling RevWalk release");
             walk.release(); // JGit 3
-            LOGGER.info("RevWalk release called");
         } catch (NoSuchMethodError noMethod) {
             _close(walk);
         }

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -61,13 +61,11 @@ public class GitUtils implements Serializable {
      * This method should be removed once the code depends on git client 2.0.0.
      * @param walk object whose close or release method will be called
      */
-    public static void close(Object walk) throws IOException {
+    private static void _close(RevWalk walk) throws IOException {
         if (walk instanceof Closeable) { // JGit 4
             ((Closeable) walk).close();
-        } else if (walk instanceof RevWalk) { // JGit 3
-            ((RevWalk) walk).release();
-        } else if (walk instanceof TreeWalk) { // JGit 3
-            ((TreeWalk) walk).release();
+        } else { // JGit 3
+            walk.release();
         }
     }
 
@@ -209,7 +207,7 @@ public class GitUtils implements Serializable {
                         }
 
                     } finally {
-                        close(walk);
+                        _close(walk);
                     }
 
                     if (log)

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -51,6 +51,7 @@ import hudson.plugins.git.util.BuildChooserContext;
 import hudson.plugins.git.util.BuildChooserDescriptor;
 import hudson.plugins.git.util.BuildData;
 import hudson.plugins.git.util.DefaultBuildChooser;
+import hudson.plugins.git.util.GitUtils;
 import hudson.scm.SCM;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
@@ -254,7 +255,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                         try {
                                             tw.release();
                                         } catch (NoSuchMethodError noMethod) {
-                                            hudson.plugins.git.util.GitUtils.callClose(tw);
+                                            GitUtils.close(tw);
                                         }
                                     }
                                 }

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -1,3 +1,4 @@
+
 /*
  * The MIT License
  *
@@ -51,7 +52,6 @@ import hudson.plugins.git.util.BuildChooserContext;
 import hudson.plugins.git.util.BuildChooserDescriptor;
 import hudson.plugins.git.util.BuildData;
 import hudson.plugins.git.util.DefaultBuildChooser;
-import hudson.plugins.git.util.GitUtils;
 import hudson.scm.SCM;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
@@ -193,6 +193,9 @@ public abstract class AbstractGitSCMSource extends SCMSource {
      * @param walk object whose close or release method will be called
      */
     private static void _close(TreeWalk walk) throws IOException {
+        if (walk == null) {
+            return;
+        }
         if (walk instanceof Closeable) { // JGit 4
             ((Closeable) walk).close();
         } else { // JGit 3
@@ -267,13 +270,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                 try {
                                     return tw != null;
                                 } finally {
-                                    if (tw != null) {
-                                        try {
-                                            tw.release();
-                                        } catch (NoSuchMethodError noMethod) {
-                                            _close(tw);
-                                        }
-                                    }
+                                    _close(tw);
                                 }
                             }
                         };

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -183,16 +183,6 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         }
     }
 
-    /**
-     * Call close method on walk using reflection.  JGit 3 uses
-     * release(), but JGit 4 uses close().  If run-time dependency on
-     * JGit 3 is not satisfied (because JGit 4 is included in git
-     * client plugin 2.0.0), then try calling the JGit 4 close()
-     * method.
-     */
-    private void callClose(TreeWalk walk) {
-    }
-
     @NonNull
     @Override
     protected void retrieve(@NonNull final SCMHeadObserver observer,
@@ -264,7 +254,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                         try {
                                             tw.release();
                                         } catch (NoSuchMethodError noMethod) {
-                                            callClose(tw);
+                                            hudson.plugins.git.util.GitUtils.callClose(tw);
                                         }
                                     }
                                 }

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -183,6 +183,16 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         }
     }
 
+    /**
+     * Call close method on walk using reflection.  JGit 3 uses
+     * release(), but JGit 4 uses close().  If run-time dependency on
+     * JGit 3 is not satisfied (because JGit 4 is included in git
+     * client plugin 2.0.0), then try calling the JGit 4 close()
+     * method.
+     */
+    private void callClose(TreeWalk walk) {
+    }
+
     @NonNull
     @Override
     protected void retrieve(@NonNull final SCMHeadObserver observer,
@@ -251,7 +261,11 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                     return tw != null;
                                 } finally {
                                     if (tw != null) {
-                                        tw.release();
+                                        try {
+                                            tw.release();
+                                        } catch (NoSuchMethodError noMethod) {
+                                            callClose(tw);
+                                        }
                                     }
                                 }
                             }

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -187,7 +187,6 @@ public abstract class AbstractGitSCMSource extends SCMSource {
     }
 
     private static void _close(@NonNull TreeWalk walk) {
-        LOGGER.info("Calling TreeWalk close");
         java.lang.reflect.Method closeMethod;
         try {
             closeMethod = walk.getClass().getDeclaredMethod("close");
@@ -207,7 +206,6 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         } catch (InvocationTargetException ex) {
             LOGGER.log(Level.SEVERE, "Calling TreeWalk close method exception {0}", ex);
         }
-        LOGGER.info("TreeWalk close called");
     }
 
     /**
@@ -222,9 +220,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             return;
         }
         try {
-            LOGGER.info("Calling TreeWalk release");
             walk.release(); // JGit 3
-            LOGGER.info("TreeWalk release called");
         } catch (NoSuchMethodError noMethod) {
             _close(walk);
         }

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -186,7 +186,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         }
     }
 
-    private static void _close(TreeWalk walk) {
+    private static void _close(@NonNull TreeWalk walk) {
         LOGGER.info("Calling TreeWalk close");
         java.lang.reflect.Method closeMethod;
         try {
@@ -213,11 +213,14 @@ public abstract class AbstractGitSCMSource extends SCMSource {
     /**
      * Call release method on walk.  JGit 3 uses release(), JGit 4 uses close() to
      * release resources.
-     * 
+     *
      * This method should be removed once the code depends on git client 2.0.0.
      * @param walk object whose close or release method will be called
      */
     private static void _release(TreeWalk walk) throws IOException {
+        if (walk == null) {
+            return;
+        }
         try {
             LOGGER.info("Calling TreeWalk release");
             walk.release(); // JGit 3


### PR DESCRIPTION
@rsandell , @ndeloof , @KostyaSha , @jglick , @stephenc , and @kohsuke , I think this is one possible way to resolve the incompatibility between JGit 3 and JGit 4 without requiring simultaneous upgrade of git client plugin and those plugins which depend on it.  

Refer to my [Jenkins Developers posting](https://groups.google.com/d/msg/jenkinsci-dev/XHwAba2kMc8/mgx4gYznAAAJ) (and the several responses) for some of the alternatives discussed for handling the problem.

The change seems small enough (to me) and allows the git plugin to use either JGit 3 ro JGit 4.