### PR TITLE
[Fix JENKINS-37066] gogs config edit fails after save

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.9</version>
+    <version>2.12</version>
   </parent>
 
   <licenses>

--- a/src/main/resources/hudson/plugins/git/browser/GogsGit/config.jelly
+++ b/src/main/resources/hudson/plugins/git/browser/GogsGit/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry field="repoUrl" title="URL">
+    <f:textbox/>
+  </f:entry>
+</j:jelly>


### PR DESCRIPTION
The gogs browser pull request was missing the required config.jelly file.  This adds that file