### PR TITLE
[JENKINS-37482] Make the cache directory, not just its parent

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -363,10 +363,11 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             return null;
         }
         File cacheDir = new File(new File(jenkins.getRootDir(), "caches"), cacheEntry);
-        File parentDir = cacheDir.getParentFile();
-        if (!parentDir.isDirectory()) {
-            boolean ok = parentDir.mkdirs();
-            if (!ok) LOGGER.info("Failed mkdirs of " + parentDir.getPath());
+        if (!cacheDir.isDirectory()) {
+            boolean ok = cacheDir.mkdirs();
+            if (!ok) {
+                LOGGER.log(Level.WARNING, "Failed mkdirs of {0}", cacheDir);
+            }
         }
         return cacheDir;
     }

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -5,6 +5,7 @@ import hudson.util.StreamTaskListener;
 import jenkins.scm.api.SCMSource;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
 import org.mockito.Mockito;
@@ -56,6 +57,7 @@ public class AbstractGitSCMSourceTest {
   }
 
     // TODO AbstractGitSCMSourceRetrieveHeadsTest *sounds* like it would be the right place, but it does not in fact retrieve any heads!
+    @Issue("JENKINS-37482")
     @Test
     public void retrieveHeads() throws Exception {
         sampleRepo.init();


### PR DESCRIPTION
[JENKINS-37482](https://issues.jenkins-ci.org/browse/JENKINS-37482)

@reviewbybees