### PR TITLE
Should be using Job instead of Item.

### DIFF
--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -82,7 +82,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
     @Extension
     public static class DescriptorImpl extends Descriptor<UserRemoteConfig> {
 
-        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item project,
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Job<?,?> project,
                                                      @QueryParameter String url,
                                                      @QueryParameter String credentialsId) {
             if (project == null || !project.hasPermission(Item.EXTENDED_READ)) {

--- a/src/main/java/jenkins/plugins/git/GitStep.java
+++ b/src/main/java/jenkins/plugins/git/GitStep.java
@@ -28,6 +28,7 @@ import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Item;
+import hudson.model.Job;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.SubmoduleConfig;
@@ -92,7 +93,7 @@ public final class GitStep extends SCMStep {
         @Inject
         private UserRemoteConfig.DescriptorImpl delegate;
 
-        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item project,
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Job<?,?> project,
                                                      @QueryParameter String url,
                                                      @QueryParameter String credentialsId) {
             return delegate.doFillCredentialsIdItems(project, url, credentialsId);


### PR DESCRIPTION
Similar to: https://github.com/jenkinsci/subversion-plugin/pull/167, the `doFillCredentialsIdItems` should be using `Job` instead of `Item`.

Credentials defined at the folder level might not appear for certain types of Items. Similar to the mercurial plugin, https://github.com/jenkinsci/mercurial-plugin/blob/41fda47ac7749cc55173cb91e0dc5d953ddf90df/src/main/java/hudson/plugins/mercurial/MercurialSCM.java#L1048, we should use `Job` instead of `Item`.

@reviewbybees 