### PR TITLE
[JENKINS-37263] Prefer remote branch if we have multiple candidates

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -990,8 +990,21 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             // will build the last built thing.
             throw new AbortException("Couldn't find any revision to build. Verify the repository and branch configuration for this job.");
         }
+        
+        // Related to JENKINS-37263
+        // If we have multiple candidates, we want to select the remote one
+        // As our local candidate is probably the branch created by the local branch behaviour.
+        Iterator<Revision> candidatesIterator = candidates.iterator();
+        Revision marked = candidatesIterator.next();
+        while(candidatesIterator.hasNext()) {
+            Revision candidate = candidatesIterator.next();
+            
+            Branch candidateBranch = candidate.getBranches().iterator().next();
+            if (candidateBranch.getName().startsWith("refs/remotes/")) {
+                marked = candidate;
+            }
+        }
 
-        Revision marked = candidates.iterator().next();
         Revision rev = marked;
         // Modify the revision based on extensions
         for (GitSCMExtension ext : extensions) {


### PR DESCRIPTION
When you use git with the local branch plugin configured with `**` and have a branch with a slash in it (like `features/my-branch`), generally the wrong branch is selected when checkout is called (the local one is selected instead of the remote one).

The proposed fix select the first revision, and iterate over the others. If one of the other contains `refs/remotes`, this revision will be selected.

Here are some points that I've to do / or you could particularly review:
- [ ] Check if the implementation of this fix is correct / clean / following the Jenkins conventions
- [ ] Check if selecting the first branch of a revision is the desired behavior, or if we should iterate over them.
- [ ] Add (or not) a condition to only run this code if the Additional Behavior Local Branch is selected. (I don't know how)
- [ ] Rewrite the commit name to fit Jenkins Contribution Guideline (put the associated bug id)
- [ ] Add unit tests

[JENKINS-37575 on JIRA](https://issues.jenkins-ci.org/browse/JENKINS-37575)
