### PR TITLE
[JENKINS-38048] Permit credentialsId dropdowns to be used from a global configuration screen

### DIFF
--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -5,6 +5,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Util;
@@ -82,6 +83,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
     @Extension
     public static class DescriptorImpl extends Descriptor<UserRemoteConfig> {
 
+        @SuppressFBWarnings(value="NP_NULL_PARAM_DEREF", justification="pending https://github.com/jenkinsci/credentials-plugin/pull/68")
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item project,
                                                      @QueryParameter String url,
                                                      @QueryParameter String credentialsId) {

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -5,7 +5,6 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
-import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Util;
@@ -36,6 +35,7 @@ import org.apache.commons.lang.StringUtils;
 
 import static hudson.Util.fixEmpty;
 import static hudson.Util.fixEmptyAndTrim;
+import javax.annotation.CheckForNull;
 
 @ExportedBean
 public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> implements Serializable {
@@ -85,7 +85,8 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item project,
                                                      @QueryParameter String url,
                                                      @QueryParameter String credentialsId) {
-            if (project == null || !project.hasPermission(Item.EXTENDED_READ)) {
+            if (project == null && !Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER) ||
+                project != null && !project.hasPermission(Item.EXTENDED_READ)) {
                 return new StandardListBoxModel().includeCurrentValue(credentialsId);
             }
             return new StandardListBoxModel()
@@ -104,7 +105,8 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
         public FormValidation doCheckCredentialsId(@AncestorInPath Item project,
                                                    @QueryParameter String url,
                                                    @QueryParameter String value) {
-            if (project == null || !project.hasPermission(Item.EXTENDED_READ)) {
+            if (project == null && !Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER) ||
+                project != null && !project.hasPermission(Item.EXTENDED_READ)) {
                 return FormValidation.ok();
             }
 
@@ -149,7 +151,8 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
 
             // Normally this permission is hidden and implied by Item.CONFIGURE, so from a view-only form you will not be able to use this check.
             // (TODO under certain circumstances being granted only USE_OWN might suffice, though this presumes a fix of JENKINS-31870.)
-            if (item == null || !item.hasPermission(CredentialsProvider.USE_ITEM)) {
+            if (item == null && !Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER) ||
+                item != null && !item.hasPermission(CredentialsProvider.USE_ITEM)) {
                 return FormValidation.ok();
             }
 
@@ -185,7 +188,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
             return FormValidation.ok();
         }
 
-        private static StandardCredentials lookupCredentials(Item project, String credentialId, String uri) {
+        private static StandardCredentials lookupCredentials(@CheckForNull Item project, String credentialId, String uri) {
             return (credentialId == null) ? null : CredentialsMatchers.firstOrNull(
                         CredentialsProvider.lookupCredentials(StandardCredentials.class, project, ACL.SYSTEM,
                                 GitURIRequirementsBuilder.fromUri(uri).build()),

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -28,6 +28,7 @@ import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import hudson.Extension;
 import hudson.Util;
@@ -189,6 +190,7 @@ public class GitSCMSource extends AbstractGitSCMSource {
             return Messages.GitSCMSource_DisplayName();
         }
 
+        @SuppressFBWarnings(value="NP_NULL_PARAM_DEREF", justification="pending https://github.com/jenkinsci/credentials-plugin/pull/68")
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath SCMSourceOwner context,
                                                      @QueryParameter String remote,
                                                      @QueryParameter String credentialsId) {

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -192,7 +192,8 @@ public class GitSCMSource extends AbstractGitSCMSource {
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath SCMSourceOwner context,
                                                      @QueryParameter String remote,
                                                      @QueryParameter String credentialsId) {
-            if (context == null || !context.hasPermission(Item.EXTENDED_READ)) {
+            if (context == null && !Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER) ||
+                context != null && !context.hasPermission(Item.EXTENDED_READ)) {
                 return new StandardListBoxModel().includeCurrentValue(credentialsId);
             }
             return new StandardListBoxModel()
@@ -209,7 +210,8 @@ public class GitSCMSource extends AbstractGitSCMSource {
         public FormValidation doCheckCredentialsId(@AncestorInPath SCMSourceOwner context,
                                                    @QueryParameter String url,
                                                    @QueryParameter String value) {
-            if (context == null || !context.hasPermission(Item.EXTENDED_READ)) {
+            if (context == null && !Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER) ||
+                context != null && !context.hasPermission(Item.EXTENDED_READ)) {
                 return FormValidation.ok();
             }
 

--- a/src/test/java/hudson/plugins/git/UserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/UserRemoteConfigTest.java
@@ -1,0 +1,67 @@
+package hudson.plugins.git;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import com.google.common.collect.Sets;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.User;
+import hudson.security.ACL;
+import hudson.util.ListBoxModel;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+
+public class UserRemoteConfigTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Issue("JENKINS-38048")
+    @Test
+    public void credentialsDropdown() throws Exception {
+        SystemCredentialsProvider.getInstance().getCredentials().add(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "mycreds", null, "jenkins", "s3cr3t"));
+        SystemCredentialsProvider.getInstance().save();
+        FreeStyleProject p1 = r.createFreeStyleProject("p1");
+        FreeStyleProject p2 = r.createFreeStyleProject("p2");
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
+            grant(Jenkins.ADMINISTER).everywhere().to("admin").
+            grant(Jenkins.READ, Item.READ).everywhere().to("dev").
+            grant(Item.EXTENDED_READ).onItems(p1).to("dev"));
+        assertCredentials(p1, null, "dev", "", "mycreds");
+        assertCredentials(p2, null, "dev", "");
+        assertCredentials(p1, null, "admin", "", "mycreds");
+        assertCredentials(p2, null, "admin", "", "mycreds");
+        assertCredentials(p1, "othercreds", "dev", "", "mycreds", "othercreds");
+        assertCredentials(null, null, "dev", "");
+        assertCredentials(null, null, "admin", "", "mycreds");
+        assertCredentials(null, "othercreds", "admin", "", "mycreds", "othercreds");
+    }
+    
+    private void assertCredentials(@CheckForNull final Item project, @CheckForNull final String currentCredentialsId, @Nonnull String user, @Nonnull String... expectedCredentialsIds) {
+        final Set<String> actual = new TreeSet<String>(); // for purposes of this test we do not care about order (though StandardListBoxModel does define some)
+        ACL.impersonate(User.get(user).impersonate(), new Runnable() {
+            @Override
+            public void run() {
+                for (ListBoxModel.Option option : r.jenkins.getDescriptorByType(UserRemoteConfig.DescriptorImpl.class).
+                        doFillCredentialsIdItems(project, "http://wherever.jenkins.io/", currentCredentialsId)) {
+                    actual.add(option.value);
+                }
+            }
+        });
+        assertEquals("expected completions on " + project + " as " + user + " starting with " + currentCredentialsId,
+                Sets.newTreeSet(Arrays.asList(expectedCredentialsIds)), actual);
+    }
+
+}


### PR DESCRIPTION
[JENKINS-38048](https://issues.jenkins-ci.org/browse/JENKINS-38048)

@reviewbybees esp. @stephenc