### PR TITLE
Fixed mixture of nonempty extensions with SpecificRevisionBuildChooser

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -397,15 +397,16 @@ public abstract class AbstractGitSCMSource extends SCMSource {
     @NonNull
     @Override
     public SCM build(@NonNull SCMHead head, @CheckForNull SCMRevision revision) {
-        BuildChooser buildChooser = revision instanceof SCMRevisionImpl ? new SpecificRevisionBuildChooser(
-                (SCMRevisionImpl) revision) : new DefaultBuildChooser();
-        List<GitSCMExtension> extensions = getExtensions();
+        List<GitSCMExtension> extensions = new ArrayList<GitSCMExtension>(getExtensions());
+        if (revision instanceof SCMRevisionImpl) {
+            extensions.add(new BuildChooserSetting(new SpecificRevisionBuildChooser((SCMRevisionImpl) revision)));
+        }
         return new GitSCM(
                 getRemoteConfigs(),
                 Collections.singletonList(new BranchSpec(head.getName())),
                 false, Collections.<SubmoduleConfig>emptyList(),
                 getBrowser(), getGitTool(),
-                extensions.isEmpty() ? Collections.<GitSCMExtension>singletonList(new BuildChooserSetting(buildChooser)) : extensions);
+                extensions);
     }
 
     protected List<UserRemoteConfig> getRemoteConfigs() {


### PR DESCRIPTION
Fixes a mistake in #350: if you are configuring some extensions, like clean before checkout for example, you still want to ensure that

```groovy
node {
  checkout scm
}
```

in a multibranch Pipeline project checks out the same revision as `Jenkinsfile` itself.

@reviewbybees