### PR TITLE
[JENKINS-38406] Permit build parameter override GitSCM multi-branch s…

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -123,6 +123,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     public static final String GIT_COMMIT = "GIT_COMMIT";
     public static final String GIT_PREVIOUS_COMMIT = "GIT_PREVIOUS_COMMIT";
     public static final String GIT_PREVIOUS_SUCCESSFUL_COMMIT = "GIT_PREVIOUS_SUCCESSFUL_COMMIT";
+    public static final String GIT_SINGLE_BRANCH_SELECTOR = "GIT_SINGLE_BRANCH_SELECTOR";
 
     /**
      * All the configured extensions attached to this.
@@ -509,11 +510,17 @@ public class GitSCM extends GitSCMBackwardCompatibility {
      * Otherwise return null.
      */
     private String getSingleBranch(EnvVars env) {
-        // if we have multiple branches skip to advanced usecase
-        if (getBranches().size() != 1) {
-            return null;
-        }
-        String branch = getBranches().get(0).getName();
+    	String branch = env.get(GIT_SINGLE_BRANCH_SELECTOR, "").trim();
+
+    	// if the caller provides an overriding branch specification
+    	// use it otherwise fall back to original behavior.
+    	if (branch.isEmpty()) {
+	        // if we have multiple branches skip to advanced usecase
+	        if (getBranches().size() != 1) {
+	            return null;
+	        }
+	        branch = getBranches().get(0).getName();
+    	}
         String repository = null;
 
         if (getRepositories().size() != 1) {

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -261,7 +261,6 @@ public class GitUtils implements Serializable {
     public static EnvVars getPollEnvironment(AbstractProject p, FilePath ws, Launcher launcher, TaskListener listener, boolean reuseLastBuildEnv)
         throws IOException,InterruptedException {
         EnvVars env;
-        StreamBuildListener buildListener = new StreamBuildListener((OutputStream)listener.getLogger());
         AbstractBuild b = p.getLastBuild();
 
         if (b == null) {
@@ -271,6 +270,8 @@ public class GitUtils implements Serializable {
             throw new IllegalArgumentException("Last build must not be null. If there really is no last build, " +
                     "a new build should be triggered without polling the SCM.");
         }
+
+        StreamBuildListener buildListener = new StreamBuildListener((OutputStream)listener.getLogger());
 
         if (reuseLastBuildEnv) {
             Node lastBuiltOn = b.getBuiltOn();
@@ -335,7 +336,7 @@ public class GitUtils implements Serializable {
                 }
             }
         }
-        
+
         // Use the default parameter values (if any) instead of the ones from the last build
         ParametersDefinitionProperty paramDefProp = (ParametersDefinitionProperty) b.getProject().getProperty(ParametersDefinitionProperty.class);
         if (paramDefProp != null) {


### PR DESCRIPTION
…election

This commit adds an optional build parameter GIT_SINGLE_BRANCH_SELECTOR
that can be given in a downstream trigger or via build parameter selection
to direct the GitSCM to build a specific branch in a multi-branch SCM
configuration.

The use case here is for multi-repo build where dependent modules are
set as downstream builds for their dependencies. When a building these
we setup the same branch across multiple repositories tracking development
streams. We cannot utilize the "Pass GIT commit" trigger parameter since
this works only for builds that share their SCM repository and the
commit is meaningful between multiple jobs.

Second use case serviced by this option is a manual build of a GitSCM
multi-branch configuration. The current behavior will default to rebuild
the last successful built branch. We have a situation that uses manual
triggered builds that aggregate results from mutliple independently
built repositories and uses branches to keep the development streams
separated. These aggregation builds most often have no commits between
builds but use dynamic dependencies to select the desired latest
development stream artifacts. The build is expected to produce a new
combined artifact with a new dynamic set of dependencies without any
commits in the source branch.
