### PR TITLE
Git SCM extension for white- and blacklisting branches during polling

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/BranchRestriction.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/BranchRestriction.java
@@ -1,0 +1,115 @@
+package hudson.plugins.git.extensions.impl;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitChangeSet;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import hudson.plugins.git.util.BuildData;
+
+/**
+ * {@link GitSCMExtension} that allows to white- and black-list branches.
+ *
+ * @author Marcus Klein
+ */
+public class BranchRestriction extends GitSCMExtension {
+
+	private String blacklist;
+	private String whitelist;
+
+    @DataBoundConstructor
+	public BranchRestriction(String whitelist, String blacklist) {
+		super();
+		this.whitelist = whitelist;
+		this.blacklist = blacklist;
+	}
+
+    @Override
+    public boolean requiresWorkspaceForPolling() {
+        return true;
+    }
+
+    public String getWhitelist() {
+		return whitelist;
+	}
+
+	public String getBlacklist() {
+		return blacklist;
+	}
+
+	private String[] normalize(String s) {
+		return StringUtils.isBlank(s) ? null : s.split(",");
+	}
+
+	private Set<String> getWhitelistSet() {
+		return getSet(normalize(whitelist));
+	}
+
+	private Set<String> getBlacklistSet() {
+		return getSet(normalize(blacklist));
+	}
+
+    private Set<String> getSet(String[] list) {
+    	if (null != list) {
+    		Set<String> retval = new HashSet<String>(list.length);
+    		for (String s : list) {
+    			retval.add(s);
+    		}
+    		return retval;
+    	}
+		return Collections.emptySet();
+	}
+
+	@Override
+    public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener, BuildData buildData) throws InterruptedException {
+		List<Branch> branches = git.getBranchesContaining(commit.getId(), true);
+		for (Branch branch : branches) {
+			String branchName = getBranchName(branch);
+			Set<String> whitelist = getWhitelistSet();
+			Set<String> blacklist = getBlacklistSet();
+			String message = "Checking branch " + branchName + " against whitelist " + whitelist + " and blacklist " + blacklist + " with result: ";
+			if (!whitelist.isEmpty()) {
+				if (whitelist.contains(branchName)) {
+					listener.getLogger().println(message + "whitelisted.");
+					return false;
+				} else {
+					listener.getLogger().println(message + "not in whitelist.");
+					return true;
+				}
+			}
+			if (!blacklist.isEmpty()) {
+				if (blacklist.contains(branchName)) {
+					listener.getLogger().println(message + "blacklisted.");
+					return true;
+				} else {
+					listener.getLogger().println(message + "not in blacklist.");
+				}
+			}
+		}
+    	return null;
+    }
+
+    private String getBranchName(Branch branch) {
+        String name = branch.getName();
+        return name.startsWith("remotes/") ? name.substring(name.indexOf('/', "remotes/".length()) + 1) : name;
+    }
+
+	@Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Polling ignores commits in certain branches";
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/BranchRestriction/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/BranchRestriction/config.groovy
@@ -1,0 +1,10 @@
+package hudson.plugins.git.extensions.impl.BranchRestriction;
+
+def f = namespace(lib.FormTagLib);
+
+f.entry(title:_("Whitelist"), field:"whitelist") {
+    f.textbox()
+}
+f.entry(title:_("Blacklist"), field:"blacklist") {
+    f.textbox()
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/BranchRestriction/help-blacklist.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/BranchRestriction/help-blacklist.html
@@ -1,0 +1,8 @@
+<div>
+  Define the comma separated list of branch names that should not be considered for being built.
+  <p/>
+  <pre>
+    refactor-something,broken
+  </pre>
+  The example above will refuse builds on branches refactor-something and broken.
+</div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/BranchRestriction/help-whitelist.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/BranchRestriction/help-whitelist.html
@@ -1,0 +1,8 @@
+<div>
+  Define the comma separated list of branch names that should be considered for being built.
+  <p/>
+  <pre>
+    master,develop
+  </pre>
+  The example above will trigger only builds on branches master and develop.
+</div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/BranchRestriction/help.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/BranchRestriction/help.html
@@ -1,0 +1,9 @@
+<div>
+ Configure comma separated white- and blacklists of branches that trigger builds or avoid triggering builds.
+ You need to define the branch names without refs/, remotes/, origin prefixes. The branch names need to match exactly.
+ <p/>
+ If one of the lists is empty, it is not considered at all. If you define both, the whitelist is considered first.
+ If the branch is not whitelisted, the blacklist will not be considered.
+ <p>
+  Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <b>Force polling using workspace</b> extension as well.
+</div>

--- a/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
@@ -47,10 +47,9 @@ public abstract class GitSCMExtensionTest {
 		return build;
 	}
 
-	protected FreeStyleProject setupBasicProject(TestGitRepo repo) throws Exception {
+	protected FreeStyleProject setupBasicProject(TestGitRepo repo, List<BranchSpec> branches) throws Exception {
 		GitSCMExtension extension = getExtension();
 		FreeStyleProject project = j.createFreeStyleProject(extension.getClass() + "Project");
-		List<BranchSpec> branches = Collections.singletonList(new BranchSpec("master"));
 		GitSCM scm = new GitSCM(
 				repo.remoteConfigs(),
 				branches,
@@ -61,5 +60,9 @@ public abstract class GitSCMExtensionTest {
 		project.setScm(scm);
 		project.getBuildersList().add(new CaptureEnvironmentBuilder());
 		return project;
+	}
+
+	protected FreeStyleProject setupBasicProject(TestGitRepo repo) throws Exception {
+		return setupBasicProject(repo, Collections.singletonList(new BranchSpec("master")));
 	}
 }

--- a/src/test/java/hudson/plugins/git/extensions/impl/BranchRestrictionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/BranchRestrictionTest.java
@@ -1,0 +1,95 @@
+package hudson.plugins.git.extensions.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.TestGitRepo;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionTest;
+
+/**
+ * {@link BranchRestrictionTest} verifies that whitelisting and blacklisting of branches works as expected.
+ *
+ * @author Marcus Klein
+ */
+@RunWith(Enclosed.class)
+public class BranchRestrictionTest {
+
+	public abstract static class BranchRestrictionExtensionTest extends GitSCMExtensionTest {
+
+        protected FreeStyleProject project;
+        protected TestGitRepo repo;
+
+        @Override
+        public void before() throws Exception {
+    		repo = new TestGitRepo("repo", tmp.newFolder(), listener);
+    		project = setupBasicProject(repo, Collections.singletonList(new BranchSpec("*")));
+        }
+    }
+
+	public static class WhitelistTest extends BranchRestrictionExtensionTest {
+
+		@Override
+		protected GitSCMExtension getExtension() {
+			return new BranchRestriction("develop", "");
+		}
+
+		@Test
+		public void testWhitelist() throws Exception {
+			repo.commit("repo-init", repo.johnDoe, "repo0 initial commit");
+			assertTrue("scm polling should detect a change after initial commit", project.poll(listener).hasChanges());
+			build(project, Result.SUCCESS);
+			assertFalse("scm polling should not detect any more changes after initial build", project.poll(listener).hasChanges());
+
+			// Commit on master should not trigger a build
+			repo.commit("file2", repo.janeDoe, "commit2");
+			assertFalse("scm polling should avoid build on master", project.poll(listener).hasChanges());
+			// no build on master branch
+
+			repo.git.checkout().ref("master").branch("develop").execute();
+			repo.commit("testOnDevelop", repo.johnDoe, "on develop");
+			assertTrue("scm polling should detect a change on the develop branch",  project.poll(listener).hasChanges());
+			build(project, Result.SUCCESS);
+
+			assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+		}
+	}
+
+	public static class BlacklistTest extends BranchRestrictionExtensionTest {
+
+		@Override
+		protected GitSCMExtension getExtension() {
+			return new BranchRestriction("", "develop");
+		}
+
+		@Test
+		public void testWhitelist() throws Exception {
+			repo.commit("repo-init", repo.johnDoe, "repo0 initial commit");
+			assertTrue("scm polling should detect a change after initial commit", project.poll(listener).hasChanges());
+			build(project, Result.SUCCESS);
+			assertFalse("scm polling should not detect any more changes after initial build", project.poll(listener).hasChanges());
+
+			// Switch to develop and do a commit
+			repo.git.checkout().ref("master").branch("develop").execute();
+			repo.commit("testOnDevelop", repo.johnDoe, "on develop");
+			assertFalse("scm polling should avoid build on develop", project.poll(listener).hasChanges());
+
+			// Back to master and a new commit
+			repo.git.checkout().ref("master").execute();
+			repo.commit("file2", repo.janeDoe, "commit2 on master");
+			assertTrue("scm polling should detect a change on the master branch",  project.poll(listener).hasChanges());
+			build(project, Result.SUCCESS);
+
+			assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+		}
+	}
+}


### PR DESCRIPTION
We work a lot with feature branches on a very large Git repository. This pollutes the workspace on Jenkins slaves a lot and occupies too much build resources. Therefore we would like to whitelist only some branches, where we do integration and only want those branches have been built automatically through polling. Therefore I wrote this extension for the git plugin.

This is just to open the pull request and see the build results.