### PR TITLE
API to get author or committer email without having to call getAuthor()

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -264,6 +264,11 @@ public class GitChangeSet extends ChangeLogSet.Entry {
         return authorOrCommitter ? authorTime : committerTime;
     }
 
+    @Exported
+    public String getAuthorEmail() {
+        return authorOrCommitter ? authorEmail : committerEmail;
+    }
+
     @Override
     public long getTimestamp() {
         String date = getDate();

--- a/src/test/java/hudson/plugins/git/GitChangeSetBasicTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetBasicTest.java
@@ -35,11 +35,13 @@ public class GitChangeSetBasicTest {
     @Test
     public void testCommitter() {
         assertEquals(GitChangeSetUtil.COMMITTER_NAME, genChangeSet(false, false).getAuthorName());
+        assertEquals(GitChangeSetUtil.COMMITTER_EMAIL, genChangeSet(false, false).getAuthorEmail());
     }
 
     @Test
     public void testAuthor() {
         assertEquals(GitChangeSetUtil.AUTHOR_NAME, genChangeSet(true, false).getAuthorName());
+        assertEquals(GitChangeSetUtil.AUTHOR_EMAIL, genChangeSet(true, false).getAuthorEmail());
     }
 
     @Test

--- a/src/test/java/hudson/plugins/git/GitChangeSetUtil.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetUtil.java
@@ -26,11 +26,13 @@ public class GitChangeSetUtil {
     static final String AUTHOR_NAME = "John Author";
     static final String AUTHOR_DATE = "1234568 -0600";
     static final String AUTHOR_DATE_FORMATTED = "1970-01-15T06:56:08-0600";
+    static final String AUTHOR_EMAIL = "jauthor@nospam.com";
     static final String COMMITTER_NAME = "John Committer";
     static final String COMMITTER_DATE = "1234566 -0600";
     static final String COMMITTER_DATE_FORMATTED = "1970-01-15T06:56:06-0600";
     static final String COMMIT_TITLE = "Commit title.";
     static final String COMMENT = COMMIT_TITLE + "\n";
+    static final String COMMITTER_EMAIL = "jcommitter@nospam.com";
 
     static GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat) {
         return genChangeSet(authorOrCommitter, useLegacyFormat, true);
@@ -47,8 +49,8 @@ public class GitChangeSetUtil {
         } else {
             lines.add("parent ");
         }
-        lines.add("author " + AUTHOR_NAME + " <jauthor@nospam.com> " + AUTHOR_DATE);
-        lines.add("committer " + COMMITTER_NAME + " <jcommitter@nospam.com> " + COMMITTER_DATE);
+        lines.add("author " + AUTHOR_NAME + " <" + AUTHOR_EMAIL + "> " + AUTHOR_DATE);
+        lines.add("committer " + COMMITTER_NAME + " <" + COMMITTER_EMAIL + "> " + COMMITTER_DATE);
         lines.add("");
         lines.add("    " + COMMIT_TITLE);
         lines.add("    Commit extended description.");


### PR DESCRIPTION
Mostly needed to avoid https://issues.jenkins-ci.org/browse/JENKINS-39694 