### PR TITLE
reference real pattern docs in help file

### DIFF
--- a/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/help-excludedRegions.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/help-excludedRegions.html
@@ -1,14 +1,12 @@
 <div>
-  Each exclusion uses regular expression pattern matching, and must be separated by a new line.
+  Each exclusion uses <a href="http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">java regular expression pattern matching</a>,
+    and must be separated by a new line.
   <p/>
   <pre>
-	myapp/src/main/web/.*\.html
-	myapp/src/main/web/.*\.jpeg
-	myapp/src/main/web/.*\.gif
+    myapp/src/main/web/.*\.html
+    myapp/src/main/web/.*\.jpeg
+    myapp/src/main/web/.*\.gif
   </pre>
   The example above illustrates that if only html/jpeg/gif files have been committed to
   the SCM a build will not occur.
-  <p/>
-  More information on regular expressions can be found
-  <a href="http://www.regular-expressions.info/" target="_blank">here</a>.
 </div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/help-includedRegions.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/help-includedRegions.html
@@ -1,16 +1,14 @@
 <div>
-  Each inclusion uses regular expression pattern matching, and must be separated by a new line.
+  Each inclusion uses <a href="http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">java regular expression pattern matching</a>,
+    and must be separated by a new line.
   An empty list implies that everything is included.
   <p/>
   <pre>
-	myapp/src/main/web/.*\.html
-	myapp/src/main/web/.*\.jpeg
-	myapp/src/main/web/.*\.gif
+    myapp/src/main/web/.*\.html
+    myapp/src/main/web/.*\.jpeg
+    myapp/src/main/web/.*\.gif
   </pre>
   The example above illustrates that a build will only occur, if html/jpeg/gif files
   have been committed to the SCM. Exclusions take precedence over inclusions, if there is
   an overlap between included and excluded regions.
-  <p/>
-  More information on regular expressions can be found
-  <a href="http://www.regular-expressions.info/" target="_blank">here</a>.
 </div>


### PR DESCRIPTION
Found user that didn't found how to make regexp. Updating help to reference real docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/git-plugin/451)
<!-- Reviewable:end -->
