### PR TITLE
[JENKINS-40376] Build was fail if branch spec as an empty string

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -552,11 +552,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         // substitute build parameters if available
         branch = getParameterString(branch, env);
 
-        // Check for empty string - replace with "**" when seen.
-        if (branch.equals("")) {
-            branch = "**";
-        }
-
         return branch;
     }
 


### PR DESCRIPTION
Issue https://issues.jenkins-ci.org/browse/JENKINS-40376