### PR TITLE
git-plugin uses same default job parameters on notifyCommit

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -97,7 +97,10 @@ public class GitSCMFileSystem extends SCMFileSystem {
      *
      * @param client the client
      * @param remote the remote GIT URL
+     * @param head   identifier for the head commit to be referenced
      * @param rev    the revision.
+     * @throws IOException on I/O error
+     * @throws InterruptedException on thread interruption
      */
     protected GitSCMFileSystem(GitClient client, String remote, final String head, @CheckForNull
             AbstractGitSCMSource.SCMRevisionImpl rev) throws IOException, InterruptedException {


### PR DESCRIPTION
If more than one job configuration uses same git repository and same branch as git SCM and jobs are triggered using notifyCommit then default parameters from different jobs are appended in one allBuildParameters listArray. So jobs with parameters with same names not changing value.