### PR TITLE
Save branch from git notification

### DIFF
--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -345,6 +345,8 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
 
                             boolean branchFound = false,
                                     parametrizedBranchSpec = false;
+                            String branchName = null;
+
                             if (branches.length == 0) {
                                 branchFound = true;
                             } else {
@@ -363,6 +365,7 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
                                                     LOGGER.fine("Branch Spec " + branchSpec + " matches modified branch " + branch + " for " + project.getFullDisplayName() + ". ");
                                                 }
                                                 branchFound = true;
+                                                branchName = branch;
                                                 break OUT;
                                             }
                                         }
@@ -398,7 +401,7 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
                                     LOGGER.info("Scheduling " + project.getFullDisplayName() + " to build commit " + sha1);
                                     scmTriggerItem.scheduleBuild2(scmTriggerItem.getQuietPeriod(),
                                             new CauseAction(new CommitHookCause(sha1)),
-                                            new RevisionParameterAction(sha1, matchedURL), new ParametersAction(allBuildParameters));
+                                            new RevisionParameterAction(sha1, matchedURL, branchName), new ParametersAction(allBuildParameters));
                                     result.add(new ScheduledResponseContributor(project));
                                 } else {
                                     /* Poll the repository for changes

--- a/src/main/java/hudson/plugins/git/RevisionParameterAction.java
+++ b/src/main/java/hudson/plugins/git/RevisionParameterAction.java
@@ -55,6 +55,7 @@ public class RevisionParameterAction extends InvisibleAction implements Serializ
     public final boolean combineCommits;
     public final Revision revision;
     private final URIish repoURL;
+    private final String branchName;
 
     public RevisionParameterAction(String commit) {
         this(commit, false, null);
@@ -64,15 +65,24 @@ public class RevisionParameterAction extends InvisibleAction implements Serializ
         this(commit, false, repoURL);
     }
 
+    public RevisionParameterAction(String commit, URIish repoURL, String branchName) {
+        this(commit, false, repoURL, branchName);
+    }
+
     public RevisionParameterAction(String commit, boolean combineCommits) {
         this(commit, combineCommits, null);
     }
 
     public RevisionParameterAction(String commit, boolean combineCommits, URIish repoURL) {
+        this(commit, combineCommits, repoURL, null);
+    }
+
+    public RevisionParameterAction(String commit, boolean combineCommits, URIish repoURL, String branchName) {
         this.commit = commit;
         this.combineCommits = combineCommits;
         this.revision = null;
         this.repoURL = repoURL;
+        this.branchName = branchName;
     }
     
     public RevisionParameterAction(Revision revision) {
@@ -84,6 +94,7 @@ public class RevisionParameterAction extends InvisibleAction implements Serializ
     	this.commit = revision.getSha1String();
     	this.combineCommits = combineCommits;
         this.repoURL = null;
+        this.branchName = null;
     }   
 
     @Deprecated
@@ -97,11 +108,19 @@ public class RevisionParameterAction extends InvisibleAction implements Serializ
     	}
         ObjectId sha1 = git.revParse(commit);
         Revision revision = new Revision(sha1);
-        // Here we do not have any local branches, containing the commit. So...
-        // we are to get all the remote branches, and show them to users, as
-        // they are local
-        final List<Branch> branches = normalizeBranches(git.getBranchesContaining(
-                ObjectId.toString(sha1), true));
+
+        List<Branch> branches = null;
+
+        if (branchName != null) {
+            branches = new ArrayList<Branch>(1);
+            branches.add(new Branch(branchName, sha1));
+        } else {
+            // Here we do not have any local branches, containing the commit. So...
+            // we are to get all the remote branches, and show them to users, as
+            // they are local
+            branches = normalizeBranches(git.getBranchesContaining(
+                    ObjectId.toString(sha1), true));
+        }
         revision.getBranches().addAll(branches);
         return revision;
     }

--- a/src/test/java/hudson/plugins/git/RevisionParameterActionTest.java
+++ b/src/test/java/hudson/plugins/git/RevisionParameterActionTest.java
@@ -29,10 +29,13 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
 import hudson.plugins.git.util.BuildData;
 
+import java.util.Collection;
 import java.util.concurrent.Future;
 import java.util.Collections;
 import static org.junit.Assert.*;
 import org.junit.Test;
+
+import org.eclipse.jgit.transport.URIish;
 
 /**
  * Tests for {@link RevisionParameterAction}
@@ -209,5 +212,29 @@ public class RevisionParameterActionTest extends AbstractGitProject {
 		assertFalse(b3.getAction(BuildData.class)
 				.getLastBuiltRevision().getSha1String().equals(r1.getSha1String()));		
 	}
+
+    @Test
+    public void testBranchFetchingIfNoBranchSpecified() throws Exception {
+        commitNewFile("test");
+        testGitClient.branch("aaa");
+        String commit = testGitClient.getBranches().iterator().next().getSHA1String();
+        RevisionParameterAction action = new RevisionParameterAction(commit, new URIish("origin"));
+        Collection<Branch> branches = action.toRevision(testGitClient).getBranches();
+        assertEquals(branches.size(), 2);
+        Branch branchesArray[] = branches.toArray(new Branch[branches.size()]);
+        assertEquals(branchesArray[0].getName(), "aaa");
+        assertEquals(branchesArray[1].getName(), "master");
+    }
+
+    @Test
+    public void testBranchFetchingIfBranchSpecified() throws Exception {
+        commitNewFile("test");
+        testGitClient.branch("aaa");
+        String commit = testGitClient.getBranches().iterator().next().getSHA1String();
+        RevisionParameterAction action = new RevisionParameterAction(commit, new URIish("origin"), "master");
+        Collection<Branch> branches = action.toRevision(testGitClient).getBranches();
+        assertEquals(branches.size(), 1);
+        assertEquals(branches.iterator().next().getName(), "master");
+    }
 }
 


### PR DESCRIPTION
Save branch from git notification to revision parameters. So we can rid of second git scan.