### PR TITLE
Do not add the GitTagAction to the Run if there are no tags

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1137,7 +1137,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         // Don't add the tag and changelog if we've already processed this BuildData before.
         if (!buildDataAlreadyPresent) {
-            build.addAction(new GitTagAction(build, workspace, revToBuild.revision));
+            GitTagAction gitTagAction = new GitTagAction(build, workspace, revToBuild.revision);
+            // Don't bother storing this action if there are no tags
+            if (!gitTagAction.getTags().isEmpty()) {
+                build.addAction(gitTagAction);
+            }
 
             if (changelogFile != null) {
                 computeChangeLog(git, revToBuild.revision, listener, previousBuildData, new FilePath(changelogFile),


### PR DESCRIPTION
This means that the result won't be serialized out to clients of the REST API (e.g. Blue Ocean) unless some tagging occurred. 

This is problematic when REST API is serializing collections of runs and is sending an a pointless data structure in JSON or XML, resulting in much larger responses than needed.

PTAL @vivek I believe you were the original author of this action.

PTAL @MarkEWaite @stephenc 