### PR TITLE
[JENKINS-40908] GitSCMSource: support custom remote and refspec

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -117,6 +117,9 @@ public abstract class AbstractGitSCMSource extends SCMSource {
     @CheckForNull
     public abstract String getCredentialsId();
 
+    /**
+     * @return Git remote URL
+     */
     public abstract String getRemote();
 
     public abstract String getIncludes();

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -89,15 +89,15 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @author Stephen Connolly
  */
 public class GitSCMSource extends AbstractGitSCMSource {
-    private static final String DEFAULT_INCLUDES = "*";
-
-    private static final String DEFAULT_EXCLUDES = "";
-
     public static final Logger LOGGER = Logger.getLogger(GitSCMSource.class.getName());
 
     private final String remote;
 
     private final String credentialsId;
+
+    private final String remoteName;
+
+    private final String rawRefSpecs;
 
     private final String includes;
 
@@ -114,13 +114,30 @@ public class GitSCMSource extends AbstractGitSCMSource {
     private List<GitSCMExtension> extensions;
 
     @DataBoundConstructor
-    public GitSCMSource(String id, String remote, String credentialsId, String includes, String excludes, boolean ignoreOnPushNotifications) {
+    public GitSCMSource(String id, String remote, String credentialsId, String remoteName, String rawRefSpecs, String includes, String excludes, boolean ignoreOnPushNotifications) {
         super(id);
         this.remote = remote;
         this.credentialsId = credentialsId;
+
+        if (remoteName == null)
+            // backwards compatibility
+            this.remoteName = "origin";
+        else
+            this.remoteName = remoteName;
+
+        if (rawRefSpecs == null)
+            // backwards compatibility
+            this.rawRefSpecs = String.format("+refs/heads/*:refs/remotes/%s/*", this.remoteName);
+        else
+            this.rawRefSpecs = rawRefSpecs;
+
         this.includes = includes;
         this.excludes = excludes;
         this.ignoreOnPushNotifications = ignoreOnPushNotifications;
+    }
+
+    public GitSCMSource(String id, String remote, String credentialsId, String includes, String excludes, boolean ignoreOnPushNotifications) {
+        this(id, remote, credentialsId, null, null, includes, excludes, ignoreOnPushNotifications);
     }
 
     public boolean isIgnoreOnPushNotifications() {
@@ -176,6 +193,15 @@ public class GitSCMSource extends AbstractGitSCMSource {
     }
 
     @Override
+    public String getRemoteName() {
+        return remoteName;
+    }
+
+    public String getRawRefSpecs() {
+        return rawRefSpecs;
+    }
+
+    @Override
     public String getIncludes() {
         return includes;
     }
@@ -187,7 +213,13 @@ public class GitSCMSource extends AbstractGitSCMSource {
 
     @Override
     protected List<RefSpec> getRefSpecs() {
-        return Arrays.asList(new RefSpec("+refs/heads/*:refs/remotes/" + getRemoteName() + "/*"));
+        List<RefSpec> refSpecs = new ArrayList<>();
+
+        for (String rawRefSpec : rawRefSpecs.split(" ")) {
+            refSpecs.add(new RefSpec(rawRefSpec));
+        }
+
+        return refSpecs;
     }
 
     @Extension

--- a/src/main/resources/jenkins/plugins/git/GitSCMSource/config-detail.jelly
+++ b/src/main/resources/jenkins/plugins/git/GitSCMSource/config-detail.jelly
@@ -48,6 +48,12 @@
   </f:entry>
 
   <f:advanced>
+    <f:entry title="${%Remote Name}" field="remoteName">
+      <f:textbox default="origin"/>
+    </f:entry>
+    <f:entry title="${%RefSpecs}" field="rawRefSpecs">
+      <f:textbox default="+refs/heads/*:refs/remotes/origin/*"/>
+    </f:entry>
     <f:entry title="${%Include branches}" field="includes">
       <f:textbox default="*"/>
     </f:entry>


### PR DESCRIPTION
Allow to set custom remote name and refspec in the advanced options of a
git source