### PR TITLE
Sets a user.name & user.email on the new repo

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -48,6 +48,8 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         git("init");
         write("file", "");
         git("add", "file");
+        git("config", "user.name", "Git SampleRepoRule");
+        git("config", "user.email", "gits@mplereporule");
         git("commit", "--message=init");
     }
 


### PR DESCRIPTION
Build will fail with an exit code of 128.
This code fails on a machine where those values aren't set.
For instance, in CI. Especially in Docker containers who will always be starting fresh where this hasn't been set IN the image itself.

Thanks @jglick @stephenc looking at recent Git history apparently, and @MarkEWaite obviously :)

How to reproduce/understand:

```
docker run -it debian bash
root@66e2fc4d8ab5:/# apt-get update > /dev/null && apt-get install -y git > /dev/null
debconf: delaying package configuration, since apt-utils is not installed
root@66e2fc4d8ab5:/# git init
Initialized empty Git repository in /.git/
root@66e2fc4d8ab5:/# touch file
root@66e2fc4d8ab5:/# git add file
root@66e2fc4d8ab5:/# git commit --message=init

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'root@66e2fc4d8ab5.(none)')
root@66e2fc4d8ab5:/# echo $?
128
```