### PR TITLE
[JENKINS-19022] Print a warning to the build log when the job seems to be in trouble due to buildsByBranchName bloat

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1011,6 +1011,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         Build revToBuild = new Build(marked, rev, build.getNumber(), null);
         buildData.saveBuild(revToBuild);
 
+        if (buildData.getBuildsByBranchName().size() >= 100) {
+            log.println("JENKINS-19022: warning: possible memory leak due to Git plugin usage; see: https://wiki.jenkins-ci.org/display/JENKINS/Remove+Git+Plugin+BuildsByBranch+BuildData");
+        }
+
         if (candidates.size() > 1) {
             log.println("Multiple candidate revisions");
             Job<?, ?> job = build.getParent();


### PR DESCRIPTION
[JENKINS-19022](https://issues.jenkins-ci.org/browse/JENKINS-19022)

Not a fix for the problem—that would probably involve deprecating `BuildData` in favor of using `SCMRevisionState` properly, which has been proposed but seen as too scary to take on—but at least a way for users to _discover_ which problem they are suffering from (and offer a workaround), rather than simply seeing Jenkins get progressively slower with no explanation.

A somewhat better workaround would use something like [`POSTHyperlinkNote`](https://github.com/jenkinsci/workflow-support-plugin/blob/eb031e04d6e314d1cae8b73ff8b15da9a9370c0d/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/POSTHyperlinkNote.java) to offer to actually correct the problem, at least for this `Run`. (AFAICT it suffices to clean up just the latest build, since subsequent builds will copy data from it.)

@reviewbybees