### PR TITLE
JENKINS-41806# Fix for failing Build.getBuildResult() during JSON serialization

### DIFF
--- a/src/main/java/hudson/plugins/git/util/Build.java
+++ b/src/main/java/hudson/plugins/git/util/Build.java
@@ -83,9 +83,13 @@ public class Build implements Serializable, Cloneable {
         return hudsonBuildNumber;
     }
 
-    @Exported
     public Result getBuildResult() {
         return hudsonBuildResult;
+    }
+
+    @Exported(name = "buildResult")
+    public String getBuildResultValue() {
+        return hudsonBuildResult.toExportedObject();
     }
 
     public @Override String toString() {


### PR DESCRIPTION
In cases where hudson.plugins.git.util.Build is serialized as JSON, Build.getBuildResult() fails to serialize as reported in https://issues.jenkins-ci.org/browse/JENKINS-41806. The failure is because Stapler expects Result to be @ExportedBean as it's exposed from hudson.plugins.git.util.Build which is ExportedBean and fails serialization.

Here the fix is to preserve Java API contract as well as JSON where buildResult element is returned correctly. 