### PR TITLE
Fix PCT for 2.32.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <version>1.16</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1885,6 +1885,9 @@ public class GitSCMTest extends AbstractGitTestCase {
 
         final Action[] actions = {new ParametersAction(real_param), new FakeParametersAction(fake_param)};
 
+        // SECURITY-170 - have to use ParametersDefinitionProperty
+        project.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("MY_BRANCH", "master")));
+
         FreeStyleBuild first_build = project.scheduleBuild2(0, new Cause.UserCause(), actions).get();
         rule.assertBuildStatus(Result.SUCCESS, first_build);
 


### PR DESCRIPTION
Include test dependencies to fix PCT for Jenkins 2.32.2 (running tests with jenkins.version=2.32.2).

Also specify the project will use a parameter.

@reviewbybees @MarkEWaite 