### PR TITLE
Reduce chattiness

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -315,7 +315,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
             if (rev != null && !(rev instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
                 return null;
             }
-            TaskListener listener = new LogTaskListener(LOGGER, Level.INFO);
+            TaskListener listener = new LogTaskListener(LOGGER, Level.FINE);
             AbstractGitSCMSource gitSCMSource = (AbstractGitSCMSource) source;
             String cacheEntry = gitSCMSource.getCacheEntry();
             Lock cacheLock = AbstractGitSCMSource.getCacheLock(cacheEntry);


### PR DESCRIPTION
Noticed in `workflow-aggregator-plugin/demo` that `build` was printing a bunch of messages during initial branch indexing, which do not belong in the master log.

In the longer term, I think `SCMFileSystem.Builder` methods need to accept `TaskListener`.

@reviewbybees esp. @stephenc