### PR TITLE
[FIXED JENKINS-35475] Relax build data present check to allow for different remote names

### DIFF
--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -317,6 +317,7 @@ public class BuildData implements Action, Serializable, Cloneable {
         // that's similar enough. If you had configured a remote name we would see these as origin/feature/foobar and
         // origin/bugfix/foobar but you have not configured a remote name, and both branches are the same revision
         // anyway... and on the same build
+        // TODO consider revisiting as part of fixing JENKINS-42665
         Set<String> thisUrls = new HashSet<>(thisSize);
         for (String url: this.remoteUrls) {
             int index = url.indexOf('/');

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -4,15 +4,24 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.model.AbstractBuild;
 import hudson.model.Action;
 import hudson.model.Api;
+import hudson.model.Run;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.UserRemoteConfig;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
 import org.eclipse.jgit.lib.ObjectId;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-
-import java.io.Serializable;
-import java.util.*;
 
 import static hudson.Util.fixNull;
 /**
@@ -50,6 +59,11 @@ public class BuildData implements Action, Serializable, Cloneable {
      */
     public Set<String> remoteUrls = new HashSet<>();
 
+    /**
+     * Allow disambiguation of the action url when multiple {@link BuildData} actions present.
+     */
+    private Integer index;
+
     public BuildData() {
     }
 
@@ -84,7 +98,25 @@ public class BuildData implements Action, Serializable, Cloneable {
     }
 
     public String getUrlName() {
-        return "git";
+        return index == null ? "git" : "git-"+index;
+    }
+
+    public void setIndex(Integer index) {
+        this.index = index;
+    }
+
+    public Integer getIndex() {
+        return index;
+    }
+
+    @Restricted(NoExternalUse.class) // only used from stapler/jelly
+    @CheckForNull
+    public Run<?,?> getOwningRun() {
+        StaplerRequest req = Stapler.getCurrentRequest();
+        if (req == null) {
+            return null;
+        }
+        return req.findAncestorObject(Run.class);
     }
 
     public Object readResolve() {
@@ -241,6 +273,57 @@ public class BuildData implements Action, Serializable, Cloneable {
                 ",remoteUrls="+remoteUrls+
                 ",buildsByBranchName="+buildsByBranchName+
                 ",lastBuild="+lastBuild+"]";
+    }
+
+    /**
+     * Like {@link #equals(Object)} but doesn't check the branch names as strictly  as those can vary depending on the
+     * configured remote name.
+     *
+     * @param that the {@link BuildData} to compare with.
+     * @return {@code true} if the supplied {@link BuildData} is similar to this {@link BuildData}.
+     * @since TODO
+     */
+    public boolean similarTo(BuildData that) {
+        if (this.remoteUrls == null ? that.remoteUrls != null : !this.remoteUrls.equals(that.remoteUrls)) {
+            return false;
+        }
+        if (this.lastBuild == null ? that.lastBuild != null : !this.lastBuild.equals(that.lastBuild)) {
+            return false;
+        }
+        if (this.remoteUrls == null || that.remoteUrls == null) {
+            // if either is null then we do not need the costly comparison
+            return this.remoteUrls == that.remoteUrls;
+        }
+        int thisSize = this.remoteUrls.size();
+        int thatSize = that.remoteUrls.size();
+        if (thisSize != thatSize) {
+            return false;
+        }
+        // assume if there is a prefix/ that the prefix is the origin name and strip it for similarity comparison
+        // now if branch names contain slashes anyway and the user has not configured an origin name
+        // we could have a false positive... but come on, it's the same repo and the same revision on the same build
+        // that's similar enough. If you had configured a remote name we would see these as origin/feature/foobar and
+        // origin/bugfix/foobar but you have not configured a remote name, and both branches are the same revision
+        // anyway... and on the same build
+        Set<String> thisUrls = new HashSet<>(thisSize);
+        for (String url: this.remoteUrls) {
+            int index = url.indexOf('/');
+            if (index == -1 || index + 1 >= url.length()) {
+                thisUrls.add(url);
+            } else {
+                thisUrls.add(url.substring(index + 1));
+            }
+        }
+        Set<String> thatUrls = new HashSet<>(thatSize);
+        for (String url: that.remoteUrls) {
+            int index = url.indexOf('/');
+            if (index == -1 || index + 1 >= url.length()) {
+                thisUrls.add(url);
+            } else {
+                thisUrls.add(url.substring(index + 1));
+            }
+        }
+        return thatUrls.equals(thatUrls);
     }
 
     @Override

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -62,6 +62,7 @@ public class BuildData implements Action, Serializable, Cloneable {
     /**
      * Allow disambiguation of the action url when multiple {@link BuildData} actions present.
      */
+    @CheckForNull
     private Integer index;
 
     public BuildData() {
@@ -101,10 +102,21 @@ public class BuildData implements Action, Serializable, Cloneable {
         return index == null ? "git" : "git-"+index;
     }
 
+    /**
+     * Sets an identifier used to disambiguate multiple {@link BuildData} actions attached to a {@link Run}
+     *
+     * @param index the index, indexes less than or equal to {@code 1} will be discarded.
+     */
     public void setIndex(Integer index) {
-        this.index = index;
+        this.index = index == null || index <= 1 ? null : index;
     }
 
+    /**
+     * Gets the identifier used to disambiguate multiple {@link BuildData} actions attached to a {@link Run}.
+     *
+     * @return the index.
+     */
+    @CheckForNull
     public Integer getIndex() {
         return index;
     }

--- a/src/main/resources/hudson/plugins/git/util/BuildData/index.jelly
+++ b/src/main/resources/hudson/plugins/git/util/BuildData/index.jelly
@@ -2,7 +2,10 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<l:layout title="Git">
 	
-	
+	  <j:set var="build" value="${it.owningRun}"/>
+		<j:if test="${build!=null}">
+			<st:include page="sidepanel" it="${build}" optional="true"/>
+		</j:if>
     <l:main-panel>
 	<h1>${%Git Build Data}</h1>
 

--- a/src/main/resources/hudson/plugins/git/util/BuildData/index.jelly
+++ b/src/main/resources/hudson/plugins/git/util/BuildData/index.jelly
@@ -1,12 +1,11 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<l:layout title="Git">
-	
-	  <j:set var="build" value="${it.owningRun}"/>
+		<j:set var="build" value="${it.owningRun}"/>
 		<j:if test="${build!=null}">
 			<st:include page="sidepanel" it="${build}" optional="true"/>
 		</j:if>
-    <l:main-panel>
+	<l:main-panel>
 	<h1>${%Git Build Data}</h1>
 
 	<b>${%Revision}:</b> ${it.lastBuild.SHA1.name()}


### PR DESCRIPTION
- Also fix side-panel on BuildData
- Also make it possible to access the multiple BuildData actions

See [JENKINS-35475](https://issues.jenkins-ci.org/browse/JENKINS-35475)

@reviewbybees