### PR TITLE
[JENKINS-40834] Report the primary branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>2.3.1-20170322.101950-1</version>
+      <version>2.3.1-20170322.110355-2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>2.3.0</version>
+      <version>2.3.1-20170322.101950-1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/jenkins/plugins/git/GitRemoteHeadRefAction.java
+++ b/src/main/java/jenkins/plugins/git/GitRemoteHeadRefAction.java
@@ -1,0 +1,67 @@
+package jenkins.plugins.git;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.InvisibleAction;
+import java.io.Serializable;
+
+/**
+ * @author Stephen Connolly
+ */
+public class GitRemoteHeadRefAction extends InvisibleAction implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @NonNull
+    private final String remote;
+    @NonNull
+    private final String name;
+
+    public GitRemoteHeadRefAction(@NonNull String remote, @NonNull String name) {
+        this.remote = remote;
+        this.name = name;
+    }
+
+    @NonNull
+    public String getRemote() {
+        return remote;
+    }
+
+    @NonNull
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GitRemoteHeadRefAction that = (GitRemoteHeadRefAction) o;
+
+        if (!remote.equals(that.remote)) {
+            return false;
+        }
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = remote.hashCode();
+        result = 31 * result + name.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "GitRemoteHeadRefAction{" +
+                "remote='" + remote + '\'' +
+                ", name='" + name + '\'' +
+                '}';
+    }
+
+
+}


### PR DESCRIPTION
See [JENKINS-40834](https://issues.jenkins-ci.org/browse/JENKINS-40834)

Downstream of https://github.com/jenkinsci/git-client-plugin/pull/236

Uses a hack for JGit to get the primary branch information prior to JGit implementing [bug 514052](https://bugs.eclipse.org/bugs/show_bug.cgi?id=514052)

When the remote server is Git 1.8.4 or earlier, will use the strategy for identification of the primary branch that Git 1.8.4 and earlier used (i.e. match by hash and prefer `master` if there are multiple matches)

@reviewbybees 