### PR TITLE
Option for resolving matrix commit IDs when they run

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -26,6 +26,7 @@ import hudson.plugins.git.extensions.impl.BuildChooserSetting;
 import hudson.plugins.git.extensions.impl.ChangelogToBranch;
 import hudson.plugins.git.extensions.impl.PathRestriction;
 import hudson.plugins.git.extensions.impl.LocalBranch;
+import hudson.plugins.git.extensions.impl.MatrixCommitIdOption;
 import hudson.plugins.git.extensions.impl.PreBuildMerge;
 import hudson.plugins.git.opt.PreBuildMergeOptions;
 import hudson.plugins.git.util.Build;
@@ -960,9 +961,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         final BuildChooserContext context = new BuildChooserContextImpl(build.getParent(), build, environment);
         getBuildChooser().prepareWorkingTree(git, listener, context);
 
-
         // every MatrixRun should build the same marked commit ID
-        if (build instanceof MatrixRun) {
+        if (build instanceof MatrixRun && getExtensions().get(MatrixCommitIdOption.class) == null) {
             MatrixBuild parentBuild = ((MatrixRun) build).getParentBuild();
             if (parentBuild != null) {
                 BuildData parentBuildData = getBuildData(parentBuild);

--- a/src/main/java/hudson/plugins/git/extensions/impl/MatrixCommitIdOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/MatrixCommitIdOption.java
@@ -1,0 +1,26 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.FakeGitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Option for disabling resolving the commit IDs for matrix builds before they are executed.
+ *
+ * @author Martin Storø Nyfløtt
+ */
+public class MatrixCommitIdOption extends FakeGitSCMExtension {
+
+    @DataBoundConstructor
+    public MatrixCommitIdOption() {
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Resolve commit id for each matrix run";
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/MatrixCommitIdOption/help-MatrixCommitIdOption.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/MatrixCommitIdOption/help-MatrixCommitIdOption.html
@@ -1,0 +1,5 @@
+<div>
+        If enabled, each matrix jobs will resolve the commit ID when they start. This may introduce inconsistency
+        across configurations but avoids the problem with pull requests when jobs are queued and new commits arrives
+        in between, invalidating the pull request commit hash.
+</div>


### PR DESCRIPTION
By default, matrix commit IDs are resolved on the master run, before each matrix run is executed. This has a major disadvantage for pull requests where the commit hash can become invalid if there are new commits between the matrix run and when the commit ID was resolved at the master node. Enabling this option can introduce build inconsistency across build configurations, but avoids the issue where checkout fails for pull requests if there are commits between the matrix run and when the master node is executed.
I see that the contribution guidelines requires a test for new features, but I don't really see how I would test this. Would appreciate input on how to test this if you guys still want this tested.

Resolves these issues:
https://github.com/jenkinsci/ghprb-plugin/issues/489
https://github.com/janinko/ghprb/issues/148
Relates to [JENKINS-26290](https://issues.jenkins-ci.org/browse/JENKINS-26290)