### PR TITLE
[JENKINS-38827] Track credentials use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,12 @@
       <version>${workflow.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-matchers</artifactId>
+      <version>2.2.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <scm>

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -764,7 +764,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 StandardUsernameCredentials credentials = CredentialsMatchers.firstOrNull(urlCredentials, idMatcher);
                 if (credentials != null) {
                     c.addCredentials(url, credentials);
-                    CredentialsProvider.track(project, credentials);
+                    CredentialsProvider.track(project.getLastBuild(), credentials);
                 }
             }
         }

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -764,6 +764,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 StandardUsernameCredentials credentials = CredentialsMatchers.firstOrNull(urlCredentials, idMatcher);
                 if (credentials != null) {
                     c.addCredentials(url, credentials);
+                    CredentialsProvider.track(project, credentials);
                 }
             }
         }

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -185,7 +185,9 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
             GitClient git = Git.with(TaskListener.NULL, environment)
                     .using(GitTool.getDefaultInstallation().getGitExe())
                     .getClient();
-            git.addDefaultCredentials(lookupCredentials(item, credentialsId, url));
+            StandardCredentials credential = lookupCredentials(item, credentialsId, url);
+            git.addDefaultCredentials(credential);
+            CredentialsProvider.track(item, credential);
 
             // attempt to connect the provided URL
             try {

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -27,6 +27,7 @@ package jenkins.plugins.git;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -257,7 +258,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 GitClient client = git.getClient();
                 String credentialsId = config.getCredentialsId();
                 if (credentialsId != null) {
-                    client.addDefaultCredentials(CredentialsMatchers.firstOrNull(
+                    StandardCredentials credential = CredentialsMatchers.firstOrNull(
                             CredentialsProvider.lookupCredentials(
                                 StandardUsernameCredentials.class,
                                 owner,
@@ -268,8 +269,9 @@ public class GitSCMFileSystem extends SCMFileSystem {
                                 CredentialsMatchers.withId(credentialsId),
                                 GitClient.CREDENTIALS_MATCHER
                             )
-                        )
-                    );
+                        );
+                    client.addDefaultCredentials(credential);
+                    CredentialsProvider.track(owner, credential);
                 }
 
                 if (!client.hasGitRepo()) {

--- a/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
@@ -1,5 +1,10 @@
 package hudson.plugins.git;
 
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -9,6 +14,8 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
 import hudson.model.FreeStyleProject;
 import hudson.model.Node;
 import hudson.plugins.git.extensions.GitSCMExtension;
@@ -21,6 +28,8 @@ import hudson.plugins.git.extensions.impl.SparseCheckoutPaths;
 import hudson.plugins.git.extensions.impl.UserExclusion;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
 import hudson.triggers.SCMTrigger;
 import hudson.util.StreamTaskListener;
 
@@ -41,8 +50,10 @@ import org.junit.Rule;
 import jenkins.plugins.git.GitSampleRepoRule;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Base class for single repository git plugin tests.
@@ -100,6 +111,10 @@ public abstract class AbstractGitTestCase {
         return testRepo.remoteConfigs();
     }
 
+    protected List<UserRemoteConfig> createRemoteRepositories(StandardCredentials credential) throws IOException {
+        return testRepo.remoteConfigs(credential);
+    }
+
     protected FreeStyleProject createFreeStyleProject() throws IOException {
         return rule.createFreeStyleProject();
     }
@@ -140,6 +155,13 @@ public abstract class AbstractGitTestCase {
                             includedRegions);
     }
 
+    protected FreeStyleProject setupProject(String branchString, StandardCredentials credential) throws Exception {
+        return setupProject(Collections.singletonList(new BranchSpec(branchString)),
+                false, null, null,
+                null, null, false,
+                null, null, credential);
+    }
+
     protected FreeStyleProject setupProject(List<BranchSpec> branches, boolean authorOrCommitter,
                                             String relativeTargetDir, String excludedRegions,
                                             String excludedUsers, String localBranch, boolean fastRemotePoll,
@@ -147,27 +169,31 @@ public abstract class AbstractGitTestCase {
         return setupProject(branches,
                 authorOrCommitter, relativeTargetDir, excludedRegions,
                 excludedUsers, localBranch, fastRemotePoll,
-                includedRegions, null);
+                includedRegions, null, null);
     }
 
     protected FreeStyleProject setupProject(String branchString, List<SparseCheckoutPath> sparseCheckoutPaths) throws Exception {
         return setupProject(Collections.singletonList(new BranchSpec(branchString)),
                 false, null, null,
                 null, null, false,
-                null, sparseCheckoutPaths);
+                null, sparseCheckoutPaths, null);
     }
 
     protected FreeStyleProject setupProject(List<BranchSpec> branches, boolean authorOrCommitter,
                 String relativeTargetDir, String excludedRegions,
                 String excludedUsers, String localBranch, boolean fastRemotePoll,
-                String includedRegions, List<SparseCheckoutPath> sparseCheckoutPaths) throws Exception {
+                String includedRegions, List<SparseCheckoutPath> sparseCheckoutPaths,
+                StandardCredentials credential) throws Exception {
         FreeStyleProject project = createFreeStyleProject();
         GitSCM scm = new GitSCM(
-                createRemoteRepositories(),
+                createRemoteRepositories(credential),
                 branches,
                 false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
+        if (credential != null) {
+            project.getBuildersList().add(new HasCredentialBuilder(credential.getId()));
+        }
         scm.getExtensions().add(new DisableRemotePoll()); // don't work on a file:// repository
         if (relativeTargetDir!=null)
             scm.getExtensions().add(new RelativeTargetDirectory(relativeTargetDir));
@@ -291,6 +317,48 @@ public abstract class AbstractGitTestCase {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             int returnCode = new Launcher.LocalLauncher(listener).launch().cmds("git", "log","--all","--graph","--decorate","--oneline").pwd(repo.gitDir.getCanonicalPath()).stdout(out).join();
             System.out.println(out.toString());
+        }
+    }
+
+    public static class HasCredentialBuilder extends Builder {
+
+        private final String id;
+
+        @DataBoundConstructor
+        public HasCredentialBuilder(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
+            IdCredentials credentials = CredentialsProvider.findCredentialById(id, IdCredentials.class, build);
+            if (credentials == null) {
+                listener.getLogger().printf("Could not find any credentials with id %s%n", id);
+                build.setResult(Result.FAILURE);
+                return false;
+            } else {
+                listener.getLogger().printf("Found %s credentials with id %s%n", CredentialsNameProvider.name(credentials), id);
+                return true;
+            }
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return true;
+            }
+
+            @Override
+            public String getDisplayName() {
+                return "Check that credentials exist";
+            }
         }
     }
 }

--- a/src/test/java/hudson/plugins/git/TestGitRepo.java
+++ b/src/test/java/hudson/plugins/git/TestGitRepo.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git;
 
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;
@@ -128,8 +129,13 @@ public class TestGitRepo {
     }
 
     public List<UserRemoteConfig> remoteConfigs() throws IOException {
+        return remoteConfigs(null);
+    }
+
+    List<UserRemoteConfig> remoteConfigs(StandardCredentials credentials) {
+        String credentialsId = credentials == null ? null : credentials.getId();
         List<UserRemoteConfig> list = new ArrayList<>();
-        list.add(new UserRemoteConfig(gitDir.getAbsolutePath(), "origin", "", null));
+        list.add(new UserRemoteConfig(gitDir.getAbsolutePath(), "origin", "", credentialsId));
         return list;
     }
 }


### PR DESCRIPTION
These were easy cases because CredentialsProvider.track() arguments were available in the method where credentials were added.

There are still cases where credentials are not tracked correctly by the plugin.  Credential checks from the job definition page are not currently tracked.  Other contexts (like pipeline) may also not be tracked by these changes.

I've resolved the issue shown in the attached output (circled in red) in 588d8984.  The earlier code was using the project that was available in the GitSCM object.  I changed it to use project.lastBuild() instead.  The tests in the credentials plugin were a great guide to understand and resolve my mistake.

![unexpected-credential-tracking-message](https://cloud.githubusercontent.com/assets/156685/25113765/f984bb08-23b6-11e7-8529-9e96da0c1d06.png)
