### PR TITLE
Added setting to pull largs files after checking out submodules.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
+++ b/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
@@ -204,7 +204,7 @@ public abstract class GitSCMBackwardCompatibility extends SCM implements Seriali
                 skipTag = null;
             }
             if (disableSubmodules || recursiveSubmodules || trackingSubmodules) {
-                addIfMissing(new SubmoduleOption(disableSubmodules, recursiveSubmodules, trackingSubmodules, null, null, false));
+                addIfMissing(new SubmoduleOption(disableSubmodules, recursiveSubmodules, trackingSubmodules, null, null, false, false));
             }
             if (isNotBlank(gitConfigName) || isNotBlank(gitConfigEmail)) {
                 addIfMissing(new UserIdentity(gitConfigName,gitConfigEmail));

--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -43,15 +43,17 @@ public class SubmoduleOption extends GitSCMExtension {
     private String reference;
     private boolean parentCredentials;
     private Integer timeout;
+    private boolean withLFS;
 
     @DataBoundConstructor
-    public SubmoduleOption(boolean disableSubmodules, boolean recursiveSubmodules, boolean trackingSubmodules, String reference,Integer timeout, boolean parentCredentials) {
+    public SubmoduleOption(boolean disableSubmodules, boolean recursiveSubmodules, boolean trackingSubmodules, String reference,Integer timeout, boolean parentCredentials, boolean withLFS) {
         this.disableSubmodules = disableSubmodules;
         this.recursiveSubmodules = recursiveSubmodules;
         this.trackingSubmodules = trackingSubmodules;
         this.parentCredentials = parentCredentials;
         this.reference = reference;
         this.timeout = timeout;
+        this.withLFS = withLFS;
     }
 
     public boolean isDisableSubmodules() {
@@ -68,6 +70,10 @@ public class SubmoduleOption extends GitSCMExtension {
 
     public boolean isParentCredentials() {
         return parentCredentials;
+    }
+
+    public boolean isWithLFS() {
+        return withLFS;
     }
 
     public String getReference() {
@@ -99,6 +105,7 @@ public class SubmoduleOption extends GitSCMExtension {
                 .parentCredentials(parentCredentials)
                 .ref(build.getEnvironment(listener).expand(reference))
                 .timeout(timeout)
+                .lfsRemote(withLFS ? "origin" : null)
                 .execute();
         }
 

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
@@ -20,6 +20,9 @@ f.entry(title:_("Use credentials from default remote of parent repository"), fie
 f.entry(title:_("Timeout (in minutes) for submodules operations"), field:"timeout") {
     f.number(clazz:"number", min:1, step:1)
 }
+f.entry(title:_("Run 'git lfs pull' in each submodule after checkout"), field:"withLFS") {
+    f.checkbox()
+}
 
 /*
   This needs more thought

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/help-withLFS.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/help-withLFS.html
@@ -1,0 +1,3 @@
+<div>
+  Run "git lfs pull" after checkout.
+</div>


### PR DESCRIPTION
This is a follow-up to #463 "Add simple git lfs support".

These changes add support for downloading large files using git LFS in submodules after the submodules are initialized and checked out.

See the PR for the jenkinsci/git-client-plugin repository at jenkinsci/git-client-plugin#241 for more information.