### PR TITLE
[JENKINS-44087] Only track project credentials if last build exists

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -764,7 +764,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 StandardUsernameCredentials credentials = CredentialsMatchers.firstOrNull(urlCredentials, idMatcher);
                 if (credentials != null) {
                     c.addCredentials(url, credentials);
-                    CredentialsProvider.track(project.getLastBuild(), credentials);
+                    if (project != null && project.getLastBuild() != null) {
+                        CredentialsProvider.track(project.getLastBuild(), credentials);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Git parameters plugin etected a null pointer exception when it was used before the first run of a job.

[JENKINS-44087](https://issues.jenkins-ci.org/browse/JENKINS-44087) describes the testing that has been performed.  I've checked it interactively, Boguslaw has checked it interactively.

@reviewbybees