### PR TITLE
Call User.getById when available

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -377,7 +377,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                 }
             }
         } else {
-            user = User.get(csAuthor, false);
+            user = getById(csAuthor, false);
 
             if (user == null) {
                 // Ensure that malformed email addresses (in this case, just '@')

--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -28,6 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static hudson.Util.fixEmpty;
+import javax.annotation.Nullable;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeFieldType;
@@ -398,6 +399,19 @@ public class GitChangeSet extends ChangeLogSet.Entry {
             }
         }
         return user;
+    }
+
+    // TODO 1.651.2+ replace by API method
+    @Nullable
+    private static User getById(String id, boolean create) {
+        try {
+            return (User) User.class.getMethod("getById", String.class, boolean.class).invoke(null, id, create);
+        } catch (NoSuchMethodException x) {
+            // fine, 1.651.1 or earlier
+        } catch (Exception x) {
+            LOGGER.log(Level.WARNING, null, x);
+        }
+        return User.get(id, create);
     }
 
     private void setMail(User user, String csAuthorEmail) throws IOException {


### PR DESCRIPTION
See [this thread dump](https://gist.githubusercontent.com/rtyler/b4cfc39b3f4c1a04a5eccfed33919c43/raw/8dbeee9bc3e8fb16c6f7962c319dc95384a84f2c/20170531-170749.236.txt) for example.

Picks up https://github.com/jenkinsci/jenkins/commit/49d10a9034b280b5e59535519c3f0d12d96c9f2d where available, bypassing `User.FullNameIdResolver` and thus `getAll`.

@reviewbybees