### PR TITLE
JENKINS-44640 - Fix NPE checking legacy git SCM URL

### DIFF
--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -192,8 +192,6 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
             // credentials use at the point where the credential is used to perform an
             // action (like poll the repository, clone the repository, publish a change
             // to the repository).
-            //
-            // CredentialsProvider.track(item, credential);
 
             // attempt to connect the provided URL
             try {

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -187,7 +187,13 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
                     .getClient();
             StandardCredentials credential = lookupCredentials(item, credentialsId, url);
             git.addDefaultCredentials(credential);
-            CredentialsProvider.track(item, credential);
+
+            // Should not track credentials use in any checkURL method, rather should track
+            // credentials use at the point where the credential is used to perform an
+            // action (like poll the repository, clone the repository, publish a change
+            // to the repository).
+            //
+            // CredentialsProvider.track(item, credential);
 
             // attempt to connect the provided URL
             try {


### PR DESCRIPTION
Credential tracking is intended to track relevant and valuable use of
the credential, not something as simple as using that credential in a
form validation.

Form validation is valuable for the user experience of the
administrator, but it is not valuable enough to track the credential
use in validating the form.

Requesting @reviewbybees and by @stephenc to confirm that I've 
correctly understood the vision for credential tracking.