### PR TITLE
It is 6 years since the version range dependency was removed from parameterized trigger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,9 +218,9 @@
 
 
     <dependency><!-- we contribute AbstractBuildParameters for Git if it's available -->
-      <groupId>org.jvnet.hudson.plugins</groupId>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>parameterized-trigger</artifactId>
-      <version>2.4</version>
+      <version>2.9</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
Arguably we should bump to a newer version, but proposing just the minimal change to pick up https://github.com/jenkinsci/parameterized-trigger-plugin/commit/440065d3c5e86fff9955338ef3a22abf0bfba0ea

@reviewbybees