### PR TITLE
[JENKINS-44271] doFillcredentialsId to look for Item not SCMSourceOwner.

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -424,7 +424,7 @@ public class GitSCMSource extends AbstractGitSCMSource {
             return Messages.GitSCMSource_DisplayName();
         }
 
-        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath SCMSourceOwner context,
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context,
                                                      @QueryParameter String remote,
                                                      @QueryParameter String credentialsId) {
             if (context == null && !Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER) ||
@@ -441,8 +441,8 @@ public class GitSCMSource extends AbstractGitSCMSource {
                             GitClient.CREDENTIALS_MATCHER)
                     .includeCurrentValue(credentialsId);
         }
-
-        public FormValidation doCheckCredentialsId(@AncestorInPath SCMSourceOwner context,
+        
+        public FormValidation doCheckCredentialsId(@AncestorInPath Item context,
                                                    @QueryParameter String remote,
                                                    @QueryParameter String value) {
             if (context == null && !Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER) ||


### PR DESCRIPTION
The method GitSCMSource.DescriptorImpl#doFillCredentialsIdItems
expects the parameter 'context' to be an SCMSourceOwner which breaks
the ability to add a global library at the level of a folder with the
modern SCM implementation. Changing the parameter type from
SCMSourceOwner to Item solves the issue.