### PR TITLE
Reverting #498 as it broke association of users to commits by fullName

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -28,7 +28,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static hudson.Util.fixEmpty;
-import javax.annotation.Nullable;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeFieldType;
@@ -377,7 +376,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                 }
             }
         } else {
-            user = getById(csAuthor, false);
+            user = User.get(csAuthor, false);
 
             if (user == null) {
                 // Ensure that malformed email addresses (in this case, just '@')
@@ -399,19 +398,6 @@ public class GitChangeSet extends ChangeLogSet.Entry {
             }
         }
         return user;
-    }
-
-    // TODO 1.651.2+ replace by API method
-    @Nullable
-    private static User getById(String id, boolean create) {
-        try {
-            return (User) User.class.getMethod("getById", String.class, boolean.class).invoke(null, id, create);
-        } catch (NoSuchMethodException x) {
-            // fine, 1.651.1 or earlier
-        } catch (Exception x) {
-            LOGGER.log(Level.WARNING, null, x);
-        }
-        return User.get(id, create);
     }
 
     private void setMail(User user, String csAuthorEmail) throws IOException {

--- a/src/test/java/hudson/plugins/git/GitChangeSetTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTest.java
@@ -32,4 +32,14 @@ public class GitChangeSetTest {
         assertEquals(User.getUnknown(), committerCS.findOrCreateUser(null, email, false));
         assertEquals(User.getUnknown(), committerCS.findOrCreateUser(null, email, true));
     }
+
+    @Test
+    public void findOrCreateByFullName() throws Exception {
+        GitChangeSet cs = GitChangeSetUtil.genChangeSet(false, false);
+        User user = User.get("john");
+        user.setFullName(GitChangeSetUtil.COMMITTER_NAME);
+        user.addProperty(new Mailer.UserProperty(GitChangeSetUtil.COMMITTER_EMAIL));
+        assertEquals(user, cs.getAuthor());
+    }
+
 }


### PR DESCRIPTION
Reverts #498 and demonstrates what I suppose is the expected behavior in a test, which otherwise fails (when given `-Djenkins.version=1.651.3` to active the reflective code). I have a hard time following exactly what the existing `testFindOrCreateUser` demonstrated, but it seemed to be testing `createAccountBasedOnEmail` mode, which is not on by default.

@reviewbybees