### PR TITLE
allow per-run env override of proxy settings for git client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,11 @@
       <version>${workflow.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <version>${workflow.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
       <version>1.7.1</version>

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -10,7 +10,6 @@ import com.google.common.collect.Iterables;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import hudson.*;
 import hudson.init.Initializer;
 import hudson.matrix.MatrixBuild;
@@ -57,6 +56,8 @@ import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.JGitTool;
+import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
+import org.jenkinsci.plugins.workflow.support.actions.EnvironmentAction;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
@@ -82,6 +83,7 @@ import static hudson.init.InitMilestone.PLUGINS_STARTED;
 import hudson.plugins.git.browser.GithubWeb;
 import static hudson.scm.PollingResult.*;
 import hudson.util.LogTaskListener;
+
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1101,6 +1103,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         EnvVars environment = build.getEnvironment(listener);
+        EnvironmentAction action = build.getAction(EnvironmentAction.class);
+        if (action != null) {
+            environment = EnvironmentExpander.getEffectiveEnvironment(environment, action.getEnvironment(), null);
+            if (VERBOSE)
+                listener.getLogger().println("Environment after merge with env step: " + environment);
+        }
         GitClient git = createClient(listener, environment, build, workspace);
 
         for (GitSCMExtension ext : extensions) {


### PR DESCRIPTION
This change works in conjunction with https://github.com/jenkinsci/git-client-plugin/pull/201 to allow use of the `env` step to override on a per run basis the proxy settings from the plugin manager for the git-client created by this plugin during the `checkout` operation.

See https://github.com/jenkinsci/git-client-plugin/pull/201#issuecomment-311430720 for some of the particulars.

@MarkEWaite @scattym fyi