### PR TITLE
[JENKINS-26100] Supply GitSCM/buildEnv

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1286,6 +1286,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                String remoteBranchName = getBranchName(branch);
                 env.put(GIT_BRANCH, remoteBranchName);
 
+                // TODO this is unmodular; should rather override LocalBranch.populateEnvironmentVariables
                 LocalBranch lb = getExtensions().get(LocalBranch.class);
                 if (lb != null) {
                    // Set GIT_LOCAL_BRANCH variable from the LocalBranch extension

--- a/src/main/resources/hudson/plugins/git/GitSCM/buildEnv.groovy
+++ b/src/main/resources/hudson/plugins/git/GitSCM/buildEnv.groovy
@@ -1,0 +1,10 @@
+package hudson.plugins.git.GitSCM;
+
+def l = namespace(lib.JenkinsTagLib)
+
+// TODO handle GitSCMExtension.populateEnvironmentVariables somehow, say by optionally including GitSCMExtension/buildEnv.groovy; though GIT_{COMMITTER,AUTHOR}_{NAME,EMAIL} are only overridden by UserIdentity
+['GIT_COMMIT', 'GIT_PREVIOUS_COMMIT', 'GIT_PREVIOUS_SUCCESSFUL_COMMIT', 'GIT_BRANCH', 'GIT_LOCAL_BRANCH', 'GIT_URL', 'GIT_COMMITTER_NAME', 'GIT_AUTHOR_NAME', 'GIT_COMMITTER_EMAIL', 'GIT_AUTHOR_EMAIL'].each {name ->
+    l.buildEnvVar(name: name) {
+        raw(_("${name}.blurb"))
+    }
+}

--- a/src/main/resources/hudson/plugins/git/GitSCM/buildEnv.properties
+++ b/src/main/resources/hudson/plugins/git/GitSCM/buildEnv.properties
@@ -1,0 +1,10 @@
+GIT_COMMIT.blurb=The commit hash being checked out.
+GIT_PREVIOUS_COMMIT.blurb=The hash of the commit last built on this branch, if any.
+GIT_PREVIOUS_SUCCESSFUL_COMMIT.blurb=The hash of the commit last successfully built on this branch, if any.
+GIT_BRANCH.blurb=The remote branch name, if any.
+GIT_LOCAL_BRANCH.blurb=The local branch name being checked out, if applicable.
+GIT_URL.blurb=The remote URL. If there are multiple, will be <code>GIT_URL_1</code>, <code>GIT_URL_2</code>, etc.
+GIT_COMMITTER_NAME.blurb=The configured Git committer name, if any.
+GIT_AUTHOR_NAME.blurb=The configured Git author name, if any.
+GIT_COMMITTER_EMAIL.blurb=The configured Git committer email, if any.
+GIT_AUTHOR_EMAIL.blurb=The configured Git author email, if any.


### PR DESCRIPTION
Supplies data to https://github.com/jenkinsci/workflow-scm-step-plugin/pull/18 or, indeed, to `env-vars.html/` displayed for freestyle projects when you configure a shell step. How could this have been forgotten for so many years, when the Subversion plugin has it?

@reviewbybees