### PR TITLE
Feature/disable automatic scheduling

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1028,9 +1028,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             disableAutomaticScheduling = ext.disableAutomaticScheduling();
         }
 
-        if (!disableAutomaticScheduling) {
-            if (candidates.size() > 1) {
-                log.println("Multiple candidate revisions");
+        if (candidates.size() > 1) {
+            log.println("Multiple candidate revisions");
+            if (!disableAutomaticScheduling) {
                 Job<?, ?> job = build.getParent();
                 if (job instanceof AbstractProject) {
                     AbstractProject project = (AbstractProject) job;

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1023,17 +1023,23 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         if (buildData.getBuildsByBranchName().size() >= 100) {
             log.println("JENKINS-19022: warning: possible memory leak due to Git plugin usage; see: https://wiki.jenkins-ci.org/display/JENKINS/Remove+Git+Plugin+BuildsByBranch+BuildData");
         }
+        boolean disableAutomaticScheduling = false;
+        for (GitSCMExtension ext: extensions) {
+            disableAutomaticScheduling = ext.disableAutomaticScheduling();
+        }
 
-        if (candidates.size() > 1) {
-            log.println("Multiple candidate revisions");
-            Job<?, ?> job = build.getParent();
-            if (job instanceof AbstractProject) {
-                AbstractProject project = (AbstractProject) job;
-                if (!project.isDisabled()) {
-                    log.println("Scheduling another build to catch up with " + project.getFullDisplayName());
-                    if (!project.scheduleBuild(0, new SCMTrigger.SCMTriggerCause("This build was triggered by build "
-                            + build.getNumber() + " because more than one build candidate was found."))) {
-                        log.println("WARNING: multiple candidate revisions, but unable to schedule build of " + project.getFullDisplayName());
+        if (!disableAutomaticScheduling) {
+            if (candidates.size() > 1) {
+                log.println("Multiple candidate revisions");
+                Job<?, ?> job = build.getParent();
+                if (job instanceof AbstractProject) {
+                    AbstractProject project = (AbstractProject) job;
+                    if (!project.isDisabled()) {
+                        log.println("Scheduling another build to catch up with " + project.getFullDisplayName());
+                        if (!project.scheduleBuild(0, new SCMTrigger.SCMTriggerCause("This build was triggered by build "
+                                + build.getNumber() + " because more than one build candidate was found."))) {
+                            log.println("WARNING: multiple candidate revisions, but unable to schedule build of " + project.getFullDisplayName());
+                        }
                     }
                 }
             }

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -334,6 +334,14 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
         return GitClientType.ANY;
     }
 
+    /**
+     *
+     * @return <code>true</code> to disable the scheduling of another build to catch up
+     */
+    public boolean disableAutomaticScheduling() {
+        return false;
+    }
+
     @Override
     public GitSCMExtensionDescriptor getDescriptor() {
         return (GitSCMExtensionDescriptor) super.getDescriptor();

--- a/src/main/java/hudson/plugins/git/extensions/impl/DisableAutomaticScheduling.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/DisableAutomaticScheduling.java
@@ -1,0 +1,30 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Don't trigger another build to catch up
+ *
+ * @author Sven Hickstein
+ */
+public class DisableAutomaticScheduling extends GitSCMExtension {
+    @DataBoundConstructor
+    public DisableAutomaticScheduling() {
+    }
+
+    @Override
+    public boolean disableAutomaticScheduling() {
+        return true;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Disable \"Triggered by an SCM change\"";
+        }
+    }
+}


### PR DESCRIPTION
The git-plugin schedules a build if there are more than one canditate revisions. This can lead to many unwanted builds in a big environment. I implemented an additional behaviour to disable this feature.
Could be related to: [JENKINS-17614](https://issues.jenkins-ci.org/browse/JENKINS-17614) and [JENKINS-21464](https://issues.jenkins-ci.org/browse/JENKINS-21464).