### PR TITLE
Use parent pom 2.32, with a few exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.30</version>
+    <version>2.32</version>
     <relativePath />
   </parent>
 
@@ -102,6 +102,18 @@
             </configuration>
           </execution>
         </executions>
+        <configuration>
+          <rules>
+            <requireUpperBoundDeps>
+              <excludes combine.children="append">
+                <!-- structs requests 1.9, core requests 1.7 -->
+                <exclude>org.jenkins-ci:annotation-indexer</exclude>
+                <!-- workflow-cps requests 1.1.1, core 2.60.1 requests 1.2.1 -->
+                <exclude>org.jenkins-ci.ui:jquery-detached</exclude>
+              </excludes>
+            </requireUpperBoundDeps>
+          </rules>
+        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -206,12 +218,22 @@
       <artifactId>mockito-core</artifactId>
       <version>1.10.19</version>
       <scope>test</scope>
+      <!-- powermock wants objenesis 2.4 and mockito wants objenesis 2.1 -->
+      <!-- exclude from mockito so that powermock version is used -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.objenesis</groupId>
+          <artifactId>objenesis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
       <version>1.6.6</version>
       <scope>test</scope>
+      <!-- powermock wants objenesis 2.4 and mockito wants objenesis 2.1 -->
+      <!-- excluded from mockito so that powermock version is used -->
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
@@ -254,6 +276,13 @@
         <exclusion>
           <groupId>org.sonatype.sisu</groupId>
           <artifactId>sisu-guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- promoted-builds requests 1.9.2, core requests 1.8.4 -->
+          <!-- use core version, rather than promoted builds version -->
+          <!-- trust this optional reference will be harmless -->
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -426,6 +426,10 @@ public class GitChangeSet extends ChangeLogSet.Entry {
         }
         DescriptorImpl descriptor = (DescriptorImpl) hudson.getDescriptor(GitSCM.class);
 
+        if (descriptor == null) {
+            return false;
+        }
+
         return descriptor.isCreateAccountBasedOnEmail();
     }
 


### PR DESCRIPTION
    <!-- promoted-builds requests 1.9.2, core requests 1.8.4 -->
    <exclude>org.apache.ant:ant</exclude>
    <!-- structs requests 1.9, core requests 1.7 -->
    <exclude>org.jenkins-ci:annotation-indexer</exclude>
    <!-- mockito requests 2.1, powermock requests 2.4 -->
    <exclude>org.objenesis:objenesis</exclude>