### PR TITLE
[JENKINS-22593] - Annotate BuildChooser#getCandidateRevisions() and the related code

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -506,7 +506,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return gitTool;
     }
 
-    public static String getParameterString(String original, EnvVars env) {
+    @NonNull
+    public static String getParameterString(@CheckForNull String original, @NonNull EnvVars env) {
         return env.expand(original);
     }
 
@@ -522,8 +523,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
      * If the configuration is such that we are tracking just one branch of one repository
      * return that branch specifier (in the form of something like "origin/master" or a SHA1-hash
      *
-     * Otherwise return null.
+     * Otherwise return [@code null}.
      */
+    @CheckForNull
     private String getSingleBranch(EnvVars env) {
         // if we have multiple branches skip to advanced usecase
         if (getBranches().size() != 1) {
@@ -595,7 +597,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
     public static final Pattern GIT_REF = Pattern.compile("(refs/[^/]+)/.*");
 
-    private PollingResult compareRemoteRevisionWithImpl(Job<?, ?> project, Launcher launcher, FilePath workspace, final TaskListener listener) throws IOException, InterruptedException {
+    private PollingResult compareRemoteRevisionWithImpl(Job<?, ?> project, Launcher launcher, FilePath workspace, final @NonNull TaskListener listener) throws IOException, InterruptedException {
         // Poll for changes. Are there any unbuilt revisions that Hudson ought to build ?
 
         listener.getLogger().println("Using strategy: " + getBuildChooser().getDisplayName());
@@ -735,6 +737,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
      * @throws IOException on input or output error
      * @throws InterruptedException when interrupted
      */
+    @NonNull
     public GitClient createClient(TaskListener listener, EnvVars environment, Run<?,?> build, FilePath workspace) throws IOException, InterruptedException {
         FilePath ws = workingDirectory(build.getParent(), workspace, environment, listener);
         /* ws will be null if the node which ran the build is offline */
@@ -744,6 +747,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return createClient(listener,environment, build.getParent(), GitUtils.workspaceToNode(workspace), ws);
     }
 
+    @NonNull
     /*package*/ GitClient createClient(TaskListener listener, EnvVars environment, Job project, Node n, FilePath ws) throws IOException, InterruptedException {
 
         String gitExe = getGitExe(n, listener);
@@ -776,6 +780,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return c;
     }
 
+    @NonNull
     private BuildData fixNull(BuildData bd) {
         return bd != null ? bd : new BuildData(getScmName(), getUserRemoteConfigs()) /*dummy*/;
     }
@@ -960,10 +965,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
      * to the predictable clean state by the time this method returns.
      */
     private @NonNull Build determineRevisionToBuild(final Run build,
-                                              final BuildData buildData,
+                                              final @NonNull BuildData buildData,
                                               final EnvVars environment,
-                                              final GitClient git,
-                                              final TaskListener listener) throws IOException, InterruptedException {
+                                              final @NonNull GitClient git,
+                                              final @NonNull TaskListener listener) throws IOException, InterruptedException {
         PrintStream log = listener.getLogger();
         Collection<Revision> candidates = Collections.EMPTY_LIST;
         final BuildChooserContext context = new BuildChooserContextImpl(build.getParent(), build, environment);

--- a/src/main/java/hudson/plugins/git/util/BuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooser.java
@@ -1,5 +1,7 @@
 package hudson.plugins.git.util;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.DescriptorExtensionList;
@@ -79,8 +81,10 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
      * @throws GitException on git error
      * @throws InterruptedException when interrupted
      */
-    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch,
-                                                      GitClient git, TaskListener listener, BuildData buildData, BuildChooserContext context) throws GitException, IOException, InterruptedException {
+    public Collection<Revision> getCandidateRevisions(boolean isPollCall, @CheckForNull String singleBranch,
+                    @NonNull GitClient git, @NonNull TaskListener listener, 
+                    @NonNull BuildData buildData, @NonNull BuildChooserContext context) 
+                    throws GitException, IOException, InterruptedException {
         // fallback to the previous signature
         return getCandidateRevisions(isPollCall, singleBranch, (IGitAPI) git, listener, buildData, context);
     }

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -28,13 +28,17 @@ import java.text.MessageFormat;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 
 public class GitUtils implements Serializable {
+    
     @SuppressFBWarnings(value="SE_BAD_FIELD", justification="known non-serializable field")
+    @Nonnull
     GitClient git;
+    @Nonnull
     TaskListener listener;
 
-    public GitUtils(TaskListener listener, GitClient git) {
+    public GitUtils(@Nonnull TaskListener listener, @Nonnull GitClient git) {
         this.git = git;
         this.listener = listener;
     }


### PR DESCRIPTION
I was investigating the NPE stacktrace reported back in 2014, and it seems it is not possible anymore. Though I have added some API annotations to make the case explicitly verifyable in FindBugs. This change does not close [JENKINS-22593](https://issues.jenkins-ci.org/browse/JENKINS-22593).

Original stacktrace:
```
[poll] Last Built Revision: Revision 3026d9d56bccb4c335f8ceb97f93d093fffec68f (origin/ticket.8.sort-challenge-descriptions)
Fetching changes from the remote Git repositories
Fetching upstream changes from https://github.com/jpschewe/fll-sw.git
Polling for changes in
ERROR: Failed to record SCM polling
java.lang.NullPointerException
at hudson.plugins.git.util.InverseBuildChooser.getCandidateRevisions(InverseBuildChooser.java:45)
at hudson.plugins.git.GitSCM.compareRemoteRevisionWithImpl(GitSCM.java:534)
at hudson.plugins.git.GitSCM.compareRemoteRevisionWith(GitSCM.java:456)
at hudson.scm.SCM._compareRemoteRevisionWith(SCM.java:356)
at hudson.scm.SCM.poll(SCM.java:373)
at hudson.model.AbstractProject.pollWithWorkspace(AbstractProject.java:1588)
at hudson.model.AbstractProject._poll(AbstractProject.java:1558)
at hudson.model.AbstractProject.poll(AbstractProject.java:1490)
at com.cloudbees.jenkins.GitHubPushTrigger$1.runPolling(GitHubPushTrigger.java:73)
at com.cloudbees.jenkins.GitHubPushTrigger$1.run(GitHubPushTrigger.java:98)
at hudson.util.SequentialExecutionQueue$QueueEntry.run(SequentialExecutionQueue.java:118)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
at java.util.concurrent.FutureTask.run(FutureTask.java:166)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
at java.lang.Thread.run(Thread.java:724)
```

https://issues.jenkins-ci.org/browse/JENKINS-22593

@reviewbybees @MarkEWaite 