### PR TITLE
Fix typos in GitSCMFileSystemTest naming

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -223,10 +223,10 @@ public class GitSCMFileSystemTest {
         ObjectId git261 = client.revParse("git-2.6.1");
         AbstractGitSCMSource.SCMRevisionImpl rev261 =
                 new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git261.getName());
-        GitSCMFileSystem instance = new GitSCMFileSystem(client, "origin", git261.getName(), rev261);
+        GitSCMFileSystem gitPlugin261FS = new GitSCMFileSystem(client, "origin", git261.getName(), rev261);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        assertFalse(instance.changesSince(rev261, out));
+        assertFalse(gitPlugin261FS.changesSince(rev261, out));
         assertThat(out.toString(), is(""));
     }
 
@@ -248,7 +248,7 @@ public class GitSCMFileSystemTest {
         ObjectId git261 = client.revParse("git-2.6.1");
         AbstractGitSCMSource.SCMRevisionImpl rev261 =
                 new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git261.getName());
-        GitSCMFileSystem instance = new GitSCMFileSystem(client, "origin", git261.getName(), rev261);
+        GitSCMFileSystem gitPlugin261FS = new GitSCMFileSystem(client, "origin", git261.getName(), rev261);
 
         ObjectId git260 = client.revParse("git-2.6.0");
         AbstractGitSCMSource.SCMRevisionImpl rev260 =
@@ -257,7 +257,7 @@ public class GitSCMFileSystemTest {
         assertThat(git260, not(is(git261)));
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        assertTrue(instance.changesSince(rev260, out));
+        assertTrue(gitPlugin261FS.changesSince(rev260, out));
         assertThat(out.toString(), containsString("prepare release git-2.6.1"));
     }
 
@@ -277,21 +277,21 @@ public class GitSCMFileSystemTest {
         GitClient client = Git.with(TaskListener.NULL, new EnvVars()).in(gitDir).using("git").getClient();
 
         ObjectId git260 = client.revParse("git-2.6.0");
-        AbstractGitSCMSource.SCMRevisionImpl rev261 =
+        AbstractGitSCMSource.SCMRevisionImpl rev260 =
                 new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git260.getName());
-        GitSCMFileSystem instance = new GitSCMFileSystem(client, "origin", git260.getName(), rev261);
+        GitSCMFileSystem gitPlugin260FS = new GitSCMFileSystem(client, "origin", git260.getName(), rev260);
 
         ObjectId git261 = client.revParse("git-2.6.1");
-        AbstractGitSCMSource.SCMRevisionImpl rev260 =
+        AbstractGitSCMSource.SCMRevisionImpl rev261 =
                 new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git261.getName());
-        GitSCMFileSystem gitPlugin300FS =
-                new GitSCMFileSystem(client, "origin", git261.getName(), rev260);
-        assertEquals(git261.getName(), gitPlugin300FS.getRevision().getHash());
+        GitSCMFileSystem gitPlugin261FS =
+                new GitSCMFileSystem(client, "origin", git261.getName(), rev261);
+        assertEquals(git261.getName(), gitPlugin261FS.getRevision().getHash());
 
         assertThat(git261, not(is(git260)));
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        assertTrue(instance.changesSince(rev260, out));
+        assertTrue(gitPlugin260FS.changesSince(rev261, out));
         assertThat(out.toString(), is(""));
     }
 


### PR DESCRIPTION
The given_filesystem_when_askingChangesSinceNewRevision_then_changesArePopulatedButEmpty
test had a confusing mix of xxx261 and xxx260 variables that were
referring to tags which sometimes did not match the name of the variable.

Makes the names consistent rather than risk confusing the reader of the
test.

Other tests referred to a GitSCMFileSystem instance as "instance" when
it was then used as a file system reference to a specific commit.
Changed the name to be clearer where it was referring.

Preparing to remove the requirement that tests require all tags and
all history in the working directory.  Optimizations in git plugin
3.4.0 remove that assumption (and its resulting waste of time and
disc space).