### PR TITLE
Added PreBuildMerge as a Git Trait

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
@@ -115,8 +115,50 @@ public class PreBuildMerge extends GitSCMExtension {
         return GitClientType.GITCLI;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        if (o instanceof PreBuildMerge) {
+            PreBuildMerge that = (PreBuildMerge) o;
+            return (options != null && options.equals(that.options))
+                    || (options == null && that.options == null);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return PreBuildMerge.class.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "PreBuildMerge{" +
+                "options=" + options.toString() +
+                '}';
+    }
+
     @Extension
     public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public String getDisplayName() {
             return "Merge before build";

--- a/src/main/java/jenkins/plugins/git/traits/PreBuildMergeTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/PreBuildMergeTrait.java
@@ -1,8 +1,6 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017 CloudBees, Inc.
- *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights

--- a/src/main/java/jenkins/plugins/git/traits/PreBuildMergeTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/PreBuildMergeTrait.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package jenkins.plugins.git.traits;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.impl.PreBuildMerge;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Exposes {@link PreBuildMerge} as a {@link SCMSourceTrait}.
+ *
+ * @since 3.4.2
+ */
+public class PreBuildMergeTrait extends GitSCMExtensionTrait<PreBuildMerge> {
+    /**
+     * Stapler constructor.
+     *
+     * @param extension the {@link PreBuildMerge}
+     */
+    @DataBoundConstructor
+    public PreBuildMergeTrait(PreBuildMerge extension) {
+        super(extension);
+    }
+
+    /**
+     * Our {@link hudson.model.Descriptor}
+     */
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionTraitDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Merge before build";
+        }
+    }
+}

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.git;
 
+import hudson.plugins.git.UserMergeOptions;
 import hudson.plugins.git.browser.BitbucketWeb;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.impl.AuthorInChangelog;
@@ -9,31 +10,18 @@ import hudson.plugins.git.extensions.impl.CleanCheckout;
 import hudson.plugins.git.extensions.impl.CloneOption;
 import hudson.plugins.git.extensions.impl.GitLFSPull;
 import hudson.plugins.git.extensions.impl.LocalBranch;
+import hudson.plugins.git.extensions.impl.PreBuildMerge;
 import hudson.plugins.git.extensions.impl.PruneStaleBranch;
 import hudson.plugins.git.extensions.impl.SubmoduleOption;
 import hudson.plugins.git.extensions.impl.UserIdentity;
 import hudson.plugins.git.extensions.impl.WipeWorkspace;
 import java.util.Collections;
 import jenkins.model.Jenkins;
-import jenkins.plugins.git.traits.AuthorInChangelogTrait;
-import jenkins.plugins.git.traits.BranchDiscoveryTrait;
-import jenkins.plugins.git.traits.CheckoutOptionTrait;
-import jenkins.plugins.git.traits.CleanAfterCheckoutTrait;
-import jenkins.plugins.git.traits.CleanBeforeCheckoutTrait;
-import jenkins.plugins.git.traits.CloneOptionTrait;
-import jenkins.plugins.git.traits.GitBrowserSCMSourceTrait;
-import jenkins.plugins.git.traits.GitLFSPullTrait;
-import jenkins.plugins.git.traits.IgnoreOnPushNotificationTrait;
-import jenkins.plugins.git.traits.LocalBranchTrait;
-import jenkins.plugins.git.traits.PruneStaleBranchTrait;
-import jenkins.plugins.git.traits.RefSpecsSCMSourceTrait;
-import jenkins.plugins.git.traits.RemoteNameSCMSourceTrait;
-import jenkins.plugins.git.traits.SubmoduleOptionTrait;
-import jenkins.plugins.git.traits.UserIdentityTrait;
-import jenkins.plugins.git.traits.WipeWorkspaceTrait;
+import jenkins.plugins.git.traits.*;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
 import org.hamcrest.Matchers;
+import org.jenkinsci.plugins.gitclient.MergeCommand;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -141,6 +129,20 @@ public class GitSCMSourceTraitsTest {
                                 )
                         ),
                         Matchers.<SCMSourceTrait>instanceOf(GitLFSPullTrait.class),
+                        Matchers.<SCMSourceTrait>allOf(
+                                instanceOf(PreBuildMergeTrait.class),
+                                hasProperty("extension",
+                                        hasProperty("options",
+                                                allOf(
+                                                        instanceOf(UserMergeOptions.class),
+                                                        hasProperty("mergeRemote", is("foo")),
+                                                        hasProperty("mergeTarget", is("bar")),
+                                                        hasProperty("mergeStrategy", is(MergeCommand.Strategy.RECURSIVE)),
+                                                        hasProperty("fastForwardMode", is(MergeCommand.GitPluginFastForwardMode.NO_FF))
+                                                )
+                                        )
+                                )
+                        ),
                         Matchers.<SCMSourceTrait>instanceOf(PruneStaleBranchTrait.class),
                         Matchers.<SCMSourceTrait>instanceOf(IgnoreOnPushNotificationTrait.class),
                         Matchers.<SCMSourceTrait>instanceOf(AuthorInChangelogTrait.class),
@@ -196,6 +198,18 @@ public class GitSCMSourceTraitsTest {
                                 hasProperty("email", is("bob@example.com"))
                         ),
                         Matchers.<GitSCMExtension>instanceOf(GitLFSPull.class),
+                        Matchers.<GitSCMExtension>allOf(
+                                instanceOf(PreBuildMerge.class),
+                                hasProperty("options",
+                                        allOf(
+                                                instanceOf(UserMergeOptions.class),
+                                                hasProperty("mergeRemote", is("foo")),
+                                                hasProperty("mergeTarget", is("bar")),
+                                                hasProperty("mergeStrategy", is(MergeCommand.Strategy.RECURSIVE)),
+                                                hasProperty("fastForwardMode", is(MergeCommand.GitPluginFastForwardMode.NO_FF))
+                                        )
+                                )
+                        ),
                         Matchers.<GitSCMExtension>instanceOf(PruneStaleBranch.class),
                         Matchers.<GitSCMExtension>instanceOf(AuthorInChangelog.class),
                         Matchers.<GitSCMExtension>instanceOf(WipeWorkspace.class)


### PR DESCRIPTION
For a Multibranch Pipeline job, we need to be able to pre-merge the Jenkinsfile so that the latest changes can be tested properly. This feature was available before the introductions to Git Traits.