### PR TITLE
[JENKINS-35230] Export GIT_* variables to environment for pipeline

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitContributor.java
+++ b/src/main/java/jenkins/plugins/git/GitContributor.java
@@ -1,0 +1,36 @@
+package jenkins.plugins.git;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.util.BuildData;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+@Extension
+public class GitContributor extends EnvironmentContributor {
+
+    @Override
+    public void buildEnvironmentFor(@Nonnull final Run run,
+            @Nonnull final EnvVars envs,
+            @Nonnull final TaskListener listener)
+    throws IOException, InterruptedException {
+        final BuildData buildData = run.getAction(BuildData.class);
+        if (buildData != null) {
+            String[] urls = buildData.getRemoteUrls().toArray(new String[0]);
+            if (urls.length > 0) {
+                GitSCM scm = new GitSCM(urls[0]);
+                if (scm != null) {
+                    scm.buildEnvironment(run, envs);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I couldn't come up with any better way to get GitSCM instance, but as this is my first contribution to jenkins, I am open for suggestions.

Copying the GitSCM#buildEnvironment as Mike Kobit has started in the issue, could not be easily done for all the variables. It would also be copying code around which is not good idea even if it would've been easy. 

The test is copied and reworked from GitSCMTest. I would say that parts of the test (and probably others as well) could be reused between GitSCMTest and GitStepTest, but I don't think the fixing of the bug is the place for this to happen.