### PR TITLE
Added required overrides to PreBuildMerge extension

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
@@ -115,8 +115,50 @@ public class PreBuildMerge extends GitSCMExtension {
         return GitClientType.GITCLI;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        if (o instanceof PreBuildMerge) {
+            PreBuildMerge that = (PreBuildMerge) o;
+            return (options != null && options.equals(that.options))
+                    || (options == null && that.options == null);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return PreBuildMerge.class.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "PreBuildMerge{" +
+                "options=" + options.toString() +
+                '}';
+    }
+
     @Extension
     public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public String getDisplayName() {
             return "Merge before build";


### PR DESCRIPTION
By adding the required PreBuildMerge overrides, it will enable the to extend the class for use as a Trait.

Please see MR https://github.com/jenkinsci/git-plugin/pull/513 for further information.

@stephenc 