### PR TITLE
Resolving UserMergeOptions Object

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
@@ -59,7 +59,7 @@ public class PreBuildMerge extends GitSCMExtension {
             return rev;
 
         // Only merge if there's a branch to merge that isn't us..
-        listener.getLogger().println("Merging " + rev + " to " + remoteBranchRef + ", " + options);
+        listener.getLogger().println("Merging " + rev + " to " + remoteBranchRef + ", " + GitSCM.getParameterString(options.toString(), build.getEnvironment(listener)));
 
         // checkout origin/blah
         ObjectId target = git.revParse(remoteBranchRef);


### PR DESCRIPTION
If you pass the merge parameter as following:
Merge Before Build:
Name of repository : refs/remotes/origin
Branch to merge to : ${BRANCH_NAME}
Merge Strategy: default
Fast-forward mode: --ff

Here **BRANCH_NAME** is a String Parameter.
Then the output printed in console is something like:
Merging Revision 54f103b61f0b3504503f4990204f8dec8ea612ea (refs/remotes/origin/sample) to refs/remotes/origin/master, UserMergeOptions{mergeRemote='refs/remotes/origin', mergeTarget='**${BRANCH_NAME}**', mergeStrategy='default', fastForwardMode='--ff'}

With this Pull Request , the output is correct as the object is resolved correctly:
Merging Revision 54f103b61f0b3504503f4990204f8dec8ea612ea (refs/remotes/origin/sample) to refs/remotes/origin/master, UserMergeOptions{mergeRemote='refs/remotes/origin', mergeTarget='**master**', mergeStrategy='default', fastForwardMode='--ff'}
