### PR TITLE
Expose `invoke` method & required interface for downstream plugins

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -153,7 +153,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
      * 
      * An example usage might be:
      * 
-     * <blockquote><pre>{@code
+     * <pre>{@code
      *      return fs.invoke(new GitSCMFileSystem.FSFunction<byte[]>() {
      *          public byte[] invoke(Repository repository) throws IOException, InterruptedException {
      *              Git activeRepo = getClonedRepository(repository);
@@ -170,7 +170,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
      *              }
      *          }
      *      });
-     * }</pre></blockquote>
+     * }</pre>
      * 
      * @param <V> return type
      * @param function callback executed with a locked repository

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -147,7 +147,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
         return commitId;
     }
 
-    /*package*/ <V> V invoke(final FSFunction<V> function) throws IOException, InterruptedException {
+    public <V> V invoke(final FSFunction<V> function) throws IOException, InterruptedException {
         Lock cacheLock = AbstractGitSCMSource.getCacheLock(cacheEntry);
         cacheLock.lock();
         try {
@@ -211,7 +211,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
         }
     }
 
-    /*package*/ interface FSFunction<V> {
+    public interface FSFunction<V> {
         V invoke(Repository repository) throws IOException, InterruptedException;
     }
 

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -155,7 +155,6 @@ public class GitSCMFileSystem extends SCMFileSystem {
      * 
      * <blockquote><pre>{@code
      *      return fs.invoke(new GitSCMFileSystem.FSFunction<byte[]>() {
-     *          @Override
      *          public byte[] invoke(Repository repository) throws IOException, InterruptedException {
      *              Git activeRepo = getClonedRepository(repository);
      *              File repoDir = activeRepo.getRepository().getDirectory().getParentFile();

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -177,9 +177,9 @@ public class GitSCMFileSystem extends SCMFileSystem {
      * 
      * @param <V> return type
      * @param function callback executed with a locked repository
-     * @return something
-     * @throws IOException
-     * @throws InterruptedException 
+     * @return whatever you return from the provided function
+     * @throws IOException if there is an I/O error
+     * @throws InterruptedException if interrupted
      */
     public <V> V invoke(final FSFunction<V> function) throws IOException, InterruptedException {
         Lock cacheLock = AbstractGitSCMSource.getCacheLock(cacheEntry);

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -153,8 +153,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
      * 
      * An example usage might be:
      * 
-     * <pre>
-     * {@code
+     * <blockquote><pre>{@code
      *      return fs.invoke(new GitSCMFileSystem.FSFunction<byte[]>() {
      *          @Override
      *          public byte[] invoke(Repository repository) throws IOException, InterruptedException {
@@ -172,8 +171,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
      *              }
      *          }
      *      });
-     * }
-     * </pre>
+     * }</pre></blockquote>
      * 
      * @param <V> return type
      * @param function callback executed with a locked repository
@@ -249,11 +247,16 @@ public class GitSCMFileSystem extends SCMFileSystem {
      * Simple callback that is used with
      * {@link #invoke(jenkins.plugins.git.GitSCMFileSystem.FSFunction)}
      * in order to provide a locked view of the Git repository
+     * @param <V> the return type
      */
     public interface FSFunction<V> {
         /**
          * Called with a lock on the repository in order to perform some
          * operations that might result in changes and necessary re-indexing
+         * @param repository the bare git repository
+         * @return value to return from {@link #invoke(jenkins.plugins.git.GitSCMFileSystem.FSFunction)}
+         * @throws IOException if there is an I/O error
+         * @throws InterruptedException if interrupted
          */
         V invoke(Repository repository) throws IOException, InterruptedException;
     }


### PR DESCRIPTION
Minor change to allow downstream plugins to access repository cache in a synchronous manner with appropriate locks.

This is necessary for enabling efficient and hopefully Jenkins-accurate git read/write in blueocean

@reviewbybees esp. @stephenc 