### PR TITLE
Use latest dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.13</version>
+      <version>2.1.14</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,6 @@
           <rules>
             <requireUpperBoundDeps>
               <excludes combine.children="append">
-                <!-- structs requests 1.9, core requests 1.7 -->
-                <exclude>org.jenkins-ci:annotation-indexer</exclude>
                 <!-- workflow-cps requests 1.1.1, core 2.60.1 requests 1.2.1 -->
                 <exclude>org.jenkins-ci.ui:jquery-detached</exclude>
               </excludes>
@@ -158,7 +156,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.9</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
       <plugin>
         <groupId>com.infradna.tool</groupId>
         <artifactId>bridge-method-injector</artifactId>
-        <version>1.15</version>
+        <version>1.17</version>
         <executions>
           <execution>
             <goals>
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>com.infradna.tool</groupId>
       <artifactId>bridge-method-annotation</artifactId>
-      <version>1.15</version>
+      <version>1.17</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
* Removes one of the upper bound exclusions by updating to structs 1.10
* Depends on the recommended credentials plugin version
* Use latest bridge method annotation

@reviewbybees 

Does not remove the powermock / mockito exclusion.