### PR TITLE
Disable code coverage unless COVERAGE=true passed to build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,24 +52,6 @@
     </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>report</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
@@ -343,4 +325,39 @@
        <url>https://repo.jenkins-ci.org/public/</url>
      </pluginRepository>
   </pluginRepositories>
+
+  <profiles>
+    <profile>
+      <id>with-code-coverage</id>
+      <activation>
+        <property>
+          <name>COVERAGE</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>report</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
Code coverage reports "method too large" when instrumenting the jenkins
war file, and is only checked in the context of certain custom jobs.

There is very little value leaving coverage enabled by default.