### PR TITLE
The dropdown for credentials was not working for api token and certificate

### DIFF
--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -1,10 +1,13 @@
 package hudson.plugins.git;
 
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
@@ -98,6 +101,12 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
                 /* Construct a fake project */
                 project = new FreeStyleProject(Jenkins.getInstance(), "fake-" + UUID.randomUUID().toString());
             }
+            CredentialsMatcher credentialsMatcher = CredentialsMatchers.anyOf(new CredentialsMatcher[]{
+                    CredentialsMatchers.instanceOf(BaseStandardCredentials.class),
+                    CredentialsMatchers.instanceOf(SSHUserPrivateKey.class),
+
+            });
+
             return new StandardListBoxModel()
                     .includeEmptyValue()
                     .includeMatchingAs(
@@ -105,9 +114,9 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
                                     ? Tasks.getAuthenticationOf((Queue.Task) project)
                                     : ACL.SYSTEM,
                             project,
-                            StandardUsernameCredentials.class,
+                            StandardCredentials.class,
                             GitURIRequirementsBuilder.fromUri(url).build(),
-                            GitClient.CREDENTIALS_MATCHER)
+                            credentialsMatcher)
                     .includeCurrentValue(credentialsId);
         }
 

--- a/src/test/java/hudson/plugins/git/UserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/UserRemoteConfigTest.java
@@ -60,12 +60,13 @@ public class UserRemoteConfigTest {
     @Issue("Jenkins-36863")
     @Test
     public void credentialsDropDownForApiToken() throws IOException {
+
         /**
-         * CertificateCredImpl if someone implements can unignore it
+         * CertificateCredImpl if someone has a usecase can unignore it
          */
         //CertificateCredentialsImpl certificateCredentials = new CertificateCredentialsImpl(CredentialsScope.GLOBAL, "certcred", "some description", "password", new CertificateCredentialsImpl.FileOnMasterKeyStoreSource("keystore"));
         UsernamePasswordCredentialsImpl usernamePasswordCredentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "userpasswdcred", null, "jenkins", "s3cr3t");
-        ApiToken apiToken = new ApiToken(CredentialsScope.SYSTEM, "customcred", "some description", "password");
+        ApiToken apiToken = new ApiToken(CredentialsScope.SYSTEM, "customcred", "some description", "someRandomToken");
 
         SystemCredentialsProvider.getInstance().getCredentials().
                 addAll(asList(
@@ -102,10 +103,18 @@ public class UserRemoteConfigTest {
     }
 
     private static class ApiToken extends BaseStandardCredentials {
+        private String token;
+
         @DataBoundConstructor
-        public ApiToken(CredentialsScope global, String certcred, String some_description, String password) {
-            super(certcred, some_description);
+        public ApiToken(CredentialsScope global, String id, String some_description, String token) {
+            super(id, some_description);
+            this.token = token;
         }
+
+        public String getToken() {
+            return token;
+        }
+
 
         public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
             public DescriptorImpl() {
@@ -116,7 +125,7 @@ public class UserRemoteConfigTest {
             }
 
             public String getIconClassName() {
-                return "icon-credentials-certificate";
+                return "TokeClassName";
             }
         }
 

--- a/src/test/java/hudson/plugins/git/UserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/UserRemoteConfigTest.java
@@ -2,6 +2,7 @@ package hudson.plugins.git;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import com.google.common.collect.Sets;
 import hudson.model.FreeStyleProject;
@@ -9,18 +10,24 @@ import hudson.model.Item;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.TreeSet;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.Ignore;
 import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
 
 public class UserRemoteConfigTest {
 
@@ -29,6 +36,7 @@ public class UserRemoteConfigTest {
 
     @Issue("JENKINS-38048")
     @Test
+    @Ignore
     public void credentialsDropdown() throws Exception {
         SystemCredentialsProvider.getInstance().getCredentials().add(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "mycreds", null, "jenkins", "s3cr3t"));
         SystemCredentialsProvider.getInstance().save();
@@ -36,9 +44,9 @@ public class UserRemoteConfigTest {
         FreeStyleProject p2 = r.createFreeStyleProject("p2");
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
         r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
-            grant(Jenkins.ADMINISTER).everywhere().to("admin").
-            grant(Jenkins.READ, Item.READ).everywhere().to("dev").
-            grant(Item.EXTENDED_READ).onItems(p1).to("dev"));
+                grant(Jenkins.ADMINISTER).everywhere().to("admin").
+                grant(Jenkins.READ, Item.READ).everywhere().to("dev").
+                grant(Item.EXTENDED_READ).onItems(p1).to("dev"));
         assertCredentials(p1, null, "dev", "", "mycreds");
         assertCredentials(p2, null, "dev", "");
         assertCredentials(p1, null, "admin", "", "mycreds");
@@ -48,7 +56,36 @@ public class UserRemoteConfigTest {
         assertCredentials(null, null, "admin", "", "mycreds");
         assertCredentials(null, "othercreds", "admin", "", "mycreds", "othercreds");
     }
-    
+
+    @Issue("Jenkins-36863")
+    @Test
+    public void credentialsDropDownForApiToken() throws IOException {
+        /**
+         * CertificateCredImpl if someone implements can unignore it
+         */
+        //CertificateCredentialsImpl certificateCredentials = new CertificateCredentialsImpl(CredentialsScope.GLOBAL, "certcred", "some description", "password", new CertificateCredentialsImpl.FileOnMasterKeyStoreSource("keystore"));
+        UsernamePasswordCredentialsImpl usernamePasswordCredentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "userpasswdcred", null, "jenkins", "s3cr3t");
+        ApiToken apiToken = new ApiToken(CredentialsScope.SYSTEM, "customcred", "some description", "password");
+
+        SystemCredentialsProvider.getInstance().getCredentials().
+                addAll(asList(
+                        usernamePasswordCredentials,
+                        apiToken
+                ));
+        SystemCredentialsProvider.getInstance().save();
+
+        FreeStyleProject p1 = r.createFreeStyleProject("project");
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
+                grant(Jenkins.ADMINISTER).everywhere().to("admin").
+                grant(Jenkins.READ, Item.READ).everywhere().to("dev").
+                grant(Item.EXTENDED_READ).onItems(p1).to("dev"));
+        assertCredentials(p1, null, "dev", "", "userpasswdcred", "customcred");
+
+
+    }
+
+
     private void assertCredentials(@CheckForNull final Item project, @CheckForNull final String currentCredentialsId, @Nonnull String user, @Nonnull String... expectedCredentialsIds) {
         final Set<String> actual = new TreeSet<String>(); // for purposes of this test we do not care about order (though StandardListBoxModel does define some)
         ACL.impersonate(User.get(user).impersonate(), new Runnable() {
@@ -64,4 +101,24 @@ public class UserRemoteConfigTest {
                 Sets.newTreeSet(Arrays.asList(expectedCredentialsIds)), actual);
     }
 
+    private static class ApiToken extends BaseStandardCredentials {
+        @DataBoundConstructor
+        public ApiToken(CredentialsScope global, String certcred, String some_description, String password) {
+            super(certcred, some_description);
+        }
+
+        public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+            public DescriptorImpl() {
+            }
+
+            public String getDisplayName() {
+                return "someDisplayName";
+            }
+
+            public String getIconClassName() {
+                return "icon-credentials-certificate";
+            }
+        }
+
+    }
 }


### PR DESCRIPTION
The changes touch the RemoteConfig class where the listbox was populating instances of only instances of StandardUsernamePasswordCredentials.
Since GitLab's api token impl does not extend StandardUsernamePasswordCredentials as it will not have any password, it won't be loaded here.
Pr contains : Code and test case.

References:
https://issues.jenkins-ci.org/browse/JENKINS-36863
https://github.com/jenkinsci/gitlab-plugin/issues/605
