### PR TITLE
[JENKINS-46929] Limit number of projects added to response headers

### DIFF
--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -166,8 +166,13 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
                     throws IOException, ServletException {
                 rsp.setStatus(SC_OK);
                 rsp.setContentType("text/plain");
-                for (ResponseContributor c : contributors) {
-                    c.addHeaders(req, rsp);
+                for (int i = 0; i < contributors.size(); i++) {
+                    if (i == MAX_REPORTED_CONTRIBUTORS) {
+                        rsp.addHeader("Triggered", "<" + (contributors.size() - i) + " more>");
+                        break;
+                    } else {
+                        contributors.get(i).addHeaders(req, rsp);
+                    }
                 }
                 PrintWriter w = rsp.getWriter();
                 for (ResponseContributor c : contributors) {
@@ -609,6 +614,7 @@ public class GitStatus extends AbstractModelObject implements UnprotectedRootAct
     }
 
     private static final Logger LOGGER = Logger.getLogger(GitStatus.class.getName());
+    private static final int MAX_REPORTED_CONTRIBUTORS = 10;
 
     /** Allow arbitrary notify commit parameters.
      *

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -11,6 +11,7 @@ import hudson.tasks.CommandInterpreter;
 import hudson.tasks.Shell;
 import hudson.triggers.SCMTrigger;
 import java.io.File;
+import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.util.*;
 
@@ -23,9 +24,13 @@ import static org.junit.Assert.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.WithoutJenkins;
 
 import javax.servlet.http.HttpServletRequest;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 public class GitStatusTest extends AbstractGitProject {
 
@@ -515,5 +520,30 @@ public class GitStatusTest extends AbstractGitProject {
      */
     private boolean isWindows() {
         return File.pathSeparatorChar == ';';
+    }
+
+    @Test
+    @Issue("JENKINS-46929")
+    public void testDoNotifyCommitTriggeredHeadersLimited() throws Exception {
+        SCMTrigger[] projectTriggers = new SCMTrigger[50];
+        for (int i = 0; i < projectTriggers.length; i++) {
+            projectTriggers[i] = setupProjectWithTrigger("a", "master", false);
+        }
+
+        HttpResponse rsp = this.gitStatus.doNotifyCommit(requestWithNoParameter, "a", "master", null);
+
+        // Up to 10 "Triggered" headers + 1 extra warning are returned.
+        StaplerRequest sReq = mock(StaplerRequest.class);
+        StaplerResponse sRsp = mock(StaplerResponse.class);
+        Mockito.when(sRsp.getWriter()).thenReturn(mock(PrintWriter.class));
+        rsp.generateResponse(sReq, sRsp, null);
+        Mockito.verify(sRsp, Mockito.times(11)).addHeader(Mockito.eq("Triggered"), Mockito.anyString());
+
+        // All triggers run.
+        for (int i = 0; i < projectTriggers.length; i++) {
+            Mockito.verify(projectTriggers[i]).run();
+        }
+
+        assertEquals("URL: a Branches: master", this.gitStatus.toString());
     }
 }


### PR DESCRIPTION
[JENKINS-46929](https://issues.jenkins-ci.org/browse/JENKINS-46929)

I changed `GitStatus#doNotifyCommit` to only add up to 10 "Triggered" headers (which contain URLs to downstream projects for which polling or builds have been scheduled by this commit) to its response. This should prevent `java.io.IOException: Response header too large` exceptions when a repository is used in a large number of projects.

@reviewbybees 