### PR TITLE
Allow up to 4 second time offset in Windows file system

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -181,7 +181,7 @@ public class GitSCMFileSystemTest {
         SCMRevision revision = source.fetch(new SCMHead("dev"), null);
         sampleRepo.write("file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
-        final long fileSystemAllowedOffset = isWindows() ? 3000 : 1500;
+        final long fileSystemAllowedOffset = isWindows() ? 4000 : 1500;
         SCMFileSystem fs = SCMFileSystem.of(source, new SCMHead("dev"), revision);
         long currentTime = isWindows() ? System.currentTimeMillis() / 1000L * 1000L : System.currentTimeMillis();
         long lastModified = fs.lastModified();


### PR DESCRIPTION
Some Windows file systems only track time on 2 second intervals.
Test failures on Windows machines have shown a 1 second offset between
the allowed value and the actual value.

Rather than have a flaky test, increase the offset to cover that
interesting tracking of file system time stamps on Windows.