### PR TITLE
[JENKINS-47526] Provide an API to allow an AbstractGitSCMSource to work at a distance from the repository rather than requiring a local checkout

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -18,6 +18,8 @@ import hudson.matrix.MatrixRun;
 import hudson.model.*;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Hudson.MasterComputer;
+import hudson.model.Queue;
+import hudson.model.queue.Tasks;
 import hudson.plugins.git.browser.GitRepositoryBrowser;
 import hudson.plugins.git.extensions.GitClientConflictException;
 import hudson.plugins.git.extensions.GitClientType;
@@ -762,8 +764,14 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             String ucCredentialsId = uc.getCredentialsId();
             if (ucCredentialsId != null) {
                 String url = getParameterString(uc.getUrl(), environment);
-                List<StandardUsernameCredentials> urlCredentials = CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, project,
-                                        ACL.SYSTEM, URIRequirementBuilder.fromUri(url).build());
+                List<StandardUsernameCredentials> urlCredentials = CredentialsProvider.lookupCredentials(
+                        StandardUsernameCredentials.class,
+                        project,
+                        project instanceof Queue.Task
+                                ? Tasks.getDefaultAuthenticationOf((Queue.Task)project)
+                                : ACL.SYSTEM,
+                        URIRequirementBuilder.fromUri(url).build()
+                );
                 CredentialsMatcher ucMatcher = CredentialsMatchers.withId(ucCredentialsId);
                 CredentialsMatcher idMatcher = CredentialsMatchers.allOf(ucMatcher, GitClient.CREDENTIALS_MATCHER);
                 StandardUsernameCredentials credentials = CredentialsMatchers.firstOrNull(urlCredentials, idMatcher);

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -427,7 +427,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                         listener.getLogger().println("Checking branches...");
                         int count = 0;
                         for (final SCMRevision revision : revisions) {
-                            if (!(revision instanceof SCMRevisionImpl)) {
+                            if (!(revision instanceof SCMRevisionImpl) || (revision instanceof GitTagSCMRevision)) {
                                 continue;
                             }
                             count++;

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -24,7 +24,9 @@
 package jenkins.plugins.git;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -80,6 +82,7 @@ import jenkins.plugins.git.traits.GitToolSCMSourceTrait;
 import jenkins.plugins.git.traits.RefSpecsSCMSourceTrait;
 import jenkins.plugins.git.traits.RemoteNameSCMSourceTrait;
 import jenkins.scm.api.SCMFile;
+import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadCategory;
 import jenkins.scm.api.SCMHeadEvent;
@@ -98,6 +101,7 @@ import jenkins.scm.api.trait.SCMTrait;
 import jenkins.scm.impl.TagSCMHeadCategory;
 import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
 import jenkins.scm.impl.trait.WildcardSCMSourceFilterTrait;
+import net.jcip.annotations.GuardedBy;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.FileMode;
@@ -358,6 +362,13 @@ public abstract class AbstractGitSCMSource extends SCMSource {
     protected SCMRevision retrieve(@NonNull final SCMHead head, @NonNull TaskListener listener)
             throws IOException, InterruptedException {
         final GitSCMSourceContext context = new GitSCMSourceContext<>(null, SCMHeadObserver.none()).withTraits(getTraits());
+        GitSCMTelescope telescope = GitSCMTelescope.of(this);
+        if (telescope != null) {
+            String remote = getRemote();
+            StandardUsernameCredentials credentials = getCredentials();
+            telescope.validate(remote, credentials);
+            return telescope.getRevision(remote, credentials, head);
+        }
         return doRetrieve(new Retriever<SCMRevision>() {
                               @Override
                               public SCMRevision run(GitClient client, String remoteName) throws IOException, InterruptedException {
@@ -396,6 +407,116 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             throws IOException, InterruptedException {
         final GitSCMSourceContext context =
                 new GitSCMSourceContext<>(criteria, observer).withTraits(getTraits());
+        final GitSCMTelescope telescope = GitSCMTelescope.of(this);
+        if (telescope != null) {
+            final String remote = getRemote();
+            final StandardUsernameCredentials credentials = getCredentials();
+            telescope.validate(remote, credentials);
+            Set<GitSCMTelescope.ReferenceType> referenceTypes = new HashSet<>();
+            if (context.wantBranches()) {
+                referenceTypes.add(GitSCMTelescope.ReferenceType.HEAD);
+            }
+            if (context.wantTags()) {
+                referenceTypes.add(GitSCMTelescope.ReferenceType.TAG);
+            }
+            if (!referenceTypes.isEmpty()) {
+                try (GitSCMSourceRequest request = context.newRequest(AbstractGitSCMSource.this, listener)) {
+                    listener.getLogger().println("Listing remote references...");
+                    Iterable<SCMRevision> revisions = telescope.getRevisions(remote, credentials, referenceTypes);
+                    if (context.wantBranches()) {
+                        listener.getLogger().println("Checking branches...");
+                        int count = 0;
+                        for (final SCMRevision revision : revisions) {
+                            if (!(revision instanceof SCMRevisionImpl)) {
+                                continue;
+                            }
+                            count++;
+                            if (request.process(revision.getHead(),
+                                    new SCMSourceRequest.RevisionLambda<SCMHead, SCMRevisionImpl>() {
+                                        @NonNull
+                                        @Override
+                                        public SCMRevisionImpl create(@NonNull SCMHead head)
+                                                throws IOException, InterruptedException {
+                                            listener.getLogger()
+                                                    .println("  Checking branch " + revision.getHead().getName());
+                                            return (SCMRevisionImpl) revision;
+                                        }
+                                    },
+                                    new SCMSourceRequest.ProbeLambda<SCMHead, SCMRevisionImpl>() {
+                                        @NonNull
+                                        @Override
+                                        public SCMSourceCriteria.Probe create(@NonNull SCMHead head,
+                                                                              @Nullable SCMRevisionImpl revision)
+                                                throws IOException, InterruptedException {
+                                            return new TelescopingSCMProbe(telescope, remote, credentials, revision);
+                                        }
+                                    }, new SCMSourceRequest.Witness() {
+                                        @Override
+                                        public void record(@NonNull SCMHead head, SCMRevision revision,
+                                                           boolean isMatch) {
+                                            if (isMatch) {
+                                                listener.getLogger().println("    Met criteria");
+                                            } else {
+                                                listener.getLogger().println("    Does not meet criteria");
+                                            }
+                                        }
+                                    }
+                            )) {
+                                listener.getLogger().format("Processed %d branches (query complete)%n", count);
+                                return;
+                            }
+                        }
+                        listener.getLogger().format("Processed %d branches%n", count);
+                    }
+                    if (context.wantTags()) {
+                        listener.getLogger().println("Checking tags...");
+                        int count = 0;
+                        for (final SCMRevision revision : revisions) {
+                            if (!(revision instanceof GitTagSCMRevision)) {
+                                continue;
+                            }
+                            count++;
+                            if (request.process((GitTagSCMHead) revision.getHead(),
+                                    new SCMSourceRequest.RevisionLambda<GitTagSCMHead, GitTagSCMRevision>() {
+                                        @NonNull
+                                        @Override
+                                        public GitTagSCMRevision create(@NonNull GitTagSCMHead head)
+                                                throws IOException, InterruptedException {
+                                            listener.getLogger()
+                                                    .println("  Checking tag " + revision.getHead().getName());
+                                            return (GitTagSCMRevision) revision;
+                                        }
+                                    },
+                                    new SCMSourceRequest.ProbeLambda<GitTagSCMHead, GitTagSCMRevision>() {
+                                        @NonNull
+                                        @Override
+                                        public SCMSourceCriteria.Probe create(@NonNull final GitTagSCMHead head,
+                                                                              @Nullable GitTagSCMRevision revision)
+                                                throws IOException, InterruptedException {
+                                            return new TelescopingSCMProbe(telescope, remote, credentials, revision);
+                                        }
+                                    }, new SCMSourceRequest.Witness() {
+                                        @Override
+                                        public void record(@NonNull SCMHead head, SCMRevision revision,
+                                                           boolean isMatch) {
+                                            if (isMatch) {
+                                                listener.getLogger().println("    Met criteria");
+                                            } else {
+                                                listener.getLogger().println("    Does not meet criteria");
+                                            }
+                                        }
+                                    }
+                            )) {
+                                listener.getLogger().format("Processed %d tags (query complete)%n", count);
+                                return;
+                            }
+                        }
+                        listener.getLogger().format("Processed %d tags%n", count);
+                    }
+                }
+                return;
+            }
+        }
         doRetrieve(new Retriever<Void>() {
             @Override
             public Void run(GitClient client, String remoteName) throws IOException, InterruptedException {
@@ -548,6 +669,13 @@ public abstract class AbstractGitSCMSource extends SCMSource {
 
         final GitSCMSourceContext context =
                 new GitSCMSourceContext<>(null, SCMHeadObserver.none()).withTraits(getTraits());
+        final GitSCMTelescope telescope = GitSCMTelescope.of(this);
+        if (telescope != null) {
+            final String remote = getRemote();
+            final StandardUsernameCredentials credentials = getCredentials();
+            telescope.validate(remote, credentials);
+            return telescope.getRevision(remote, credentials, revision);
+        }
         return doRetrieve(new Retriever<SCMRevision>() {
                               @Override
                               public SCMRevision run(GitClient client, String remoteName) throws IOException, InterruptedException {
@@ -580,6 +708,24 @@ public abstract class AbstractGitSCMSource extends SCMSource {
 
         final GitSCMSourceContext context =
                 new GitSCMSourceContext<>(null, SCMHeadObserver.none()).withTraits(getTraits());
+        final GitSCMTelescope telescope = GitSCMTelescope.of(this);
+        if (telescope != null) {
+            final String remote = getRemote();
+            final StandardUsernameCredentials credentials = getCredentials();
+            telescope.validate(remote, credentials);
+            Set<GitSCMTelescope.ReferenceType> referenceTypes = new HashSet<>();
+            if (context.wantBranches()) {
+                referenceTypes.add(GitSCMTelescope.ReferenceType.HEAD);
+            }
+            if (context.wantTags()) {
+                referenceTypes.add(GitSCMTelescope.ReferenceType.TAG);
+            }
+            Set<String> result = new HashSet<>();
+            for (SCMRevision r : telescope.getRevisions(remote, credentials, referenceTypes)) {
+                result.add(r.getHead().getName());
+            }
+            return result;
+        }
         Git git = Git.with(listener, new EnvVars(EnvVars.masterEnvVars));
         GitTool tool = resolveGitTool(context.gitTool());
         if (tool != null) {
@@ -615,6 +761,22 @@ public abstract class AbstractGitSCMSource extends SCMSource {
     @Override
     protected List<Action> retrieveActions(@CheckForNull SCMSourceEvent event, @NonNull TaskListener listener)
             throws IOException, InterruptedException {
+        final GitSCMTelescope telescope = GitSCMTelescope.of(this);
+        if (telescope != null) {
+            final String remote = getRemote();
+            final StandardUsernameCredentials credentials = getCredentials();
+            telescope.validate(remote, credentials);
+            String target = telescope.getDefaultTarget(remote, credentials);
+            if (target.startsWith(Constants.R_HEADS)) {
+                // shorten standard names
+                target = target.substring(Constants.R_HEADS.length());
+            }
+            List<Action> result = new ArrayList<>();
+            if (StringUtils.isNotBlank(target)) {
+                result.add(new GitRemoteHeadRefAction(getRemote(), target));
+            }
+            return result;
+        }
         final GitSCMSourceContext context =
                 new GitSCMSourceContext<>(null, SCMHeadObserver.none()).withTraits(getTraits());
         Git git = Git.with(listener, new EnvVars(EnvVars.masterEnvVars));
@@ -986,6 +1148,11 @@ public abstract class AbstractGitSCMSource extends SCMSource {
 
     }
 
+    /**
+     * A {@link SCMProbe} that uses a local cache of the repository.
+     *
+     * @since TODO
+     */
     private static class TreeWalkingSCMProbe extends SCMProbe {
         private final String name;
         private final long lastModified;
@@ -999,21 +1166,33 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             this.tree = tree;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public void close() throws IOException {
             // no-op
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public String name() {
             return name;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public long lastModified() {
             return lastModified;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         @NonNull
         @SuppressFBWarnings(value = "NP_LOAD_OF_KNOWN_NULL_VALUE",
@@ -1043,6 +1222,126 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                 }
                 return SCMProbeStat.fromType(SCMFile.Type.OTHER);
             }
+        }
+    }
+
+    /**
+     * A {@link SCMProbe} that uses a {@link GitSCMTelescope}.
+     *
+     * @since TODO
+     */
+    private static class TelescopingSCMProbe extends SCMProbe {
+        /**
+         * Our telescope.
+         */
+        @NonNull
+        private final GitSCMTelescope telescope;
+        /**
+         * The repository URL.
+         */
+        @NonNull
+        private final String remote;
+        /**
+         * The credentials to use.
+         */
+        @CheckForNull
+        private final StandardCredentials credentials;
+        /**
+         * The revision this probe operates on.
+         */
+        @NonNull
+        private final SCMRevision revision;
+        /**
+         * The filesystem (lazy init).
+         */
+        @GuardedBy("this")
+        @CheckForNull
+        private SCMFileSystem fileSystem;
+        /**
+         * The last modified timestamp (lazy init).
+         */
+        @GuardedBy("this")
+        @CheckForNull
+        private Long lastModified;
+
+        /**
+         * Constructor.
+         * @param telescope the telescope.
+         * @param remote the repository URL
+         * @param credentials the credentials to use.
+         * @param revision the revision to probe.
+         */
+        public TelescopingSCMProbe(GitSCMTelescope telescope, String remote, StandardCredentials credentials,
+                                   SCMRevision revision) {
+            this.telescope = telescope;
+            this.remote = remote;
+            this.credentials = credentials;
+            this.revision = revision;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public SCMProbeStat stat(@NonNull String path) throws IOException {
+            try {
+                SCMFileSystem fileSystem;
+                synchronized (this) {
+                    if (this.fileSystem == null) {
+                        this.fileSystem = telescope.build(remote, credentials, revision.getHead(), revision);
+                    }
+                    fileSystem = this.fileSystem;
+                }
+                if (fileSystem == null) {
+                    throw new IOException("Cannot connect to " + remote + " as "
+                            + (credentials == null ? "anonymous" : CredentialsNameProvider.name(credentials)));
+                }
+                return SCMProbeStat.fromType(fileSystem.child(path).getType());
+            } catch (InterruptedException e) {
+                throw new IOException(e);
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public synchronized void close() throws IOException {
+            if (fileSystem != null) {
+                fileSystem.close();
+            }
+            fileSystem = null;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String name() {
+            return revision.getHead().getName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public long lastModified() {
+            synchronized (this) {
+                if (lastModified != null) {
+                    return lastModified;
+                }
+            }
+            long lastModified;
+            try {
+                lastModified = telescope.getTimestamp(remote, credentials, revision.getHead());
+            } catch (IOException | InterruptedException e) {
+                return -1L;
+            }
+            synchronized (this) {
+                this.lastModified = lastModified;
+            }
+            return lastModified;
         }
     }
 }

--- a/src/main/java/jenkins/plugins/git/GitSCMTelescope.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMTelescope.java
@@ -256,6 +256,7 @@ public abstract class GitSCMTelescope extends SCMFileSystem.Builder {
      * @param remote      the repository URL.
      * @param credentials the credentials or {@code null} for an anonymous connection.
      * @param refOrHash   the reference or hash. If this is a reference then it will start with {@link Constants#R_REFS}
+     *                    If this is a hash, it may be a full hash or a short hash.
      * @return the timestamp.
      * @throws IOException          if the operation failed due to an IO error.
      * @throws InterruptedException if the operation was interrupted.
@@ -269,6 +270,7 @@ public abstract class GitSCMTelescope extends SCMFileSystem.Builder {
      * @param remote      the repository URL.
      * @param credentials the credentials or {@code null} for an anonymous connection.
      * @param refOrHash   the reference or hash. If this is a reference then it will start with {@link Constants#R_REFS}
+     *                    If this is a hash, it may be a full hash or a short hash.
      * @return the revision or {@code null} if the reference or hash does not exist.
      * @throws IOException          if the operation failed due to an IO error.
      * @throws InterruptedException if the operation was interrupted.
@@ -355,7 +357,7 @@ public abstract class GitSCMTelescope extends SCMFileSystem.Builder {
      *
      * @param remote      the repository URL.
      * @param credentials the credentials or {@code null} for an anonymous connection.
-     * @return the default target of the repository, 
+     * @return the default target of the repository.
      * @throws IOException          if the operation failed due to an IO error.
      * @throws InterruptedException if the operation was interrupted.
      */

--- a/src/main/java/jenkins/plugins/git/GitSCMTelescope.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMTelescope.java
@@ -1,0 +1,379 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Stephen Connolly
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package jenkins.plugins.git;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
+import hudson.model.Item;
+import hudson.model.Queue;
+import hudson.model.queue.Tasks;
+import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
+import hudson.scm.SCM;
+import hudson.security.ACL;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import jenkins.scm.api.SCMFileSystem;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceOwner;
+import jenkins.scm.api.mixin.TagSCMHead;
+import org.eclipse.jgit.lib.Constants;
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+/**
+ * An implementation of this extension point allows {@link AbstractGitSCMSource} to examine a repository from a distance
+ * without requiring a local checkout.
+ *
+ * @since TODO
+ */
+public abstract class GitSCMTelescope extends SCMFileSystem.Builder {
+
+    /**
+     * Returns the {@link GitSCMTelescope} to use for the specified {@link GitSCM} or {@code null} if none match.
+     * @param source the {@link GitSCM}.
+     * @return the {@link GitSCMTelescope} to use for the specified {@link GitSCM} or {@code null}
+     */
+    @CheckForNull
+    public static GitSCMTelescope of(@NonNull GitSCM source) {
+        for (SCMFileSystem.Builder b : ExtensionList.lookup(SCMFileSystem.Builder.class)) {
+            if (b instanceof GitSCMTelescope && b.supports(source)) {
+                return (GitSCMTelescope) b;
+            }
+            if (b instanceof GitSCMFileSystem.BuilderImpl) {
+                // telescopes must come before the fallback GitSCMFileSystem.BuilderImpl otherwise they would
+                // not prevent a local checkout
+                break;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the {@link GitSCMTelescope} to use for the specified {@link AbstractGitSCMSource} or {@code null} if
+     * none match.
+     *
+     * @param source the {@link AbstractGitSCMSource}.
+     * @return the {@link GitSCMTelescope} to use for the specified {@link AbstractGitSCMSource} or {@code null}
+     */
+    @CheckForNull
+    public static GitSCMTelescope of(@NonNull AbstractGitSCMSource source) {
+        for (SCMFileSystem.Builder b : ExtensionList.lookup(SCMFileSystem.Builder.class)) {
+            if (b instanceof GitSCMTelescope && b.supports(source)) {
+                return (GitSCMTelescope) b;
+            }
+            if (b instanceof GitSCMFileSystem.BuilderImpl) {
+                // telescopes must come before the fallback GitSCMFileSystem.BuilderImpl otherwise they would
+                // not prevent a local checkout
+                break;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if this {@link SCMFileSystem.Builder} supports the repository at the supplied remote URL.
+     * <strong>NOTE:</strong> returning {@code true} mandates that {@link #build(Item, SCM, SCMRevision)} and
+     * {@link #build(SCMSource, SCMHead, SCMRevision)} must return non-{@code null} when they are configured
+     * with the corresponding repository URL.
+     *
+     * @param remote the repository URL.
+     * @return {@code true} if and only if the remote URL is supported by this {@link GitSCMTelescope}.
+     */
+    public abstract boolean supports(@NonNull String remote);
+
+    /**
+     * Checks if the supplied credentials are valid against the specified repository URL.
+     *
+     * @param remote      the repository URL.
+     * @param credentials the credentials or {@code null} to validate anonymous connection.
+     * @throws IOException          if the operation failed due to an IO error or invalid credentials.
+     * @throws InterruptedException if the operation was interrupted.
+     */
+    public abstract void validate(@NonNull String remote, @CheckForNull StandardCredentials credentials)
+            throws IOException, InterruptedException;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final boolean supports(@NonNull SCM source) {
+        if (source instanceof GitSCM) {
+            // we only support the GitSCM if the branch is completely unambiguous
+            GitSCM git = (GitSCM) source;
+            List<UserRemoteConfig> configs = git.getUserRemoteConfigs();
+            List<BranchSpec> branches = git.getBranches();
+            return configs.size() == 1
+                    && supports(configs.get(0).getUrl())
+                    && branches.size() == 1
+                    && !branches.get(0).getName().contains("*");
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final boolean supports(@NonNull SCMSource source) {
+        return source instanceof AbstractGitSCMSource && source.getOwner() != null && supports(
+                ((AbstractGitSCMSource) source).getRemote());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final SCMFileSystem build(@NonNull SCMSource source, @NonNull SCMHead head, @CheckForNull SCMRevision rev)
+            throws IOException, InterruptedException {
+        SCMSourceOwner owner = source.getOwner();
+        if (source instanceof AbstractGitSCMSource && owner != null && supports(
+                ((AbstractGitSCMSource) source).getRemote())) {
+            AbstractGitSCMSource git = (AbstractGitSCMSource) source;
+            String remote = git.getRemote();
+            StandardUsernameCredentials credentials = git.getCredentials();
+            validate(remote, credentials);
+            return build(remote, credentials, head, rev);
+        }
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final SCMFileSystem build(@NonNull Item owner, @NonNull SCM scm, SCMRevision rev)
+            throws IOException, InterruptedException {
+        if (scm instanceof GitSCM) {
+            // we only support the GitSCM if the branch is completely unambiguous
+            GitSCM git = (GitSCM) scm;
+            List<UserRemoteConfig> configs = git.getUserRemoteConfigs();
+            List<BranchSpec> branches = git.getBranches();
+            if (configs.size() == 1 && supports(configs.get(0).getUrl())
+                    && branches.size() == 1 && !branches.get(0).getName().contains("*")) {
+                UserRemoteConfig config = configs.get(0);
+                StandardCredentials credentials;
+                String credentialsId = config.getCredentialsId();
+                String remote = config.getUrl();
+                if (credentialsId != null) {
+                    List<StandardUsernameCredentials> urlCredentials = CredentialsProvider
+                            .lookupCredentials(StandardUsernameCredentials.class, owner,
+                                    owner instanceof Queue.Task
+                                            ? Tasks.getAuthenticationOf((Queue.Task) owner)
+                                            : ACL.SYSTEM, URIRequirementBuilder.fromUri(remote).build());
+                    credentials = CredentialsMatchers.firstOrNull(
+                            urlCredentials,
+                            CredentialsMatchers
+                                    .allOf(CredentialsMatchers.withId(credentialsId), GitClient.CREDENTIALS_MATCHER)
+                    );
+                } else {
+                    credentials = null;
+                }
+                validate(remote, credentials);
+                SCMHead head;
+                if (rev == null) {
+                    String name = branches.get(0).getName();
+                    if (name.startsWith(Constants.R_TAGS)) {
+                        head = new GitTagSCMHead(
+                                name.substring(Constants.R_TAGS.length()),
+                                getTimestamp(remote, credentials, name)
+                        );
+                    } else if (name.startsWith(Constants.R_HEADS)) {
+                        head = new SCMHead(name.substring(Constants.R_HEADS.length()));
+                    } else {
+                        if (name.startsWith(config.getName() + "/")) {
+                            head = new SCMHead(name.substring(config.getName().length() + 1));
+                        } else {
+                            head = new SCMHead(name);
+                        }
+                    }
+                } else {
+                    head = rev.getHead();
+                }
+                return build(remote, credentials, head, rev);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Given a {@link SCM} this should try to build a corresponding {@link SCMFileSystem} instance that
+     * reflects the content at the specified {@link SCMRevision}. If the {@link SCM} is supported but not
+     * for a fixed revision, best effort is acceptable as the most capable {@link SCMFileSystem} will be returned
+     * to the caller.
+     *
+     * @param remote      the repository URL
+     * @param credentials the credentials or {@code null} for an anonymous connection.
+     * @param head        the specified {@link SCMHead}
+     * @param rev         the specified {@link SCMRevision}.
+     * @return the corresponding {@link SCMFileSystem} or {@code null} if this builder cannot create a {@link
+     * SCMFileSystem} for the specified repository URL.
+     * @throws IOException          if the attempt to create a {@link SCMFileSystem} failed due to an IO error
+     *                              (such as the remote system being unavailable)
+     * @throws InterruptedException if the attempt to create a {@link SCMFileSystem} was interrupted.
+     */
+    @CheckForNull
+    protected abstract SCMFileSystem build(@NonNull String remote, @CheckForNull StandardCredentials credentials,
+                                           @NonNull SCMHead head, @CheckForNull SCMRevision rev)
+            throws IOException, InterruptedException;
+
+    /**
+     * Retrives the timestamp of the specified reference or object hash.
+     *
+     * @param remote      the repository URL.
+     * @param credentials the credentials or {@code null} for an anonymous connection.
+     * @param refOrHash   the reference or hash.
+     * @return the timestamp.
+     * @throws IOException          if the operation failed due to an IO error.
+     * @throws InterruptedException if the operation was interrupted.
+     */
+    public abstract long getTimestamp(@NonNull String remote, @CheckForNull StandardCredentials credentials,
+                                      @NonNull String refOrHash) throws IOException, InterruptedException;
+
+    /**
+     * Retrives the current revision of the specified reference or object hash.
+     *
+     * @param remote      the repository URL.
+     * @param credentials the credentials or {@code null} for an anonymous connection.
+     * @param refOrHash   the reference or hash.
+     * @return the revision or {@code null} if the reference or hash does not exist.
+     * @throws IOException          if the operation failed due to an IO error.
+     * @throws InterruptedException if the operation was interrupted.
+     */
+    @CheckForNull
+    public abstract SCMRevision getRevision(@NonNull String remote,
+                                            @CheckForNull StandardCredentials credentials,
+                                            @NonNull String refOrHash)
+            throws IOException, InterruptedException;
+
+    /**
+     * Retrives the timestamp of the specified reference or object hash.
+     *
+     * @param remote      the repository URL.
+     * @param credentials the credentials or {@code null} for an anonymous connection.
+     * @param head        the head.
+     * @return the timestamp.
+     * @throws IOException          if the operation failed due to an IO error.
+     * @throws InterruptedException if the operation was interrupted.
+     */
+    public long getTimestamp(@NonNull String remote, @CheckForNull StandardCredentials credentials,
+                             @NonNull SCMHead head) throws IOException, InterruptedException {
+        if ((head instanceof TagSCMHead)) {
+            return getTimestamp(remote, credentials, Constants.R_TAGS + head.getName());
+        } else {
+            return getTimestamp(remote, credentials, Constants.R_HEADS + head.getName());
+        }
+    }
+
+    /**
+     * Retrives the current revision of the specified head.
+     *
+     * @param remote      the repository URL.
+     * @param credentials the credentials or {@code null} for an anonymous connection.
+     * @param head        the head.
+     * @return the revision or {@code null} if the head does not exist.
+     * @throws IOException          if the operation failed due to an IO error.
+     * @throws InterruptedException if the operation was interrupted.
+     */
+    @CheckForNull
+    public SCMRevision getRevision(@NonNull String remote,
+                                   @CheckForNull StandardCredentials credentials,
+                                   @NonNull SCMHead head)
+            throws IOException, InterruptedException {
+        if ((head instanceof TagSCMHead)) {
+            return getRevision(remote, credentials, Constants.R_TAGS + head.getName());
+        } else {
+            return getRevision(remote, credentials, Constants.R_HEADS + head.getName());
+        }
+    }
+
+    /**
+     * Retrives the current revisions of the specified repository.
+     *
+     * @param remote      the repository URL.
+     * @param credentials the credentials or {@code null} for an anonymous connection.
+     * @return the revisions.
+     * @throws IOException          if the operation failed due to an IO error.
+     * @throws InterruptedException if the operation was interrupted.
+     */
+    public final Iterable<SCMRevision> getRevisions(@NonNull String remote,
+                                                    @CheckForNull StandardCredentials credentials)
+            throws IOException, InterruptedException {
+        return getRevisions(remote, credentials, EnumSet.allOf(ReferenceType.class));
+    }
+
+    /**
+     * Retrives the current revisions of the specified repository.
+     *
+     * @param remote         the repository URL.
+     * @param credentials    the credentials or {@code null} for an anonymous connection.
+     * @param referenceTypes the types of reference to retrieve revisions of.
+     * @return the revisions.
+     * @throws IOException          if the operation failed due to an IO error.
+     * @throws InterruptedException if the operation was interrupted.
+     */
+    public abstract Iterable<SCMRevision> getRevisions(@NonNull String remote,
+                                                       @CheckForNull StandardCredentials credentials,
+                                                       @NonNull Set<ReferenceType> referenceTypes)
+            throws IOException, InterruptedException;
+
+    /**
+     * Retrives the default target of the specified repository.
+     *
+     * @param remote      the repository URL.
+     * @param credentials the credentials or {@code null} for an anonymous connection.
+     * @return the default target of the repository.
+     * @throws IOException          if the operation failed due to an IO error.
+     * @throws InterruptedException if the operation was interrupted.
+     */
+    public abstract String getDefaultTarget(@NonNull String remote,
+                                            @CheckForNull StandardCredentials credentials)
+            throws IOException, InterruptedException;
+
+    /**
+     * The potential types of reference supported by a {@link GitSCMTelescope}.
+     */
+    enum ReferenceType {
+        /**
+         * A regular reference.
+         */
+        HEAD,
+        /**
+         * A tag reference.
+         */
+        TAG;
+    }
+}

--- a/src/main/java/jenkins/plugins/git/GitSCMTelescope.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMTelescope.java
@@ -95,7 +95,7 @@ public abstract class GitSCMTelescope extends SCMFileSystem.Builder {
             if (b instanceof GitSCMTelescope && b.supports(source)) {
                 return (GitSCMTelescope) b;
             }
-            if (b instanceof GitSCMFileSystem.BuilderImpl) {
+            if (GitSCMFileSystem.BuilderImpl.class.equals(b.getClass())) {
                 // telescopes must come before the fallback GitSCMFileSystem.BuilderImpl otherwise they would
                 // not prevent a local checkout
                 break;

--- a/src/main/java/jenkins/plugins/git/GitSCMTelescope.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMTelescope.java
@@ -255,7 +255,7 @@ public abstract class GitSCMTelescope extends SCMFileSystem.Builder {
      *
      * @param remote      the repository URL.
      * @param credentials the credentials or {@code null} for an anonymous connection.
-     * @param refOrHash   the reference or hash.
+     * @param refOrHash   the reference or hash. If this is a reference then it will start with {@link Constants#R_REFS}
      * @return the timestamp.
      * @throws IOException          if the operation failed due to an IO error.
      * @throws InterruptedException if the operation was interrupted.
@@ -268,7 +268,7 @@ public abstract class GitSCMTelescope extends SCMFileSystem.Builder {
      *
      * @param remote      the repository URL.
      * @param credentials the credentials or {@code null} for an anonymous connection.
-     * @param refOrHash   the reference or hash.
+     * @param refOrHash   the reference or hash. If this is a reference then it will start with {@link Constants#R_REFS}
      * @return the revision or {@code null} if the reference or hash does not exist.
      * @throws IOException          if the operation failed due to an IO error.
      * @throws InterruptedException if the operation was interrupted.
@@ -355,7 +355,7 @@ public abstract class GitSCMTelescope extends SCMFileSystem.Builder {
      *
      * @param remote      the repository URL.
      * @param credentials the credentials or {@code null} for an anonymous connection.
-     * @return the default target of the repository.
+     * @return the default target of the repository, 
      * @throws IOException          if the operation failed due to an IO error.
      * @throws InterruptedException if the operation was interrupted.
      */

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
@@ -3,12 +3,19 @@ package jenkins.plugins.git;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
+import hudson.model.Action;
+import hudson.model.Actionable;
 import hudson.model.Item;
 import hudson.model.TopLevelItem;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitStatus;
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -16,6 +23,7 @@ import java.util.concurrent.TimeoutException;
 import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.plugins.git.traits.TagDiscoveryTrait;
 import jenkins.scm.api.SCMEventListener;
+import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadEvent;
@@ -23,6 +31,7 @@ import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
+import jenkins.scm.api.metadata.PrimaryInstanceMetadataAction;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -36,10 +45,15 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Collections;
 import org.jvnet.hudson.test.TestExtension;
+import org.mockito.Mockito;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -76,9 +90,11 @@ public class GitSCMSourceTest {
 
         gitStatus.doNotifyCommit(mock(HttpServletRequest.class), REMOTE, "master", "");
 
-        SCMHeadEvent event = jenkins.getInstance().getExtensionList(SCMEventListener.class).get(SCMEventListenerImpl.class).waitSCMHeadEvent(1, TimeUnit.SECONDS);
+        SCMHeadEvent event =
+                jenkins.getInstance().getExtensionList(SCMEventListener.class).get(SCMEventListenerImpl.class)
+                        .waitSCMHeadEvent(1, TimeUnit.SECONDS);
         assertThat(event, notNullValue());
-        assertThat((Iterable<SCMHead>)event.heads(gitSCMSource).keySet(), hasItem(is(new SCMHead("master"))));
+        assertThat((Iterable<SCMHead>) event.heads(gitSCMSource).keySet(), hasItem(is(new SCMHead("master"))));
         verify(scmSourceOwner, times(0)).onSCMSourceUpdated(gitSCMSource);
 
     }
@@ -90,7 +106,8 @@ public class GitSCMSourceTest {
         return owner;
     }
 
-    private interface GitSCMSourceOwner extends TopLevelItem, SCMSourceOwner {}
+    private interface GitSCMSourceOwner extends TopLevelItem, SCMSourceOwner {
+    }
 
     @TestExtension
     public static class SCMEventListenerImpl extends SCMEventListener {
@@ -168,11 +185,105 @@ public class GitSCMSourceTest {
                 )));
     }
 
-    @TestExtension("telescopeFetch")
+    @Issue("JENKINS-47526")
+    @Test
+    public void telescopeFetchRevisions() throws Exception {
+
+        GitSCMSource instance = new GitSCMSource("http://git.test/telescope.git");
+        assertThat(GitSCMTelescope.of(instance), nullValue());
+        instance.setOwner(mock(SCMSourceOwner.class));
+        assertThat(GitSCMTelescope.of(instance), notNullValue());
+
+        instance.setTraits(Arrays.<SCMSourceTrait>asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait()));
+        Set<String> result = instance.fetchRevisions(null);
+        assertThat(result, containsInAnyOrder("foo", "bar", "manchu", "v1.0.0"));
+
+        instance.setTraits(Collections.<SCMSourceTrait>singletonList(new BranchDiscoveryTrait()));
+        result = instance.fetchRevisions(null);
+        assertThat(result, containsInAnyOrder("foo", "bar", "manchu"));
+
+        instance.setTraits(Collections.<SCMSourceTrait>singletonList(new TagDiscoveryTrait()));
+        result = instance.fetchRevisions(null);
+        assertThat(result, containsInAnyOrder("v1.0.0"));
+    }
+
+    @Issue("JENKINS-47526")
+    @Test
+    public void telescopeFetchRevision() throws Exception {
+
+        GitSCMSource instance = new GitSCMSource("http://git.test/telescope.git");
+        assertThat(GitSCMTelescope.of(instance), nullValue());
+        instance.setOwner(mock(SCMSourceOwner.class));
+        assertThat(GitSCMTelescope.of(instance), notNullValue());
+
+        instance.setTraits(Arrays.<SCMSourceTrait>asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait()));
+        assertThat(instance.fetch(new SCMHead("foo"), null),
+                hasProperty("hash", is("6769413a79793e242c73d7377f0006c6aea95480")));
+        assertThat(instance.fetch(new SCMHead("bar"), null),
+                hasProperty("hash", is("3f0b897057d8b43d3b9ff55e3fdefbb021493470")));
+        assertThat(instance.fetch(new SCMHead("manchu"), null),
+                hasProperty("hash", is("a94782d8d90b56b7e0d277c04589bd2e6f70d2cc")));
+        assertThat(instance.fetch(new GitTagSCMHead("v1.0.0", 0L), null),
+                hasProperty("hash", is("315fd8b5cae3363b29050f1aabfc27c985e22f7e")));
+    }
+
+    @Issue("JENKINS-47526")
+    @Test
+    public void telescopeFetchRevisionByName() throws Exception {
+
+        GitSCMSource instance = new GitSCMSource("http://git.test/telescope.git");
+        assertThat(GitSCMTelescope.of(instance), nullValue());
+        instance.setOwner(mock(SCMSourceOwner.class));
+        assertThat(GitSCMTelescope.of(instance), notNullValue());
+
+        instance.setTraits(Arrays.<SCMSourceTrait>asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait()));
+        assertThat(instance.fetch("foo", null),
+                hasProperty("hash", is("6769413a79793e242c73d7377f0006c6aea95480")));
+        assertThat(instance.fetch("bar", null),
+                hasProperty("hash", is("3f0b897057d8b43d3b9ff55e3fdefbb021493470")));
+        assertThat(instance.fetch("manchu", null),
+                hasProperty("hash", is("a94782d8d90b56b7e0d277c04589bd2e6f70d2cc")));
+        assertThat(instance.fetch("v1.0.0", null),
+                hasProperty("hash", is("315fd8b5cae3363b29050f1aabfc27c985e22f7e")));
+    }
+
+    @Issue("JENKINS-47526")
+    @Test
+    public void telescopeFetchActions() throws Exception {
+
+        GitSCMSource instance = new GitSCMSource("http://git.test/telescope.git");
+        assertThat(GitSCMTelescope.of(instance), nullValue());
+        AbstractGitSCMSourceTest.ActionableSCMSourceOwner owner =
+                Mockito.mock(AbstractGitSCMSourceTest.ActionableSCMSourceOwner.class);
+        when(owner.getSCMSource(instance.getId())).thenReturn(instance);
+        when(owner.getSCMSources()).thenReturn(Collections.<SCMSource>singletonList(instance));
+        instance.setOwner(owner);
+        assertThat(GitSCMTelescope.of(instance), notNullValue());
+
+        instance.setTraits(Arrays.<SCMSourceTrait>asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait()));
+
+        List<Action> actions = instance.fetchActions(null, null);
+        assertThat(actions,
+                contains(allOf(
+                        instanceOf(GitRemoteHeadRefAction.class),
+                        hasProperty("remote", is("http://git.test/telescope.git")),
+                        hasProperty("name", is("manchu"))
+                ))
+        );
+        when(owner.getActions(GitRemoteHeadRefAction.class)).thenReturn(Collections.singletonList((GitRemoteHeadRefAction) actions.get(0)));
+
+        assertThat(instance.fetchActions(new SCMHead("foo"), null, null), is(Collections.<Action>emptyList()));
+        assertThat(instance.fetchActions(new SCMHead("bar"), null, null), is(Collections.<Action>emptyList()));
+        assertThat(instance.fetchActions(new SCMHead("manchu"), null, null), contains(
+                instanceOf(PrimaryInstanceMetadataAction.class)));
+        assertThat(instance.fetchActions(new GitTagSCMHead("v1.0.0", 0L), null, null), is(Collections.<Action>emptyList()));
+    }
+
+    @TestExtension
     public static class MyGitSCMTelescope extends GitSCMTelescope {
         @Override
         public boolean supports(@NonNull String remote) {
-            return true;
+            return "http://git.test/telescope.git".equals(remote);
         }
 
         @Override
@@ -183,20 +294,105 @@ public class GitSCMSourceTest {
         @Override
         protected SCMFileSystem build(@NonNull String remote, StandardCredentials credentials,
                                       @NonNull SCMHead head,
-                                      SCMRevision rev) throws IOException, InterruptedException {
-            return null;
+                                      final SCMRevision rev) throws IOException, InterruptedException {
+            final String hash;
+            if (rev instanceof AbstractGitSCMSource.SCMRevisionImpl) {
+                hash = ((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash();
+            } else {
+                switch (head.getName()) {
+                    case "foo":
+                        hash = "6769413a79793e242c73d7377f0006c6aea95480";
+                        break;
+                    case "bar":
+                        hash = "3f0b897057d8b43d3b9ff55e3fdefbb021493470";
+                        break;
+                    case "manchu":
+                        hash = "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc";
+                        break;
+                    case "v1.0.0":
+                        hash = "315fd8b5cae3363b29050f1aabfc27c985e22f7e";
+                        break;
+                    default:
+                        return null;
+                }
+            }
+            return new SCMFileSystem(rev) {
+                @Override
+                public long lastModified() throws IOException, InterruptedException {
+                    switch (hash) {
+                        case "6769413a79793e242c73d7377f0006c6aea95480":
+                            return 15086163840000L;
+                        case "3f0b897057d8b43d3b9ff55e3fdefbb021493470":
+                            return 15086173840000L;
+                        case "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc":
+                            return 15086183840000L;
+                        case "315fd8b5cae3363b29050f1aabfc27c985e22f7e":
+                            return 15086193840000L;
+                    }
+                    return 0L;
+                }
+
+                @NonNull
+                @Override
+                public SCMFile getRoot() {
+                    return new MySCMFile(hash);
+                }
+            };
         }
 
         @Override
         public long getTimestamp(@NonNull String remote, StandardCredentials credentials, @NonNull String refOrHash)
                 throws IOException, InterruptedException {
-            return 0;
+            switch (refOrHash) {
+                case "refs/heads/foo":
+                    refOrHash = "6769413a79793e242c73d7377f0006c6aea95480";
+                    break;
+                case "refs/heads/bar":
+                    refOrHash = "3f0b897057d8b43d3b9ff55e3fdefbb021493470";
+                    break;
+                case "refs/heads/manchu":
+                    refOrHash = "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc";
+                    break;
+                case "refs/tags/v1.0.0":
+                    refOrHash = "315fd8b5cae3363b29050f1aabfc27c985e22f7e";
+                    break;
+            }
+            switch (refOrHash) {
+                case "6769413a79793e242c73d7377f0006c6aea95480":
+                    return 15086163840000L;
+                case "3f0b897057d8b43d3b9ff55e3fdefbb021493470":
+                    return 15086173840000L;
+                case "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc":
+                    return 15086183840000L;
+                case "315fd8b5cae3363b29050f1aabfc27c985e22f7e":
+                    return 15086193840000L;
+            }
+            return 0L;
         }
 
         @Override
         public SCMRevision getRevision(@NonNull String remote, StandardCredentials credentials,
                                        @NonNull String refOrHash)
                 throws IOException, InterruptedException {
+            switch (refOrHash) {
+                case "refs/heads/foo":
+                    return new AbstractGitSCMSource.SCMRevisionImpl(
+                            new SCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
+                    );
+                case "refs/heads/bar":
+                    return new AbstractGitSCMSource.SCMRevisionImpl(
+                            new SCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
+                    );
+                case "refs/heads/manchu":
+                    return new AbstractGitSCMSource.SCMRevisionImpl(
+                            new SCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
+                    );
+                case "refs/tags/v1.0.0":
+                    return new GitTagSCMRevision(
+                            new GitTagSCMHead("v1.0.0", 15086193840000L),
+                            "315fd8b5cae3363b29050f1aabfc27c985e22f7e"
+                    );
+            }
             return null;
         }
 
@@ -224,6 +420,102 @@ public class GitSCMSourceTest {
         public String getDefaultTarget(@NonNull String remote, StandardCredentials credentials)
                 throws IOException, InterruptedException {
             return "manchu";
+        }
+
+        private static class MySCMFile extends SCMFile {
+            private final String hash;
+            private final SCMFile.Type type;
+
+            public MySCMFile(String hash) {
+                this.hash = hash;
+                this.type = Type.DIRECTORY;
+            }
+
+            public MySCMFile(MySCMFile parent, String name, SCMFile.Type type) {
+                super(parent, name);
+                this.type = type;
+                this.hash = parent.hash;
+            }
+
+            @NonNull
+            @Override
+            protected SCMFile newChild(@NonNull String name, boolean assumeIsDirectory) {
+                return new MySCMFile(this, name, assumeIsDirectory ? Type.DIRECTORY : Type.REGULAR_FILE);
+            }
+
+            @NonNull
+            @Override
+            public Iterable<SCMFile> children() throws IOException, InterruptedException {
+                if (parent().isRoot()) {
+                    switch (hash) {
+                        case "6769413a79793e242c73d7377f0006c6aea95480":
+                            return Collections.singleton(newChild("Jenkinsfile", false));
+                        case "3f0b897057d8b43d3b9ff55e3fdefbb021493470":
+                            return Arrays.asList(newChild("Jenkinsfile", false),
+                                    newChild("README.md", false));
+                        case "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc":
+                            return Collections.singleton(newChild("README.md", false));
+                        case "315fd8b5cae3363b29050f1aabfc27c985e22f7e":
+                            return Collections.singleton(newChild("Jenkinsfile", false));
+                    }
+                }
+                return Collections.emptySet();
+            }
+
+            @Override
+            public long lastModified() throws IOException, InterruptedException {
+                switch (hash) {
+                    case "6769413a79793e242c73d7377f0006c6aea95480":
+                        return 15086163840000L;
+                    case "3f0b897057d8b43d3b9ff55e3fdefbb021493470":
+                        return 15086173840000L;
+                    case "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc":
+                        return 15086183840000L;
+                    case "315fd8b5cae3363b29050f1aabfc27c985e22f7e":
+                        return 15086193840000L;
+                }
+                return 0L;
+            }
+
+            @NonNull
+            @Override
+            protected Type type() throws IOException, InterruptedException {
+                return type;
+            }
+
+            @NonNull
+            @Override
+            public InputStream content() throws IOException, InterruptedException {
+                switch (hash) {
+                    case "6769413a79793e242c73d7377f0006c6aea95480":
+                        switch (getPath()){
+                            case "Jenkinsfile":
+                                return new ByteArrayInputStream("pipeline{}".getBytes(StandardCharsets.UTF_8));
+                        }
+                        break;
+                    case "3f0b897057d8b43d3b9ff55e3fdefbb021493470":
+                        switch (getPath()) {
+                            case "Jenkinsfile":
+                                return new ByteArrayInputStream("pipeline{}".getBytes(StandardCharsets.UTF_8));
+                            case "README.md":
+                                return new ByteArrayInputStream("Welcome".getBytes(StandardCharsets.UTF_8));
+                        }
+                        break;
+                    case "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc":
+                        switch (getPath()) {
+                            case "README.md":
+                                return new ByteArrayInputStream("Welcome".getBytes(StandardCharsets.UTF_8));
+                        }
+                        break;
+                    case "315fd8b5cae3363b29050f1aabfc27c985e22f7e":
+                        switch (getPath()) {
+                            case "Jenkinsfile":
+                                return new ByteArrayInputStream("pipeline{}".getBytes(StandardCharsets.UTF_8));
+                        }
+                        break;
+                }
+                throw new FileNotFoundException(getPath() + " does not exist");
+            }
         }
     }
 }

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
@@ -1,18 +1,34 @@
 package jenkins.plugins.git;
 
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
 import hudson.model.Item;
 import hudson.model.TopLevelItem;
+import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitStatus;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import jenkins.plugins.git.traits.BranchDiscoveryTrait;
+import jenkins.plugins.git.traits.TagDiscoveryTrait;
 import jenkins.scm.api.SCMEventListener;
+import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadEvent;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import javax.servlet.ServletException;
@@ -21,9 +37,13 @@ import java.io.IOException;
 import java.util.Collections;
 import org.jvnet.hudson.test.TestExtension;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.mock;
@@ -99,6 +119,111 @@ public class GitSCMSourceTest {
                 }
             }
             throw new TimeoutException();
+        }
+    }
+
+    @Issue("JENKINS-47526")
+    @Test
+    public void telescopeFetch() throws Exception {
+
+        GitSCMSource instance = new GitSCMSource("http://git.test/telescope.git");
+        assertThat(GitSCMTelescope.of(instance), nullValue());
+        instance.setOwner(mock(SCMSourceOwner.class));
+        assertThat(GitSCMTelescope.of(instance), notNullValue());
+
+        instance.setTraits(Arrays.<SCMSourceTrait>asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait()));
+        Map<SCMHead, SCMRevision> result = instance.fetch(SCMHeadObserver.collect(), null).result();
+        assertThat(result.values(), Matchers.<SCMRevision>containsInAnyOrder(
+                new AbstractGitSCMSource.SCMRevisionImpl(
+                        new SCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
+                ),
+                new AbstractGitSCMSource.SCMRevisionImpl(
+                        new SCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
+                ),
+                new AbstractGitSCMSource.SCMRevisionImpl(
+                        new SCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
+                ),
+                new GitTagSCMRevision(
+                        new GitTagSCMHead("v1.0.0", 15086193840000L), "315fd8b5cae3363b29050f1aabfc27c985e22f7e"
+                )));
+
+        instance.setTraits(Collections.<SCMSourceTrait>singletonList(new BranchDiscoveryTrait()));
+        result = instance.fetch(SCMHeadObserver.collect(), null).result();
+        assertThat(result.values(), Matchers.<SCMRevision>containsInAnyOrder(
+                new AbstractGitSCMSource.SCMRevisionImpl(
+                        new SCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
+                ),
+                new AbstractGitSCMSource.SCMRevisionImpl(
+                        new SCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
+                ),
+                new AbstractGitSCMSource.SCMRevisionImpl(
+                        new SCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
+                )));
+
+        instance.setTraits(Collections.<SCMSourceTrait>singletonList(new TagDiscoveryTrait()));
+        result = instance.fetch(SCMHeadObserver.collect(), null).result();
+        assertThat(result.values(), Matchers.<SCMRevision>containsInAnyOrder(
+                new GitTagSCMRevision(
+                        new GitTagSCMHead("v1.0.0", 15086193840000L), "315fd8b5cae3363b29050f1aabfc27c985e22f7e"
+                )));
+    }
+
+    @TestExtension("telescopeFetch")
+    public static class MyGitSCMTelescope extends GitSCMTelescope {
+        @Override
+        public boolean supports(@NonNull String remote) {
+            return true;
+        }
+
+        @Override
+        public void validate(@NonNull String remote, StandardCredentials credentials)
+                throws IOException, InterruptedException {
+        }
+
+        @Override
+        protected SCMFileSystem build(@NonNull String remote, StandardCredentials credentials,
+                                      @NonNull SCMHead head,
+                                      SCMRevision rev) throws IOException, InterruptedException {
+            return null;
+        }
+
+        @Override
+        public long getTimestamp(@NonNull String remote, StandardCredentials credentials, @NonNull String refOrHash)
+                throws IOException, InterruptedException {
+            return 0;
+        }
+
+        @Override
+        public SCMRevision getRevision(@NonNull String remote, StandardCredentials credentials,
+                                       @NonNull String refOrHash)
+                throws IOException, InterruptedException {
+            return null;
+        }
+
+        @Override
+        public Iterable<SCMRevision> getRevisions(@NonNull String remote, StandardCredentials credentials,
+                                                  @NonNull Set<ReferenceType> referenceTypes)
+                throws IOException, InterruptedException {
+            return Arrays.<SCMRevision>asList(
+                    new AbstractGitSCMSource.SCMRevisionImpl(
+                            new SCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
+                    ),
+                    new AbstractGitSCMSource.SCMRevisionImpl(
+                            new SCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
+                    ),
+                    new AbstractGitSCMSource.SCMRevisionImpl(
+                            new SCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
+                    ),
+                    new GitTagSCMRevision(
+                            new GitTagSCMHead("v1.0.0", 15086193840000L), "315fd8b5cae3363b29050f1aabfc27c985e22f7e"
+                    )
+            );
+        }
+
+        @Override
+        public String getDefaultTarget(@NonNull String remote, StandardCredentials credentials)
+                throws IOException, InterruptedException {
+            return "manchu";
         }
     }
 }


### PR DESCRIPTION
Note: I have tested this against a prototype implementation for https://git-wip-us.apache.org/repos/asf

@reviewbybees