### PR TITLE
[FIXED JENKINS-45822] Swap semantics of 'Do not fetch tags' to 'Fetch tags'

### DIFF
--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
@@ -2,17 +2,17 @@ package hudson.plugins.git.extensions.impl.CloneOption;
 
 def f = namespace(lib.FormTagLib);
 
+f.entry(title:_("Fetch tags"), field:"noTags") {
+    f.checkbox(negative:true, checked:(instance==null||!instance.noTags))
+}
+f.entry(title:_("Honor refspec on initial clone"), field:"honorRefspec") {
+    f.checkbox()
+}
 f.entry(title:_("Shallow clone"), field:"shallow") {
     f.checkbox()
 }
 f.entry(title:_("Shallow clone depth"), field:"depth") {
     f.number(clazz:"number", min:1, step:1)
-}
-f.entry(title:_("Do not fetch tags"), field:"noTags") {
-	f.checkbox()
-}
-f.entry(title:_("Honor refspec on initial clone"), field:"honorRefspec") {
-	f.checkbox()
 }
 f.entry(title:_("Path of the reference repo to use during clone"), field:"reference") {
     f.textbox()

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-noTags.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-noTags.html
@@ -1,4 +1,4 @@
 <div>
-  Perform a clone without tags, saving time and disk space when you just want to access
+  Deselect this to perform a clone without tags, saving time and disk space when you just want to access
   what is specified by the refspec.
 </div>


### PR DESCRIPTION
See [JENKINS-45822](https://issues.jenkins-ci.org/browse/JENKINS-45822)

With this change, Advanced Clone Behaviours UI now looks like this:
<img width="1000" alt="screen shot 2017-10-22 at 21 40 42" src="https://user-images.githubusercontent.com/209336/31866106-eca1e8f8-b771-11e7-8300-7103c0ee9f5f.png">

Which should make it clear that this will fetch tags. This is a UI change as

> 'Do not fetch tags [ ]' == 'Fetch tags [x]'

The configuration on disk remains the same, the constructor remains the same, the default configuration remains the same... we just change how the boolean option is described and displayed.

@reviewbybees