### PR TITLE
Annotate Probe.create(head, @NonNull revision)

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -446,7 +446,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                         @NonNull
                                         @Override
                                         public SCMSourceCriteria.Probe create(@NonNull SCMHead head,
-                                                                              @Nullable SCMRevisionImpl revision)
+                                                                              @NonNull SCMRevisionImpl revision)
                                                 throws IOException, InterruptedException {
                                             return new TelescopingSCMProbe(telescope, remote, credentials, revision);
                                         }
@@ -491,7 +491,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                         @NonNull
                                         @Override
                                         public SCMSourceCriteria.Probe create(@NonNull final GitTagSCMHead head,
-                                                                              @Nullable GitTagSCMRevision revision)
+                                                                              @NonNull GitTagSCMRevision revision)
                                                 throws IOException, InterruptedException {
                                             return new TelescopingSCMProbe(telescope, remote, credentials, revision);
                                         }


### PR DESCRIPTION
The revision argument to TelescopingSCMProbe is annotated as @NonNull,
so the method that passes it to TelescopingSCMProbe should also be
annotated @NonNull.

To see the findbugs warning before this change:

  mvn clean -Dtest=KilnGitTest install

@stephenc please review