### PR TITLE
[FIXED JENKINS-47629] Forgot to apply the credentials in the short-cut

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -748,6 +748,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             git.using(tool.getGitExe());
         }
         GitClient client = git.getClient();
+        client.addDefaultCredentials(getCredentials());
         Set<String> revisions = new HashSet<>();
         if (context.wantBranches() || context.wantTags()) {
             listener.getLogger().println("Listing remote references...");
@@ -801,6 +802,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             git.using(tool.getGitExe());
         }
         GitClient client = git.getClient();
+        client.addDefaultCredentials(getCredentials());
         Map<String, String> symrefs = client.getRemoteSymbolicReferences(getRemote(), null);
         if (symrefs.containsKey(Constants.HEAD)) {
             // Hurrah! The Server is Git 1.8.5 or newer and our client has symref reporting


### PR DESCRIPTION
See [JENKINS-47629](https://issues.jenkins-ci.org/browse/JENKINS-47629)

A noddy fix IIUC