### PR TITLE
Return unknown user if csAuthor is empty string.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -358,7 +358,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
      */
     public User findOrCreateUser(String csAuthor, String csAuthorEmail, boolean createAccountBasedOnEmail) {
         User user;
-        if (csAuthor == null) {
+        if (csAuthor == null || csAuthor.isEmpty()) {
             return User.getUnknown();
         }
         if (createAccountBasedOnEmail) {


### PR DESCRIPTION
If csAuthor is an empty string, we end up trying to create User and getting an exception. Can we return unknown user if csAuthor is empty string as well?