### PR TITLE
[JENKINS-9016] Added an option to search for users based on email attribute

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -430,6 +430,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return (gitDescriptor != null && gitDescriptor.isCreateAccountBasedOnEmail());
     }
 
+    public boolean isUseExistingAccountWithSameEmail() {
+        DescriptorImpl gitDescriptor = getDescriptor();
+        return (gitDescriptor != null && gitDescriptor.isUseExistingAccountWithSameEmail());
+    }
+
     public BuildChooser getBuildChooser() {
         BuildChooser bc;
 
@@ -1461,6 +1466,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         private String globalConfigName;
         private String globalConfigEmail;
         private boolean createAccountBasedOnEmail;
+        private boolean useExistingAccountWithSameEmail;
 //        private GitClientType defaultClientType = GitClientType.GITCLI;
         private boolean showEntireCommitSummaryInChanges;
 
@@ -1561,6 +1567,14 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         public void setCreateAccountBasedOnEmail(boolean createAccountBasedOnEmail) {
             this.createAccountBasedOnEmail = createAccountBasedOnEmail;
+        }
+
+        public boolean isUseExistingAccountWithSameEmail() {
+            return useExistingAccountWithSameEmail;
+        }
+
+        public void setUseExistingAccountWithSameEmail(boolean useExistingAccountWithSameEmail) {
+            this.useExistingAccountWithSameEmail = useExistingAccountWithSameEmail;
         }
 
         /**

--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -8,9 +8,11 @@
     <f:entry title="${%Global Config user.email Value}" field="globalConfigEmail">
       <f:textbox />
     </f:entry>
-    <f:entry title="${%Create new accounts based on author/committer's email}" field="createAccountBasedOnEmail">
-           <f:checkbox name="createAccountBasedOnEmail" checked="${descriptor.createAccountBasedOnEmail}"/>
-    </f:entry>
+    <f:optionalBlock title="${%Create new accounts based on author/committer's email}" field="createAccountBasedOnEmail" checked="${descriptor.createAccountBasedOnEmail}" inline="true">
+      <f:entry title="${%Use existing account with same email if found}" field="useExistingAccountWithSameEmail">
+        <f:checkbox name="useExistingAccountWithSameEmail" checked="${descriptor.useExistingAccountWithSameEmail}" />
+      </f:entry>
+    </f:optionalBlock>
     <f:entry title="${%Show the entire commit summary in changes}" field="showEntireCommitSummaryInChanges">
       <f:checkbox name="showEntireCommitSummaryInChanges" checked="${descriptor.showEntireCommitSummaryInChanges}"/>
     </f:entry>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-useExistingAccountWithSameEmail.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-useExistingAccountWithSameEmail.html
@@ -1,0 +1,6 @@
+<p>
+    Will make sure that user will be searched by their actual e-mail address before resorting to creating the user with its mail address as id.<br/>
+    This allows instances using specific user realms to match their users based on the assumption that same mail address means same user.<br/>
+    <br/>
+    Note that this behavior requires mailer plugin to be installed.
+</p>

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1031,6 +1031,10 @@ public class GitSCMTest extends AbstractGitTestCase {
         descriptor.setCreateAccountBasedOnEmail(true);
         assertTrue("Create account based on e-mail not set", scm.isCreateAccountBasedOnEmail());
 
+        assertFalse("Wrong initial value for use existing user if same e-mail already found", scm.isUseExistingAccountWithSameEmail());
+        descriptor.setUseExistingAccountWithSameEmail(true);
+        assertTrue("Use existing user if same e-mail already found is not set", scm.isUseExistingAccountWithSameEmail());
+
         // create initial commit and then run the build against it:
         final String commitFile1 = "commitFile1";
         commit(commitFile1, johnDoe, "Commit number 1");


### PR DESCRIPTION
## [JENKINS-9016](https://issues.jenkins-ci.org/browse/JENKINS-9016) - Added an option to search for users based on email attribute

This option is added in order to try to reduce unnecessary user
creation when user ids in jenkins are not based on email addresses.
It will allow optional search for users based on their mail address
property, assuming a single mail address should match only one user.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Further comments

This is sort of a common sense implementation allowing to wait for
the implementation of JENKINS-14849, as the actual target, requiring
SecurityRealm plugins to expose the logic to match SCM ids to the
users belonging to the realm.