### PR TITLE
[FIXED JENKINS-48064] Fisheye Git browser now validates its URL in th…

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
@@ -85,7 +85,7 @@ public class FisheyeGitRepositoryBrowser extends GitRepositoryBrowser {
                  * @throws ServletException on servlet error
 		 */
 		@SuppressFBWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification="Jenkins.getInstance() is not null")
-		public FormValidation doCheckUrl(@QueryParameter(fixEmpty = true) String value) throws IOException,
+		public FormValidation doCheckRepoUrl(@QueryParameter(fixEmpty = true) String value) throws IOException,
 				ServletException {
 			if (value == null) // nothing entered yet
 				return FormValidation.ok();


### PR DESCRIPTION
…e configuration.

Simply restores the binding between the page view and the check method.