### PR TITLE
[JENKINS-48061] Allow retrieve of a commit hash with no known branch or tag association

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -819,7 +819,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                       if (branches.isEmpty()) {
                                           listener.getLogger().printf("Could not find a branch containing commit %s%n",
                                                   hash);
-                                          return null;
+                                          return new SCMRevisionImpl(new SCMHead(/* arbitrary */revision), hash);
                                       }
                                       String name = branches.get(0).getName();
                                       listener.getLogger()

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -406,6 +406,7 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.git("checkout", "-b", "dev");
         sampleRepo.write("file", "v3");
         sampleRepo.git("commit", "--all", "--message=v3"); // dev
+        String v3 = sampleRepo.head();
         // SCM.checkout does not permit a null build argument, unfortunately.
         Run<?,?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
@@ -426,6 +427,11 @@ public class AbstractGitSCMSourceTest {
         assertNull(fileAt("\n", run, source, listener));
         assertThat(source.fetchRevisions(listener), hasItems("master", "dev", "v1"));
         // we do not care to return commit hashes or other references
+        // Commit hashes which are not heads:
+        sampleRepo.write("file", "v4");
+        sampleRepo.git("commit", "--all", "--message=v4"); // dev
+        assertEquals("v3", fileAt(v3, run, source, listener));
+        assertEquals("v3", fileAt(v3.substring(0, 7), run, source, listener));
     }
     private String fileAt(String revision, Run<?,?> run, SCMSource source, TaskListener listener) throws Exception {
         SCMRevision rev = source.fetch(revision, listener);


### PR DESCRIPTION
[JENKINS-48061](https://issues.jenkins-ci.org/browse/JENKINS-48061)

#551 regressed a valid use case. PCT found that `ResourceStepTest.duplicatedResources` in `workflow-cps-global-lib` passes against 3.6.3 but fails against 3.6.4.

@reviewbybees