### PR TITLE
[JENKINS-48385] Migrate from SCMHead to concrete subclass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   </licenses>
 
   <artifactId>git</artifactId>
-  <version>3.6.5-SNAPSHOT</version>
+  <version>3.7.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Jenkins Git plugin</name>
   <description>Integrates Jenkins with GIT SCM</description>
@@ -51,6 +51,13 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <compatibleSinceVersion>3.7.0</compatibleSinceVersion>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/jenkins/plugins/git/BranchSpecSCMHead.java
+++ b/src/main/java/jenkins/plugins/git/BranchSpecSCMHead.java
@@ -23,48 +23,24 @@
  */
 package jenkins.plugins.git;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.plugins.git.BranchSpec;
 import jenkins.scm.api.SCMHead;
-import jenkins.scm.api.mixin.TagSCMHead;
-import org.eclipse.jgit.lib.Constants;
+import jenkins.scm.api.mixin.SCMHeadMixin;
 
 /**
- * Represents a Git Tag.
+ * A mix-in interface for {@link SCMHead} that indicates that the {@link SCMHead} has a corresponding
+ * {@link BranchSpec}.
  *
- * @since TODO
+ * @since 3.7.0
  */
-public class GitTagSCMHead extends SCMHead implements TagSCMHead, BranchSpecSCMHead {
-    /**
-     * The timestamp of the tag, for lightweight tags this should be the last commit, for annotated
-     * tags this should be the tag date.
-     */
-    private final long timestamp;
+public interface BranchSpecSCMHead extends SCMHeadMixin {
 
     /**
-     * Constructor.
+     * The branch spec of this SCMHead.
      *
-     * @param name      the name.
-     * @param timestamp the timestamp of the tag, for lightweight tags this should be the last commit, for annotated
-     *                  tags this should be the tag date.
+     * @return The branch spec.
+     * @see BranchSpec#getName()
      */
-    public GitTagSCMHead(@NonNull String name, long timestamp) {
-        super(name);
-        this.timestamp = timestamp;
-    }
+    String getBranchSpec();
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public long getTimestamp() {
-        return timestamp;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getBranchSpec() {
-        return Constants.R_TAGS + getName();
-    }
 }

--- a/src/main/java/jenkins/plugins/git/GitBranchSCMHead.java
+++ b/src/main/java/jenkins/plugins/git/GitBranchSCMHead.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.plugins.git;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadMigration;
+import jenkins.scm.api.SCMRevision;
+import org.eclipse.jgit.lib.Constants;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Represents a Git Branch in {@code refs/origin/} (but uses
+ * {@link AbstractGitSCMSource#REF_SPEC_REMOTE_NAME_PLACEHOLDER_STR} so that it correctly handles when the remote
+ * name is customized.)
+ *
+ * @since 3.7.0
+ */
+public class GitBranchSCMHead extends SCMHead implements BranchSpecSCMHead {
+
+    /**
+     * Constructor.
+     *
+     * @param name the name.
+     */
+    public GitBranchSCMHead(@NonNull String name) {
+        super(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getBranchSpec() {
+        return Constants.R_REFS + AbstractGitSCMSource.REF_SPEC_REMOTE_NAME_PLACEHOLDER_STR + "/" + getName();
+    }
+
+    /**
+     * Migrate legacy bare {@link SCMHead} usage to {@link GitBranchSCMHead}.
+     *
+     * @since 3.7.0
+     */
+    @Extension
+    @Restricted(NoExternalUse.class)
+    public static class FixBareSCMHead
+            extends SCMHeadMigration<GitSCMSource, SCMHead, AbstractGitSCMSource.SCMRevisionImpl> {
+
+        /**
+         * Constructor.
+         */
+        public FixBareSCMHead() {
+            super(GitSCMSource.class, SCMHead.class, AbstractGitSCMSource.SCMRevisionImpl.class);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public SCMHead migrate(@NonNull GitSCMSource source, @NonNull SCMHead head) {
+            return new GitBranchSCMHead(head.getName());
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public SCMRevision migrate(@NonNull GitSCMSource source,
+                                   @NonNull AbstractGitSCMSource.SCMRevisionImpl revision) {
+            return new GitBranchSCMRevision(new GitBranchSCMHead(revision.getHead().getName()), revision.getHash());
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/git/GitBranchSCMRevision.java
+++ b/src/main/java/jenkins/plugins/git/GitBranchSCMRevision.java
@@ -24,47 +24,20 @@
 package jenkins.plugins.git;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import jenkins.scm.api.SCMHead;
-import jenkins.scm.api.mixin.TagSCMHead;
-import org.eclipse.jgit.lib.Constants;
 
 /**
- * Represents a Git Tag.
+ * Represents the revision of a {@link GitBranchSCMHead}.
  *
- * @since TODO
+ * @since 3.7.0
  */
-public class GitTagSCMHead extends SCMHead implements TagSCMHead, BranchSpecSCMHead {
-    /**
-     * The timestamp of the tag, for lightweight tags this should be the last commit, for annotated
-     * tags this should be the tag date.
-     */
-    private final long timestamp;
-
+public class GitBranchSCMRevision extends AbstractGitSCMSource.SCMRevisionImpl {
     /**
      * Constructor.
      *
-     * @param name      the name.
-     * @param timestamp the timestamp of the tag, for lightweight tags this should be the last commit, for annotated
-     *                  tags this should be the tag date.
+     * @param head the head.
+     * @param hash the revision hash.
      */
-    public GitTagSCMHead(@NonNull String name, long timestamp) {
-        super(name);
-        this.timestamp = timestamp;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public long getTimestamp() {
-        return timestamp;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getBranchSpec() {
-        return Constants.R_TAGS + getName();
+    public GitBranchSCMRevision(@NonNull GitBranchSCMHead head, @NonNull String hash) {
+        super(head, hash);
     }
 }

--- a/src/main/java/jenkins/plugins/git/GitRefSCMHead.java
+++ b/src/main/java/jenkins/plugins/git/GitRefSCMHead.java
@@ -25,39 +25,32 @@ package jenkins.plugins.git;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.scm.api.SCMHead;
-import jenkins.scm.api.mixin.TagSCMHead;
 import org.eclipse.jgit.lib.Constants;
 
 /**
- * Represents a Git Tag.
+ * Represents a git reference outside of either {@link Constants#R_HEADS} or {@link Constants#R_TAGS}.
  *
- * @since TODO
+ * @since 3.7.0
  */
-public class GitTagSCMHead extends SCMHead implements TagSCMHead, BranchSpecSCMHead {
+public class GitRefSCMHead extends SCMHead implements BranchSpecSCMHead {
+
     /**
-     * The timestamp of the tag, for lightweight tags this should be the last commit, for annotated
-     * tags this should be the tag date.
+     * The reference, will have {@link AbstractGitSCMSource#REF_SPEC_REMOTE_NAME_PLACEHOLDER} substitution
+     * applied.
      */
-    private final long timestamp;
+    @NonNull
+    private final String branchSpec;
 
     /**
      * Constructor.
      *
-     * @param name      the name.
-     * @param timestamp the timestamp of the tag, for lightweight tags this should be the last commit, for annotated
-     *                  tags this should be the tag date.
+     * @param name the name.
+     * @param branchSpec  the branchSpec name, will have {@link AbstractGitSCMSource#REF_SPEC_REMOTE_NAME_PLACEHOLDER} substitution
+     *             applied.
      */
-    public GitTagSCMHead(@NonNull String name, long timestamp) {
+    public GitRefSCMHead(@NonNull String name, @NonNull String branchSpec) {
         super(name);
-        this.timestamp = timestamp;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public long getTimestamp() {
-        return timestamp;
+        this.branchSpec = branchSpec;
     }
 
     /**
@@ -65,6 +58,6 @@ public class GitTagSCMHead extends SCMHead implements TagSCMHead, BranchSpecSCMH
      */
     @Override
     public String getBranchSpec() {
-        return Constants.R_TAGS + getName();
+        return branchSpec;
     }
 }

--- a/src/main/java/jenkins/plugins/git/GitRefSCMRevision.java
+++ b/src/main/java/jenkins/plugins/git/GitRefSCMRevision.java
@@ -24,47 +24,20 @@
 package jenkins.plugins.git;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import jenkins.scm.api.SCMHead;
-import jenkins.scm.api.mixin.TagSCMHead;
-import org.eclipse.jgit.lib.Constants;
 
 /**
- * Represents a Git Tag.
+ * Represents the revision of a {@link GitRefSCMHead}.
  *
- * @since TODO
+ * @since 3.7.0
  */
-public class GitTagSCMHead extends SCMHead implements TagSCMHead, BranchSpecSCMHead {
-    /**
-     * The timestamp of the tag, for lightweight tags this should be the last commit, for annotated
-     * tags this should be the tag date.
-     */
-    private final long timestamp;
-
+public class GitRefSCMRevision extends AbstractGitSCMSource.SCMRevisionImpl {
     /**
      * Constructor.
      *
-     * @param name      the name.
-     * @param timestamp the timestamp of the tag, for lightweight tags this should be the last commit, for annotated
-     *                  tags this should be the tag date.
+     * @param head the head.
+     * @param hash the revision hash.
      */
-    public GitTagSCMHead(@NonNull String name, long timestamp) {
-        super(name);
-        this.timestamp = timestamp;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public long getTimestamp() {
-        return timestamp;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getBranchSpec() {
-        return Constants.R_TAGS + getName();
+    public GitRefSCMRevision(@NonNull GitRefSCMHead head, @NonNull String hash) {
+        super(head, hash);
     }
 }

--- a/src/main/java/jenkins/plugins/git/GitSCMBuilder.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMBuilder.java
@@ -514,9 +514,10 @@ public class GitSCMBuilder<B extends GitSCMBuilder<B>> extends SCMBuilder<B, Git
             extensions.add(new BuildChooserSetting(new AbstractGitSCMSource.SpecificRevisionBuildChooser(
                     (AbstractGitSCMSource.SCMRevisionImpl) revision)));
         }
+        SCMHead head = head();
         return new GitSCM(
                 asRemoteConfigs(),
-                Collections.singletonList(new BranchSpec(head().getName())),
+                Collections.singletonList(new BranchSpec(branchSpecOf(head(), remoteName()))),
                 false, Collections.<SubmoduleConfig>emptyList(),
                 browser(), gitTool(),
                 extensions);
@@ -606,4 +607,16 @@ public class GitSCMBuilder<B extends GitSCMBuilder<B>> extends SCMBuilder<B, Git
         }
     }
 
+    /**
+     * Returns the {@link BranchSpec#getName()} for a specific {@link SCMHead}.
+     *
+     * @param head the {@link SCMHead}
+     * @param remoteName the remote name.
+     * @return the {@link BranchSpec#getName()}
+     * @since 3.7.0
+     */
+    public static String branchSpecOf(SCMHead head, String remoteName) {
+        return head instanceof BranchSpecSCMHead ? ((BranchSpecSCMHead) head).getBranchSpec().replaceAll(
+                AbstractGitSCMSource.REF_SPEC_REMOTE_NAME_PLACEHOLDER, remoteName) : head.getName();
+    }
 }

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -626,14 +626,17 @@ public class GitSCMSource extends AbstractGitSCMSource {
                                         return Collections.emptyMap();
                                     }
                                     if (GitStatus.looselyMatches(u, remote)) {
-                                        SCMHead head = new SCMHead(branch);
+                                        GitBranchSCMHead head = new GitBranchSCMHead(branch);
                                         for (SCMHeadPrefilter filter: ctx.prefilters()) {
                                             if (filter.isExcluded(git, head)) {
                                                 return Collections.emptyMap();
                                             }
                                         }
+                                        // ideally we'd like to know if this was a tag, but all we need is that
+                                        // this name is flagged as having being changed and that will trigger a
+                                        // recheck which will create the correct SCMHead subtype for us.
                                         return Collections.<SCMHead, SCMRevision>singletonMap(head,
-                                                sha1 != null ? new SCMRevisionImpl(head, sha1) : null);
+                                                sha1 != null ? new GitBranchSCMRevision(head, sha1) : null);
                                     }
                                 }
                                 return Collections.emptyMap();

--- a/src/main/java/jenkins/plugins/git/GitSCMTelescope.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMTelescope.java
@@ -212,12 +212,12 @@ public abstract class GitSCMTelescope extends SCMFileSystem.Builder {
                                 getTimestamp(remote, credentials, name)
                         );
                     } else if (name.startsWith(Constants.R_HEADS)) {
-                        head = new SCMHead(name.substring(Constants.R_HEADS.length()));
+                        head = new GitBranchSCMHead(name.substring(Constants.R_HEADS.length()));
                     } else {
                         if (name.startsWith(config.getName() + "/")) {
-                            head = new SCMHead(name.substring(config.getName().length() + 1));
+                            head = new GitBranchSCMHead(name.substring(config.getName().length() + 1));
                         } else {
-                            head = new SCMHead(name);
+                            head = new GitBranchSCMHead(name);
                         }
                     }
                 } else {

--- a/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import jenkins.plugins.git.AbstractGitSCMSource;
+import jenkins.plugins.git.GitBranchSCMHead;
 import jenkins.scm.api.SCMHead;
 import org.eclipse.jgit.transport.RefSpec;
 
@@ -145,7 +146,7 @@ public class GithubWebTest {
         assertGuessURL("https://github.com/kohsuke/msv.git", "https://github.com/kohsuke/msv/", "+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*/merge:refs/remotes/origin/pr/*");
     }
     private void assertGuessURL(String remote, String web, String... refSpecs) {
-        RepositoryBrowser<?> guess = new MockSCMSource(remote, refSpecs).build(new SCMHead("master")).guessBrowser();
+        RepositoryBrowser<?> guess = new MockSCMSource(remote, refSpecs).build(new GitBranchSCMHead("master")).guessBrowser();
         String actual = guess instanceof GithubWeb ? ((GithubWeb) guess).getRepoUrl() : null;
         assertEquals(web, actual);
     }

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceRetrieveHeadsTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceRetrieveHeadsTest.java
@@ -67,7 +67,7 @@ public class AbstractGitSCMSourceRetrieveHeadsTest {
     public void correctGitToolIsUsed() throws Exception {
         try {
             // Should throw exception confirming that Git#using was used correctly
-            gitSCMSource.retrieve(new SCMHead("master"), TaskListener.NULL);
+            gitSCMSource.retrieve(new GitBranchSCMHead("master"), TaskListener.NULL);
         } catch (GitToolNotSpecified e) {
             Assert.fail("Git client was constructed with arbitrary git tool");
         }

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -503,8 +503,8 @@ public class AbstractGitSCMSourceTest {
                 )
         ));
 
-        SCMHead head = new SCMHead("master");
-        SCMRevision revision = new AbstractGitSCMSource.SCMRevisionImpl(head, "beaded4deed2bed4feed2deaf78933d0f97a5a34");
+        GitBranchSCMHead head = new GitBranchSCMHead("master");
+        SCMRevision revision = new GitBranchSCMRevision(head, "beaded4deed2bed4feed2deaf78933d0f97a5a34");
 
         // because we are ignoring push notifications we also ignore commits
         extensions.add(new IgnoreNotifyCommit());
@@ -542,7 +542,7 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.init();
 
         GitSCMSource source = new GitSCMSource(null, sampleRepo.toString(), "", "upstream", null, "*", "", true);
-        SCMHead head = new SCMHead("master");
+        GitBranchSCMHead head = new GitBranchSCMHead("master");
         GitSCM scm = (GitSCM) source.build(head);
         List<UserRemoteConfig> configs = scm.getUserRemoteConfigs();
         assertEquals(1, configs.size());
@@ -556,7 +556,7 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.init();
 
         GitSCMSource source = new GitSCMSource(null, sampleRepo.toString(), "", null, "+refs/heads/*:refs/remotes/origin/*          +refs/merge-requests/*/head:refs/remotes/origin/merge-requests/*", "*", "", true);
-        SCMHead head = new SCMHead("master");
+        GitBranchSCMHead head = new GitBranchSCMHead("master");
         GitSCM scm = (GitSCM) source.build(head);
         List<UserRemoteConfig> configs = scm.getUserRemoteConfigs();
 

--- a/src/test/java/jenkins/plugins/git/GitSCMBuilderTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMBuilderTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assume.assumeThat;
 public class GitSCMBuilderTest {
 
     private GitSCMBuilder<?> instance = new GitSCMBuilder<>(
-            new SCMHead("master"),
+            new GitBranchSCMHead("master"),
             null,
             "http://git.test/repo.git",
             null);
@@ -59,7 +59,7 @@ public class GitSCMBuilderTest {
         assertThat(scm.getExtensions().get(BuildChooserSetting.class).getBuildChooser(),
                 instanceOf(InverseBuildChooser.class));
         instance.withRevision(
-                new AbstractGitSCMSource.SCMRevisionImpl(instance.head(), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"));
+                new GitBranchSCMRevision((GitBranchSCMHead)instance.head(), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"));
         scm = instance.build();
         assertThat(scm.getBrowser(), is(nullValue()));
         assertThat(scm.getUserRemoteConfigs(), contains(allOf(

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -115,7 +115,7 @@ public class GitSCMFileSystemTest {
         sampleRepo.write("file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
         SCMSource source = new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true);
-        SCMFileSystem fs = SCMFileSystem.of(source, new SCMHead("dev"));
+        SCMFileSystem fs = SCMFileSystem.of(source, new GitBranchSCMHead("dev"));
         assertThat(fs, notNullValue());
         SCMFile root = fs.getRoot();
         assertThat(root, notNullValue());
@@ -137,10 +137,10 @@ public class GitSCMFileSystemTest {
         sampleRepo.init();
         sampleRepo.git("checkout", "-b", "dev");
         SCMSource source = new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true);
-        SCMRevision revision = source.fetch(new SCMHead("dev"), null);
+        SCMRevision revision = source.fetch(new GitBranchSCMHead("dev"), null);
         sampleRepo.write("file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
-        SCMFileSystem fs = SCMFileSystem.of(source, new SCMHead("dev"), revision);
+        SCMFileSystem fs = SCMFileSystem.of(source, new GitBranchSCMHead("dev"), revision);
         assertThat(fs, notNullValue());
         assertThat(fs.getRoot(), notNullValue());
         Iterable<SCMFile> children = fs.getRoot().children();
@@ -178,11 +178,11 @@ public class GitSCMFileSystemTest {
         sampleRepo.init();
         sampleRepo.git("checkout", "-b", "dev");
         SCMSource source = new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true);
-        SCMRevision revision = source.fetch(new SCMHead("dev"), null);
+        SCMRevision revision = source.fetch(new GitBranchSCMHead("dev"), null);
         sampleRepo.write("file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
         final long fileSystemAllowedOffset = isWindows() ? 4000 : 1500;
-        SCMFileSystem fs = SCMFileSystem.of(source, new SCMHead("dev"), revision);
+        SCMFileSystem fs = SCMFileSystem.of(source, new GitBranchSCMHead("dev"), revision);
         long currentTime = isWindows() ? System.currentTimeMillis() / 1000L * 1000L : System.currentTimeMillis();
         long lastModified = fs.lastModified();
         assertThat(lastModified, greaterThanOrEqualTo(currentTime - fileSystemAllowedOffset));
@@ -203,7 +203,7 @@ public class GitSCMFileSystemTest {
         sampleRepo.write("dir/subdir/file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
         SCMSource source = new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true);
-        SCMFileSystem fs = SCMFileSystem.of(source, new SCMHead("dev"));
+        SCMFileSystem fs = SCMFileSystem.of(source, new GitBranchSCMHead("dev"));
         assertThat(fs, notNullValue());
         assertThat(fs.getRoot(), notNullValue());
         Iterable<SCMFile> children = fs.getRoot().children();
@@ -240,7 +240,7 @@ public class GitSCMFileSystemTest {
         sampleRepo.git("add", "file", "dir/file3");
         sampleRepo.git("commit", "--all", "--message=dev");
         SCMSource source = new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true);
-        SCMFileSystem fs = SCMFileSystem.of(source, new SCMHead("dev"));
+        SCMFileSystem fs = SCMFileSystem.of(source, new GitBranchSCMHead("dev"));
         assertThat(fs, notNullValue());
         assertThat(fs.getRoot(), notNullValue());
         Iterable<SCMFile> children = fs.getRoot().children();
@@ -273,7 +273,7 @@ public class GitSCMFileSystemTest {
 
         ObjectId git261 = client.revParse(GIT_2_6_1_TAG);
         AbstractGitSCMSource.SCMRevisionImpl rev261 =
-                new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git261.getName());
+                new GitBranchSCMRevision(new GitBranchSCMHead("origin"), git261.getName());
         GitSCMFileSystem gitPlugin261FS = new GitSCMFileSystem(client, "origin", git261.getName(), rev261);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -287,13 +287,13 @@ public class GitSCMFileSystemTest {
         GitClient client = Git.with(TaskListener.NULL, new EnvVars()).in(gitDir).using("git").getClient();
 
         ObjectId git261 = client.revParse(GIT_2_6_1_TAG);
-        AbstractGitSCMSource.SCMRevisionImpl rev261 =
-                new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git261.getName());
+        GitBranchSCMRevision rev261 =
+                new GitBranchSCMRevision(new GitBranchSCMHead("origin"), git261.getName());
         GitSCMFileSystem gitPlugin261FS = new GitSCMFileSystem(client, "origin", git261.getName(), rev261);
 
         ObjectId git260 = client.revParse(GIT_2_6_0_TAG);
-        AbstractGitSCMSource.SCMRevisionImpl rev260 =
-                new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git260.getName());
+        GitBranchSCMRevision rev260 =
+                new GitBranchSCMRevision(new GitBranchSCMHead("origin"), git260.getName());
 
         assertThat(git260, not(is(git261)));
 
@@ -308,13 +308,13 @@ public class GitSCMFileSystemTest {
         GitClient client = Git.with(TaskListener.NULL, new EnvVars()).in(gitDir).using("git").getClient();
 
         ObjectId git260 = client.revParse(GIT_2_6_0_TAG);
-        AbstractGitSCMSource.SCMRevisionImpl rev260 =
-                new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git260.getName());
+        GitBranchSCMRevision rev260 =
+                new GitBranchSCMRevision(new GitBranchSCMHead("origin"), git260.getName());
         GitSCMFileSystem gitPlugin260FS = new GitSCMFileSystem(client, "origin", git260.getName(), rev260);
 
         ObjectId git261 = client.revParse(GIT_2_6_1_TAG);
-        AbstractGitSCMSource.SCMRevisionImpl rev261 =
-                new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git261.getName());
+        GitBranchSCMRevision rev261 =
+                new GitBranchSCMRevision(new GitBranchSCMHead("origin"), git261.getName());
         GitSCMFileSystem gitPlugin261FS =
                 new GitSCMFileSystem(client, "origin", git261.getName(), rev261);
         assertEquals(git261.getName(), gitPlugin261FS.getRevision().getHash());

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
@@ -94,7 +94,7 @@ public class GitSCMSourceTest {
                 jenkins.getInstance().getExtensionList(SCMEventListener.class).get(SCMEventListenerImpl.class)
                         .waitSCMHeadEvent(1, TimeUnit.SECONDS);
         assertThat(event, notNullValue());
-        assertThat((Iterable<SCMHead>) event.heads(gitSCMSource).keySet(), hasItem(is(new SCMHead("master"))));
+        assertThat((Iterable<SCMHead>) event.heads(gitSCMSource).keySet(), hasItem(is(new GitBranchSCMHead("master"))));
         verify(scmSourceOwner, times(0)).onSCMSourceUpdated(gitSCMSource);
 
     }
@@ -151,14 +151,14 @@ public class GitSCMSourceTest {
         instance.setTraits(Arrays.<SCMSourceTrait>asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait()));
         Map<SCMHead, SCMRevision> result = instance.fetch(SCMHeadObserver.collect(), null).result();
         assertThat(result.values(), Matchers.<SCMRevision>containsInAnyOrder(
-                new AbstractGitSCMSource.SCMRevisionImpl(
-                        new SCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
+                new GitBranchSCMRevision(
+                        new GitBranchSCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
                 ),
-                new AbstractGitSCMSource.SCMRevisionImpl(
-                        new SCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
+                new GitBranchSCMRevision(  // should get migrated to GitBranchSCMRevision
+                        new GitBranchSCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
                 ),
-                new AbstractGitSCMSource.SCMRevisionImpl(
-                        new SCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
+                new GitBranchSCMRevision(
+                        new GitBranchSCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
                 ),
                 new GitTagSCMRevision(
                         new GitTagSCMHead("v1.0.0", 15086193840000L), "315fd8b5cae3363b29050f1aabfc27c985e22f7e"
@@ -167,14 +167,14 @@ public class GitSCMSourceTest {
         instance.setTraits(Collections.<SCMSourceTrait>singletonList(new BranchDiscoveryTrait()));
         result = instance.fetch(SCMHeadObserver.collect(), null).result();
         assertThat(result.values(), Matchers.<SCMRevision>containsInAnyOrder(
-                new AbstractGitSCMSource.SCMRevisionImpl(
-                        new SCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
+                new GitBranchSCMRevision(
+                        new GitBranchSCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
                 ),
-                new AbstractGitSCMSource.SCMRevisionImpl(
-                        new SCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
+                new GitBranchSCMRevision(
+                        new GitBranchSCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
                 ),
-                new AbstractGitSCMSource.SCMRevisionImpl(
-                        new SCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
+                new GitBranchSCMRevision(
+                        new GitBranchSCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
                 )));
 
         instance.setTraits(Collections.<SCMSourceTrait>singletonList(new TagDiscoveryTrait()));
@@ -198,11 +198,11 @@ public class GitSCMSourceTest {
         Map<SCMHead, SCMRevision> result = instance.fetch(new MySCMSourceCriteria("Jenkinsfile"),
                 SCMHeadObserver.collect(), null).result();
         assertThat(result.values(), Matchers.<SCMRevision>containsInAnyOrder(
-                new AbstractGitSCMSource.SCMRevisionImpl(
-                        new SCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
+                new GitBranchSCMRevision(
+                        new GitBranchSCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
                 ),
-                new AbstractGitSCMSource.SCMRevisionImpl(
-                        new SCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
+                new GitBranchSCMRevision(
+                        new GitBranchSCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
                 ),
                 new GitTagSCMRevision(
                         new GitTagSCMHead("v1.0.0", 15086193840000L), "315fd8b5cae3363b29050f1aabfc27c985e22f7e"
@@ -210,21 +210,21 @@ public class GitSCMSourceTest {
         result = instance.fetch(new MySCMSourceCriteria("README.md"),
                 SCMHeadObserver.collect(), null).result();
         assertThat(result.values(), Matchers.<SCMRevision>containsInAnyOrder(
-                new AbstractGitSCMSource.SCMRevisionImpl(
-                        new SCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
+                new GitBranchSCMRevision(
+                        new GitBranchSCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
                 ),
-                new AbstractGitSCMSource.SCMRevisionImpl(
-                        new SCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
+                new GitBranchSCMRevision(
+                        new GitBranchSCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
                 )));
 
         instance.setTraits(Collections.<SCMSourceTrait>singletonList(new BranchDiscoveryTrait()));
         result = instance.fetch(new MySCMSourceCriteria("Jenkinsfile"), SCMHeadObserver.collect(), null).result();
         assertThat(result.values(), Matchers.<SCMRevision>containsInAnyOrder(
-                new AbstractGitSCMSource.SCMRevisionImpl(
-                        new SCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
+                new GitBranchSCMRevision(
+                        new GitBranchSCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
                 ),
-                new AbstractGitSCMSource.SCMRevisionImpl(
-                        new SCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
+                new GitBranchSCMRevision(
+                        new GitBranchSCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
                 )));
 
         instance.setTraits(Collections.<SCMSourceTrait>singletonList(new TagDiscoveryTrait()));
@@ -267,11 +267,11 @@ public class GitSCMSourceTest {
         assertThat(GitSCMTelescope.of(instance), notNullValue());
 
         instance.setTraits(Arrays.<SCMSourceTrait>asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait()));
-        assertThat(instance.fetch(new SCMHead("foo"), null),
+        assertThat(instance.fetch(new GitBranchSCMHead("foo"), null),
                 hasProperty("hash", is("6769413a79793e242c73d7377f0006c6aea95480")));
-        assertThat(instance.fetch(new SCMHead("bar"), null),
+        assertThat(instance.fetch(new GitBranchSCMHead("bar"), null),
                 hasProperty("hash", is("3f0b897057d8b43d3b9ff55e3fdefbb021493470")));
-        assertThat(instance.fetch(new SCMHead("manchu"), null),
+        assertThat(instance.fetch(new GitBranchSCMHead("manchu"), null),
                 hasProperty("hash", is("a94782d8d90b56b7e0d277c04589bd2e6f70d2cc")));
         assertThat(instance.fetch(new GitTagSCMHead("v1.0.0", 0L), null),
                 hasProperty("hash", is("315fd8b5cae3363b29050f1aabfc27c985e22f7e")));
@@ -323,9 +323,9 @@ public class GitSCMSourceTest {
         when(owner.getActions(GitRemoteHeadRefAction.class))
                 .thenReturn(Collections.singletonList((GitRemoteHeadRefAction) actions.get(0)));
 
-        assertThat(instance.fetchActions(new SCMHead("foo"), null, null), is(Collections.<Action>emptyList()));
-        assertThat(instance.fetchActions(new SCMHead("bar"), null, null), is(Collections.<Action>emptyList()));
-        assertThat(instance.fetchActions(new SCMHead("manchu"), null, null), contains(
+        assertThat(instance.fetchActions(new GitBranchSCMHead("foo"), null, null), is(Collections.<Action>emptyList()));
+        assertThat(instance.fetchActions(new GitBranchSCMHead("bar"), null, null), is(Collections.<Action>emptyList()));
+        assertThat(instance.fetchActions(new GitBranchSCMHead("manchu"), null, null), contains(
                 instanceOf(PrimaryInstanceMetadataAction.class)));
         assertThat(instance.fetchActions(new GitTagSCMHead("v1.0.0", 0L), null, null),
                 is(Collections.<Action>emptyList()));
@@ -428,16 +428,16 @@ public class GitSCMSourceTest {
                 throws IOException, InterruptedException {
             switch (refOrHash) {
                 case "refs/heads/foo":
-                    return new AbstractGitSCMSource.SCMRevisionImpl(
-                            new SCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
+                    return new GitBranchSCMRevision(
+                            new GitBranchSCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
                     );
                 case "refs/heads/bar":
                     return new AbstractGitSCMSource.SCMRevisionImpl(
                             new SCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
                     );
                 case "refs/heads/manchu":
-                    return new AbstractGitSCMSource.SCMRevisionImpl(
-                            new SCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
+                    return new GitBranchSCMRevision(
+                            new GitBranchSCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
                     );
                 case "refs/tags/v1.0.0":
                     return new GitTagSCMRevision(
@@ -453,14 +453,14 @@ public class GitSCMSourceTest {
                                                   @NonNull Set<ReferenceType> referenceTypes)
                 throws IOException, InterruptedException {
             return Arrays.<SCMRevision>asList(
-                    new AbstractGitSCMSource.SCMRevisionImpl(
-                            new SCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
+                    new GitBranchSCMRevision(
+                            new GitBranchSCMHead("foo"), "6769413a79793e242c73d7377f0006c6aea95480"
                     ),
-                    new AbstractGitSCMSource.SCMRevisionImpl(
-                            new SCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
+                    new GitBranchSCMRevision(
+                            new GitBranchSCMHead("bar"), "3f0b897057d8b43d3b9ff55e3fdefbb021493470"
                     ),
-                    new AbstractGitSCMSource.SCMRevisionImpl(
-                            new SCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
+                    new GitBranchSCMRevision(
+                            new GitBranchSCMHead("manchu"), "a94782d8d90b56b7e0d277c04589bd2e6f70d2cc"
                     ),
                     new GitTagSCMRevision(
                             new GitTagSCMHead("v1.0.0", 15086193840000L), "315fd8b5cae3363b29050f1aabfc27c985e22f7e"

--- a/src/test/java/jenkins/plugins/git/GitSCMTelescopeTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMTelescopeTest.java
@@ -215,7 +215,7 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
 
     @Test
     public void testGetTimestamp_3args_2() throws Exception {
-        SCMHead head = new SCMHead("git-tag-name");
+        SCMHead head = new GitBranchSCMHead("git-tag-name");
         assertThat(telescope.getTimestamp(remote, credentials, head), is(12345L));
     }
 
@@ -229,9 +229,9 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
         SCMSource source = new GitSCMSource(remote);
         SCMSourceOwner sourceOwner = new SCMSourceOwnerImpl();
         source.setOwner(sourceOwner);
-        SCMHead head = new SCMHead("some-name");
+        GitBranchSCMHead head = new GitBranchSCMHead("some-name");
         String SHA1 = "0123456789abcdef0123456789abcdef01234567";
-        SCMRevision rev = new AbstractGitSCMSource.SCMRevisionImpl(head, SHA1);
+        SCMRevision rev = new GitBranchSCMRevision(head, SHA1);
         SCMFileSystem fileSystem = telescope.build(source, head, rev);
         assertThat(fileSystem.getRevision(), is(rev));
         assertThat(fileSystem.isFixedRevision(), is(true));
@@ -240,7 +240,7 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
     @Test
     public void testBuild_3args_1NoOwner() throws Exception {
         SCMSource source = new GitSCMSource(remote);
-        SCMHead head = new SCMHead("some-name");
+        GitBranchSCMHead head = new GitBranchSCMHead("some-name");
         SCMRevision rev = null;
         // When source has no owner, build returns null
         assertThat(telescope.build(source, head, rev), is(nullValue()));
@@ -250,9 +250,9 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
     public void testBuild_3args_2() throws Exception {
         Item owner = new ItemImpl();
         SCM scm = getSingleBranchSource(remote);
-        SCMHead head = new SCMHead("some-name");
+        GitBranchSCMHead head = new GitBranchSCMHead("some-name");
         String SHA1 = "0123456789abcdef0123456789abcdef01234567";
-        SCMRevision rev = new AbstractGitSCMSource.SCMRevisionImpl(head, SHA1);
+        SCMRevision rev = new GitBranchSCMRevision(head, SHA1);
         SCMFileSystem fileSystem = telescope.build(owner, scm, rev);
         assertThat(fileSystem.getRevision(), is(rev));
         assertThat(fileSystem.isFixedRevision(), is(true));
@@ -260,9 +260,9 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
 
     @Test
     public void testBuild_4args() throws Exception {
-        SCMHead head = new SCMHead("some-name");
+        GitBranchSCMHead head = new GitBranchSCMHead("some-name");
         String SHA1 = "0123456789abcdef0123456789abcdef01234567";
-        SCMRevision rev = new AbstractGitSCMSource.SCMRevisionImpl(head, SHA1);
+        SCMRevision rev = new GitBranchSCMRevision(head, SHA1);
         SCMFileSystem fileSystem = telescope.build(remote, credentials, head, rev);
         assertThat(fileSystem, is(notNullValue()));
         assertThat(fileSystem.getRevision(), is(rev));
@@ -271,9 +271,9 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
 
     @Test
     public void testGetRevision_3args_1() throws Exception {
-        SCMHead head = new SCMHead("some-name");
+        GitBranchSCMHead head = new GitBranchSCMHead("some-name");
         String SHA1 = "0123456789abcdef0123456789abcdef01234567";
-        SCMRevision rev = new AbstractGitSCMSource.SCMRevisionImpl(head, SHA1);
+        SCMRevision rev = new GitBranchSCMRevision(head, SHA1);
         GitSCMTelescope telescopeWithRev = new GitSCMTelescopeImpl(remote, rev);
         String refOrHash = "master";
         assertThat(telescopeWithRev.getRevision(remote, credentials, refOrHash), is(rev));
@@ -281,9 +281,9 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
 
     @Test
     public void testGetRevision_3args_2() throws Exception {
-        SCMHead head = new GitTagSCMHead("git-tag-name", 56789L);
+        GitTagSCMHead head = new GitTagSCMHead("git-tag-name", 56789L);
         String SHA1 = "0123456789abcdef0123456789abcdef01234567";
-        SCMRevision rev = new AbstractGitSCMSource.SCMRevisionImpl(head, SHA1);
+        SCMRevision rev = new GitTagSCMRevision(head, SHA1);
         GitSCMTelescope telescopeWithRev = new GitSCMTelescopeImpl(remote, rev);
         assertThat(telescopeWithRev.getRevision(remote, credentials, head), is(rev));
     }
@@ -299,9 +299,9 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
     @Test
     public void testGetRevisions_3argsWithRev() throws Exception {
         Set<GitSCMTelescope.ReferenceType> referenceTypes = new HashSet<>();
-        SCMHead head = new GitTagSCMHead("git-tag-name", 56789L);
+        GitTagSCMHead head = new GitTagSCMHead("git-tag-name", 56789L);
         String SHA1 = "0123456789abcdef0123456789abcdef01234567";
-        SCMRevision rev = new AbstractGitSCMSource.SCMRevisionImpl(head, SHA1);
+        SCMRevision rev = new GitTagSCMRevision(head, SHA1);
         GitSCMTelescope telescopeWithRev = new GitSCMTelescopeImpl(remote, rev);
         Iterable<SCMRevision> revisions = telescopeWithRev.getRevisions(remote, credentials, referenceTypes);
         assertThat(revisions, is(notNullValue()));
@@ -313,8 +313,8 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
     @Test
     public void testGetRevisions_String_StandardCredentials() throws Exception {
         String SHA1 = "0123456789abcdef0123456789abcdef01234567";
-        SCMHead head = new GitTagSCMHead("git-tag-name", 56789L);
-        SCMRevision rev = new AbstractGitSCMSource.SCMRevisionImpl(head, SHA1);
+        GitTagSCMHead head = new GitTagSCMHead("git-tag-name", 56789L);
+        SCMRevision rev = new GitTagSCMRevision(head, SHA1);
         GitSCMTelescope telescopeWithRev = new GitSCMTelescopeImpl(remote, rev);
         Iterable<SCMRevision> revisions = telescopeWithRev.getRevisions(remote, credentials);
         assertThat(revisions, is(notNullValue()));


### PR DESCRIPTION
Todo:

- [ ] Decide if BranchSpecSCMHead should be the local or remote branch spec. Currently using remote but may be better as local
- [ ] Test against rebuild storm (cannot add test here because of dependency cycle with branch-api plugin)
- [ ] Check for any side-effects with github, gitea and bitbucket subclasses
- [ ] Check for any side-effects with github, gitea and bitbucket subclasses after subclasses change inheritance to extend GitBranchSCMHead etc
- [ ] Check for any side-effects with GitSCMTelescope implementations (only one known implementation at time of commit)

See [JENKINS-48385](https://issues.jenkins-ci.org/browse/JENKINS-48385)