### PR TITLE
Revert "Use parent pom 3.0 - latest update"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.36</version>
+    <version>2.37</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.0</version>
+    <version>2.36</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Not supported to use parent pom 3.0 with old Jenkins versions like 1.625.

Since git plugin will be moving to Jenkins 2.60 in the near future, there is no reason to use an unsupported configuration prior to the move to Jenkin 2.60.

This reverts commit a924bb3be0016e7974fb92aa27575eb9333631b5.