### PR TITLE
[JENKINS-48061] Partial fix for the easy case of non-head revision in history of branch

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -815,13 +815,20 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                   try {
                                       objectId = client.revParse(revision);
                                       hash = objectId.name();
-                                      List<Branch> branches = client.getBranchesContaining(hash, false);
-                                      if (branches.isEmpty()) {
+                                      String candidatePrefix = Constants.R_REMOTES.substring(Constants.R_REFS.length())
+                                              + context.remoteName() + "/";
+                                      String name = null;
+                                      for (Branch b: client.getBranchesContaining(hash, true)) {
+                                          if (b.getName().startsWith(candidatePrefix)) {
+                                              name = b.getName().substring(candidatePrefix.length());
+                                              break;
+                                          }
+                                      }
+                                      if (name == null) {
                                           listener.getLogger().printf("Could not find a branch containing commit %s%n",
                                                   hash);
                                           return null;
                                       }
-                                      String name = branches.get(0).getName();
                                       listener.getLogger()
                                               .printf("Selected match: %s revision %s%n", name, hash);
                                       return new SCMRevisionImpl(new SCMHead(name), hash);


### PR DESCRIPTION
See [JENKINS-48061](https://issues.jenkins-ci.org/browse/JENKINS-48061) 

Supercedes #557

This is only a partial fix, the two additional ignored test cases are required for the full fix