### PR TITLE
Allow repository guessing for bitbucket and gitlab

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -81,6 +81,8 @@ import static com.google.common.collect.Lists.newArrayList;
 import static hudson.Util.*;
 import static hudson.init.InitMilestone.JOB_LOADED;
 import static hudson.init.InitMilestone.PLUGINS_STARTED;
+import hudson.plugins.git.browser.BitbucketWeb;
+import hudson.plugins.git.browser.GitLab;
 import hudson.plugins.git.browser.GithubWeb;
 import static hudson.scm.PollingResult.*;
 import hudson.util.LogTaskListener;
@@ -329,10 +331,33 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         this.browser = browser;
     }
 
+    private static final String HOSTNAME_MATCH
+            = "([\\w\\d[-.]]+)" // hostname
+            ;
+    private static final String REPOSITORY_PATH_MATCH
+            = "/*" // Zero or more slashes as start of repository path
+            + "(.+?)" // repository path without leading slashes
+            + "(?:[.]git)?" // optional '.git' suffix
+            + "/*" // optional trailing '/'
+            ;
+
     private static final Pattern[] URL_PATTERNS = {
-        Pattern.compile("https://github[.]com/([^/]+/[^/]+?)([.]git)*/*"),
-        Pattern.compile("(?:git@)?github[.]com:([^/]+/[^/]+?)([.]git)*/*"),
-        Pattern.compile("ssh://(?:git@)?github[.]com/([^/]+/[^/]+?)([.]git)*/*"),
+        /* URL style - like https://github.com/jenkinsci/git-plugin */
+        Pattern.compile(
+        "(?:\\w+://)" // protocol (scheme)
+        + "(?:.+@)?" // optional username/password
+        + HOSTNAME_MATCH
+        + "(?:[:][\\d]+)?" // optional port number (only honored by git for ssh:// scheme)
+        + "/" // separator between hostname and repository path - '/'
+        + REPOSITORY_PATH_MATCH
+        ),
+        /* Alternate ssh style - like git@github.com:jenkinsci/git-plugin */
+        Pattern.compile(
+        "(?:git@)" // required username (only optional if local username is 'git')
+        + HOSTNAME_MATCH
+        + ":" // separator between hostname and repository path - ':'
+        + REPOSITORY_PATH_MATCH
+        )
     };
 
     @Override public RepositoryBrowser<?> guessBrowser() {
@@ -341,21 +366,33 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             for (RemoteConfig config : remoteRepositories) {
                 for (URIish uriIsh : config.getURIs()) {
                     String uri = uriIsh.toString();
-                    // TODO make extensible by introducing an abstract GitRepositoryBrowserDescriptor
                     for (Pattern p : URL_PATTERNS) {
                         Matcher m = p.matcher(uri);
                         if (m.matches()) {
-                            webUrls.add("https://github.com/" + m.group(1) + "/");
+                            webUrls.add("https://" + m.group(1) + "/" + m.group(2) + "/");
                         }
                     }
                 }
             }
         }
-        if (webUrls.size() == 1) {
-            return new GithubWeb(webUrls.iterator().next());
-        } else {
+        if (webUrls.isEmpty()) {
             return null;
         }
+        if (webUrls.size() == 1) {
+            String url = webUrls.iterator().next();
+            if (url.startsWith("https://bitbucket.org/")) {
+                return new BitbucketWeb(url);
+            }
+            if (url.startsWith("https://gitlab.com/")) {
+                return new GitLab(url, "");
+            }
+            if (url.startsWith("https://github.com/")) {
+                return new GithubWeb(url);
+            }
+            return null;
+        }
+        LOGGER.log(Level.INFO, "Multiple browser guess matches for {0}", remoteRepositories);
+        return null;
     }
 
     public boolean isCreateAccountBasedOnEmail() {

--- a/src/test/java/hudson/plugins/git/GitSCMBrowserTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMBrowserTest.java
@@ -1,0 +1,147 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Mark Waite.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.git;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.plugins.git.browser.GitRepositoryBrowser;
+import hudson.plugins.git.browser.GithubWeb;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class GitSCMBrowserTest {
+
+    private final String gitURI;
+    private final Class<? extends GitRepositoryBrowser> expectedClass;
+    private final String expectedURI;
+
+    public GitSCMBrowserTest(String gitURI,
+            Class<? extends GitRepositoryBrowser> expectedClass,
+            String expectedURI) {
+        this.gitURI = gitURI;
+        this.expectedClass = expectedClass;
+        this.expectedURI = expectedURI;
+    }
+
+    private static final String GITHUB_EXPECTED = "https://github.com/jenkinsci/git-plugin/";
+
+    private static boolean guessBrowserExpectedToReturnNull(@NonNull String hostname) {
+        return !hostname.equals("github.com");
+    }
+
+    private static boolean guessBrowserExpectedToReturnNull(
+            @NonNull String protocol,
+            @NonNull String hostname,
+            @NonNull String username) {
+        if (guessBrowserExpectedToReturnNull(hostname)) {
+            return true;
+        }
+        if (protocol.equals("https") && !username.isEmpty()) {
+            return true;
+        }
+        return protocol.equals("git");
+    }
+
+    private static Class<? extends GitRepositoryBrowser> expectedClass(String hostname) {
+        return GithubWeb.class;
+    }
+
+    private static Class<? extends GitRepositoryBrowser> expectedClass(String protocol, String hostname, String userName) {
+        if (guessBrowserExpectedToReturnNull(protocol, hostname, userName)) {
+            return null;
+        }
+        return GithubWeb.class;
+    }
+
+    private static String expectedURL(String hostname) {
+        if (guessBrowserExpectedToReturnNull(hostname)) {
+            return null;
+        }
+        return GITHUB_EXPECTED;
+    }
+
+    private static String expectedURL(String protocol, String hostname, String userName) {
+        if (guessBrowserExpectedToReturnNull(protocol, hostname, userName)) {
+            return null;
+        }
+        return GITHUB_EXPECTED;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection permuteRepositoryURL() {
+        /* Systematically formed test URLs */
+        String[] protocols = {"https", "ssh", "git"};
+        String[] userNames = {"git:password@", "git@", ""};
+        String[] hostnames = {"github.com", "bitbucket.org", "gitlab.com"};
+        String[] suffixes = {".git/", ".git", "/", ""};
+        String owner = "jenkinsci";
+        String repo = "git-plugin";
+        List<Object[]> values = new ArrayList<>();
+        for (String protocol : protocols) {
+            for (String userName : userNames) {
+                for (String hostname : hostnames) {
+                    for (String suffix : suffixes) {
+                        Object[] testCase = {
+                            protocol + "://" + userName + hostname + "/" + owner + "/" + repo + suffix,
+                            expectedClass(protocol, hostname, userName),
+                            expectedURL(protocol, hostname, userName)
+                        };
+                        values.add(testCase);
+                    }
+                }
+            }
+        }
+        /* ssh alternate syntax */
+        for (String hostname : hostnames) {
+            for (String suffix : suffixes) {
+                Object[] testCase = {
+                    "git@" + hostname + ":jenkinsci/git-plugin" + suffix,
+                    expectedClass(hostname),
+                    expectedURL(hostname)
+                };
+                values.add(testCase);
+            }
+        }
+        return values;
+    }
+
+    @Test
+    public void autoBrowser() {
+        GitSCM gitSCM = new GitSCM(gitURI);
+        GitRepositoryBrowser browser = (GitRepositoryBrowser) gitSCM.guessBrowser();
+        if (expectedClass == null || expectedURI == null) {
+            assertThat(browser, is(nullValue()));
+        } else {
+            assertThat(browser, is(instanceOf(expectedClass)));
+            assertThat(browser.getRepoUrl(), is(expectedURI));
+        }
+    }
+}


### PR DESCRIPTION
The plugin has a repository browser guesser if a repository browser is not selected.  Previously, that guesser was limited to a subset of github URLs.

This pull request broadens the types of github URLs which will be recognized and adds bitbucket.org and gitlab.com as possible guesses.

Repository browser guessing is only useful for those repository hosting services which have a well-known host name, like github.com, bitbucket.org, and gitlab.com.  Internally hosted GitHub enterprise, or Bitbucket, or GitLab will still need to specify the repository browser, as will other browser types.

I intentionally chose the simpler implementation rather than implementing this using an abstract GitRepositoryBrowserDescriptor.  Since the number of public git repository browsers supported by the plugin is quite small, it seemed simpler to extend the existing regular expression based detection technique and return the matching browser rather than modify GitSCM and the relevant repository browser classes.

@reviewbybees