### PR TITLE
Skip LOGNAME dependent test if LOGNAME not defined

### DIFF
--- a/src/test/java/hudson/plugins/git/GitPublisherTest.java
+++ b/src/test/java/hudson/plugins/git/GitPublisherTest.java
@@ -48,12 +48,17 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.concurrent.atomic.AtomicInteger;
 import jenkins.plugins.git.CliGitCommand;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assume.*;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -621,10 +626,13 @@ public class GitPublisherTest extends AbstractGitProject {
     @Issue("JENKINS-24786")
     @Test
     public void testMergeAndPushWithSystemEnvVar() throws Exception {
-        FreeStyleProject project = setupSimpleProject("master");
-
         String envName = isWindows() ? "COMPUTERNAME" : "LOGNAME";
         String envValue = System.getenv().get(envName);
+        assumeThat(envValue, notNullValue());
+        assumeThat(envValue, not(isEmptyString()));
+
+        FreeStyleProject project = setupSimpleProject("master");
+
         assertNotNull("Env " + envName + " not set", envValue);
         assertFalse("Env " + envName + " empty", envValue.isEmpty());
 


### PR DESCRIPTION
Most non-Windows execution environments define the LOGNAME environment
variable.  When running the Jenkins Dockerfile-slim, it does not appear
to define that environment variable on the master.  Rather than create
complicated searching for another environment variable whose value is
valid as a branch name, we will skip this test if LOGNAME is not set.

LOGNAME is set in enough contexts (like ci.jenkins.io and developer
desktop machines and other test environments) that it is not a good use of
time to embed additional logic into the test for a relatively rare case.
Skip the test if the environment won't support the test.