### PR TITLE
[JENKINS-19022] add extension to stop storing buildsByBranch history

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -41,6 +41,7 @@ import hudson.plugins.git.extensions.impl.ChangelogToBranch;
 import hudson.plugins.git.extensions.impl.PathRestriction;
 import hudson.plugins.git.extensions.impl.LocalBranch;
 import hudson.plugins.git.extensions.impl.PreBuildMerge;
+import hudson.plugins.git.extensions.impl.NoBuildsByBranchHistory;
 import hudson.plugins.git.opt.PreBuildMergeOptions;
 import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.*;
@@ -92,6 +93,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -1169,6 +1171,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         BuildData previousBuildData = getBuildData(build.getPreviousBuild());   // read only
         BuildData buildData = copyBuildData(build.getPreviousBuild());
+
+        if (getExtensions().get(NoBuildsByBranchHistory.class)!=null) {
+            listener.getLogger().println("Discarding 'builds by branch' history.");
+            buildData.buildsByBranchName = new HashMap<>();
+        }
 
         if (VERBOSE && buildData.lastBuild != null) {
             listener.getLogger().println("Last Built Revision: " + buildData.lastBuild.revision);

--- a/src/main/java/hudson/plugins/git/extensions/impl/NoBuildsByBranchHistory.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/NoBuildsByBranchHistory.java
@@ -1,0 +1,59 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.FakeGitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Avoid storing unnecessary builds-by-branch data for every build.
+ *
+ * @author Jacob Keller
+ */
+public class NoBuildsByBranchHistory extends FakeGitSCMExtension {
+
+    @DataBoundConstructor
+    public NoBuildsByBranchHistory() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return o instanceof NoBuildsByBranchHistory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return NoBuildsByBranchHistory.class.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "NoBuildsByBranchHistory{}";
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Do not store history of builds by branch";
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/git/traits/NoBuildsByBranchHistoryTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/NoBuildsByBranchHistoryTrait.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package jenkins.plugins.git.traits;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.impl.NoBuildsByBranchHistory;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Exposes {@link NoBuildsByBranchHistory} as a {@link SCMSourceTrait}.
+ *
+ * @since 3.4.0
+ */
+public class NoBuildsByBranchHistoryTrait extends GitSCMExtensionTrait<NoBuildsByBranchHistory> {
+    /**
+     * Stapler constructor.
+     */
+    @DataBoundConstructor
+    public NoBuildsByBranchHistoryTrait() {
+        super(new NoBuildsByBranchHistory());
+    }
+
+    /**
+     * Our {@link hudson.model.Descriptor}
+     */
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionTraitDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Do not store history of builds by branch";
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/NoBuildsByBranchHistory/help.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/NoBuildsByBranchHistory/help.html
@@ -1,0 +1,5 @@
+<div>
+  Disable storing of the builds by branch history each build, instead opting to only track the current branches each build.
+  <p>
+  If this option is selected, it will preclude certain build strategies from working correctly, and identifying which builds have already been built.
+</div>


### PR DESCRIPTION
We store a new copy of the entire history buildsByBranch every build, as
part of BuildData. This is used for a few cases of determining which
revisions already built, and how to select the branch. Unfortunately, it
bloats the build.xml and takes time to process, as it grows indefinitely
under some use-cases, such as using the GerritTrigger plugin, in which
every build is essentially run on a different branch.

To avoid this, add an extension which allows disabling the saving of
this buildsByBranch history, only maintaining the current data for each
build.

Add tests to make sure that buildsByBranchName tracks history by
default, and doesn't track history when the extension is enabled.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>