### PR TITLE
[JENKINS-30475] Allow tip branch filtering to be disabled

### DIFF
--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -23,8 +23,19 @@ public class DefaultBuildChooser extends BuildChooser {
     /* Ignore symbolic default branch ref. */
     private static final BranchSpec HEAD = new BranchSpec("*/HEAD");
 
+    private final boolean filterTipBranches;
+
     @DataBoundConstructor
+    public DefaultBuildChooser(boolean filterTipBranches) {
+        this.filterTipBranches = filterTipBranches;
+    }
+
     public DefaultBuildChooser() {
+        this(true);
+    }
+
+    public boolean isFilterTipBranches() {
+        return filterTipBranches;
     }
 
     /**
@@ -187,7 +198,7 @@ public class DefaultBuildChooser extends BuildChooser {
      *  2. Filter out branches that we don't care about from the revisions.
      *     Any Revisions with no interesting branches are dropped.
      *  3. Get rid of any revisions that are wholly subsumed by another
-     *     revision we're considering.
+     *     revision we're considering (may be disabled).
      *  4. Get rid of any revisions that we've already built.
      *  5. Sort revisions from old to new.
      *
@@ -246,9 +257,13 @@ public class DefaultBuildChooser extends BuildChooser {
 
         verbose(listener, "After branch filtering: {0}", revs);
 
-        // 3. We only want 'tip' revisions
-        revs = utils.filterTipBranches(revs);
-        verbose(listener, "After non-tip filtering: {0}", revs);
+        // 3. We only want 'tip' revisions (if enabled)
+        if (isFilterTipBranches()) {
+            revs = utils.filterTipBranches(revs);
+            verbose(listener, "After non-tip filtering: {0}", revs);
+        } else {
+            verbose(listener, "Non-tip filtering is disabled");
+        }
 
         // 4. Finally, remove any revisions that have already been built.
         verbose(listener, "Removing what''s already been built: {0}", data.getBuildsByBranchName());

--- a/src/main/resources/hudson/plugins/git/util/DefaultBuildChooser/config.groovy
+++ b/src/main/resources/hudson/plugins/git/util/DefaultBuildChooser/config.groovy
@@ -1,0 +1,11 @@
+package hudson.plugins.git.util.DefaultBuildChooser;
+
+def f = namespace(lib.FormTagLib);
+
+f.description {
+    raw(_("filter_tip_branches_blurb"))
+}
+
+f.entry(title:_("Filter tip branches"), field:"filterTipBranches") {
+    f.checkbox(default: true)
+}

--- a/src/main/resources/hudson/plugins/git/util/DefaultBuildChooser/config.properties
+++ b/src/main/resources/hudson/plugins/git/util/DefaultBuildChooser/config.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2018-, Modestas Vainius
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+filter_tip_branches_blurb=Do not build branches that are wholly subsumed by other branches being considered (multi-branch case only).


### PR DESCRIPTION
Add an option to disable tip branch filtering. Arguably, this should be
a default but having an option is better than nothing.

https://issues.jenkins-ci.org/browse/JENKINS-30475