### PR TITLE
Fetch tags from public repo for GitSCMFileSystemTest

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -86,8 +86,7 @@ public class GitSCMFileSystemTest {
      * If you do not have that tag, you will need to include that tag in
      * your fork.  You can do that with the commands:
      *
-     * $ git remote add upstream https://github.com/jenkinsci/git-plugin
-     * $ git fetch --tags upstream
+     * $ git fetch --tags https://github.com/jenkinsci/git-plugin
      * $ git push --tags origin
      */
     @BeforeClass
@@ -102,7 +101,7 @@ public class GitSCMFileSystemTest {
                 tagId = client.revParse(tag);
             } catch (GitException ge) {
                 CliGitCommand gitCmd = new CliGitCommand(null);
-                gitCmd.run("fetch", "--tags");
+                gitCmd.run("fetch", "--tags", "https://github.com/jenkinsci/git-plugin");
                 tagId = client.revParse(tag); /* throws if tag not available */
             }
         }


### PR DESCRIPTION
## Fetch tags from public repo if not found locally

Tests running in a continuous integration job from a private forked repo may fail because the job itself does not have access to the private fork during its execution.  The checkout step of the job uses the credentials for the private forked repo, but (correctly) does not allow the job
access to those credentials.

Found this issue while fixing SECURITY-723 - Unauthenticated user information disclosure.

The fetch is only performed if the required tags are not already found in the repository.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes (not applicable)
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

Small change to pass tests in more continuous integration jobs.