### PR TITLE
JENKINS-50556 don't check local refs if we have remote ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The master branch is the primary development branch for the git plugin.
 ## Contributing to the Plugin
 
 Plugin source code is hosted on [GitHub](https://github.com/jenkinsci/git-plugin).
-New feature proposals and bug fix proposals should be submitted as
+New feature proposals and bug fixes should be submitted as
 [pull requests](https://help.github.com/articles/creating-a-pull-request).
 Fork the repository, prepare your change on your forked
 copy, and submit a pull request.  Your pull request will be evaluated

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -81,7 +81,7 @@ public class DefaultBuildChooser extends BuildChooser {
                 String repository = config.getName();
                 String fqbn = repository + "/" + branchSpec;
                 verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
-                revisions.addAll(getHeadRevision(isPollCall, fqbn, git, listener, data));
+                revisions.addAll(getHeadRevision(fqbn, git, listener));
             }
         } else {
             // either the branch is qualified (first part should match a valid remote)
@@ -109,7 +109,7 @@ public class DefaultBuildChooser extends BuildChooser {
                 possibleQualifiedBranches.add(fqbn);
             }
             for (String fqbn : possibleQualifiedBranches) {
-              revisions.addAll(getHeadRevision(isPollCall, fqbn, git, listener, data));
+              revisions.addAll(getHeadRevision(fqbn, git, listener));
             }
         }
 
@@ -117,7 +117,7 @@ public class DefaultBuildChooser extends BuildChooser {
             // the 'branch' could actually be a non branch reference (for example a tag or a gerrit change)
             // only check for this type of reference if branch references did not return anything.
 
-            revisions.addAll(getHeadRevision(isPollCall, branchSpec, git, listener, data));
+            revisions.addAll(getHeadRevision(branchSpec, git, listener));
             if (!revisions.isEmpty()) {
                 verbose(listener, "{0} seems to be a non-branch reference (tag?)");
             }
@@ -145,7 +145,7 @@ public class DefaultBuildChooser extends BuildChooser {
         return revisions;
     }
 
-    private Collection<Revision> getHeadRevision(boolean isPollCall, String singleBranch, GitClient git, TaskListener listener, BuildData data) throws InterruptedException {
+    private Collection<Revision> getHeadRevision(String singleBranch, GitClient git, TaskListener listener) throws InterruptedException {
         try {
             ObjectId sha1 = git.revParse(singleBranch);
             verbose(listener, "rev-parse {0} -> {1}", singleBranch, sha1);

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -138,9 +138,7 @@ public class DefaultBuildChooser extends BuildChooser {
             }
 
             verbose(listener, "Found a new commit {0} to be built on {1}", sha1, singleBranch);
-            Revision revision = new Revision(sha1);
-            revision.getBranches().add(new Branch(singleBranch, sha1));
-            return Collections.singletonList(revision);
+            return (Collections.singletonList(objectId2Revision(singleBranch, sha1)));
         } catch (GitException e) {
             // branch does not exist, there is nothing to build
             verbose(listener, "Failed to rev-parse: {0}", singleBranch);

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -141,31 +141,6 @@ public class DefaultBuildChooser extends BuildChooser {
             Revision revision = new Revision(sha1);
             revision.getBranches().add(new Branch(singleBranch, sha1));
             return Collections.singletonList(revision);
-            /*
-            // calculate the revisions that are new compared to the last build
-            List<Revision> candidateRevs = new ArrayList<Revision>();
-            List<ObjectId> allRevs = git.revListAll(); // index 0 contains the newest revision
-            if (data != null && allRevs != null) {
-                Revision lastBuiltRev = data.getLastBuiltRevision();
-                if (lastBuiltRev == null) {
-                    return Collections.singletonList(objectId2Revision(singleBranch, sha1));
-                }
-                int indexOfLastBuildRev = allRevs.indexOf(lastBuiltRev.getSha1());
-                if (indexOfLastBuildRev == -1) {
-                    // mhmmm ... can happen when branches are switched.
-                    return Collections.singletonList(objectId2Revision(singleBranch, sha1));
-                }
-                List<ObjectId> newRevisionsSinceLastBuild = allRevs.subList(0, indexOfLastBuildRev);
-                // translate list of ObjectIds into list of Revisions
-                for (ObjectId objectId : newRevisionsSinceLastBuild) {
-                    candidateRevs.add(objectId2Revision(singleBranch, objectId));
-                }
-            }
-            if (candidateRevs.isEmpty()) {
-                return Collections.singletonList(objectId2Revision(singleBranch, sha1));
-            }
-            return candidateRevs;
-            */
         } catch (GitException e) {
             // branch does not exist, there is nothing to build
             verbose(listener, "Failed to rev-parse: {0}", singleBranch);

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -116,7 +116,7 @@ public class DefaultBuildChooser extends BuildChooser {
         if (revisions.isEmpty()) {
             // the 'branch' could actually be a non branch reference (for example a tag or a gerrit change)
 
-            revisions = getHeadRevision(isPollCall, branchSpec, git, listener, data);
+            revisions.addAll(getHeadRevision(isPollCall, branchSpec, git, listener, data));
             if (!revisions.isEmpty()) {
                 verbose(listener, "{0} seems to be a non-branch reference (tag?)");
             }

--- a/src/test/java/hudson/plugins/git/CliGitSCMTriggerLocalPollTest.java
+++ b/src/test/java/hudson/plugins/git/CliGitSCMTriggerLocalPollTest.java
@@ -3,6 +3,46 @@ package hudson.plugins.git;
 import hudson.plugins.git.extensions.GitClientType;
 import hudson.plugins.git.extensions.impl.EnforceGitClient;
 
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.git.extensions.impl.EnforceGitClient;
+import hudson.scm.PollingResult;
+import hudson.triggers.SCMTrigger;
+import hudson.util.RunList;
+import hudson.model.TaskListener;
+import hudson.util.StreamTaskListener;
+
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+import org.eclipse.jgit.lib.ObjectId;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.apache.commons.io.FileUtils;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+
 public class CliGitSCMTriggerLocalPollTest extends SCMTriggerTest
 {
 
@@ -17,5 +57,63 @@ public class CliGitSCMTriggerLocalPollTest extends SCMTriggerTest
     {
         return true;
     }
+
+    @Test
+    public void testNamespaces_with_refsHeadsMaster() throws Exception {
+        check(namespaceRepoZip, namespaceRepoCommits,
+            "refs/heads/master",
+            namespaceRepoCommits.getProperty("refs/heads/master"),
+            "origin/master");
+    }
+
+    /*
+     * local workspace polling should avoid using out-of-date local branches
+     * when reporting new candidates to build. This does not affect remote
+     * polling as it does not use a workspace.
+     */
+    @Test
+    public void testLocalBranchesDontImpactPolling() throws Exception {
+        TaskListener listener = StreamTaskListener.fromStderr();
+
+        String remote = prepareRepo(namespaceRepoZip);
+
+        FreeStyleProject project = setupProject(asList(new UserRemoteConfig(remote, null, null, null)),
+                    asList(new BranchSpec("master")),
+                    //empty scmTriggerSpec, SCMTrigger triggered manually
+                    "", isDisableRemotePoll(), getGitClient()); 
+
+        //Speedup test - avoid waiting 1 minute
+        triggerSCMTrigger(project.getTrigger(SCMTrigger.class));
+
+        FreeStyleBuild build1 = waitForBuildFinished(project, 1, 60000);
+        assertNotNull("Job has not been triggered", build1);
+
+        assertEquals("Unexpected GIT_COMMIT", 
+                    namespaceRepoCommits.getProperty("refs/heads/master"),
+                    build1.getEnvironment(null).get("GIT_COMMIT"));
+        assertEquals("Unexpected GIT_BRANCH", 
+                    "origin/master", build1.getEnvironment(null).get("GIT_BRANCH"));
+
+        GitSCM scm = (GitSCM)project.getScm();
+        GitClient client = scm.createClient(listener, null, build1, build1.getWorkspace());
+
+        // Set master to a commit which isn't in the remote
+        build1.getWorkspace().child("aNewFile").touch(0);
+        client.add("aNewFile");
+        client.commit("add a new file");
+        client.checkout("HEAD", "master");
+
+        // Verify that polling doesn't think the local master branch is a new commit to build
+        PollingResult poll = project.poll(listener);
+        assertEquals("Expected and actual polling results disagree", false, poll.hasChanges());
+
+        //Speedup test - avoid waiting 1 minute
+        triggerSCMTrigger(project.getTrigger(SCMTrigger.class)).get(20, SECONDS);
+
+        FreeStyleBuild build2 = waitForBuildFinished(project, 2, 2000);
+        assertNull("Found build 2 although no new changes and no multi candidate build", build2);
+
+    }
+
 
 }

--- a/src/test/java/hudson/plugins/git/SCMTriggerTest.java
+++ b/src/test/java/hudson/plugins/git/SCMTriggerTest.java
@@ -38,9 +38,9 @@ import org.jvnet.hudson.test.Issue;
 
 public abstract class SCMTriggerTest extends AbstractGitProject
 {
-    private ZipFile namespaceRepoZip;
-    private Properties namespaceRepoCommits;
-    private ExecutorService singleThreadExecutor;
+    protected ZipFile namespaceRepoZip;
+    protected Properties namespaceRepoCommits;
+    protected ExecutorService singleThreadExecutor;
     protected boolean expectChanges = false;
 
     @Rule
@@ -268,13 +268,13 @@ public abstract class SCMTriggerTest extends AbstractGitProject
                     expected_GIT_BRANCH, build1.getEnvironment(null).get("GIT_BRANCH"));
     }
 
-    private String prepareRepo(ZipFile repoZip) throws IOException {
+    protected String prepareRepo(ZipFile repoZip) throws IOException {
         File tempRemoteDir = tempFolder.newFolder();
         extract(repoZip, tempRemoteDir);
         return tempRemoteDir.getAbsolutePath();
     }
 
-    private Future<Void> triggerSCMTrigger(final SCMTrigger trigger)
+    protected Future<Void> triggerSCMTrigger(final SCMTrigger trigger)
     {
         if(trigger == null) return null;
         Callable<Void> callable = new Callable<Void>() {
@@ -287,7 +287,7 @@ public abstract class SCMTriggerTest extends AbstractGitProject
         return singleThreadExecutor.submit(callable);
     }
 
-    private FreeStyleBuild waitForBuildFinished(FreeStyleProject project, int expectedBuildNumber, long timeout)
+    protected FreeStyleBuild waitForBuildFinished(FreeStyleProject project, int expectedBuildNumber, long timeout)
                 throws Exception
     {
         long endTime = System.currentTimeMillis() + timeout;
@@ -304,7 +304,7 @@ public abstract class SCMTriggerTest extends AbstractGitProject
         return null;
     }
 
-    private Properties parseLsRemote(File file) throws IOException
+    protected Properties parseLsRemote(File file) throws IOException
     {
         Properties properties = new Properties();
         Pattern pattern = Pattern.compile("([a-f0-9]{40})\\s*(.*)");
@@ -320,7 +320,7 @@ public abstract class SCMTriggerTest extends AbstractGitProject
         return properties;
     }
     
-    private void extract(ZipFile zipFile, File outputDir) throws IOException
+    protected void extract(ZipFile zipFile, File outputDir) throws IOException
     {
         Enumeration<? extends ZipEntry> entries = zipFile.entries();
         while (entries.hasMoreElements()) {


### PR DESCRIPTION
JENKINS-50556 don't check local refs if we had remote ones

Fix an issue related to how polling works with remote vs local references. In the DefaultBuildChooser, we currently check branch-like references first, by converting them to remote/name lookups. This is done so that we can check the status of the branches according to the remote references. If we don't find one, then we assume that the branchSpec is actually a tag or tag-like reference.

Unfortunately, during polling, we prune these references that have already been built. This results in an accidental check of local branches, in the case where remote branches exist, but have no new changes. In some cases, this can result in polling reporting a change to build, but which will never be found by the build chooser during run time (as isPollCall would be false then, and we would not report the local branches in this case).

Fix this by instead pruning the list of references at the end, after collecting them. This ensures that the DefaultBuildChooser will work similarly in both the normal and polling cases, and avoids the possibility of permanently polling which can happen if a local branch gets a reference checked out.

Note that the polling bug may not be caught in many cases, because it happens that local branches do not get setup by the git plugin normally. Additionally, the remote polling setup is not susceptible to this issue, as it does not use the workspace for polling, instead using only ls-remote.

Add a test case which forces this sequence of events in order to highlight the issue, and make sure we don't re-introduce it.