### PR TITLE
[JENKINS-34070] Fixing UserMergeOptions.mergeStrategy databinding

### DIFF
--- a/src/main/java/hudson/plugins/git/UserMergeOptions.java
+++ b/src/main/java/hudson/plugins/git/UserMergeOptions.java
@@ -1,14 +1,15 @@
 package hudson.plugins.git;
 
 import hudson.Extension;
+import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.plugins.git.opt.PreBuildMergeOptions;
-import hudson.util.ListBoxModel;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.Serializable;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * User-provided configuration that dictates which branch in which repository we'll be
@@ -18,7 +19,7 @@ import java.io.Serializable;
 public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions>  implements Serializable {
 
     private String mergeRemote;
-    private String mergeTarget;
+    private final String mergeTarget;
     private String mergeStrategy;
     private MergeCommand.GitPluginFastForwardMode fastForwardMode;
 
@@ -39,13 +40,17 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
      * @param mergeStrategy merge strategy
      * @param fastForwardMode fast forward mode
      */
-    @DataBoundConstructor
     public UserMergeOptions(String mergeRemote, String mergeTarget, String mergeStrategy,
             MergeCommand.GitPluginFastForwardMode fastForwardMode) {
         this.mergeRemote = mergeRemote;
         this.mergeTarget = mergeTarget;
         this.mergeStrategy = mergeStrategy;
         this.fastForwardMode = fastForwardMode;
+    }
+
+    @DataBoundConstructor
+    public UserMergeOptions(String mergeTarget) {
+        this.mergeTarget = mergeTarget;
     }
 
     /**
@@ -62,6 +67,11 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
      */
     public String getMergeRemote() {
         return mergeRemote;
+    }
+
+    @DataBoundSetter
+    public void setMergeRemote(String mergeRemote) {
+        this.mergeRemote = Util.fixEmptyAndTrim(mergeRemote);
     }
 
     /**
@@ -89,11 +99,21 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
         return MergeCommand.Strategy.DEFAULT;
     }
 
+    @DataBoundSetter
+    public void setMergeStrategy(MergeCommand.Strategy mergeStrategy) {
+        this.mergeStrategy = mergeStrategy.toString(); // not .name() as you might expect! TODO in Turkey this will be e.g. recursıve
+    }
+
     public MergeCommand.GitPluginFastForwardMode getFastForwardMode() {
         for (MergeCommand.GitPluginFastForwardMode ffMode : MergeCommand.GitPluginFastForwardMode.values())
             if (ffMode.equals(fastForwardMode))
                 return ffMode;
         return MergeCommand.GitPluginFastForwardMode.FF;
+    }
+
+    @DataBoundSetter
+    public void setFastForwardMode(MergeCommand.GitPluginFastForwardMode fastForwardMode) {
+        this.fastForwardMode = fastForwardMode;
     }
 
     @Override
@@ -148,11 +168,5 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
             return "";
         }
 
-        public ListBoxModel doFillMergeStrategyItems() {
-            ListBoxModel m = new ListBoxModel();
-            for (MergeCommand.Strategy strategy: MergeCommand.Strategy.values())
-                m.add(strategy.toString(), strategy.toString());
-            return m;
-        }
     }
 }

--- a/src/main/resources/hudson/plugins/git/UserMergeOptions/config.jelly
+++ b/src/main/resources/hudson/plugins/git/UserMergeOptions/config.jelly
@@ -1,13 +1,15 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Name of repository}" field="mergeRemote">
-    <f:textbox id="git.mergeRemote" />
+    <f:textbox/>
   </f:entry>
   <f:entry title="${%Branch to merge to}" field="mergeTarget">
-    <f:textbox id="git.mergeTarget" clazz="required"/>
+    <f:textbox clazz="required"/>
   </f:entry>
   <f:entry title="${%Merge strategy}" field="mergeStrategy">
-      <f:select />
+      <f:enum>
+          ${it.toString()}
+      </f:enum>
   </f:entry>
   <f:entry title="${%Fast-forward mode}" field="fastForwardMode">
       <f:enum>


### PR DESCRIPTION
## JENKINS-34070 - `UserMergeOptions.mergeStrategy` databinding was incorrect

Broke **Pipeline Syntax** for **Merge before build**. Replaces #392 by @martinda more simply and I guess compatibly—there is no change to the behavior of the existing constructor, nor any change to settings format.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [X] I have referenced the Jira issue related to my changes in one or more commit messages
- [X] I have added tests that verify my changes (these are upstream in `structs-plugin`)
- [X] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No findbugs warnings were introduced with my changes
- [X] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.