### PR TITLE
using author in the changelog should not require workspace polling

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/AuthorInChangelog.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/AuthorInChangelog.java
@@ -21,14 +21,6 @@ public class AuthorInChangelog extends FakeGitSCMExtension {
      * {@inheritDoc}
      */
     @Override
-    public boolean requiresWorkspaceForPolling() {
-        return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;


### PR DESCRIPTION
Commit d8338ce4bca9 ("[FIXED JENKINS-19001] extension can declare
requirement for a workspace during polling", 2014-03-06) appears to have
accidentally set the workspace to poll whenever AuthorInChangelog is
used.

The extension only modifies two things, (a) the changelog parser which
should not depend on polling and (b) the check for user exclusion in
isRevExcluded.

One might consider that the second case does depend on polling, however
it is only triggered in the case where the UserExclude extension is
enabled! Thus, we should not need to poll when only using the
AuthorInChangelog extension.

It appears this functionality should already be tested by
testAuthorOrComitterTrue() in GitSCMTest.java.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>

## JENKINS-xxxxx - summarize pull request in one line

Describe the big picture of your changes here to explain to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, include a link to the issue.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

I don't think new tests are required, as the functionality should be verified by existing tests. As far as I can tell, this extension forcing polling in workspace was an oversight of the commit which introduced the requirement. I'm currently in the process of doing interactive testing locally.