### PR TITLE
don't require polling for ChangeLogToBranch

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/ChangelogToBranch.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/ChangelogToBranch.java
@@ -29,11 +29,6 @@ public class ChangelogToBranch extends GitSCMExtension {
         return options;
     }
 
-    @Override
-    public boolean requiresWorkspaceForPolling() {
-        return true;
-    }
-
     @Extension
     public static class DescriptorImpl extends GitSCMExtensionDescriptor {
 


### PR DESCRIPTION
This extension only modifies how we compute the changelog which does not
occur during polling, and thus should not impact how polling behaves.
The extension does mark that it requires the workspace when polling, but
this seems incorrect. Behavior should be identical regardless of whether
we poll in the workspace or not.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>

## JENKINS-xxxxx - summarize pull request in one line

Describe the big picture of your changes here to explain to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, include a link to the issue.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments


This is similar to https://github.com/jenkinsci/git-plugin/pull/583 in that I don't believe we ever needed to force workspace polling for this extension and it was an accident in the commit which introduced the extension api changes related to polling.