### PR TITLE
[JENKINS-36451] Set scm instance for showing current browser

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -15,6 +15,7 @@
         </f:entry>
     </j:if>
 
+    <j:set var="scm" value="${instance}"/>
     <t:listScmBrowsers name="git.browser" />
 
     <f:entry title="${%Additional Behaviours}">


### PR DESCRIPTION
## [JENKINS-36451](https://issues.jenkins-ci.org/browse/JENKINS-36451) - set scm instance for showing current browser

Since someone said 'multibranch pipeline projects seem unaffected', I checked multibranch pipeline and found [the code](https://github.com/ikikko/git-plugin/blob/git-3.8.0/src/main/resources/jenkins/plugins/git/traits/GitBrowserSCMSourceTrait/config.jelly#L28). Checking the code above and [listScmBrowsers tag](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/lib/hudson/listScmBrowsers.jelly#L35), I fixed and it worked fine.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

Since this is a very small and UI fix, I haven't added tests / documentation.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
