### PR TITLE
Suppress findbugs warnings from Jenkins 2.60 builds

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -35,6 +35,8 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.ISODateTimeFormat;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Represents a change set.
  * @author Nigel Magnay
@@ -323,7 +325,6 @@ public class GitChangeSet extends ChangeLogSet.Entry {
         return parentCommit;
     }
 
-
     @Override
     public Collection<String> getAffectedPaths() {
         Collection<String> affectedPaths = new HashSet<>(this.paths.size());
@@ -430,6 +431,8 @@ public class GitChangeSet extends ChangeLogSet.Entry {
         }
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+                        justification = "Tests use null instance, Jenkins 2.60 declares instance is not null")
     private boolean isCreateAccountBasedOnEmail() {
         Hudson hudson = Hudson.getInstance();
         if (hudson == null) {

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -116,6 +116,8 @@ import java.util.regex.Pattern;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.isBlank;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Git SCM.
  *
@@ -1873,6 +1875,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     }
 
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+                        justification = "Tests use null instance, Jenkins 2.60 declares instance is not null")
     @Initializer(after=PLUGINS_STARTED)
     public static void onLoaded() {
         Jenkins jenkins = Jenkins.getInstance();

--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -34,6 +34,7 @@ import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
 import org.kohsuke.stapler.*;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Information screen for the use of Git in Hudson.
@@ -113,6 +114,8 @@ public class GitStatus implements UnprotectedRootAction {
         return s.toString();
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+                        justification = "Tests use null instance, Jenkins 2.60 declares instance is not null")
     public HttpResponse doNotifyCommit(HttpServletRequest request, @QueryParameter(required=true) String url,
                                        @QueryParameter(required=false) String branches,
                                        @QueryParameter(required=false) String sha1) throws ServletException, IOException {
@@ -325,7 +328,8 @@ public class GitStatus implements UnprotectedRootAction {
          * {@inheritDoc}
          */
         @Override
-        @SuppressFBWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification="Jenkins.getInstance() is not null")
+        @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+                            justification = "Tests use null instance, Jenkins 2.60 declares instance is not null")
         public List<ResponseContributor> onNotifyCommit(String origin, URIish uri, String sha1, List<ParameterValue> buildParameters, String... branches) {
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "Received notification from {0} for uri = {1} ; sha1 = {2} ; branches = {3}",
@@ -348,7 +352,7 @@ public class GitStatus implements UnprotectedRootAction {
                     LOGGER.severe("Jenkins.getInstance() is null in GitStatus.onNotifyCommit");
                     return result;
                 }
-                for (final Item project : Jenkins.getInstance().getAllItems()) {
+                for (final Item project : jenkins.getAllItems()) {
                     SCMTriggerItem scmTriggerItem = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(project);
                     if (scmTriggerItem == null) {
                         continue;

--- a/src/main/java/hudson/plugins/git/GitTagAction.java
+++ b/src/main/java/hudson/plugins/git/GitTagAction.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.util.*;
 import java.util.logging.Logger;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * @author Vivek Pandey
  */
@@ -47,6 +49,8 @@ public class GitTagAction extends AbstractScmTagAction implements Describable<Gi
 
     private static final Logger LOGGER = Logger.getLogger(GitTagAction.class.getName());
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+                        justification = "Tests use null instance, Jenkins 2.60 declares instance is not null")
     public Descriptor<GitTagAction> getDescriptor() {
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins == null) {

--- a/src/main/java/hudson/plugins/git/util/BuildChooserDescriptor.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooserDescriptor.java
@@ -6,6 +6,8 @@ import jenkins.model.Jenkins;
 import hudson.model.Item;
 import java.util.logging.Logger;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * @author Kohsuke Kawaguchi
  */
@@ -22,6 +24,8 @@ public abstract class BuildChooserDescriptor extends Descriptor<BuildChooser> {
         return null;
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+                        justification = "Tests use null instance, Jenkins 2.60 declares instance is not null")
     public static DescriptorExtensionList<BuildChooser,BuildChooserDescriptor> all() {
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins == null) {

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -1183,6 +1183,8 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         return getCacheEntry(getRemote());
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+                        justification = "Tests use null instance, Jenkins 2.60 declares instance is not null")
     protected static File getCacheDir(String cacheEntry) {
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins == null) {

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -30,6 +30,7 @@ import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.RestrictedSince;
 import hudson.Util;
@@ -547,6 +548,8 @@ public class GitSCMSource extends AbstractGitSCMSource {
 
     @Extension
     public static class ListenerImpl extends GitStatus.Listener {
+        @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+                            justification = "Tests use null instance, Jenkins 2.60 declares instance is not null")
         @Override
         public List<GitStatus.ResponseContributor> onNotifyCommit(String origin,
                                                                   URIish uri,

--- a/src/main/java/jenkins/plugins/git/traits/GitBrowserSCMSourceTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/GitBrowserSCMSourceTrait.java
@@ -27,6 +27,7 @@ package jenkins.plugins.git.traits;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.plugins.git.GitSCM;
@@ -108,6 +109,8 @@ public class GitBrowserSCMSourceTrait extends SCMSourceTrait {
          *
          * @return the {@link GitRepositoryBrowser} instances
          */
+        @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                            justification = "Tests use null instance, Jenkins 2.60 declares instance is not null")
         @Restricted(NoExternalUse.class) // stapler
         public List<Descriptor<RepositoryBrowser<?>>> getBrowserDescriptors() {
             return ((GitSCM.DescriptorImpl) Jenkins.getActiveInstance().getDescriptor(GitSCM.class))


### PR DESCRIPTION
There are tests which call methods that rely on a valid Jenkins instance, but the test is being called outside a JenkinsRule.  Thus there is not a valid Jenkins instance.  Rather than alter behavior of those tests, suppress the findbugs warning for the Jenkins.getInstance() reference.

Problem is visible with:

    mvn clean -Djenkins.version=2.60.1 -Dtest=StashTest test findbugs:findbugs

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)