### PR TITLE
Stabilizing tests

### DIFF
--- a/essentials.yml
+++ b/essentials.yml
@@ -1,6 +1,7 @@
 ---
 ath:
   athRevision: "dad333092159cb368efc2f9869572f0a05d255ac"
+  jenkins: "2.121-rc15727.3b61b96119b9"
   tests:
     - "GitPluginTest"
     - "GitUserContentTest"

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,22 @@
       <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency> <!-- TODO pending core upgrade or haveged, test against a newer sshd so we do not run into NativePRNG hangs -->
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>sshd</artifactId>
+      <version>1.11</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>instance-identity</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>ssh-cli-auth</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <scm>


### PR DESCRIPTION
* Pick up https://github.com/jenkinsci/jenkins/pull/3428 in ATH builds to avoid timeouts.
* Avoid entropy-based timeouts in functional tests. (ported from #582)