### PR TITLE
JENKINS-51280 - skip checkout extension got GitSCM

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1243,7 +1243,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 	        }
         }
         else {
-            listener.getLogger().println("Skipping check out operation for" + revToBuild.revision);
+            listener.getLogger().println("Skipping check out operation for " + revToBuild.revision);
         }
 
         // Needs to be after the checkout so that revToBuild is in the workspace

--- a/src/main/java/hudson/plugins/git/extensions/impl/CheckoutNOOP.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CheckoutNOOP.java
@@ -1,0 +1,70 @@
+package hudson.plugins.git.extensions.impl;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.FakeGitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+
+/**
+ * Add option to suppress the checkout command.
+ */
+public class CheckoutNOOP extends FakeGitSCMExtension {
+
+    @DataBoundConstructor
+    public CheckoutNOOP() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean requiresWorkspaceForPolling() {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        return true; // all instances are equal.
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        // as this is like a singleton, use its classes hashCode to avoid collision with other Extensions in Collection
+        return CheckoutNOOP.class.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "CheckoutNOOP";
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Suppress checkout operation (NOOP)";
+        }
+    }
+
+}


### PR DESCRIPTION
todo: automated tests - manual tests passed and the code is in production use

## [JENKINS-51280](https://issues.jenkins-ci.org/browse/JENKINS-51280) - added extension to support skipping checkout operation

On our integration systems there are users and large 2+GB source bases. We are using Jenkins to automate updates to the source base, but a checkout is disruptive when not meeting all the require criteria. This extension allows the checkout method to skip the actual git checkout.

I may need some guidance on authoring tests for Jenkins / Git SCM plugin.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [X] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [X] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No findbugs warnings were introduced with my changes
- [X] I have interactively tested my changes
- [X] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.

A lot of google searches - unanswered pages asking for the same feature.
e.g. 

- https://stackoverflow.com/questions/29263538/monitor-a-repository-in-jenkins-but-dont-pull
- http://jenkins-ci.361315.n4.nabble.com/Configure-Hudson-To-Poll-SCM-But-Prevent-Checkout-Update-td624303.html
- for pipeline (but does not fetch then)  https://devops.stackexchange.com/a/1074 and https://jenkins.io/doc/book/pipeline/syntax/#options
