### PR TITLE
Use Jenkins 2.122 for acceptance tests

### DIFF
--- a/essentials.yml
+++ b/essentials.yml
@@ -1,7 +1,7 @@
 ---
 ath:
   athRevision: "dad333092159cb368efc2f9869572f0a05d255ac"
-  jenkins: "2.121-rc15727.3b61b96119b9"
+  jenkins: "2.122"
   tests:
     - "GitPluginTest"
     - "GitUserContentTest"


### PR DESCRIPTION
Cherry picks a change from the master branch for use on the stable-3.9 branch