### PR TITLE
[JENKINS-45504] Add discovery symbol to branch and tag trait

### DIFF
--- a/src/main/java/jenkins/plugins/git/traits/BranchDiscoveryTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/BranchDiscoveryTrait.java
@@ -80,7 +80,7 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
-    @Symbol("gitBranchDiscoveryTrait")
+    @Symbol("gitBranchDiscovery")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {

--- a/src/main/java/jenkins/plugins/git/traits/BranchDiscoveryTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/BranchDiscoveryTrait.java
@@ -43,6 +43,7 @@ import jenkins.scm.api.trait.SCMSourceRequest;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -79,6 +80,7 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
+    @Symbol("gitBranchDiscoveryTrait")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {

--- a/src/main/java/jenkins/plugins/git/traits/BranchDiscoveryTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/BranchDiscoveryTrait.java
@@ -78,7 +78,7 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
     }
 
     /**
-     * Our descriptor.
+     * BranchDiscoveryTrait descriptor.
      */
     @Symbol("gitBranchDiscovery")
     @Extension

--- a/src/main/java/jenkins/plugins/git/traits/TagDiscoveryTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/TagDiscoveryTrait.java
@@ -46,6 +46,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.TagSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -82,6 +83,7 @@ public class TagDiscoveryTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
+    @Symbol("gitTagDiscoveryTrait")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {

--- a/src/main/java/jenkins/plugins/git/traits/TagDiscoveryTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/TagDiscoveryTrait.java
@@ -83,7 +83,7 @@ public class TagDiscoveryTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
-    @Symbol("gitTagDiscoveryTrait")
+    @Symbol("gitTagDiscovery")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {


### PR DESCRIPTION
When configuring multibranch pipelines without blueocean installed, the Git SCM source for branch discovery and tag discovery works fine.  However, when installing blue ocean it includes dependencies which cause a conflict in the DSL.  The conflicting plugins are:

- cloudbees-bitbucket-branch-source
- github-branch-source

The exception experienced when using Job DSL to call on the branch discovery trait or tag discovery trait is the following.

```
ERROR: Found multiple extensions which provide method branchDiscoveryTrait with arguments []: [[com.cloudbees.jenkins.plugins.bitbucket.BranchDiscoveryTrait, jenkins.plugins.git.traits.BranchDiscoveryTrait, org.jenkinsci.plugins.github_branch_source.BranchDiscoveryTrait]]
```

See also:

- [JENKINS-45504][JENKINS-45504] Add `@Symbol` annotations to traits
- [JENKINS-45688][JENKINS-45688] Unable to set extensions for Git SCM Source via DSL

**What I Tested**

Installed the development snapshot of this change into Jenkins 2.107.3 which required also compiling [git-client-plugin][git-client] from master branch source at commit https://github.com/jenkinsci/git-client-plugin/commit/b4130534522ba299be8125b416e4237612d5f289.

[JENKINS-45688]: https://issues.jenkins-ci.org/browse/JENKINS-45688
[JENKINS-45504]: https://issues.jenkins-ci.org/browse/JENKINS-45504
[git-client]: https://github.com/jenkinsci/git-client-plugin

# Additional information

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

This is a breaking change because: if a user is using the Job DSL plugin and referencing this part of the DSL, then the configuration as code name will be different.  They will get an error when attempting to generate jobs.
