### PR TITLE
Update git client and test dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ branches["ATH"] = {
                 infra.runMaven(["clean", "package", "-DskipTests"])
                 // Include experimental git-client in target dir for ATH
                 // This Git plugin requires experimental git-client
-                infra.runMaven(["dependency:copy", "-Dartifact=org.jenkins-ci.plugins:git-client:3.0.0-beta2:hpi", "-DoutputDirectory=target", "-Dmdep.stripVersion=true"])
+                infra.runMaven(["dependency:copy", "-Dartifact=org.jenkins-ci.plugins:git-client:3.0.0-beta3:hpi", "-DoutputDirectory=target", "-Dmdep.stripVersion=true"])
                 dir("target") {
                     stash name: "localPlugins", includes: "*.hpi"
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.3-2.0</version>
+      <version>4.5.5-2.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.27</version>
+      <version>1.44</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.0.0-beta2</version>
+      <version>3.0.0-beta3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Use latest git client, update test dependencies

* Use git client plugin 3.0.0-beta3
* Update test dependencies which don't introduce upper bounds dependency conflicts
