### PR TITLE
Remove 'requires workspace' from two help messages

### DIFF
--- a/src/main/resources/hudson/plugins/git/extensions/impl/AuthorInChangelog/help.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/AuthorInChangelog/help.html
@@ -1,6 +1,4 @@
 <div>
   The default behavior is to use the Git commit's "Committer" value in Jenkins' build changesets.
   If this option is selected, the Git commit's "Author" value would be used instead.
-  <p/>
-  Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <b>Force polling using workspace</b> extension as well.
 </div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/ChangelogToBranch/help.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/ChangelogToBranch/help.html
@@ -1,5 +1,3 @@
 <div>
     This method calculates the changelog against the specified branch.
-  <p/>
-    Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <b>Force polling using workspace</b> extension as well.
 </div>


### PR DESCRIPTION
Git plugin 3.9.0 removed the requirement that the "Author in Changelog" extension and the "Changelog to Branch" extension must use a workspace for polling.  The online help was not updated with that change.  This fixes the online help.

See 04152e98a19da6c43658a22c3f3340a26ac2fb49 for "Author in Changelog".

See 9331e03cd06577f824103d170fbd2131b0395bd6 for "Changelog to Branch".

## Unreported bug in help text

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
