### PR TITLE
changes to ChangelogToBranch additional behavior: allow empty remote name and do parameter substition

### DIFF
--- a/src/main/java/hudson/plugins/git/ChangelogToBranchOptions.java
+++ b/src/main/java/hudson/plugins/git/ChangelogToBranchOptions.java
@@ -34,10 +34,6 @@ public class ChangelogToBranchOptions extends AbstractDescribableImpl<ChangelogT
         return compareTarget;
     }
 
-    public String getRef() {
-        return compareRemote + "/" + compareTarget;
-    }
-
     @Extension
     public static class DescriptorImpl extends Descriptor<ChangelogToBranchOptions> {
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1317,10 +1317,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             ChangelogToBranch changelogToBranch = getExtensions().get(ChangelogToBranch.class);
             if (changelogToBranch != null) {
                 listener.getLogger().println("Using 'Changelog to branch' strategy.");
-                // Enhancement to allow to use environment variables in "Changelog to branch" behavior
+                // JENKINS-27080 NFR to allow to use environment variables in "Changelog to branch" behavior
                 String remote = getParameterString(changelogToBranch.getOptions().getCompareRemote(), env);
                 String target = getParameterString(changelogToBranch.getOptions().getCompareTarget(), env);
-                // Enhancement to allow leaving empty remote in order to compare to a local file
+                // JENKINS-51633 Improvement to allow leaving empty remote in order to compare to a local file
                 String ref = remote == null || "".equals(remote) ? target : remote +"/"+target;
                 changelog.excludes(ref);
                 exclusion = true;

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1246,7 +1246,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
 
             if (changelogFile != null) {
-                computeChangeLog(git, revToBuild.revision, listener, previousBuildData, new FilePath(changelogFile),
+                computeChangeLog(git, revToBuild.revision, listener, previousBuildData, new FilePath(changelogFile), environment,
                         new BuildChooserContextImpl(build.getParent(), build, environment));
             }
         }
@@ -1308,7 +1308,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
      *      Information that captures what we did during the last build. We need this for changelog,
      *      or else we won't know where to stop.
      */
-    private void computeChangeLog(GitClient git, Revision revToBuild, TaskListener listener, BuildData previousBuildData, FilePath changelogFile, BuildChooserContext context) throws IOException, InterruptedException {
+    private void computeChangeLog(GitClient git, Revision revToBuild, TaskListener listener, BuildData previousBuildData, FilePath changelogFile, EnvVars env, BuildChooserContext context) throws IOException, InterruptedException {
         boolean executed = false;
         ChangelogCommand changelog = git.changelog();
         changelog.includes(revToBuild.getSha1());
@@ -1317,7 +1317,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             ChangelogToBranch changelogToBranch = getExtensions().get(ChangelogToBranch.class);
             if (changelogToBranch != null) {
                 listener.getLogger().println("Using 'Changelog to branch' strategy.");
-                changelog.excludes(changelogToBranch.getOptions().getRef());
+                // Enhancement to allow to use environment variables in "Changelog to branch" behavior
+                String remote = getParameterString(changelogToBranch.getOptions().getCompareRemote(), env);
+                String target = getParameterString(changelogToBranch.getOptions().getCompareTarget(), env);
+                // Enhancement to allow leaving empty remote in order to compare to a local file
+                String ref = remote == null || "".equals(remote) ? target : remote +"/"+target;
+                changelog.excludes(ref);
                 exclusion = true;
             } else {
                 for (Branch b : revToBuild.getBranches()) {

--- a/src/main/java/hudson/plugins/git/extensions/impl/ChangelogToBranch.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/ChangelogToBranch.java
@@ -9,7 +9,7 @@ import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 
 /**
  * This extension activates the alternative changelog computation,
- * where the changelog is calculated against a specified branch.
+ * where the changelog is calculated against a specified branch or tag.
  *
  * @author <a href="mailto:dirk.reske@t-systems.com">Dirk Reske (dirk.reske@t-systems.com)</a>
  */
@@ -34,7 +34,7 @@ public class ChangelogToBranch extends GitSCMExtension {
 
         @Override
         public String getDisplayName() {
-            return "Calculate changelog against a specific branch";
+            return "Calculate changelog against a specific branch or tag";
         }
     }
 }

--- a/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/config.jelly
+++ b/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Name of repository}" field="compareRemote">
-    <f:textbox id="git.compareRemote" clazz="required" />
+    <f:textbox id="git.compareRemote" />
   </f:entry>
   <f:entry title="${%Name of branch}" field="compareTarget">
     <f:textbox id="git.compareTarget" clazz="required"/>

--- a/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/help-compareRemote.html
+++ b/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/help-compareRemote.html
@@ -1,3 +1,3 @@
 <div>
-    Name of the repository, such as <tt>origin</tt>, that contains the branch you specify below.
+    Name of the repository, such as <tt>origin</tt>, that contains the branch you specify below.  Current build parameters and/or environment variables can be used in form: ${PARAM} or $PARAM.
 </div>

--- a/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/help-compareTarget.html
+++ b/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/help-compareTarget.html
@@ -1,3 +1,3 @@
 <div>
-    The name of the branch within the named repository to compare against.
+    The name of the branch within the named repository to compare against.  Current build parameters and/or environment variables can be used in form: ${PARAM} or $PARAM.
 </div>

--- a/src/test/java/hudson/plugins/git/ChangelogToBranchOptionsTest.java
+++ b/src/test/java/hudson/plugins/git/ChangelogToBranchOptionsTest.java
@@ -50,11 +50,6 @@ public class ChangelogToBranchOptionsTest {
     }
 
     @Test
-    public void testGetRef() {
-        assertThat(options.getRef(), is(compareRemote + "/" + compareTarget));
-    }
-
-    @Test
     public void testAlternateConstructor() {
         ChangelogToBranchOptions newOptions = new ChangelogToBranchOptions(options);
         assertThat(newOptions.getCompareRemote(), is(options.getCompareRemote()));

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1166,15 +1166,15 @@ public class GitSCMTest extends AbstractGitTestCase {
     }
 
     private final Random random = new Random();
-    private boolean useChangelogToBranch = random.nextBoolean();
+    private int useChangelogToBranch = random.nextInt(4);
 
     private void addChangelogToBranchExtension(GitSCM scm) {
-        if (useChangelogToBranch) {
+        if (useChangelogToBranch > 0) {
             /* Changelog should be no different with this enabled or disabled */
-            ChangelogToBranchOptions changelogOptions = new ChangelogToBranchOptions("origin", "master");
+            ChangelogToBranchOptions changelogOptions = new ChangelogToBranchOptions(useChangelogToBranch == 1 ? "origin" : useChangelogToBranch == 2 ? "" : null, "master");
             scm.getExtensions().add(new ChangelogToBranch(changelogOptions));
         }
-        useChangelogToBranch = !useChangelogToBranch;
+        useChangelogToBranch = (useChangelogToBranch+1)%4;
     }
 
     @Test


### PR DESCRIPTION

## [JENKINS-27080](https://issues.jenkins-ci.org/browse/JENKINS-27080) - support tokens in "compare to branch" option (calculate changelog)

## [JENKINS-51633](https://issues.jenkins-ci.org/browse/JENKINS-51633) - Calculate Changelog against a specific branch should allow empty remote

My use case is to dynamically compute the difference between two tags, so I need both of these changes to accomplish what I am looking for.  

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [X ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [X ] I have added tests that verify my changes
- [X ] Unit tests pass locally with my changes
- [X ] I have added documentation as necessary
- [X ] No Javadoc warnings were introduced with my changes
- [ X] No findbugs warnings were introduced with my changes
- [X ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

The changes are non-breaking except if a job had a target branch named $PARAM and were relying on that treated as a string instead of a variable.  Such a setup seems pathological.
