### PR TITLE
Add coverage reporting instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ run tests.
 
 Code coverage reporting is available as a maven target and is actively
 monitored.  Please improve code coverage with the tests you submit.
+Code coverage reporting is written to `target/site/jacoco/` by the maven command:
+
+```
+  $ mvn -P enable-jacoco clean install jacoco:report
+```
 
 Before submitting your change, review the findbugs output to
 assure that you haven't introduced new findbugs warnings.


### PR DESCRIPTION
## Trigger build by changing README

Submit a README improvement as a low-cost technique to launch a build on ci.jenkins.io.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Documentation