### PR TITLE
Disable acceptance test harness and plugin compatibility tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 // Test plugin compatibility to recent Jenkins LTS
 // Allow failing tests to retry execution
-buildPlugin(jenkinsVersions: [null, '2.121.1'],
+buildPlugin(jenkinsVersions: [null, '2.121.2'],
             findbugs: [run:true, archive:true, unstableTotalAll: '0'],
             failFast: false)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,4 +56,5 @@ branches["PCT"] = {
     }
 }
 
-parallel branches
+// Intentionally disabled until tests are more reliable
+// parallel branches


### PR DESCRIPTION
Tests are not running reliably in local or remote environments currently.  Rather than distract with failures to investigate, return to not running those tests.

Hope to restore them later and make them regular contributors to the plugin tests.