### PR TITLE
Fix Javadoc for tests

### DIFF
--- a/src/test/java/hudson/plugins/git/AbstractGitProject.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitProject.java
@@ -169,13 +169,13 @@ public class AbstractGitProject extends AbstractGitRepository {
     /**
      * Creates a new project and configures the GitSCM according the parameters.
      *
-     * @param repos
-     * @param branchSpecs
-     * @param scmTriggerSpec
-     * @param disableRemotePoll Disable Workspace-less polling via "git
-     * ls-remote"
-     * @return
-     * @throws Exception
+     * @param repos git remote repositories
+     * @param branchSpecs branch specs
+     * @param scmTriggerSpec scm trigger spec
+     * @param disableRemotePoll disable workspace-less polling via "git ls-remote"
+     * @param enforceGitClient enforce git client
+     * @return the created project
+     * @throws Exception on error
      */
     protected FreeStyleProject setupProject(List<UserRemoteConfig> repos, List<BranchSpec> branchSpecs,
             String scmTriggerSpec, boolean disableRemotePoll, EnforceGitClient enforceGitClient) throws Exception {

--- a/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
@@ -211,12 +211,13 @@ public abstract class AbstractGitTestCase {
 
     /**
      * Creates a new project and configures the GitSCM according the parameters.
-     * @param repos
-     * @param branchSpecs
-     * @param scmTriggerSpec
-     * @param disableRemotePoll Disable Workspace-less polling via "git ls-remote"
-     * @return
-     * @throws Exception
+     * @param repos git remote repositories
+     * @param branchSpecs branch specs
+     * @param scmTriggerSpec scm trigger spec
+     * @param disableRemotePoll disable workspace-less polling via "git ls-remote"
+     * @param enforceGitClient enforce git client
+     * @return the created project
+     * @throws Exception on error
      */
     protected FreeStyleProject setupProject(List<UserRemoteConfig> repos, List<BranchSpec> branchSpecs,
                 String scmTriggerSpec, boolean disableRemotePoll, EnforceGitClient enforceGitClient) throws Exception {
@@ -311,7 +312,7 @@ public abstract class AbstractGitTestCase {
             });
     }
 
-    /** A utility method that displays a git repo. Useful to visualise merges. */
+    /* A utility method that displays a git repo. Useful to visualise merges. */
     public void showRepo(TestGitRepo repo, String msg) throws Exception {
         System.out.println("*********** "+msg+" ***********");
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {

--- a/src/test/java/hudson/plugins/git/GitChangeLogParserTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeLogParserTest.java
@@ -15,11 +15,7 @@ public class GitChangeLogParserTest {
     @Rule
     public TemporaryFolder tmpFolder = new TemporaryFolder();
 
-    /**
-     * Test duplicate changes filtered from parsed change set list.
-     *
-     * @throws Exception
-     */
+    /* Test duplicate changes filtered from parsed change set list. */
     @Test
     public void testDuplicatesFiltered() throws Exception {
         GitChangeLogParser parser = new GitChangeLogParser(true);

--- a/src/test/java/hudson/plugins/git/GitPublisherTest.java
+++ b/src/test/java/hudson/plugins/git/GitPublisherTest.java
@@ -565,9 +565,7 @@ public class GitPublisherTest extends AbstractGitProject {
         assertFalse("otherCommit2 in otherbranch", testGitClient.revList("otherbranch").contains(otherCommit2));
     }
 
-    /**
-     * Fix push to remote when skipTag is enabled
-     */
+    /* Fix push to remote when skipTag is enabled */
     @Issue("JENKINS-17769")
     @Test
     public void testMergeAndPushWithSkipTagEnabled() throws Exception {

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -168,7 +168,7 @@ public class GitSCMTest extends AbstractGitTestCase {
      * Basic test - create a GitSCM based project, check it out and build for the first time.
      * Next test that polling works correctly, make another commit, check that polling finds it,
      * then build it and finally test the build culprits as well as the contents of the workspace.
-     * @throws Exception if an exception gets thrown.
+     * @throws Exception on error
      */
     @Test
     public void testBasic() throws Exception {
@@ -480,7 +480,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertTrue("scm polling did not detect changes in server project", serverProject.poll(listener).hasChanges());
     }
 
-    /**
+    /*
      * With multiple branches specified in the project and having commits from a user
      * excluded should not build the excluded revisions when another branch changes.
      */
@@ -725,9 +725,6 @@ public class GitSCMTest extends AbstractGitTestCase {
                 johnDoe.getName(), secondCulprits.iterator().next().getFullName());
     }
 
-    /**
-     * Method name is self-explanatory.
-     */
     @Test
     public void testNewCommitToUntrackedBranchDoesNotTriggerBuild() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");
@@ -787,7 +784,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertEquals("slaveValue", getEnvVars(project).get("TESTKEY"));
     }
 
-    /**
+    /*
      * A previous version of GitSCM would only build against branches, not tags. This test checks that that
      * regression has been fixed.
      */
@@ -845,7 +842,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertFalse("scm polling should not detect any more changes after last build", project.poll(listener).hasChanges());
     }
 
-    /**
+    /*
      * Not specifying a branch string in the project implies that we should be polling for changes in
      * all branches.
      */
@@ -1484,7 +1481,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         return repoList;
     }
 
-    /**
+    /*
      * Makes sure that git browser URL is preserved across config round trip.
      */
     @Issue("JENKINS-22604")
@@ -1503,7 +1500,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertEquals("Wrong key", "git " + url, scm.getKey());
     }
 
-    /**
+    /*
      * Makes sure that git extensions are preserved across config round trip.
      */
     @Issue("JENKINS-33695")
@@ -1541,7 +1538,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertEquals(localBranchExtension.getLocalBranch(), reloadedLocalBranch.getLocalBranch());
     }
 
-    /**
+    /*
      * Makes sure that the configuration form works.
      */
     @Test
@@ -1553,7 +1550,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         rule.assertEqualDataBoundBeans(scm,p.getScm());
     }
 
-    /**
+    /*
      * Sample configuration that should result in no extensions at all
      */
     @Test
@@ -1611,11 +1608,10 @@ public class GitSCMTest extends AbstractGitTestCase {
      * that the checkout to a local branch using remote branch name sans 'origin'.
      * This feature is necessary to support Maven release builds that push updated
      * pom.xml to remote branch as 
-     * <br/>
      * <pre>
      * git push origin localbranch:localbranch
      * </pre>
-     * @throws Exception
+     * @throws Exception on error
      */
     @Test
     public void testCheckoutToDefaultLocalBranch_StarStar() throws Exception {
@@ -1636,11 +1632,10 @@ public class GitSCMTest extends AbstractGitTestCase {
      * that the checkout to a local branch using remote branch name sans 'origin'.
      * This feature is necessary to support Maven release builds that push updated
      * pom.xml to remote branch as 
-     * <br/>
      * <pre>
      * git push origin localbranch:localbranch
      * </pre>
-     * @throws Exception
+     * @throws Exception on error
      */
     @Test
     public void testCheckoutToDefaultLocalBranch_NULL() throws Exception {
@@ -1656,10 +1651,9 @@ public class GitSCMTest extends AbstractGitTestCase {
        assertEquals("GIT_LOCAL_BRANCH", "master", getEnvVars(project).get(GitSCM.GIT_LOCAL_BRANCH));
     }
 
-    /**
+    /*
      * Verifies that GIT_LOCAL_BRANCH is not set if LocalBranch extension
      * is not configured.
-     * @throws Exception
      */
     @Test
     public void testCheckoutSansLocalBranchExtension() throws Exception {
@@ -1673,10 +1667,9 @@ public class GitSCMTest extends AbstractGitTestCase {
        assertEquals("GIT_LOCAL_BRANCH", null, getEnvVars(project).get(GitSCM.GIT_LOCAL_BRANCH));
     }
     
-     /**
+    /*
      * Verifies that GIT_CHECKOUT_DIR is set to "checkoutDir" if RelativeTargetDirectory extension
      * is configured.
-     * @throws Exception
      */
     @Test
     public void testCheckoutRelativeTargetDirectoryExtension() throws Exception {
@@ -1690,10 +1683,10 @@ public class GitSCMTest extends AbstractGitTestCase {
 
        assertEquals("GIT_CHECKOUT_DIR", "checkoutDir", getEnvVars(project).get(GitSCM.GIT_CHECKOUT_DIR));
     }
-    /**
+
+    /*
      * Verifies that GIT_CHECKOUT_DIR is not set if RelativeTargetDirectory extension
      * is not configured.
-     * @throws Exception
      */
     @Test
     public void testCheckoutSansRelativeTargetDirectoryExtension() throws Exception {
@@ -1851,11 +1844,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertFalse(build1.getWorkspace().child(commitFile1).exists());
     }
 
-    /**
-     * Test for JENKINS-22009.
-     *
-     * @throws Exception
-     */
+    @Issue("JENKINS-22009")
     @Test
     public void testPolling_environmentValueInBranchSpec() throws Exception {
         // create parameterized project with environment value in branch specification
@@ -2016,11 +2005,7 @@ public class GitSCMTest extends AbstractGitTestCase {
 		assertFalse(pollingResult.hasChanges());
 	}
 
-    /**
-     * Test for JENKINS-24467.
-     *
-     * @throws Exception
-     */
+    @Issue("JENKINS-24467")
     @Test
     public void testPolling_environmentValueAsEnvironmentContributingAction() throws Exception {
         // create parameterized project with environment value in branch specification
@@ -2063,9 +2048,8 @@ public class GitSCMTest extends AbstractGitTestCase {
     }
 
     /**
-     * Tests that builds have the correctly specified Custom SCM names, associated with
-     * each build.
-     * @throws Exception on various exceptions
+     * Tests that builds have the correctly specified Custom SCM names, associated with each build.
+     * @throws Exception on error
      */
     // Flaky test distracting from primary goal
     // @Test
@@ -2133,7 +2117,7 @@ public class GitSCMTest extends AbstractGitTestCase {
      * @param expectedScmName Expected SCM name for commit.
      * @param ordinal number of commit to log into errors, if any
      * @param git git SCM
-     * @throws Exception on various exceptions occur
+     * @throws Exception on error
      */
     private int notifyAndCheckScmName(FreeStyleProject project, ObjectId commit,
             String expectedScmName, int ordinal, GitSCM git, ObjectId... priorCommits) throws Exception {
@@ -2162,10 +2146,9 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertEquals("Wrong SCM Name", expectedScmName, buildData.getScmName());
     }
 
-    /**
+    /*
      * Tests that builds have the correctly specified branches, associated with
      * the commit id, passed with "notifyCommit" URL.
-     * @throws Exception on various exceptions
      */
     @Issue("JENKINS-24133")
     // Flaky test distracting from primary focus
@@ -2383,7 +2366,7 @@ public class GitSCMTest extends AbstractGitTestCase {
      * @param expectedBranch branch, that is expected to be built
      * @param ordinal number of commit to log into errors, if any
      * @param git git SCM
-     * @throws Exception on various exceptions occur
+     * @throws Exception on error
      */
     private void notifyAndCheckBranch(FreeStyleProject project, ObjectId commit,
             String expectedBranch, int ordinal, GitSCM git) throws Exception {
@@ -2406,7 +2389,7 @@ public class GitSCMTest extends AbstractGitTestCase {
      * @param project project to trigger
      * @return whether the new build has been triggered (<code>true</code>) or
      *         not (<code>false</code>).
-     * @throws Exception on various exceptions
+     * @throws Exception on error
      */
     private boolean notifyCommit(FreeStyleProject project, ObjectId commitId) throws Exception {
         final int initialBuildNumber = project.getLastBuild().getNumber();

--- a/src/test/java/hudson/plugins/git/browser/BitbucketWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/BitbucketWebTest.java
@@ -21,47 +21,28 @@ import org.junit.Test;
 
 /**
  * @author mattsemar
- *
  */
 public class BitbucketWebTest {
 
     private static final String BITBUCKET_URL = "http://bitbucket.org/USER/REPO";
     private final BitbucketWeb bitbucketWeb = new BitbucketWeb(BITBUCKET_URL);
 
-    /**
-     * Test method for {@link BitbucketWeb#getUrl()}.
-     * @throws java.net.MalformedURLException
-     */
     @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(bitbucketWeb.getUrl()), BITBUCKET_URL + "/");
     }
 
-    /**
-     * Test method for {@link BitbucketWeb#getUrl()}.
-     * @throws java.net.MalformedURLException
-     */
     @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new BitbucketWeb(BITBUCKET_URL + "/").getUrl()), BITBUCKET_URL + "/");
     }
 
-    /**
-     * Test method for {@link BitbucketWeb#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
-     * throws SAXException on XML serialization error
-     * throws IOException on I/O error
-     */
     @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = bitbucketWeb.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(BITBUCKET_URL + "/commits/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
     }
 
-    /**
-     * Test method for {@link BitbucketWeb#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * throws SAXException on XML serialization error
-     * throws IOException on I/O error
-     */
     @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -78,11 +59,6 @@ public class BitbucketWebTest {
         assertNull("Do not return a diff link for added files.", bitbucketWeb.getDiffLink(path3));
     }
 
-    /**
-     * Test method for {@link GithubWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * throws SAXException on XML serialization error
-     * throws IOException on I/O error
-     */
     @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
@@ -91,11 +67,6 @@ public class BitbucketWebTest {
         assertEquals(BITBUCKET_URL + "/history/src/main/java/hudson/plugins/git/browser/GithubWeb.java", String.valueOf(fileLink));
     }
 
-    /**
-     * Test method for {@link BitbucketWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * throws SAXException on XML serialization error
-     * throws IOException on I/O error
-     */
     @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
@@ -110,12 +81,6 @@ public class BitbucketWebTest {
         return changeSetList.get(0);
     }
 
-    /**
-     * @param changelog
-     * @return
-     * throws IOException on I/O error
-     * throws SAXException on XML serialization error
-     */
     private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
         final HashMap<String, Path> pathMap = new HashMap<>();
         final Collection<Path> changeSet = createChangeSet(changelog).getPaths();
@@ -124,6 +89,4 @@ public class BitbucketWebTest {
         }
         return pathMap;
     }
-
-
 }

--- a/src/test/java/hudson/plugins/git/browser/GitLabTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitLabTest.java
@@ -37,9 +37,6 @@ public class GitLabTest {
     private final String SHA1 = "396fc230a3db05c427737aa5c2eb7856ba72b05d";
     private final String fileName = "src/main/java/hudson/plugins/git/browser/GithubWeb.java";
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitLab#getVersion()}.
-     */
     @Test
     public void testGetVersion() {
         assertEquals(2.9, gitlab29.getVersion(), .001);
@@ -54,12 +51,6 @@ public class GitLabTest {
         assertEquals(9999.0, gitlabGreater.getVersion(), .001);
     }
 
-    /**
-     * Test method for
-     * {@link hudson.plugins.git.browser.GitLab#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
-     *
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final GitChangeSet changeSet = createChangeSet("rawchangelog");
@@ -77,12 +68,6 @@ public class GitLabTest {
         assertEquals(expectedURL, gitlabGreater.getChangeSetLink(changeSet).toString());
     }
 
-    /**
-     * Test method for
-     * {@link hudson.plugins.git.browser.GitLab#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
-     *
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -106,12 +91,6 @@ public class GitLabTest {
         assertEquals(expectedDefault, gitlabInfinity.getDiffLink(modified1).toString());
     }
 
-    /**
-     * Test method for
-     * {@link hudson.plugins.git.browser.GitLab#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     *
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -132,12 +111,6 @@ public class GitLabTest {
         assertEquals(expectedURL, gitlabGreater.getFileLink(path).toString());
     }
 
-    /**
-     * Test method for
-     * {@link hudson.plugins.git.browser.GitLab#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     *
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
@@ -179,5 +152,4 @@ public class GitLabTest {
         }
         return pathMap;
     }
-
 }

--- a/src/test/java/hudson/plugins/git/browser/GitListTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitListTest.java
@@ -25,47 +25,28 @@ import org.xml.sax.SAXException;
 /**
  * @author mirko
  * @author fauxpark
- *
  */
 public class GitListTest {
 
     private static final String GITLIST_URL = "http://gitlist.org/REPO";
     private final GitList gitlist = new GitList(GITLIST_URL);
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitList#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(gitlist.getUrl()), GITLIST_URL + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitList#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new GitList(GITLIST_URL + "/").getUrl()), GITLIST_URL + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitList#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = gitlist.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(GITLIST_URL + "/commit/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitList#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -77,11 +58,6 @@ public class GitListTest {
         assertNull("Do not return a diff link for added files.", gitlist.getDiffLink(path3));
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitList#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
@@ -90,11 +66,6 @@ public class GitListTest {
         assertEquals(GITLIST_URL + "/blob/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/main/java/hudson/plugins/git/browser/GithubWeb.java", String.valueOf(fileLink));
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitList#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
@@ -109,12 +80,6 @@ public class GitListTest {
         return changeSetList.get(0);
     }
 
-    /**
-     * @param changelog
-     * @return
-     * @throws IOException on input or output error
-     * @throws SAXException on XML parsing exception
-     */
     private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
         final HashMap<String, Path> pathMap = new HashMap<>();
         final Collection<Path> changeSet = createChangeSet(changelog).getPaths();

--- a/src/test/java/hudson/plugins/git/browser/GitWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitWebTest.java
@@ -24,32 +24,17 @@ public class GitWebTest {
     private static final String GITWEB_URL = "https://SERVER/gitweb?repo.git";
     private final GitWeb gitwebWeb = new GitWeb(GITWEB_URL);
 
-
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitWeb#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(gitwebWeb.getUrl()), GITWEB_URL);
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitWeb#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = gitwebWeb.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(GITWEB_URL + "&a=commit&h=396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitWeb#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -57,11 +42,6 @@ public class GitWebTest {
         assertEquals(GITWEB_URL + "&a=blobdiff&f=src/main/java/hudson/plugins/git/browser/GithubWeb.java&fp=src/main/java/hudson/plugins/git/browser/GithubWeb.java&h=3f28ad75f5ecd5e0ea9659362e2eef18951bd451&hp=2e0756cd853dccac638486d6aab0e74bc2ef4041&hb=396fc230a3db05c427737aa5c2eb7856ba72b05d&hpb=f28f125f4cc3e5f6a32daee6a26f36f7b788b8ff", gitwebWeb.getDiffLink(modified1).toString());
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
@@ -70,11 +50,6 @@ public class GitWebTest {
         assertEquals(GITWEB_URL  + "&a=blob&f=src/main/java/hudson/plugins/git/browser/GithubWeb.java&h=2e0756cd853dccac638486d6aab0e74bc2ef4041&hb=396fc230a3db05c427737aa5c2eb7856ba72b05d", String.valueOf(fileLink));
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
@@ -89,12 +64,6 @@ public class GitWebTest {
         return changeSetList.get(0);
     }
 
-    /**
-     * @param changelog
-     * @return
-     * @throws IOException on input or output error
-     * @throws SAXException on XML parsing exception
-     */
     private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
         final HashMap<String, Path> pathMap = new HashMap<>();
         final Collection<Path> changeSet = createChangeSet(changelog).getPaths();
@@ -103,6 +72,4 @@ public class GitWebTest {
         }
         return pathMap;
     }
-
-
 }

--- a/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
@@ -30,48 +30,28 @@ import org.xml.sax.SAXException;
 
 /**
  * @author mirko
- *
  */
 public class GithubWebTest {
 
     private static final String GITHUB_URL = "http://github.com/USER/REPO";
     private final GithubWeb githubWeb = new GithubWeb(GITHUB_URL);
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(githubWeb.getUrl()), GITHUB_URL  + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new GithubWeb(GITHUB_URL + "/").getUrl()), GITHUB_URL  + "/");
     }
 
-
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = githubWeb.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(GITHUB_URL + "/commit/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -83,11 +63,6 @@ public class GithubWebTest {
         assertNull("Do not return a diff link for added files.", githubWeb.getDiffLink(path3));
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
@@ -96,11 +71,6 @@ public class GithubWebTest {
         assertEquals(GITHUB_URL  + "/blob/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/main/java/hudson/plugins/git/browser/GithubWeb.java", String.valueOf(fileLink));
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
@@ -130,6 +100,7 @@ public class GithubWebTest {
             }
         }
     }
+
     private void assertGuessURL(String repo, String web) {
         RepositoryBrowser<?> guess = new GitSCM(repo).guessBrowser();
         String actual = guess instanceof GithubWeb ? ((GithubWeb) guess).getRepoUrl() : null;
@@ -144,11 +115,13 @@ public class GithubWebTest {
         // like GitHubSCMSource:
         assertGuessURL("https://github.com/kohsuke/msv.git", "https://github.com/kohsuke/msv/", "+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*/merge:refs/remotes/origin/pr/*");
     }
+
     private void assertGuessURL(String remote, String web, String... refSpecs) {
         RepositoryBrowser<?> guess = new MockSCMSource(remote, refSpecs).build(new SCMHead("master")).guessBrowser();
         String actual = guess instanceof GithubWeb ? ((GithubWeb) guess).getRepoUrl() : null;
         assertEquals(web, actual);
     }
+
     private static class MockSCMSource extends AbstractGitSCMSource {
         private final String remote;
         private final String[] refSpecs;
@@ -188,12 +161,6 @@ public class GithubWebTest {
         return changeSetList.get(0);
     }
 
-    /**
-     * @param changelog
-     * @return
-     * @throws IOException on input or output error
-     * @throws SAXException on XML parsing exception
-     */
     private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
         final HashMap<String, Path> pathMap = new HashMap<>();
         final Collection<Path> changeSet = createChangeSet(changelog).getPaths();
@@ -202,6 +169,4 @@ public class GithubWebTest {
         }
         return pathMap;
     }
-
-
 }

--- a/src/test/java/hudson/plugins/git/browser/GitoriousWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitoriousWebTest.java
@@ -24,41 +24,22 @@ public class GitoriousWebTest {
     private static final String GITORIOUS_URL = "https://SERVER/PROJECT";
     private final GitoriousWeb gitoriousWeb = new GitoriousWeb(GITORIOUS_URL);
 
-
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitoriousWeb#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(gitoriousWeb.getUrl()), GITORIOUS_URL  + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitoriousWeb#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new GitoriousWeb(GITORIOUS_URL + "/").getUrl()), GITORIOUS_URL  + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitoriousWeb#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = gitoriousWeb.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(GITORIOUS_URL + "/commit/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GitoriousWeb#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -69,11 +50,6 @@ public class GitoriousWebTest {
         assertEquals(GITORIOUS_URL + "/commit/396fc230a3db05c427737aa5c2eb7856ba72b05d/diffs?diffmode=sidebyside&fragment=1#src/test/resources/hudson/plugins/git/browser/rawchangelog-with-deleted-file", gitoriousWeb.getDiffLink(added).toString());
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
@@ -82,11 +58,6 @@ public class GitoriousWebTest {
         assertEquals(GITORIOUS_URL  + "/blobs/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/main/java/hudson/plugins/git/browser/GithubWeb.java", String.valueOf(fileLink));
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
@@ -101,12 +72,6 @@ public class GitoriousWebTest {
         return changeSetList.get(0);
     }
 
-    /**
-     * @param changelog
-     * @return
-     * @throws IOException on input or output error
-     * @throws SAXException on XML parsing exception
-     */
     private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
         final HashMap<String, Path> pathMap = new HashMap<>();
         final Collection<Path> changeSet = createChangeSet(changelog).getPaths();
@@ -115,6 +80,4 @@ public class GitoriousWebTest {
         }
         return pathMap;
     }
-
-
 }

--- a/src/test/java/hudson/plugins/git/browser/GogsGitTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GogsGitTest.java
@@ -26,41 +26,22 @@ public class GogsGitTest {
     private static final String GOGS_URL = "http://USER.kilnhg.com/Code/PROJECT/Group/REPO";
     private final GogsGit GogsGit = new GogsGit(GOGS_URL);
 
-
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GogsGit#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(GogsGit.getUrl()), GOGS_URL  + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GogsGit#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new GogsGit(GOGS_URL + "/").getUrl()), GOGS_URL  + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GogsGit#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = GogsGit.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(GOGS_URL + "/commit/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GogsGit#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -72,11 +53,6 @@ public class GogsGitTest {
         assertNull("Do not return a diff link for added files.", GogsGit.getDiffLink(path3));
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GogsGit#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
@@ -85,11 +61,6 @@ public class GogsGitTest {
         assertEquals(GOGS_URL  + "/src/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/main/java/hudson/plugins/git/browser/GithubWeb.java", String.valueOf(fileLink));
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GogsGit#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
@@ -104,12 +75,6 @@ public class GogsGitTest {
         return changeSetList.get(0);
     }
 
-    /**
-     * @param changelog
-     * @return path map
-     * @throws IOException on input or output error
-     * @throws SAXException on XML parsing exception
-     */
     private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
         final HashMap<String, Path> pathMap = new HashMap<>();
         final Collection<Path> changeSet = createChangeSet(changelog).getPaths();
@@ -118,6 +83,4 @@ public class GogsGitTest {
         }
         return pathMap;
     }
-
-
 }

--- a/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
+++ b/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
@@ -26,41 +26,22 @@ public class KilnGitTest {
     private static final String KILN_URL = "http://USER.kilnhg.com/Code/PROJECT/Group/REPO";
     private final KilnGit kilnGit = new KilnGit(KILN_URL);
 
-
-    /**
-     * Test method for {@link hudson.plugins.git.browser.KilnGit#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(kilnGit.getUrl()), KILN_URL  + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.KilnGit#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new KilnGit(KILN_URL + "/").getUrl()), KILN_URL  + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.KilnGit#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = kilnGit.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(KILN_URL + "/History/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.KilnGit#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -72,11 +53,6 @@ public class KilnGitTest {
         assertNull("Do not return a diff link for added files.", kilnGit.getDiffLink(path3));
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.KilnGit#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
@@ -85,11 +61,6 @@ public class KilnGitTest {
         assertEquals(KILN_URL  + "/FileHistory/src/main/java/hudson/plugins/git/browser/GithubWeb.java?rev=396fc230a3db05c427737aa5c2eb7856ba72b05d", String.valueOf(fileLink));
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.KilnGit#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
@@ -104,12 +75,6 @@ public class KilnGitTest {
         return changeSetList.get(0);
     }
 
-    /**
-     * @param changelog
-     * @return
-     * @throws IOException on input or output error
-     * @throws SAXException on XML parsing exception
-     */
     private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
         final HashMap<String, Path> pathMap = new HashMap<>();
         final Collection<Path> changeSet = createChangeSet(changelog).getPaths();
@@ -118,6 +83,4 @@ public class KilnGitTest {
         }
         return pathMap;
     }
-
-
 }

--- a/src/test/java/hudson/plugins/git/browser/RedmineWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/RedmineWebTest.java
@@ -25,40 +25,22 @@ public class RedmineWebTest {
     private static final String REDMINE_URL = "https://SERVER/PATH/projects/PROJECT/repository";
     private final RedmineWeb redmineWeb = new RedmineWeb(REDMINE_URL);
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.RedmineWeb#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(redmineWeb.getUrl()), REDMINE_URL  + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.RedmineWeb#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new RedmineWeb(REDMINE_URL + "/").getUrl()), REDMINE_URL  + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.RedmineWeb#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = redmineWeb.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(REDMINE_URL + "/diff?rev=396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.RedmineWeb#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -71,11 +53,6 @@ public class RedmineWebTest {
         assertEquals(REDMINE_URL + "/revisions/396fc230a3db05c427737aa5c2eb7856ba72b05d/entry/src/test/resources/hudson/plugins/git/browser/rawchangelog-with-deleted-file", redmineWeb.getDiffLink(added).toString());
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
@@ -84,11 +61,6 @@ public class RedmineWebTest {
         assertEquals(REDMINE_URL  + "/revisions/396fc230a3db05c427737aa5c2eb7856ba72b05d/entry/src/main/java/hudson/plugins/git/browser/GithubWeb.java", String.valueOf(fileLink));
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
@@ -103,12 +75,6 @@ public class RedmineWebTest {
         return changeSetList.get(0);
     }
 
-    /**
-     * @param changelog
-     * @return
-     * @throws IOException on input or output error
-     * @throws SAXException on XML parsing exception
-     */
     private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
         final HashMap<String, Path> pathMap = new HashMap<>();
         final Collection<Path> changeSet = createChangeSet(changelog).getPaths();
@@ -117,6 +83,4 @@ public class RedmineWebTest {
         }
         return pathMap;
     }
-
-
 }

--- a/src/test/java/hudson/plugins/git/browser/RhodeCodeTest.java
+++ b/src/test/java/hudson/plugins/git/browser/RhodeCodeTest.java
@@ -24,40 +24,22 @@ public class RhodeCodeTest {
     private static final String RHODECODE_URL = "https://SERVER/r/PROJECT";
     private final RhodeCode rhodecode = new RhodeCode(RHODECODE_URL);
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.RhodeCode#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(rhodecode.getUrl()), RHODECODE_URL  + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.RhodeCode#getUrl()}.
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new RhodeCode(RHODECODE_URL + "/").getUrl()), RHODECODE_URL  + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.RhodeCode#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = rhodecode.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals(RHODECODE_URL + "/changeset/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.RhodeCode#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -68,11 +50,6 @@ public class RhodeCodeTest {
         assertEquals(RHODECODE_URL + "/diff/src/main/java/hudson/plugins/git/browser/GithubWeb.java?diff2=f28f125f4cc3e5f6a32daee6a26f36f7b788b8ff&diff1=396fc230a3db05c427737aa5c2eb7856ba72b05d&diff=diff+to+revision", rhodecode.getDiffLink(added).toString());
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
@@ -81,11 +58,6 @@ public class RhodeCodeTest {
         assertEquals(RHODECODE_URL  + "/files/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/main/java/hudson/plugins/git/browser/GithubWeb.java", String.valueOf(fileLink));
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.GithubWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
@@ -100,12 +72,6 @@ public class RhodeCodeTest {
         return changeSetList.get(0);
     }
 
-    /**
-     * @param changelog
-     * @return
-     * @throws IOException on input or output error
-     * @throws SAXException on XML parsing exception
-     */
     private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
         final HashMap<String, Path> pathMap = new HashMap<>();
         final Collection<Path> changeSet = createChangeSet(changelog).getPaths();
@@ -114,6 +80,4 @@ public class RhodeCodeTest {
         }
         return pathMap;
     }
-
-
 }

--- a/src/test/java/hudson/plugins/git/browser/ViewGitWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/ViewGitWebTest.java
@@ -27,48 +27,22 @@ public class ViewGitWebTest {
     private static final String PROJECT_NAME = "PROJECT";
     private final ViewGitWeb viewGitWeb = new ViewGitWeb(VIEWGIT_URL, PROJECT_NAME);
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.ViewGitWeb#getUrl()}.
-     * 
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrl() throws IOException {
         assertEquals(String.valueOf(viewGitWeb.getUrl()), VIEWGIT_URL + "/");
     }
 
-    /**
-     * Test method for {@link hudson.plugins.git.browser.ViewGitWeb#getUrl()}.
-     * 
-     * @throws MalformedURLException
-     */
     @Test
     public void testGetUrlForRepoWithTrailingSlash() throws IOException {
         assertEquals(String.valueOf(new ViewGitWeb(VIEWGIT_URL + "/", PROJECT_NAME).getUrl()), VIEWGIT_URL + "/");
     }
 
-    /**
-     * Test method for
-     * {@link hudson.plugins.git.browser.ViewGitWeb#getChangeSetLink(hudson.plugins.git.GitChangeSet)}
-     * .
-     * 
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
         final URL changeSetLink = viewGitWeb.getChangeSetLink(createChangeSet("rawchangelog"));
         assertEquals("http://SERVER/viewgit/?p=PROJECT&a=commit&h=396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
     }
 
-    /**
-     * Test method for
-     * {@link hudson.plugins.git.browser.ViewGitWeb#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}
-     * .
-     * 
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetDiffLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -80,14 +54,6 @@ public class ViewGitWebTest {
         assertNull("Do not return a diff link for added files.", viewGitWeb.getDiffLink(path3));
     }
 
-    /**
-     * Test method for
-     * {@link hudson.plugins.git.browser.ViewGitWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}
-     * .
-     * 
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPath() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
@@ -105,14 +71,6 @@ public class ViewGitWebTest {
 
     }
 
-    /**
-     * Test method for
-     * {@link hudson.plugins.git.browser.ViewGitWeb#getFileLink(hudson.plugins.git.GitChangeSet.Path)}
-     * .
-     * 
-     * @throws SAXException on XML parsing exception
-     * @throws IOException on input or output error
-     */
     @Test
     public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
         final HashMap<String, Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
@@ -127,12 +85,6 @@ public class ViewGitWebTest {
         return changeSetList.get(0);
     }
 
-    /**
-     * @param changelog
-     * @return
-     * @throws IOException on input or output error
-     * @throws SAXException on XML parsing exception
-     */
     private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
         final HashMap<String, Path> pathMap = new HashMap<>();
         final Collection<Path> changeSet = createChangeSet(changelog).getPaths();
@@ -141,5 +93,4 @@ public class ViewGitWebTest {
         }
         return pathMap;
     }
-
 }

--- a/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
@@ -41,7 +41,7 @@ public abstract class GitSCMExtensionTest {
 	/**
 	 * The {@link GitSCMExtension} being tested - this will be added to the
 	 * project built in {@link #setupBasicProject(TestGitRepo)}
-	 * @return
+	 * @return the extension
 	 */
 	protected abstract GitSCMExtension getExtension();
 
@@ -57,9 +57,9 @@ public abstract class GitSCMExtensionTest {
 	 * Create a {@link FreeStyleProject} configured with a {@link GitSCM}
 	 * building on the {@code master} branch of the provided {@code repo},
 	 * and with the extension described in {@link #getExtension()} added.
-	 * @param repo
-	 * @return
-	 * @throws Exception
+	 * @param repo git repository
+	 * @return the created project
+	 * @throws Exception on error
 	 */
 	protected FreeStyleProject setupBasicProject(TestGitRepo repo) throws Exception {
 		GitSCMExtension extension = getExtension();

--- a/src/test/java/hudson/plugins/git/util/CandidateRevisionsTest.java
+++ b/src/test/java/hudson/plugins/git/util/CandidateRevisionsTest.java
@@ -40,7 +40,7 @@ public class CandidateRevisionsTest extends AbstractGitRepository {
                 .getClient();
     }
 
-    /**
+    /*
      * Regression test for a bug that accidentally resulted in empty build
      * candidates.
      *
@@ -115,8 +115,8 @@ public class CandidateRevisionsTest extends AbstractGitRepository {
     }
 
     /**
-     * inline ${@link hudson.Functions#isWindows()} to prevent a transient
-     * remote classloader issue
+     * Inline ${@link hudson.Functions#isWindows()} to prevent a transient
+     * remote classloader issue.
      */
     private boolean isWindows() {
         return File.pathSeparatorChar == ';';

--- a/src/test/java/hudson/plugins/git/util/CommitTimeComparatorTest.java
+++ b/src/test/java/hudson/plugins/git/util/CommitTimeComparatorTest.java
@@ -17,11 +17,8 @@ import org.junit.Test;
  */
 public class CommitTimeComparatorTest extends AbstractGitRepository {
 
-    /**
-     * Verifies that the sort is old to new.
-     */
     @Test
-    public void testSort() throws Exception {
+    public void testSort_OrderIsOldToNew() throws Exception {
         boolean first = true;
         // create repository with three commits
         for (int i=0; i<3; i++) {

--- a/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
@@ -30,10 +30,8 @@ public class DefaultBuildChooserTest extends AbstractGitRepository {
         candidateRevisions = buildChooser.getCandidateRevisions(false, "aaa" + shaHashCommit1.substring(3), testGitClient, null, null, null);
         assertTrue(candidateRevisions.isEmpty());
     }
-    /**
-     * RegExp patterns prefixed with : should pass through to DefaultBuildChooser.getAdvancedCandidateRevisions
-     * @throws Exception
-     */
+
+    /* RegExp patterns prefixed with : should pass through to DefaultBuildChooser.getAdvancedCandidateRevisions */
     @Test
     public void testIsAdvancedSpec() throws Exception {
         DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceRetrieveHeadsTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceRetrieveHeadsTest.java
@@ -59,9 +59,9 @@ public class AbstractGitSCMSourceRetrieveHeadsTest {
         PowerMockito.doReturn(mockedTool).when(gitSCMSource).resolveGitTool(EXPECTED_GIT_EXE, TaskListener.NULL);
     }
 
-    /**
-     *  Validate that the correct git installation is used when fetching latest heads.
-     *  That means {@link Git#using(String)} is called properly.
+    /*
+     * Validate that the correct git installation is used when fetching latest heads.
+     * That means {@link Git#using(String)} is called properly.
      */
     @Test(expected = GitToolSpecified.class)
     public void correctGitToolIsUsed() throws Exception {
@@ -73,9 +73,9 @@ public class AbstractGitSCMSourceRetrieveHeadsTest {
         }
     }
 
-    /**
-     *  Validate that the correct git installation is used when fetching latest heads.
-     *  That means {@link Git#using(String)} is called properly.
+    /*
+     * Validate that the correct git installation is used when fetching latest heads.
+     * That means {@link Git#using(String)} is called properly.
      */
     @Test(expected = GitToolSpecified.class)
     public void correctGitToolIsUsed2() throws Exception {

--- a/src/test/java/jenkins/plugins/git/CliGitCommand.java
+++ b/src/test/java/jenkins/plugins/git/CliGitCommand.java
@@ -141,7 +141,7 @@ public class CliGitCommand {
      * values assigned for user.name and user.email. This method checks the
      * existing values, and if they are not set, assigns default values. If the
      * values are already set, they are unchanged.
-     * @throws java.lang.Exception
+     * @throws Exception on error
      */
     public void setDefaults() throws Exception {
         setConfigIfEmpty("user.name", "Name From Git-Plugin-Test");

--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -85,7 +85,6 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         r.waitUntilNoActivity();
     }
 
-    /** Returns the (full) commit hash of the current {@link Constants#HEAD} of the repository. */
     public String head() throws Exception {
         return new RepositoryBuilder().setWorkTree(sampleRepo).build().resolve(Constants.HEAD).name();
     }


### PR DESCRIPTION
## Fix Javadoc for tests

Now `mvn javadoc:test-javadoc` runs without any errors.
    
Changes
* remove Javadocs that don't provide useful information
* add missing descriptions to make Javadoc valid
* convert Javadoc to normal comment where possible

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes

Points that don't apply
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] I have added documentation as necessary
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)