### PR TITLE
[JENKINS-44720] Update submodules in parallel

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -200,7 +200,7 @@ public class SubmoduleOption extends GitSCMExtension {
      */
     @Override
     public int hashCode() {
-        return Objects.hash(disableSubmodules, recursiveSubmodules, trackingSubmodules, parentCredentials, reference, timeout, shallow, depth);
+        return Objects.hash(disableSubmodules, recursiveSubmodules, trackingSubmodules, parentCredentials, reference, timeout, shallow, depth, threads);
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -45,9 +45,10 @@ public class SubmoduleOption extends GitSCMExtension {
     /** Use --depth flag on submodule update command - requires git>=1.8.4 */
     private boolean shallow;
     private Integer depth;
+    private Integer threads;
 
     @DataBoundConstructor
-    public SubmoduleOption(boolean disableSubmodules, boolean recursiveSubmodules, boolean trackingSubmodules, String reference,Integer timeout, boolean parentCredentials) {
+    public SubmoduleOption(boolean disableSubmodules, boolean recursiveSubmodules, boolean trackingSubmodules, String reference, Integer timeout, boolean parentCredentials) {
         this.disableSubmodules = disableSubmodules;
         this.recursiveSubmodules = recursiveSubmodules;
         this.trackingSubmodules = trackingSubmodules;
@@ -98,6 +99,15 @@ public class SubmoduleOption extends GitSCMExtension {
         return depth;
     }
 
+    public Integer getThreads() {
+        return threads;
+    }
+
+    @DataBoundSetter
+    public void setThreads(Integer threads) {
+        this.threads = threads;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -132,6 +142,8 @@ public class SubmoduleOption extends GitSCMExtension {
                     listener.getLogger().println("Using shallow submodule update with depth " + usedDepth);
                     cmd.depth(usedDepth);
                 }
+                int usedThreads = threads == null || threads < 1 ? 1 : threads;
+                cmd.threads(usedThreads);
                 cmd.execute();
             }
         } catch (GitException e) {
@@ -195,6 +207,9 @@ public class SubmoduleOption extends GitSCMExtension {
         if (depth != null ? !depth.equals(that.depth) : that.depth != null) {
             return false;
         }
+        if (threads != null ? !threads.equals(that.threads) : that.threads == null) {
+            return false;
+        }
         return true;
     }
 
@@ -220,6 +235,7 @@ public class SubmoduleOption extends GitSCMExtension {
                 ", timeout=" + timeout +
                 ", shallow=" + shallow +
                 ", depth=" + depth +
+                ", threads=" + threads +
                 '}';
     }
 

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
@@ -26,6 +26,9 @@ f.entry(title:_("Path of the reference repo to use during submodule update"), fi
 f.entry(title:_("Timeout (in minutes) for submodules operations"), field:"timeout") {
     f.number(clazz:"number", min:1, step:1)
 }
+f.entry(title:_("Number of threads to use when updating submodules"), field:"threads") {
+    f.number(clazz:"number", min:1, step:1)
+}
 
 /*
   This needs more thought

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
@@ -121,7 +121,8 @@ public class GitSCMSourceTraitsTest {
                                                 hasProperty("parentCredentials", is(true)),
                                                 hasProperty("timeout", is(4)),
                                                 hasProperty("shallow", is(true)),
-                                                hasProperty("depth", is(3))
+                                                hasProperty("depth", is(3)),
+                                                hasProperty("threads", is(4))
                                         )
                                 )
                         ),

--- a/src/test/resources/jenkins/plugins/git/GitSCMSourceTraitsTest/pimpped_out.xml
+++ b/src/test/resources/jenkins/plugins/git/GitSCMSourceTraitsTest/pimpped_out.xml
@@ -31,6 +31,7 @@
       <timeout>4</timeout>
       <shallow>true</shallow>
       <depth>3</depth>
+      <threads>4</threads>
     </hudson.plugins.git.extensions.impl.SubmoduleOption>
     <hudson.plugins.git.extensions.impl.ChangelogToBranch>
       <options>


### PR DESCRIPTION
## [JENKINS-44720](https://issues.jenkins-ci.org/browse/JENKINS-44720) - support updating submodules in parallel

This change exposes the `threads` property of the `SubmoduleUpdateCommand` (added in https://github.com/jenkinsci/git-client-plugin/pull/348), which allows for git submodules to be updated in parallel. This can greatly improve cloning/checkout times for repositories which have many submodules.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)

## Further comments

Do I need to also add support for this property in `GitSCMBackwardCompatibility`? I'm not entirely sure as to the purpose of this class, but as far as I can see, it's for older properties which have been deprecated/moved elsewhere. My understanding is that a new property shouldn't need to touch this file, is that correct?