### PR TITLE
Make GitLab version optional

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/GitLab.java
+++ b/src/main/java/hudson/plugins/git/browser/GitLab.java
@@ -10,6 +10,7 @@ import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
@@ -27,10 +28,7 @@ public class GitLab extends GitRepositoryBrowser {
 
     private static final long serialVersionUID = 1L;
 
-    private final double version;
-
-    /* package */
-    static final double DEFAULT_VERSION = 8.7;
+    private Double version;
 
     private static double valueOfVersion(String version) throws NumberFormatException {
         double tmpVersion = Double.valueOf(version);
@@ -44,19 +42,32 @@ public class GitLab extends GitRepositoryBrowser {
     }
 
     @DataBoundConstructor
-    public GitLab(String repoUrl, String version) {
+    public GitLab(String repoUrl) {
         super(repoUrl);
-        double tmpVersion;
-        try {
-            tmpVersion = valueOfVersion(version);
-        } catch (NumberFormatException nfe) {
-            tmpVersion = DEFAULT_VERSION;
-        }
-        this.version = tmpVersion;
     }
 
-    public double getVersion() {
-        return version;
+    @Deprecated
+    public GitLab(String repoUrl, String version) {
+        super(repoUrl);
+        setVersion(version);
+    }
+
+    @DataBoundSetter
+    public void setVersion(String version) {
+        try {
+            this.version = valueOfVersion(version);
+        } catch (NumberFormatException nfe) {
+            // ignore
+        }
+    }
+
+    public String getVersion() {
+        return (version != null) ? String.valueOf(version) : null;
+    }
+
+    /* package */
+    double getVersionDouble() {
+        return (version != null) ? version : Double.POSITIVE_INFINITY;
     }
 
     /**
@@ -88,7 +99,7 @@ public class GitLab extends GitRepositoryBrowser {
     public URL getDiffLink(Path path) throws IOException {
         final GitChangeSet changeSet = path.getChangeSet();
         String filelink = null;
-        if(getVersion() < 8.0) {
+        if(getVersionDouble() < 8.0) {
                 filelink = "#" + path.getPath();
         } else
         {
@@ -112,9 +123,9 @@ public class GitLab extends GitRepositoryBrowser {
         if (path.getEditType().equals(EditType.DELETE)) {
             return getDiffLink(path);
         } else {
-            if(getVersion() <= 4.2) {
+            if(getVersionDouble() <= 4.2) {
                 return new URL(getUrl(), "tree/" + path.getChangeSet().getId() + "/" + path.getPath());
-            } else if(getVersion() < 5.1) {
+            } else if(getVersionDouble() < 5.1) {
                 return new URL(getUrl(), path.getChangeSet().getId() + "/tree/" + path.getPath());
             } else {
                 return new URL(getUrl(), "blob/" + path.getChangeSet().getId() + "/" + path.getPath());
@@ -146,7 +157,7 @@ public class GitLab extends GitRepositoryBrowser {
         public FormValidation doCheckVersion(@QueryParameter(fixEmpty = true) final String version)
                 throws IOException, ServletException {
             if (version == null) {
-                return FormValidation.error("Version is required");
+                return FormValidation.ok();
             }
             try {
                 valueOfVersion(version);
@@ -158,11 +169,11 @@ public class GitLab extends GitRepositoryBrowser {
     }
 
     private String calculatePrefix() {
-        if(getVersion() < 3) {
+        if(getVersionDouble() < 3) {
             return "commits/";
         } else {
             return "commit/";
         }
-    } 
+    }
 
 }

--- a/src/main/resources/hudson/plugins/git/browser/GitLab/help-repoUrl.html
+++ b/src/main/resources/hudson/plugins/git/browser/GitLab/help-repoUrl.html
@@ -1,0 +1,4 @@
+<div>
+  Specify the root URL serving this repository (such as
+  <tt>http://gitlabserver:port/group/repo/</tt>).
+</div>

--- a/src/main/resources/hudson/plugins/git/browser/GitLab/help-url.html
+++ b/src/main/resources/hudson/plugins/git/browser/GitLab/help-url.html
@@ -1,3 +1,0 @@
-<div>
-  Specify the root URL serving this repository (such as <a href="http://gitlabserver:port/repo/">http://gitlabserver:port/repo/</a>).
-</div>

--- a/src/main/resources/hudson/plugins/git/browser/GitLab/help-version.html
+++ b/src/main/resources/hudson/plugins/git/browser/GitLab/help-version.html
@@ -1,3 +1,4 @@
 <div>
-  Specify the major and minor version of gitlab you use (such as 3.1).
+  Specify the major and minor version of GitLab you use (such as 9.1). If you
+  don't specify a version, a modern version of GitLab (>= 8.0) is assumed.
 </div>

--- a/src/test/java/hudson/plugins/git/browser/GitLabTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitLabTest.java
@@ -28,7 +28,7 @@ public class GitLabTest {
     private final GitLab gitlab7114ee = new GitLab(GITLAB_URL, "7.11");  /* Which is < 7.2 ! */
     private final GitLab gitlab80 = new GitLab(GITLAB_URL, "8.0");
     private final GitLab gitlab87 = new GitLab(GITLAB_URL, "8.7");
-    private final GitLab gitlabDefault = new GitLab(GITLAB_URL, "");
+    private final GitLab gitlabDefault = new GitLab(GITLAB_URL);
     private final GitLab gitlabNaN = new GitLab(GITLAB_URL, "NaN");
     private final GitLab gitlabInfinity = new GitLab(GITLAB_URL, "Infinity");
     private final GitLab gitlabNegative = new GitLab(GITLAB_URL, "-1");
@@ -39,16 +39,30 @@ public class GitLabTest {
 
     @Test
     public void testGetVersion() {
-        assertEquals(2.9, gitlab29.getVersion(), .001);
-        assertEquals(4.2, gitlab42.getVersion(), .001);
-        assertEquals(5.0, gitlab50.getVersion(), .001);
-        assertEquals(5.1, gitlab51.getVersion(), .001);
-        assertEquals(GitLab.DEFAULT_VERSION, gitlab87.getVersion(), .001);
-        assertEquals(GitLab.DEFAULT_VERSION, gitlabDefault.getVersion(), .001);
-        assertEquals(GitLab.DEFAULT_VERSION, gitlabNaN.getVersion(), .001);
-        assertEquals(GitLab.DEFAULT_VERSION, gitlabInfinity.getVersion(), .001);
-        assertEquals(-1.0, gitlabNegative.getVersion(), .001);
-        assertEquals(9999.0, gitlabGreater.getVersion(), .001);
+        assertEquals("2.9", gitlab29.getVersion());
+        assertEquals("4.2", gitlab42.getVersion());
+        assertEquals("5.0", gitlab50.getVersion());
+        assertEquals("5.1", gitlab51.getVersion());
+        assertEquals("8.7", gitlab87.getVersion());
+        assertNull(gitlabDefault.getVersion());
+        assertNull(gitlabNaN.getVersion());
+        assertNull(gitlabInfinity.getVersion());
+        assertEquals("-1.0", gitlabNegative.getVersion());
+        assertEquals("9999.0", gitlabGreater.getVersion());
+    }
+
+    @Test
+    public void testGetVersionDouble() {
+        assertEquals(2.9, gitlab29.getVersionDouble(), .001);
+        assertEquals(4.2, gitlab42.getVersionDouble(), .001);
+        assertEquals(5.0, gitlab50.getVersionDouble(), .001);
+        assertEquals(5.1, gitlab51.getVersionDouble(), .001);
+        assertEquals(8.7, gitlab87.getVersionDouble(), .001);
+        assertEquals(Double.POSITIVE_INFINITY, gitlabDefault.getVersionDouble(), .001);
+        assertEquals(Double.POSITIVE_INFINITY, gitlabNaN.getVersionDouble(), .001);
+        assertEquals(Double.POSITIVE_INFINITY, gitlabInfinity.getVersionDouble(), .001);
+        assertEquals(-1.0, gitlabNegative.getVersionDouble(), .001);
+        assertEquals(9999.0, gitlabGreater.getVersionDouble(), .001);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/git/browser/GitLabWorkflowTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitLabWorkflowTest.java
@@ -1,0 +1,47 @@
+package hudson.plugins.git.browser;
+
+import jenkins.plugins.git.GitSampleRepoRule;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class GitLabWorkflowTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+    @Test
+    public void checkoutWithVersion() throws Exception {
+        sampleRepo.init();
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                + "  checkout(\n"
+                + "    [$class: 'GitSCM', browser: [$class: 'GitLab',\n"
+                + "     repoUrl: 'https://a.org/a/b', version: '9.0'],\n"
+                + "    userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]]\n"
+                + "  )"
+                + "}", true));
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+
+    @Test
+    public void checkoutWithoutVersion() throws Exception {
+        sampleRepo.init();
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                        + "  checkout(\n"
+                        + "    [$class: 'GitSCM', browser: [$class: 'GitLab',\n"
+                        + "     repoUrl: 'https://a.org/a/b'],\n"
+                        + "    userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]]\n"
+                        + "  )"
+                        + "}", true));
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+    }
+}


### PR DESCRIPTION
## Make GitLab version optional

I was a bit annoyed to always specify the GitLab version whenever setting up a GitLab browser, where the GitLab URL format hasn't changed since GitLab 8.0 (which was released September 2015).

Another minor nitpick: Since the types for the version were inconsistent between constructor and getter, the Pipeline snippet generator created non-working snippets, this is also fixed now.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

The change of return type of "getVersion" might be considered a breaking change, but was necessary to fix the snippet generator. I was considering changing the getter and setter to "double", but that might break existing pipeline scripts which already hardcode the version as a string.

PS: Do you need a Jira ticket? If yes, I'll go ahead and create one.