### PR TITLE
[JENKINS-53050] Fix empty "depth" parameter handling for shallow cloning

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -31,7 +31,7 @@ public class CloneOption extends GitSCMExtension {
     private final boolean noTags;
     private final String reference;
     private final Integer timeout;
-    private int depth = 1;
+    private Integer depth;
     private boolean honorRefspec = false;
 
     public CloneOption(boolean shallow, String reference, Integer timeout) {
@@ -106,11 +106,11 @@ public class CloneOption extends GitSCMExtension {
     }
 
     @DataBoundSetter
-    public void setDepth(int depth) {
+    public void setDepth(Integer depth) {
         this.depth = depth;
     }
 
-    public int getDepth() {
+    public Integer getDepth() {
         return depth;
     }
 
@@ -122,7 +122,7 @@ public class CloneOption extends GitSCMExtension {
         if (shallow) {
             listener.getLogger().println("Using shallow clone");
             cmd.shallow();
-            if (depth > 1) {
+            if (depth != null && depth > 1) {
                 listener.getLogger().println("shallow clone depth " + depth);
                 cmd.depth(depth);
             }
@@ -164,8 +164,10 @@ public class CloneOption extends GitSCMExtension {
     @Override
     public void decorateFetchCommand(GitSCM scm, GitClient git, TaskListener listener, FetchCommand cmd) throws IOException, InterruptedException, GitException {
         cmd.shallow(shallow);
-        if (shallow && depth > 1) {
-            cmd.depth(depth);
+        if (shallow) {
+            if (depth != null && depth > 1) {
+                cmd.depth(depth);
+            }
         }
         cmd.tags(!noTags);
         /* cmd.refspecs() not required.
@@ -205,7 +207,7 @@ public class CloneOption extends GitSCMExtension {
         if (noTags != that.noTags) {
             return false;
         }
-        if (depth != that.depth) {
+        if (depth != null ? !depth.equals(that.depth) : that.depth != null) {
             return false;
         }
         if (honorRefspec != that.honorRefspec) {

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -119,13 +119,11 @@ public class CloneOption extends GitSCMExtension {
      */
     @Override
     public void decorateCloneCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, CloneCommand cmd) throws IOException, InterruptedException, GitException {
+        cmd.shallow(shallow);
         if (shallow) {
-            listener.getLogger().println("Using shallow clone");
-            cmd.shallow();
-            if (depth != null && depth > 1) {
-                listener.getLogger().println("shallow clone depth " + depth);
-                cmd.depth(depth);
-            }
+            int usedDepth = depth == null || depth < 1 ? 1 : depth;
+            listener.getLogger().println("Using shallow clone with depth " + usedDepth);
+            cmd.depth(usedDepth);
         }
         if (noTags) {
             listener.getLogger().println("Avoid fetching tags");
@@ -165,9 +163,9 @@ public class CloneOption extends GitSCMExtension {
     public void decorateFetchCommand(GitSCM scm, GitClient git, TaskListener listener, FetchCommand cmd) throws IOException, InterruptedException, GitException {
         cmd.shallow(shallow);
         if (shallow) {
-            if (depth != null && depth > 1) {
-                cmd.depth(depth);
-            }
+            int usedDepth = depth == null || depth < 1 ? 1 : depth;
+            listener.getLogger().println("Using shallow fetch with depth " + usedDepth);
+            cmd.depth(usedDepth);
         }
         cmd.tags(!noTags);
         /* cmd.refspecs() not required.

--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -128,9 +128,9 @@ public class SubmoduleOption extends GitSCMExtension {
                         .timeout(timeout)
                         .shallow(shallow);
                 if (shallow) {
-                    if (depth !=null && depth > 1) {
-                        cmd.depth(depth);
-                    }
+                    int usedDepth = depth == null || depth < 1 ? 1 : depth;
+                    listener.getLogger().println("Using shallow submodule update with depth " + usedDepth);
+                    cmd.depth(usedDepth);
                 }
                 cmd.execute();
             }

--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -44,7 +44,7 @@ public class SubmoduleOption extends GitSCMExtension {
     private Integer timeout;
     /** Use --depth flag on submodule update command - requires git>=1.8.4 */
     private boolean shallow;
-    private int depth = 1;
+    private Integer depth;
 
     @DataBoundConstructor
     public SubmoduleOption(boolean disableSubmodules, boolean recursiveSubmodules, boolean trackingSubmodules, String reference,Integer timeout, boolean parentCredentials) {
@@ -90,11 +90,11 @@ public class SubmoduleOption extends GitSCMExtension {
     }
 
     @DataBoundSetter
-    public void setDepth(int depth) {
+    public void setDepth(Integer depth) {
         this.depth = depth;
     }
 
-    public int getDepth() {
+    public Integer getDepth() {
         return depth;
     }
 
@@ -127,8 +127,10 @@ public class SubmoduleOption extends GitSCMExtension {
                         .ref(build.getEnvironment(listener).expand(reference))
                         .timeout(timeout)
                         .shallow(shallow);
-                if (shallow && depth > 1) {
-                    cmd.depth(depth);
+                if (shallow) {
+                    if (depth !=null && depth > 1) {
+                        cmd.depth(depth);
+                    }
                 }
                 cmd.execute();
             }
@@ -190,7 +192,7 @@ public class SubmoduleOption extends GitSCMExtension {
         if (shallow != that.shallow) {
             return false;
         }
-        if (depth != that.depth) {
+        if (depth != null ? !depth.equals(that.depth) : that.depth != null) {
             return false;
         }
         return true;


### PR DESCRIPTION
## [JENKINS-53050](https://issues.jenkins-ci.org/browse/JENKINS-53050) - Fix empty "depth" parameter handling for shallow cloning

When in the ui forms of "Advanced clone behaviours" and "Advanced sub-modules behaviours" the "Shallow clone depth" field is left empty, it is now persisted and shown correctly as absent value and not as 0.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

This pull request depends on pull request #610.