### PR TITLE
[JENKINS-50168] Support default parameters when polling pipeline jobs

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -687,6 +687,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
             final EnvVars environment = project instanceof AbstractProject ? GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener, false) : new EnvVars();
 
+            GitUtils.addEnvironmentContributingActionsValues(environment, project, lastBuild);
+
             GitClient git = createClient(listener, environment, project, Jenkins.getInstance(), null);
 
             for (RemoteConfig remoteConfig : getParamExpandedRepos(lastBuild, listener)) {
@@ -754,6 +756,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         final Node node = GitUtils.workspaceToNode(workspace);
         final EnvVars environment = project instanceof AbstractProject ? GitUtils.getPollEnvironment((AbstractProject) project, workspace, launcher, listener) : project.getEnvironment(node, listener);
+
+        GitUtils.addEnvironmentContributingActionsValues(environment, project, lastBuild);
 
         FilePath workingDirectory = workingDirectory(project,workspace,environment,listener);
 

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -365,22 +365,25 @@ public class GitUtils implements Serializable {
     public static void addEnvironmentContributingActionsValues(EnvVars env, Job project, Run b) {
         if (b instanceof AbstractBuild) {
             List<? extends Action> buildActions = b.getAllActions();
-            for (Action action : buildActions) {
-                // most importantly, ParametersAction will be processed here (for parameterized builds)
-                if (action instanceof ParametersAction) {
-                    ParametersAction envAction = (ParametersAction) action;
-                    envAction.buildEnvVars((AbstractBuild) b, env);
+            if (buildActions != null) {
+                for (Action action : buildActions) {
+                    // most importantly, ParametersAction will be processed here (for parameterized builds)
+                    if (action instanceof ParametersAction) {
+                        ParametersAction envAction = (ParametersAction) action;
+                        envAction.buildEnvVars((AbstractBuild) b, env);
+                    }
                 }
             }
         }
+        
         // Use the default parameter values (if any) instead of the ones from the last build
         ParametersDefinitionProperty paramDefProp = (ParametersDefinitionProperty) project.getProperty(ParametersDefinitionProperty.class);
         if (paramDefProp != null) {
             for(ParameterDefinition paramDefinition : paramDefProp.getParameterDefinitions()) {
-                ParameterValue defaultValue  = paramDefinition.getDefaultParameterValue();
-                if (defaultValue != null) {
-                    defaultValue.buildEnvironment(b, env);
-                }
+               ParameterValue defaultValue  = paramDefinition.getDefaultParameterValue();
+               if (defaultValue != null) {
+                   defaultValue.buildEnvironment(b, env);
+               }
             }
         }
     }

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -357,34 +357,30 @@ public class GitUtils implements Serializable {
             }
         }
 
-        // add env contributing actions' values from last build to environment - fixes JENKINS-22009
-        addEnvironmentContributingActionsValues(env, b);
-
         EnvVars.resolve(env);
 
         return env;
     }
 
-    private static void addEnvironmentContributingActionsValues(EnvVars env, AbstractBuild b) {
-        List<? extends Action> buildActions = b.getAllActions();
-        if (buildActions != null) {
+    public static void addEnvironmentContributingActionsValues(EnvVars env, Job project, Run b) {
+        if (b instanceof AbstractBuild) {
+            List<? extends Action> buildActions = b.getAllActions();
             for (Action action : buildActions) {
                 // most importantly, ParametersAction will be processed here (for parameterized builds)
                 if (action instanceof ParametersAction) {
                     ParametersAction envAction = (ParametersAction) action;
-                    envAction.buildEnvVars(b, env);
+                    envAction.buildEnvVars((AbstractBuild) b, env);
                 }
             }
         }
-        
         // Use the default parameter values (if any) instead of the ones from the last build
-        ParametersDefinitionProperty paramDefProp = (ParametersDefinitionProperty) b.getProject().getProperty(ParametersDefinitionProperty.class);
+        ParametersDefinitionProperty paramDefProp = (ParametersDefinitionProperty) project.getProperty(ParametersDefinitionProperty.class);
         if (paramDefProp != null) {
             for(ParameterDefinition paramDefinition : paramDefProp.getParameterDefinitions()) {
-               ParameterValue defaultValue  = paramDefinition.getDefaultParameterValue();
-               if (defaultValue != null) {
-                   defaultValue.buildEnvironment(b, env);
-               }
+                ParameterValue defaultValue  = paramDefinition.getDefaultParameterValue();
+                if (defaultValue != null) {
+                    defaultValue.buildEnvironment(b, env);
+                }
             }
         }
     }

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1907,11 +1907,11 @@ public class GitSCMTest extends AbstractGitTestCase {
 
         // Initial commit to master
         commit("file1", johnDoe, "Initial Commit");
-
+        
         // Create the branches
         git.branch("trackedbranch");
         git.branch("manualbranch");
-
+        
         final StringParameterValue branchParam = new StringParameterValue("MY_BRANCH", "manualbranch");
         final Action[] actions = {new ParametersAction(branchParam)};
         FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserCause(), actions).get();
@@ -1926,7 +1926,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         git.checkout("trackedbranch");
         commit("file3", johnDoe, "Commit to tracked branch");
         assertTrue("A change should be detected in tracked branch", project.poll(listener).hasChanges());
-
+        
     }
 
     @Issue("JENKINS-50168")

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -2026,6 +2026,8 @@ public class GitSCMTest extends AbstractGitTestCase {
         Launcher launcher = workspace.createLauncher(listener);
         final EnvVars environment = GitUtils.getPollEnvironment(project, workspace, launcher, listener);
 
+        GitUtils.addEnvironmentContributingActionsValues(environment, project, first_build);
+
         assertEquals(environment.get("MY_BRANCH"), "master");
         assertNotSame("Enviroment path should not be broken path", environment.get("PATH"), brokenPath);
     }


### PR DESCRIPTION
## [JENKINS-50168](https://issues.jenkins-ci.org/browse/JENKINS-50168) - Support default parameters when polling pipeline jobs

Refactoring to allow default parameters to also work for pipeline jobs. Based on the original change for JENKINS-27327 with an updated test. The project is not an instance of AbstractProject, so the code is skipped.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

None
