### PR TITLE
Probe git-version before attempting checkGlobalConfig

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -59,8 +59,8 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
 
     @Override
     public void init() throws Exception {
-        GitSampleRepoRule.checkGlobalConfig();
         run(true, tmp.getRoot(), "git", "version");
+        checkGlobalConfig();
         git("init");
         write("file", "");
         git("add", "file");


### PR DESCRIPTION
Amends e6476c472492e5aebc5fa959e3c4345bacd4f256, which broke one of the features of `GitSampleRepoRule`: that if CLI `git` (which the rule requires) is not installed, the test is marked skipped rather than failed. Noticed a test failure in https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/78 of the form

```
[ERROR] slashyBranches(io.jenkins.plugins.artifact_manager_jclouds.s3.JCloudsArtifactManagerTest)  Time elapsed: 1.187 s  <<< ERROR!
java.io.IOException: Cannot run program "git" (in directory "."): error=2, No such file or directory
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
	at hudson.Proc$LocalProc.<init>(Proc.java:249)
	at hudson.Proc$LocalProc.<init>(Proc.java:218)
	at hudson.Launcher$LocalLauncher.launch(Launcher.java:929)
	at hudson.Launcher$ProcStarter.start(Launcher.java:449)
	at jenkins.plugins.git.CliGitCommand.run(CliGitCommand.java:88)
	at jenkins.plugins.git.CliGitCommand.runWithoutAssert(CliGitCommand.java:120)
	at jenkins.plugins.git.CliGitCommand.setConfigIfEmpty(CliGitCommand.java:124)
	at jenkins.plugins.git.CliGitCommand.setDefaults(CliGitCommand.java:147)
	at jenkins.plugins.git.GitSampleRepoRule.checkGlobalConfig(GitSampleRepoRule.java:57)
	at jenkins.plugins.git.GitSampleRepoRule.init(GitSampleRepoRule.java:62)
	at io.jenkins.plugins.artifact_manager_jclouds.s3.JCloudsArtifactManagerTest.slashyBranches(JCloudsArtifactManagerTest.java:259)
	at …
Caused by: java.io.IOException: error=2, No such file or directory
	at java.lang.UNIXProcess.forkAndExec(Native Method)
	at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
	at java.lang.ProcessImpl.start(ProcessImpl.java:134)
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
	... 28 more
```

The solution is to always run `git version` first with the `probe` flag enabled.