### PR TITLE
[JENKINS-42597] Percent character (%) in filenames is not url-encoded…

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -78,9 +78,9 @@ public class AssemblaWeb extends GitRepositoryBrowser {
         GitChangeSet changeSet = path.getChangeSet();
         URL url = getUrl();
         if (path.getEditType() == EditType.DELETE) {
-            return new URL(url, url.getPath() + "nodes/" + changeSet.getParentCommit() + path.getPath());
+            return encodeURL(new URL(url, url.getPath() + "nodes/" + changeSet.getParentCommit() + path.getPath()));
         } else {
-            return new URL(url, url.getPath() + "nodes/" + changeSet.getId() + path.getPath());
+            return encodeURL(new URL(url, url.getPath() + "nodes/" + changeSet.getId() + path.getPath()));
         }
     }
 

--- a/src/main/java/hudson/plugins/git/browser/BitbucketWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/BitbucketWeb.java
@@ -68,7 +68,7 @@ public class BitbucketWeb extends GitRepositoryBrowser {
     public URL getFileLink(GitChangeSet.Path path) throws IOException {
         final String pathAsString = path.getPath();
         URL url = getUrl();
-        return new URL(url, url.getPath() + "history/" + pathAsString);
+        return encodeURL(new URL(url, url.getPath() + "history/" + pathAsString));
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/browser/CGit.java
+++ b/src/main/java/hudson/plugins/git/browser/CGit.java
@@ -74,9 +74,9 @@ public class CGit extends GitRepositoryBrowser {
         GitChangeSet changeSet = path.getChangeSet();
         URL url = getUrl();
         if (path.getEditType() == EditType.DELETE) {
-            return new URL(url, url.getPath() + "tree/" + path.getPath() + param(url).add("id=" + changeSet.getParentCommit()).toString());
+            return encodeURL(new URL(url, url.getPath() + "tree/" + path.getPath() + param(url).add("id=" + changeSet.getParentCommit()).toString()));
         } else {
-            return new URL(url, url.getPath() + "tree/" + path.getPath() + param(url).add("id=" + changeSet.getId()).toString());
+            return encodeURL(new URL(url, url.getPath() + "tree/" + path.getPath() + param(url).add("id=" + changeSet.getId()).toString()));
         }
     }
 

--- a/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
@@ -43,7 +43,7 @@ public class FisheyeGitRepositoryBrowser extends GitRepositoryBrowser {
 
 	@Override
 	public URL getFileLink(Path path) throws IOException {
-		return new URL(getUrl(), getPath(path));
+		return encodeURL(new URL(getUrl(), getPath(path)));
 	}
 
 	private String getPath(Path path) {

--- a/src/main/java/hudson/plugins/git/browser/GitLab.java
+++ b/src/main/java/hudson/plugins/git/browser/GitLab.java
@@ -113,11 +113,11 @@ public class GitLab extends GitRepositoryBrowser {
             return getDiffLink(path);
         } else {
             if(getVersion() <= 4.2) {
-                return new URL(getUrl(), "tree/" + path.getChangeSet().getId() + "/" + path.getPath());
+                return encodeURL(new URL(getUrl(), "tree/" + path.getChangeSet().getId() + "/" + path.getPath()));
             } else if(getVersion() < 5.1) {
-                return new URL(getUrl(), path.getChangeSet().getId() + "/tree/" + path.getPath());
+                return encodeURL(new URL(getUrl(), path.getChangeSet().getId() + "/tree/" + path.getPath()));
             } else {
-                return new URL(getUrl(), "blob/" + path.getChangeSet().getId() + "/" + path.getPath());
+                return encodeURL(new URL(getUrl(), "blob/" + path.getChangeSet().getId() + "/" + path.getPath()));
             }
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/GitList.java
+++ b/src/main/java/hudson/plugins/git/browser/GitList.java
@@ -69,7 +69,7 @@ public class GitList extends GitRepositoryBrowser {
      */
     private URL getDiffLinkRegardlessOfEditType(Path path) throws IOException {
     	//GitList diff indices begin at 1
-        return new URL(getChangeSetLink(path.getChangeSet()), "#" + String.valueOf(getIndexOfPath(path) + 1));
+        return encodeURL(new URL(getChangeSetLink(path.getChangeSet()), "#" + String.valueOf(getIndexOfPath(path) + 1)));
     }
 
     /**
@@ -87,7 +87,7 @@ public class GitList extends GitRepositoryBrowser {
         } else {
             final String spec = "blob/" + path.getChangeSet().getId() + "/" + path.getPath();
             URL url = getUrl();
-            return new URL(url, url.getPath() + spec);
+            return encodeURL(new URL(url, url.getPath() + spec));
         }
     }
 

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -11,6 +11,7 @@ import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSet> {
@@ -73,7 +74,7 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
      *      null if the browser doesn't have any suitable URL.
      * @throws IOException on input or output error
      */
-    public abstract URL getFileLink(GitChangeSet.Path path) throws IOException;
+    public abstract URL getFileLink(GitChangeSet.Path path) throws IOException, URISyntaxException;
 
     /**
      * Determines whether a URL should be normalized

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -11,6 +11,8 @@ import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
+import java.net.IDN;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
@@ -104,6 +106,14 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
     			i++;
     	}
         return i;
+    }
+
+    public static URL encodeURL(URL url) throws IOException {
+        try {
+            return new URI(url.getProtocol(), url.getUserInfo(), IDN.toASCII(url.getHost()), url.getPort(), url.getPath(), url.getQuery(), url.getRef()).toURL();
+        } catch (URISyntaxException e) {
+            throw new IOException(e);
+        }
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/plugins/git/browser/GitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GitWeb.java
@@ -79,7 +79,7 @@ public class GitWeb extends GitRepositoryBrowser {
         String h = (path.getDst() != null) ? path.getDst() : path.getSrc();
         String spec = param(url).add("a=blob").add("f=" + path.getPath())
             .add("h=" + h).add("hb=" + path.getChangeSet().getId()).toString();
-        return new URL(url, url.getPath()+spec);
+        return encodeURL(new URL(url, url.getPath()+spec));
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/browser/GithubWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GithubWeb.java
@@ -81,14 +81,7 @@ public class GithubWeb extends GitRepositoryBrowser {
             return getDiffLinkRegardlessOfEditType(path);
         } else {
             final String spec = "blob/" + path.getChangeSet().getId() + "/" + path.getPath();
-            URL url = buildURL(spec);
-            URI uri;
-            try {
-                uri = new URI(url.getProtocol(), url.getUserInfo(), IDN.toASCII(url.getHost()), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
-            } catch (URISyntaxException e) {
-                throw new IOException(e);
-            }
-            return uri.toURL();
+            return encodeURL(buildURL(spec));
         }
     }
 

--- a/src/main/java/hudson/plugins/git/browser/GithubWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GithubWeb.java
@@ -13,7 +13,10 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URI;
+import java.net.IDN;
 
 /**
  * Git Browser URLs
@@ -73,14 +76,19 @@ public class GithubWeb extends GitRepositoryBrowser {
      * @throws IOException on input or output error
      */
     @Override
-    public URL getFileLink(Path path) throws IOException {
+    public URL getFileLink(Path path) throws IOException, URISyntaxException {
         if (path.getEditType().equals(EditType.DELETE)) {
             return getDiffLinkRegardlessOfEditType(path);
         } else {
             final String spec = "blob/" + path.getChangeSet().getId() + "/" + path.getPath();
-            URL url = getUrl();
-            return new URL(url, url.getPath() + spec);
+            URL url = buildURL(spec);
+            return new URI(url.getProtocol(), url.getUserInfo(), IDN.toASCII(url.getHost()), url.getPort(), url.getPath(), url.getQuery(), url.getRef()).toURL();
         }
+    }
+
+    private URL buildURL(String spec) throws IOException {
+        URL url = getUrl();
+        return new URL(url, url.getPath() + spec);
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/browser/GithubWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GithubWeb.java
@@ -76,13 +76,19 @@ public class GithubWeb extends GitRepositoryBrowser {
      * @throws IOException on input or output error
      */
     @Override
-    public URL getFileLink(Path path) throws IOException, URISyntaxException {
+    public URL getFileLink(Path path) throws IOException {
         if (path.getEditType().equals(EditType.DELETE)) {
             return getDiffLinkRegardlessOfEditType(path);
         } else {
             final String spec = "blob/" + path.getChangeSet().getId() + "/" + path.getPath();
             URL url = buildURL(spec);
-            return new URI(url.getProtocol(), url.getUserInfo(), IDN.toASCII(url.getHost()), url.getPort(), url.getPath(), url.getQuery(), url.getRef()).toURL();
+            URI uri;
+            try {
+                uri = new URI(url.getProtocol(), url.getUserInfo(), IDN.toASCII(url.getHost()), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
+            } catch (URISyntaxException e) {
+                throw new IOException(e);
+            }
+            return uri.toURL();
         }
     }
 

--- a/src/main/java/hudson/plugins/git/browser/Gitiles.java
+++ b/src/main/java/hudson/plugins/git/browser/Gitiles.java
@@ -46,7 +46,7 @@ public class Gitiles extends GitRepositoryBrowser {
     @Override
     public URL getFileLink(Path path) throws IOException {
         URL url = getUrl();
-        return new URL(url + "+blame/" + path.getChangeSet().getId() + "/" + path.getPath());
+        return encodeURL(new URL(url + "+blame/" + path.getChangeSet().getId() + "/" + path.getPath()));
     }
 
     @Override

--- a/src/main/java/hudson/plugins/git/browser/GitoriousWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GitoriousWeb.java
@@ -44,7 +44,7 @@ public class GitoriousWeb extends GitRepositoryBrowser {
     @Override
     public URL getDiffLink(Path path) throws IOException {
         final GitChangeSet changeSet = path.getChangeSet();
-        return new URL(getUrl(), "commit/" + changeSet.getId() + "/diffs?diffmode=sidebyside&fragment=1#" + path.getPath());
+        return encodeURL(new URL(getUrl(), "commit/" + changeSet.getId() + "/diffs?diffmode=sidebyside&fragment=1#" + path.getPath()));
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/browser/GogsGit.java
+++ b/src/main/java/hudson/plugins/git/browser/GogsGit.java
@@ -67,7 +67,7 @@ public class GogsGit extends GitRepositoryBrowser {
      */
     private URL getDiffLinkRegardlessOfEditType(Path path) throws IOException {
         // Gogs diff indices begin at 1.
-        return new URL(getChangeSetLink(path.getChangeSet()), "#diff-" + String.valueOf(getIndexOfPath(path) + 1));
+        return encodeURL(new URL(getChangeSetLink(path.getChangeSet()), "#diff-" + String.valueOf(getIndexOfPath(path) + 1)));
     }
 
     /**
@@ -85,7 +85,7 @@ public class GogsGit extends GitRepositoryBrowser {
             return getDiffLinkRegardlessOfEditType(path);
         } else {
             URL url = getUrl();
-            return new URL(url, url.getPath() + "src/" + path.getChangeSet().getId() + "/" + path.getPath());
+            return encodeURL(new URL(url, url.getPath() + "src/" + path.getChangeSet().getId() + "/" + path.getPath()));
         }
     }
 

--- a/src/main/java/hudson/plugins/git/browser/KilnGit.java
+++ b/src/main/java/hudson/plugins/git/browser/KilnGit.java
@@ -45,7 +45,7 @@ public class KilnGit extends GitRepositoryBrowser {
     @Override
     public URL getChangeSetLink(GitChangeSet changeSet) throws IOException {
         URL url = getUrl();
-        return new URL(url, url.getPath() + "History/" + changeSet.getId() + param(url).toString());
+        return encodeURL(new URL(url, url.getPath() + "History/" + changeSet.getId() + param(url).toString()));
     }
 
     /**
@@ -98,7 +98,7 @@ public class KilnGit extends GitRepositoryBrowser {
         } else {
             GitChangeSet changeSet = path.getChangeSet();
             URL url = getUrl();
-            return new URL(url, url.getPath() + "FileHistory/" + path.getPath() + param(url).add("rev=" + changeSet.getId()).toString());
+            return encodeURL(new URL(url, url.getPath() + "FileHistory/" + path.getPath() + param(url).add("rev=" + changeSet.getId()).toString()));
         }
     }
 

--- a/src/main/java/hudson/plugins/git/browser/Phabricator.java
+++ b/src/main/java/hudson/plugins/git/browser/Phabricator.java
@@ -78,7 +78,7 @@ public class Phabricator extends GitRepositoryBrowser {
         final GitChangeSet changeSet = path.getChangeSet();
         final String sha = changeSet.getId();
         final String spec = String.format("/diffusion/%s/history/master/%s;%s", this.getRepo(), path.getPath(), sha);
-        return new URL(getUrl(), spec);
+        return encodeURL(new URL(getUrl(), spec));
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/browser/RedmineWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/RedmineWeb.java
@@ -75,11 +75,11 @@ public class RedmineWeb extends GitRepositoryBrowser {
     @Override
     public URL getFileLink(Path path) throws IOException {
         if (path.getEditType().equals(EditType.DELETE)) {
-            return getDiffLink(path);
+            return encodeURL(getDiffLink(path));
         } else {
             final String spec = "revisions/" + path.getChangeSet().getId() + "/entry/" + path.getPath();
             URL url = getUrl();
-            return new URL(url, url.getPath() + spec);
+            return encodeURL(new URL(url, url.getPath() + spec));
         }
     }
 

--- a/src/main/java/hudson/plugins/git/browser/RhodeCode.java
+++ b/src/main/java/hudson/plugins/git/browser/RhodeCode.java
@@ -78,9 +78,9 @@ public class RhodeCode extends GitRepositoryBrowser {
             if (parentCommit == null) {
                 parentCommit = ".";
             }
-            return new URL(url, url.getPath() + "files/" + parentCommit + '/' + path.getPath());
+            return encodeURL(new URL(url, url.getPath() + "files/" + parentCommit + '/' + path.getPath()));
         } else {
-            return new URL(url, url.getPath() + "files/" + changeSet.getId() + '/' + path.getPath());
+            return encodeURL(new URL(url, url.getPath() + "files/" + changeSet.getId() + '/' + path.getPath()));
         }
     }
 

--- a/src/main/java/hudson/plugins/git/browser/Stash.java
+++ b/src/main/java/hudson/plugins/git/browser/Stash.java
@@ -80,9 +80,9 @@ public class Stash extends GitRepositoryBrowser {
         URL url = getUrl();
 
         if (path.getEditType() == EditType.DELETE) {
-            return new URL(url, url.getPath() + "browse/" + path.getPath() + param(url).add("at=" + changeSet.getParentCommit()).toString());
+            return encodeURL(new URL(url, url.getPath() + "browse/" + path.getPath() + param(url).add("at=" + changeSet.getParentCommit()).toString()));
         } else {
-            return new URL(url, url.getPath() + "browse/" + path.getPath() + param(url).add("at=" + changeSet.getId()).toString());
+            return encodeURL(new URL(url, url.getPath() + "browse/" + path.getPath() + param(url).add("at=" + changeSet.getId()).toString()));
         }
     }
 

--- a/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
@@ -45,7 +45,7 @@ public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
     @Override
     public URL getFileLink(GitChangeSet.Path path) throws IOException {
         String spec = String.format("commit/%s#path=%s&_a=history", path.getChangeSet().getId(), path.getPath());
-        return new URL(getRepoUrl(path.getChangeSet()), spec);
+        return encodeURL(new URL(getRepoUrl(path.getChangeSet()), spec));
     }
 
     @Override

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -50,10 +50,10 @@ public class ViewGitWeb extends GitRepositoryBrowser {
         URL url = getUrl();
         if (path.getEditType() == EditType.DELETE) {
             String spec = buildCommitDiffSpec(url, path);
-            return new URL(url, url.getPath() + spec);
+            return encodeURL(new URL(url, url.getPath() + spec));
         }
         String spec = param(url).add("p=" + projectName).add("a=viewblob").add("h=" + path.getDst()).add("f=" +  path.getPath()).toString();
-        return new URL(url, url.getPath() + spec);
+        return encodeURL(new URL(url, url.getPath() + spec));
     }
 
 	private String buildCommitDiffSpec(URL url, Path path)

--- a/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
@@ -9,23 +9,22 @@ import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSet.Path;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.RepositoryBrowser;
-import jenkins.plugins.git.AbstractGitSCMSource;
-import jenkins.scm.api.SCMHead;
-import org.eclipse.jgit.transport.RefSpec;
-import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
-import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import jenkins.plugins.git.AbstractGitSCMSource;
+import jenkins.scm.api.SCMHead;
+import org.eclipse.jgit.transport.RefSpec;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+import org.xml.sax.SAXException;
 
 /**
  * @author mirko
@@ -63,7 +62,7 @@ public class GithubWebTest {
     }
 
     @Test
-    public void testGetFileLinkPath() throws IOException, SAXException, URISyntaxException {
+    public void testGetFileLinkPath() throws Exception {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
         final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
         final URL fileLink = githubWeb.getFileLink(path);
@@ -72,7 +71,7 @@ public class GithubWebTest {
 
     @Issue("JENKINS-42597")
     @Test
-    public void testGetFileLinkPathWithEscape() throws IOException, SAXException, URISyntaxException {
+    public void testGetFileLinkPathWithEscape() throws Exception {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-escape");
         final Path path = pathMap.get("src/test/java/hudson/plugins/git/browser/conf%.txt");
         final URL fileLink = githubWeb.getFileLink(path);
@@ -81,7 +80,7 @@ public class GithubWebTest {
 
     @Issue("JENKINS-42597")
     @Test
-    public void testGetFileLinkPathWithSpaceInName() throws IOException, SAXException, URISyntaxException {
+    public void testGetFileLinkPathWithSpaceInName() throws Exception {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-escape");
         final Path path = pathMap.get("src/test/java/hudson/plugins/git/browser/config file.txt");
         final URL fileLink = githubWeb.getFileLink(path);
@@ -89,7 +88,7 @@ public class GithubWebTest {
     }
 
     @Test
-    public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException, URISyntaxException {
+    public void testGetFileLinkPathForDeletedFile() throws Exception {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");
         final URL fileLink = githubWeb.getFileLink(path);

--- a/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
@@ -8,25 +8,24 @@ import hudson.plugins.git.GitChangeLogParser;
 import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSet.Path;
 import hudson.plugins.git.GitSCM;
-import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.scm.RepositoryBrowser;
+import jenkins.plugins.git.AbstractGitSCMSource;
+import jenkins.scm.api.SCMHead;
+import org.eclipse.jgit.transport.RefSpec;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import jenkins.plugins.git.AbstractGitSCMSource;
-import jenkins.scm.api.SCMHead;
-import org.eclipse.jgit.transport.RefSpec;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
-
-import org.xml.sax.SAXException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author mirko
@@ -64,15 +63,33 @@ public class GithubWebTest {
     }
 
     @Test
-    public void testGetFileLinkPath() throws IOException, SAXException {
+    public void testGetFileLinkPath() throws IOException, SAXException, URISyntaxException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog");
         final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
         final URL fileLink = githubWeb.getFileLink(path);
         assertEquals(GITHUB_URL  + "/blob/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/main/java/hudson/plugins/git/browser/GithubWeb.java", String.valueOf(fileLink));
     }
 
+    @Issue("JENKINS-42597")
     @Test
-    public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
+    public void testGetFileLinkPathWithEscape() throws IOException, SAXException, URISyntaxException {
+        final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-escape");
+        final Path path = pathMap.get("src/test/java/hudson/plugins/git/browser/conf%.txt");
+        final URL fileLink = githubWeb.getFileLink(path);
+        assertEquals(GITHUB_URL  + "/blob/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/test/java/hudson/plugins/git/browser/conf%25.txt", String.valueOf(fileLink));
+    }
+
+    @Issue("JENKINS-42597")
+    @Test
+    public void testGetFileLinkPathWithSpaceInName() throws IOException, SAXException, URISyntaxException {
+        final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-escape");
+        final Path path = pathMap.get("src/test/java/hudson/plugins/git/browser/config file.txt");
+        final URL fileLink = githubWeb.getFileLink(path);
+        assertEquals(GITHUB_URL  + "/blob/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/test/java/hudson/plugins/git/browser/config%20file.txt", String.valueOf(fileLink));
+    }
+
+    @Test
+    public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException, URISyntaxException {
         final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
         final Path path = pathMap.get("bar");
         final URL fileLink = githubWeb.getFileLink(path);
@@ -169,4 +186,5 @@ public class GithubWebTest {
         }
         return pathMap;
     }
+
 }

--- a/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
@@ -77,6 +77,32 @@ public class GithubWebTest {
         final URL fileLink = githubWeb.getFileLink(path);
         assertEquals(GITHUB_URL  + "/blob/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/test/java/hudson/plugins/git/browser/conf%25.txt", String.valueOf(fileLink));
     }
+    @Issue("JENKINS-42597")
+    @Test
+    public void testGetFileLinkPathWithWindowsUnescapeChar() throws Exception {
+        final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-escape");
+        final Path path = pathMap.get("src/test/java/hudson/plugins/git/browser/conf^%.txt");
+        final URL fileLink = githubWeb.getFileLink(path);
+        assertEquals(GITHUB_URL  + "/blob/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/test/java/hudson/plugins/git/browser/conf%5E%25.txt", String.valueOf(fileLink));
+    }
+
+    @Issue("JENKINS-42597")
+    @Test
+    public void testGetFileLinkPathWithDoubleEscape() throws Exception {
+        final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-escape");
+        final Path path = pathMap.get("src/test/java/hudson/plugins/git/browser/conf%%.txt");
+        final URL fileLink = githubWeb.getFileLink(path);
+        assertEquals(GITHUB_URL  + "/blob/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/test/java/hudson/plugins/git/browser/conf%25%25.txt", String.valueOf(fileLink));
+    }
+
+    @Issue("JENKINS-42597")
+    @Test
+    public void testGetFileLinkPathWithWindowsEnvironmentalVariable() throws Exception {
+        final HashMap<String,Path> pathMap = createPathMap("rawchangelog-with-escape");
+        final Path path = pathMap.get("src/test/java/hudson/plugins/git/browser/conf%abc%.txt");
+        final URL fileLink = githubWeb.getFileLink(path);
+        assertEquals(GITHUB_URL  + "/blob/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/test/java/hudson/plugins/git/browser/conf%25abc%25.txt", String.valueOf(fileLink));
+    }
 
     @Issue("JENKINS-42597")
     @Test

--- a/src/test/resources/hudson/plugins/git/browser/rawchangelog-with-escape
+++ b/src/test/resources/hudson/plugins/git/browser/rawchangelog-with-escape
@@ -1,0 +1,12 @@
+commit 396fc230a3db05c427737aa5c2eb7856ba72b05d
+tree 196333547f8b9a5fcc8b1fffe4accb01da42c5a6
+parent f28f125f4cc3e5f6a32daee6a26f36f7b788b8ff
+author Mirko Friedenhagen <mfriedenhagen@dev.java.net> 1277411790 +0200
+committer Mirko Friedenhagen <mfriedenhagen@dev.java.net> 1277411790 +0200
+
+    Github seems to have no URL for deleted files, so just return a difflink instead.
+
+:100644 100644 3f28ad75f5ecd5e0ea9659362e2eef18951bd451 2e0756cd853dccac638486d6aab0e74bc2ef4041 M	src/main/java/hudson/plugins/git/browser/GithubWeb.java
+:100644 100644 019d377767702b6c572fa4ae97c982e02dcd76ff 7c89764ba7a51c23e809b24376d90d7d06337434 M	src/test/java/hudson/plugins/git/browser/conf%.txt
+:100644 100644 019d377767702b6c572fa4ae97c982e02dcd76fa 7c89764ba7a51c23e809b24376d90d7d06337435 M	src/test/java/hudson/plugins/git/browser/config file.txt
+:000000 100644 0000000000000000000000000000000000000000 885ce99421b3ae3a413a5c7fb0cdf9ec477d3f64 A	src/test/resources/hudson/plugins/git/browser/rawchangelog-with-escape

--- a/src/test/resources/hudson/plugins/git/browser/rawchangelog-with-escape
+++ b/src/test/resources/hudson/plugins/git/browser/rawchangelog-with-escape
@@ -8,5 +8,8 @@ committer Mirko Friedenhagen <mfriedenhagen@dev.java.net> 1277411790 +0200
 
 :100644 100644 3f28ad75f5ecd5e0ea9659362e2eef18951bd451 2e0756cd853dccac638486d6aab0e74bc2ef4041 M	src/main/java/hudson/plugins/git/browser/GithubWeb.java
 :100644 100644 019d377767702b6c572fa4ae97c982e02dcd76ff 7c89764ba7a51c23e809b24376d90d7d06337434 M	src/test/java/hudson/plugins/git/browser/conf%.txt
+:100644 100644 019d377767702b6c572fa4ae97c982e02dcd76fb 7c89764ba7a51c23e809b24376d90d7d06337436 M	src/test/java/hudson/plugins/git/browser/conf%%.txt
+:100644 100644 019d377767702b6c572fa4ae97c982e02dcd76fc 7c89764ba7a51c23e809b24376d90d7d06337437 M	src/test/java/hudson/plugins/git/browser/conf%abc%.txt
+:100644 100644 019d377767702b6c572fa4ae97c982e02dcd76fd 7c89764ba7a51c23e809b24376d90d7d06337438 M	src/test/java/hudson/plugins/git/browser/conf^%.txt
 :100644 100644 019d377767702b6c572fa4ae97c982e02dcd76fa 7c89764ba7a51c23e809b24376d90d7d06337435 M	src/test/java/hudson/plugins/git/browser/config file.txt
 :000000 100644 0000000000000000000000000000000000000000 885ce99421b3ae3a413a5c7fb0cdf9ec477d3f64 A	src/test/resources/hudson/plugins/git/browser/rawchangelog-with-escape


### PR DESCRIPTION
… in the CHANGES page

## [JENKINS-42597](https://issues.jenkins-ci.org/browse/JENKINS-42597) - Percent character (%) in filenames is not url-encoded in the CHANGES page

Percent character (%) in filenames is not url-encoded in the CHANGES page.  It results in broken links. 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

The fix has been applied to GitHubWeb.java, has to be tested on others 