### PR TITLE
[JENKINS-52964] Add SCMFileSystem.Builder supports for descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <concurrency>1C</concurrency>
-    <scm-api-plugin.version>2.2.0</scm-api-plugin.version>
+    <scm-api-plugin.version>2.2.9-rc414.0c084f357646</scm-api-plugin.version>
   </properties>
 
   <build>

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -61,6 +61,7 @@ import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceDescriptor;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
@@ -263,6 +264,11 @@ public class GitSCMFileSystem extends SCMFileSystem {
         @Override
         public boolean supports(SCMSource source) {
             return source instanceof AbstractGitSCMSource;
+        }
+
+        @Override
+        public boolean supports(SCMSourceDescriptor descriptor) {
+            return AbstractGitSCMSource.class.isAssignableFrom(descriptor.clazz);
         }
 
         @Override

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -44,6 +44,7 @@ import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceDescriptor;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
@@ -349,6 +350,13 @@ public class GitSCMFileSystemTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         assertTrue(gitPlugin260FS.changesSince(rev261, out));
         assertThat(out.toString(), is(""));
+    }
+
+    @Issue("JENKINS-52964")
+    @Test
+    public void filesystem_supports_descriptor() throws Exception {
+        SCMSourceDescriptor descriptor = r.jenkins.getDescriptorByType(GitSCMSource.DescriptorImpl.class);
+        assertTrue(SCMFileSystem.supports(descriptor));
     }
 
     /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */


### PR DESCRIPTION
## [JENKINS-52964](https://issues.jenkins-ci.org/browse/JENKINS-52964) - summarize pull request in one line

Add `GitSCMFileSystem.Builder#supports(SCMSourceDescriptor)`. See upstream PR https://github.com/jenkinsci/scm-api-plugin/pull/58 for more details.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
