### PR TITLE
Catch and print MissingObjectException

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -63,6 +63,7 @@ import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMMatrixUtil;
 import net.sf.json.JSONObject;
 
+import org.eclipse.jgit.errors.MissingObjectException;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -1250,7 +1251,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         try {
             RevCommit commit = git.withRepository(new RevCommitRepositoryCallback(revToBuild));
             listener.getLogger().println("Commit message: \"" + commit.getShortMessage() + "\"");
-        } catch (InterruptedException e) {
+        } catch (InterruptedException | MissingObjectException e) {
             e.printStackTrace(listener.error("Unable to retrieve commit message"));
         }
     }


### PR DESCRIPTION
## [JENKINS-53725](https://issues.jenkins-ci.org/browse/JENKINS-53725) - Catch and print MissingObjectException

This exception can occur if the repository JGit sees does, for whatever reason, not correspond to the repository Git sees.
For instance, JGit does not support git-worktree, so it will report that it could not find the object Jenkins was looking for.

This change allows git-plugin to work with git-worktree again.

Fixes JENKINS-53725

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
        - I don't see a good way to reproduce this issue in a unit test. Also, the catch clause for `InterruptedException` is also not covered by a unit test, so I followed that example
- [x] Unit tests pass locally with my changes
         - There was an unrelated warning, probably due to me running this on WSL on the regular windows part of the filesystem, which does not store milliseconds:

               [WARNING] Flakes:
               [WARNING] jenkins.plugins.git.GitSCMFileSystemTest.lastModified_Smokes(jenkins.plugins.git.GitSCMFileSystemTest)
               [ERROR]   Run 1: GitSCMFileSystemTest.lastModified_Smokes:207
               Expected: a value equal to or greater than <1538654592567L>
                    but: <1538654592000L> was less than <1538654592567L>
               [ERROR]   Run 2: GitSCMFileSystemTest.lastModified_Smokes:207
               Expected: a value equal to or greater than <1538654601715L>
                    but: <1538654601000L> was less than <1538654601715L>
               [ERROR]   Run 3: GitSCMFileSystemTest.lastModified_Smokes:207
               Expected: a value equal to or greater than <1538654604151L>
                    but: <1538654604000L> was less than <1538654604151L>
               [ERROR]   Run 4: GitSCMFileSystemTest.lastModified_Smokes:207
               Expected: a value equal to or greater than <1538654607645L>
                    but: <1538654607000L> was less than <1538654607645L>
               [INFO]   Run 5: PASS

- [x] I have added documentation as necessary
        - Documentation for a stop-gap measure is probably not necessary. You want people to stay away from this if they can, but still be able to use it if they must.
- [x] No Javadoc warnings were introduced with my changes
         - Not sure where these would show up, but since I didn't change any Javadoc, I probably didn't introduce any Javadoc warnings
- [x] No findbugs warnings were introduced with my changes
         - I don't have findbugs set up, but I don't think my changes will introduce any
- [x] I have interactively tested my changes
         - I interactively tested my changes with a separate, empty catch block for `MissingObjectException` and that works for me so far and fixes my build
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)
         - I'm not aware of any dependent changes that need to be done

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
