### PR TITLE
[JENKINS-21896] Merge commit message now gives more meaningful information

### DIFF
--- a/src/test/java/hudson/plugins/git/extensions/impl/PreBuildMergeMessageTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/PreBuildMergeMessageTest.java
@@ -1,0 +1,114 @@
+package hudson.plugins.git.extensions.impl;
+
+import static org.eclipse.jgit.lib.ObjectId.fromString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.jenkinsci.plugins.gitclient.CheckoutCommand;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.gitclient.MergeCommand;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import hudson.EnvVars;
+import hudson.Util;
+import hudson.model.FreeStyleBuild;
+import hudson.model.Saveable;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.Revision;
+import hudson.plugins.git.UserMergeOptions;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import hudson.util.DescribableList;
+
+public class PreBuildMergeMessageTest {
+
+    private final FreeStyleBuild build = mock(FreeStyleBuild.class);
+
+    private final GitSCM gitSCM = mock(GitSCM.class);
+
+    private final GitClient git = mock(GitClient.class);
+
+    private final TaskListener listener = mock(TaskListener.class);
+
+    private final Revision marked = mock(Revision.class);
+
+    private final MergeCommand mergeCommand = mock(MergeCommand.class);
+
+    @Before
+    public void setup() throws InterruptedException, IOException {
+        given(build.getEnvironment(listener)).willReturn(new EnvVars());
+
+        PrintStream logger = mock(PrintStream.class);
+        given(listener.getLogger()).willReturn(logger);
+
+        given(git.revParse(Mockito.anyString())).willReturn(fromString("11ec153f34767f7638378735dc2b907ed251a67d"));
+
+        CheckoutCommand checkoutCommand = mock(CheckoutCommand.class);
+        given(git.checkout()).willReturn(checkoutCommand);
+        given(checkoutCommand.branch(Mockito.anyString())).willReturn(checkoutCommand);
+        given(checkoutCommand.ref(Mockito.anyString())).willReturn(checkoutCommand);
+        given(checkoutCommand.deleteBranchIfExist(Mockito.anyBoolean())).willReturn(checkoutCommand);
+
+        DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> extensions = new DescribableList<>(Saveable.NOOP,
+                Util.fixNull(new ArrayList<GitSCMExtension>()));
+        given(gitSCM.getExtensions()).willReturn(extensions);
+
+        given(git.merge()).willReturn(mergeCommand);
+        given(mergeCommand.setRevisionToMerge(Mockito.any(ObjectId.class))).willReturn(mergeCommand);
+        given(mergeCommand.setMessage(Mockito.anyString())).willReturn(mergeCommand);
+    }
+
+    private void decorateRevisionToBuild(String initialBranch, String mergeToBranch)
+            throws InterruptedException, IOException {
+        Branch branch = new Branch(initialBranch, fromString("2cec153f34767f7638378735dc2b907ed251a67d"));
+        Revision rev = new Revision(branch.getSHA1(), Arrays.asList(branch));
+
+        UserMergeOptions userMergeOptions = new UserMergeOptions(mergeToBranch);
+        PreBuildMerge preBuildMerge = new PreBuildMerge(userMergeOptions);
+        preBuildMerge.decorateRevisionToBuild(gitSCM, build, git, listener, marked, rev);
+    }
+
+    @Test
+    public void branchNameSingleForwardSlash() throws InterruptedException, IOException {
+        decorateRevisionToBuild("origin/stable-3.9", "origin/stable-3.10");
+
+        verify(mergeCommand).setMessage("Merge branch stable-3.9 into stable-3.10");
+    }
+
+    @Test
+    public void branchNameMultipleForwardSlashes() throws InterruptedException, IOException {
+        decorateRevisionToBuild("refs/remotes/origin/stable-3.9", "refs/remotes/origin/stable-3.10");
+
+        verify(mergeCommand).setMessage("Merge branch stable-3.9 into stable-3.10");
+    }
+
+    @Test
+    public void branchNameNoForwardSlashes() throws InterruptedException, IOException {
+        decorateRevisionToBuild("stable-3.9", "stable-3.10");
+
+        verify(mergeCommand).setMessage("Merge branch stable-3.9 into stable-3.10");
+    }
+
+    @Test
+    public void emptyRevisionBranches() throws InterruptedException, IOException {
+        Revision rev = new Revision(fromString("2cec153f34767f7638378735dc2b907ed251a67d"));
+
+        UserMergeOptions userMergeOptions = new UserMergeOptions("123");
+        PreBuildMerge preBuildMerge = new PreBuildMerge(userMergeOptions);
+        preBuildMerge.decorateRevisionToBuild(gitSCM, build, git, listener, marked, rev);
+
+        verify(mergeCommand).setMessage("Merge branch null into 123");
+    }
+
+}


### PR DESCRIPTION
## [JENKINS-21896](https://issues.jenkins-ci.org/browse/JENKINS-21896) - Merge commit message now gives more meaningful information

If we want to actually push the merged changes to the repository the default message doesn't give us enough meaningful information which branches had been merged. This changes sets a more descriptive commit message to the merge.
For example if two branches are being merged:
- refs/remotes/origin/stable-3.9
- origin/stable-3.10

Then the commit message will be "Merge branch stable-3.9 into stable-3.10"

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
