### PR TITLE
Jenkins 29977

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pom.xml.releaseBackup
 *.swp
 Session.vim
 /nbproject/
+
+# Mac OSX
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.0.0-beta5</version>
+      <version>3.0.0-beta6-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.5-2.1</version>
+      <version>4.5.5-3.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -57,6 +57,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
     private static final String NULL_HASH = "0000000000000000000000000000000000000000";
     private static final String ISO_8601 = "yyyy-MM-dd'T'HH:mm:ss";
     private static final String ISO_8601_WITH_TZ = "yyyy-MM-dd'T'HH:mm:ssX";
+    private static final int TRUNCATE_LIMIT = 65;
 
     private final DateTimeFormatter [] dateFormatters;
 
@@ -225,14 +226,17 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                 }
             }
         }
-
         this.comment = message.toString();
 
-        int endOfFirstLine = this.comment.indexOf('\n');
-        if (endOfFirstLine == -1) {
-            this.title = this.comment;
-        } else {
-            this.title = this.comment.substring(0, endOfFirstLine);
+        if(new DescriptorImpl().isTruncateSummary()) {
+            this.title = this.comment.substring(0, TRUNCATE_LIMIT);
+        }else {
+            int endOfFirstLine = this.comment.indexOf('\n');
+            if (endOfFirstLine == -1) {
+                this.title = this.comment;
+            } else {
+                this.title = this.comment.substring(0, endOfFirstLine);
+            }
         }
     }
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1455,10 +1455,19 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         private String globalConfigEmail;
         private boolean createAccountBasedOnEmail;
 //        private GitClientType defaultClientType = GitClientType.GITCLI;
+        private boolean truncateSummary;
 
         public DescriptorImpl() {
             super(GitSCM.class, GitRepositoryBrowser.class);
             load();
+        }
+
+        public boolean isTruncateSummary() {
+            return truncateSummary;
+        }
+
+        public void setTruncateSummary(boolean truncateSummary) {
+            this.truncateSummary = truncateSummary;
         }
 
         public String getDisplayName() {

--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -11,6 +11,9 @@
     <f:entry title="${%Create new accounts based on author/committer's email}" field="createAccountBasedOnEmail">
            <f:checkbox name="createAccountBasedOnEmail" checked="${descriptor.createAccountBasedOnEmail}"/>
     </f:entry>
+    <f:entry title="${%Truncate changelog summary in Change View}" field="truncateSummary">
+      <f:checkbox name="truncateSummary" checked="${descriptor.truncateSummary}"/>
+    </f:entry>
     <!--
     <f:entry title="${%Default git client implementation}" field="defaultClientType">
         <select>

--- a/src/test/java/hudson/plugins/git/GitChangeSetBasicTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetBasicTest.java
@@ -2,7 +2,10 @@ package hudson.plugins.git;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+
 import static org.junit.Assert.*;
+
+import org.junit.Assert;
 import org.junit.Test;
 
 public class GitChangeSetBasicTest {
@@ -17,7 +20,8 @@ public class GitChangeSetBasicTest {
 
     @Test
     public void testLegacyChangeSet() {
-        GitChangeSetUtil.assertChangeSet(genChangeSet(false, true));
+        GitChangeSet gitChangeSet = GitChangeSetUtil.genChangeSet(false, true, false, GitChangeSetUtil.COMMIT_TITLE ,false);
+        GitChangeSetUtil.assertChangeSet( gitChangeSet );
     }
 
     @Test
@@ -130,4 +134,77 @@ public class GitChangeSetBasicTest {
     public void testSwedishTimestamp() {
         assertEquals(1363875404000L, genChangeSetForSwedCase(true).getTimestamp());
     }
+
+    @Test
+    public void testChangeLogTruncationWithShortMessage(){
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                "Lorem ipsum dolor sit amet.",
+                true);
+        String msg = changeSet.getMsg();
+        Assert.assertTrue("title is correct", msg.contains("Lorem ipsum dolor sit amet."));
+        Assert.assertTrue("title has correct size", msg.length() <= GitChangeSet.TRUNCATE_LIMIT);
+    }
+    @Test
+    public void testChangeLogTruncationWithNewLine(){
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                "Lorem ipsum dolor sit amet, "+System.lineSeparator()+"consectetur adipiscing elit.",
+                true);
+        String msg = changeSet.getMsg();
+        Assert.assertTrue("title is correct", msg.contains("Lorem ipsum dolor sit amet,"));
+        Assert.assertTrue("title has correct size", msg.length() <= GitChangeSet.TRUNCATE_LIMIT);
+    }
+
+    @Test
+    public void testChangeLogTruncationWithoutNewLine(){
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pellentesque ipsum non aliquam interdum. Integer metus orci, vulputate id turpis in, pharetra pretium magna. Fusce sollicitudin vehicula lectus. Nam ut eros purus. Mauris aliquam mi et nunc porta, non consectetur mauris pretium. Fusce a venenatis dolor. Sed commodo, dui ac posuere dignissim, dolor tortor semper eros, varius consequat nulla purus a lacus. Vestibulum egestas, orci vitae pellentesque laoreet, dolor lorem molestie tellus, nec luctus lorem ex quis orci. Phasellus interdum elementum luctus. Nam commodo, turpis in sollicitudin auctor, ipsum lectus finibus erat, in iaculis sapien neque ultrices sapien. In congue diam semper tortor laoreet aliquet. Mauris lacinia quis nunc vel accumsan. Nullam sed nisl eget orci porttitor venenatis. Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                true);
+        String msg = changeSet.getMsg();
+        Assert.assertTrue("title is correct", msg.contains("Lorem ipsum dolor sit amet, consectetur adipiscing elit."));
+        Assert.assertTrue("title has correct size", msg.length() <= GitChangeSet.TRUNCATE_LIMIT);
+    }
+
+    @Test
+    public void testChangeLogNoTruncationWithoutNewLine(){
+        String msg = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pellentesque ipsum non aliquam interdum. Integer metus orci, vulputate id turpis in, pharetra pretium magna. Fusce sollicitudin vehicula lectus. Nam ut eros purus. Mauris aliquam mi et nunc porta, non consectetur mauris pretium. Fusce a venenatis dolor. Sed commodo, dui ac posuere dignissim, dolor tortor semper eros, varius consequat nulla purus a lacus. Vestibulum egestas, orci vitae pellentesque laoreet, dolor lorem molestie tellus, nec luctus lorem ex quis orci. Phasellus interdum elementum luctus. Nam commodo, turpis in sollicitudin auctor, ipsum lectus finibus erat, in iaculis sapien neque ultrices sapien. In congue diam semper tortor laoreet aliquet. Mauris lacinia quis nunc vel accumsan. Nullam sed nisl eget orci porttitor venenatis. Lorem ipsum dolor sit amet, consectetur adipiscing elit";
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                msg,
+                false);
+        String changelogMessage = changeSet.getMsg();
+        Assert.assertTrue("title is correct", changelogMessage.equals(msg));
+    }
+
+    @Test
+    public void testChangeLogNoTruncationWithNewLine(){
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                "Lorem ipsum dolor sit amet, consectetur "+System.lineSeparator()+" adipiscing elit. Phasellus pellentesque ipsum non aliquam interdum. Integer metus orci, vulputate id turpis in, pharetra pretium magna. Fusce sollicitudin vehicula lectus. Nam ut eros purus. Mauris aliquam mi et nunc porta, non consectetur mauris pretium. Fusce a venenatis dolor. Sed commodo, dui ac posuere dignissim, dolor tortor semper eros, varius consequat nulla purus a lacus. Vestibulum egestas, orci vitae pellentesque laoreet, dolor lorem molestie tellus, nec luctus lorem ex quis orci. Phasellus interdum elementum luctus. Nam commodo, turpis in sollicitudin auctor, ipsum lectus finibus erat, in iaculis sapien neque ultrices sapien. In congue diam semper tortor laoreet aliquet. Mauris lacinia quis nunc vel accumsan. Nullam sed nisl eget orci porttitor venenatis. Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                false);
+        String msg = changeSet.getMsg();
+        Assert.assertEquals("title is correct", msg, "Lorem ipsum dolor sit amet, consectetur");
+    }
+
+    @Test
+    public void stringSplitter(){
+        String msg = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pellentesque ipsum non aliquam interdum. Integer metus orci, vulputate id turpis in, pharetra pretium magna. Fusce sollicitudin vehicula lectus. Nam ut eros purus. Mauris aliquam mi et nunc porta, non consectetur mauris pretium. Fusce a venenatis dolor. Sed commodo, dui ac posuere dignissim, dolor tortor semper eros, varius consequat nulla purus a lacus. Vestibulum egestas, orci vitae pellentesque laoreet, dolor lorem molestie tellus, nec luctus lorem ex quis orci. Phasellus interdum elementum luctus. Nam commodo, turpis in sollicitudin auctor, ipsum lectus finibus erat, in iaculis sapien neque ultrices sapien. In congue diam semper tortor laoreet aliquet. Mauris lacinia quis nunc vel accumsan. Nullam sed nisl eget orci porttitor venenatis. Lorem ipsum dolor sit amet, consectetur adipiscing elit";
+        Assert.assertEquals("Lorem ipsum", GitChangeSet.splitString(msg, 15));
+        Assert.assertEquals("Lorem ipsum", GitChangeSet.splitString(msg, 16));
+        Assert.assertEquals("Lorem ipsum", GitChangeSet.splitString(msg, 17));
+        Assert.assertEquals("Lorem ipsum dolor", GitChangeSet.splitString(msg, 18));
+        Assert.assertEquals("Lorem ipsum dolor", GitChangeSet.splitString(msg, 19));
+        Assert.assertEquals("Lorem ipsum dolor", GitChangeSet.splitString(msg, 20));
+        Assert.assertEquals("Lorem ipsum dolor", GitChangeSet.splitString(msg, 21));
+        Assert.assertEquals("Lorem ipsum dolor sit", GitChangeSet.splitString(msg, 22));
+
+        Assert.assertEquals("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus", GitChangeSet.splitString(msg, GitChangeSet.TRUNCATE_LIMIT));
+
+
+        msg = "Lorem ipsum dolor sit amet, " + System.lineSeparator() + "consectetur adipiscing elit. Phasellus pellentesque ipsum non aliquam interdum.";
+        System.out.println( GitChangeSet.splitString(msg, GitChangeSet.TRUNCATE_LIMIT));
+        Assert.assertEquals("Lorem ipsum dolor sit amet,",
+                GitChangeSet.splitString(msg, GitChangeSet.TRUNCATE_LIMIT));
+
+    }
+
+
 }
+

--- a/src/test/java/hudson/plugins/git/GitChangeSetEuroTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetEuroTest.java
@@ -60,7 +60,7 @@ public class GitChangeSetEuroTest {
         gitChangeLog.add("    Tested-by: Jenkins <jenkins@no-mail.com>");
         gitChangeLog.add("    Reviewed-by: Mister Another <mister.another@ericsson.com>");
         gitChangeLog.add("");
-        changeSet = new GitChangeSet(gitChangeLog, useAuthorName);
+        changeSet = new GitChangeSet(gitChangeLog, useAuthorName, false);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/git/GitChangeSetUtil.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetUtil.java
@@ -39,6 +39,13 @@ public class GitChangeSetUtil {
     }
 
     public static GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat, boolean hasParent) {
+        return genChangeSet(authorOrCommitter, useLegacyFormat, hasParent, COMMIT_TITLE);
+    }
+
+    public static GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat, boolean hasParent, String commitTitle) {
+       return genChangeSet(authorOrCommitter, useLegacyFormat, hasParent, commitTitle, false);
+    }
+    public static GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat, boolean hasParent, String commitTitle, boolean truncate) {
         ArrayList<String> lines = new ArrayList<>();
         lines.add("Some header junk we should ignore...");
         lines.add("header line 2");
@@ -52,7 +59,7 @@ public class GitChangeSetUtil {
         lines.add("author " + AUTHOR_NAME + " <" + AUTHOR_EMAIL + "> " + AUTHOR_DATE);
         lines.add("committer " + COMMITTER_NAME + " <" + COMMITTER_EMAIL + "> " + COMMITTER_DATE);
         lines.add("");
-        lines.add("    " + COMMIT_TITLE);
+        lines.add("    " + commitTitle);
         lines.add("    Commit extended description.");
         lines.add("");
         if (useLegacyFormat) {
@@ -65,7 +72,7 @@ public class GitChangeSetUtil {
         lines.add(":123456 789012 123abc456def789abc012def345abc678def901a bc234def567abc890def123abc456def789abc01 M\tsrc/test/modified.file");
         lines.add(":123456 789012 123abc456def789abc012def345abc678def901a bc234def567abc890def123abc456def789abc01 R012\tsrc/test/renamedFrom.file\tsrc/test/renamedTo.file");
         lines.add(":000000 123456 bc234def567abc890def123abc456def789abc01 123abc456def789abc012def345abc678def901a C100\tsrc/test/original.file\tsrc/test/copyOf.file");
-        return new GitChangeSet(lines, authorOrCommitter);
+        return new GitChangeSet(lines, authorOrCommitter, truncate);
     }
 
     static void assertChangeSet(GitChangeSet changeSet) {


### PR DESCRIPTION
## [JENKINS-29977](https://issues.jenkins-ci.org/browse/JENKINS-29977) - The commit messages in the changes view began to be truncated at some recent version of the Git plugin.

In order to fix this the git-client has been changed to deliver always the commit change message raw, no altercations done.
Therefore, this plugin will be able to truncate that message as configured in Jenkins.
> Manage Jenkins > Configure System > Git Plugin -> Truncate changelog summary in Change View

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x ] I have referenced the Jira issue related to my changes in one or more commit messages
- [x ] I have added tests that verify my changes
- [x ] Unit tests pass locally with my changes
- [x ] I have added documentation as necessary
- [x ] No Javadoc warnings were introduced with my changes
- [x ] No findbugs warnings were introduced with my changes
- [x ] I have interactively tested my changes
- [x ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

 The *GitChangeSet* class will had an extra contractor parameter to show is the truncation has to be done. That new param is provided by a static method, but is also visible for testing.
For truncating strings keeping words whole, regex has been used.