### PR TITLE
Update help-createAccountBasedOnEmail.html

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitSCM/help-createAccountBasedOnEmail.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-createAccountBasedOnEmail.html
@@ -1,4 +1,4 @@
 <p>
-    As git changelog is parsed to identify authors/committers and populate Jenkins user database, use email as ID for
-    new users.
+    If checked, upon parsing of git change logs, new user accounts are created on demand for the identified
+    committers / authors in the internal Jenkins database. The e-mail address is used as the id of the account.
 </p>


### PR DESCRIPTION
## Update help-createAccountBasedOnEmail.html

This updates the createAccountBasedOnEmail description to match the [Git Plugin wiki](https://wiki.jenkins.io/display/JENKINS/Git+Plugin). It is clear from both descriptions the checkbox will enable emails as the source of the user ID. The wiki description removes the ambiguity of whether the plugin always populates the user database by default or only when the checkbox is checked.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
