### PR TITLE
[JENKINS-53732] Don't alter git config outside Jenkins

### DIFF
--- a/src/test/java/hudson/plugins/git/GitChangeSetTruncateTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTruncateTest.java
@@ -18,6 +18,7 @@ import org.eclipse.jgit.lib.ObjectId;
 
 import hudson.EnvVars;
 import hudson.model.TaskListener;
+import jenkins.plugins.git.CliGitCommand;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 
@@ -116,6 +117,8 @@ public class GitChangeSetTruncateTest {
         String initialImpl = random.nextBoolean() ? "git" : "jgit";
         GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(repoRoot).using(initialImpl).getClient();
         gitClient.init_().workspace(repoRoot.getAbsolutePath()).execute();
+        new CliGitCommand(gitClient, "config", "user.name", "ChangeSet Truncation Test");
+        new CliGitCommand(gitClient, "config", "user.email", "ChangeSetTruncation@example.com");
     }
 
     private ObjectId commitOneFile(GitClient gitClient, final String commitSummary) throws Exception {

--- a/src/test/java/jenkins/plugins/git/CliGitCommand.java
+++ b/src/test/java/jenkins/plugins/git/CliGitCommand.java
@@ -139,12 +139,16 @@ public class CliGitCommand {
      * already set. Many tests assume that "git commit" can be called without
      * failure, but a newly installed user account does not necessarily have
      * values assigned for user.name and user.email. This method checks the
-     * existing values, and if they are not set, assigns default values. If the
+     * existing values when run in a Jenkins job, and if they are not set,
+     * assigns default values. If the
      * values are already set, they are unchanged.
      * @throws Exception on error
      */
     public void setDefaults() throws Exception {
-        setConfigIfEmpty("user.name", "Name From Git-Plugin-Test");
-        setConfigIfEmpty("user.email", "email.from.git.plugin.test@example.com");
+        if (System.getenv("JENKINS_URL") != null && System.getenv("BUILD_NUMBER") != null) {
+            /* We're in a Jenkins agent environment */
+	    setConfigIfEmpty("user.name", "Name From Git-Plugin-Test");
+	    setConfigIfEmpty("user.email", "email.from.git.plugin.test@example.com");
+	}
     }
 }


### PR DESCRIPTION
## [JENKINS-53732](https://issues.jenkins-ci.org/browse/JENKINS-53732) - Don't alter local git config unless in Jenkins

Automated tests were failing on newly installed agents because the git user.name and user.email were not configured.  However, the setConfigIfEmpty() function is not smart enough to detect all the cases where values are configured.

Since the most crucial test failure case is when running inside a Jenkins agent, this change leaves the values unmodified unless JENKINS_URL and BUILD_NUMBER environment variables are defined.

Unit tests of the git plugin fail if the user.name and user.email values are not defined.  This code attempts to set values for those configuration items if they are not set.  Unfortunately, the "is not set" test does not detect cases like the one reported in [JENKINS-53732](https://issues.jenkins-ci.org/browse/JENKINS-53732).

Rather than attempt to detect all the cases, this change acknowledges that the unit tests running inside a Jenkins job are the most useful place to assure values are set.  Developers can adjust their environments.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

@casz is this sufficient for the case that you're reporting in JENKINS-53732, or are there other cases that are important to you?