### PR TITLE
[WIP] JENKINS-14138: Fix new git branch has empty changelist

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitStepTest.java
+++ b/src/test/java/jenkins/plugins/git/GitStepTest.java
@@ -227,7 +227,8 @@ public class GitStepTest {
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals(1, b.getActions(BuildData.class).size());
         assertEquals(1, b.getActions(GitTagAction.class).size());
-        assertEquals(0, b.getChangeSets().size());
+        assertEquals(1, b.getChangeSets().size());
+        assertFalse(b.getChangeSets().get(0).isEmptySet());
         assertEquals(1, p.getSCMs().size());
 
         otherRepo.write("secondfile", "");


### PR DESCRIPTION
## [JENKINS-14138](https://issues.jenkins-ci.org/browse/JENKINS-xxxxx) - Fix new git branch has empty changelist

If previous build is not set, iterating over ancestors of current rev, while always on same branches.
History traversal stops on the first commit which is not on all branches of the checkouted commit, or if we have already inspected MAX_CHANGELOG commits.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

