### PR TITLE
JENKINS-29977 add option to retain full changelog summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pom.xml.releaseBackup
 *.swp
 Session.vim
 /nbproject/
+
+# Mac OSX
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.0.0-beta5</version>
+      <version>3.0.0-beta6-rc1822.65df57d49890</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -57,6 +57,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
     private static final String NULL_HASH = "0000000000000000000000000000000000000000";
     private static final String ISO_8601 = "yyyy-MM-dd'T'HH:mm:ss";
     private static final String ISO_8601_WITH_TZ = "yyyy-MM-dd'T'HH:mm:ssX";
+    static final int TRUNCATE_LIMIT = 72;
 
     private final DateTimeFormatter [] dateFormatters;
 
@@ -93,15 +94,28 @@ public class GitChangeSet extends ChangeLogSet.Entry {
     private String parentCommit;
     private Collection<Path> paths = new HashSet<>();
     private boolean authorOrCommitter;
+    private boolean showEntireCommitSummaryInChanges;
 
     /**
-     * Create Git change set using information in given lines
+     * Create Git change set using information in given lines.
      *
      * @param lines change set lines read to construct change set
      * @param authorOrCommitter if true, use author information (name, time), otherwise use committer information
      */
     public GitChangeSet(List<String> lines, boolean authorOrCommitter) {
+        this(lines, authorOrCommitter, isShowEntireCommitSummaryInChanges());
+    }
+
+    /**
+     * Create Git change set using information in given lines.
+     *
+     * @param lines change set lines read to construct change set
+     * @param authorOrCommitter if true, use author information (name, time), otherwise use committer information
+     * @param retainFullCommitSummary if true, do not truncate commit summary in the 'Changes' page
+     */
+    public GitChangeSet(List<String> lines, boolean authorOrCommitter, boolean retainFullCommitSummary) {
         this.authorOrCommitter = authorOrCommitter;
+        this.showEntireCommitSummaryInChanges = retainFullCommitSummary;
         if (lines.size() > 0) {
             parseCommit(lines);
         }
@@ -150,6 +164,14 @@ public class GitChangeSet extends ChangeLogSet.Entry {
         dateFormatters[0] = gitDateFormatter; // First priority +%cI format
         dateFormatters[1] = nearlyISOFormatter; // Second priority seen in git-plugin
         dateFormatters[2] = isoDateFormat; // Third priority, ISO 8601 format
+    }
+
+    static boolean isShowEntireCommitSummaryInChanges() {
+        try {
+            return new DescriptorImpl().isShowEntireCommitSummaryInChanges();
+        }catch (Throwable t){
+            return false;
+        }
     }
 
     private void parseCommit(List<String> lines) {
@@ -225,15 +247,34 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                 }
             }
         }
-
         this.comment = message.toString();
-
         int endOfFirstLine = this.comment.indexOf('\n');
         if (endOfFirstLine == -1) {
-            this.title = this.comment;
+            this.title = this.comment.trim();
         } else {
-            this.title = this.comment.substring(0, endOfFirstLine);
+            this.title = this.comment.substring(0, endOfFirstLine).trim();
         }
+         if(!showEntireCommitSummaryInChanges){
+            this.title = splitString(this.title, TRUNCATE_LIMIT);
+        }
+    }
+
+    /* Package protected for testing */
+    static String splitString(String msg, int lineSize) {
+        if (msg ==  null) return "";
+        if (msg.matches(".*[\r\n].*")) {
+            String [] msgArray = msg.split("[\r\n]");
+            msg = msgArray[0];
+        }
+        if (msg.length() <= lineSize || !msg.contains(" ")) {
+            return msg;
+        }
+        int lastSpace = msg.lastIndexOf(' ', lineSize);
+        if (lastSpace == -1) {
+            /* String contains a space but space is outside truncation limit, truncate at first space */
+            lastSpace = msg.indexOf(' ');
+        }
+        return (lastSpace == -1) ? msg : msg.substring(0, lastSpace);
     }
 
     /** Convert to iso date format if required */

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1455,10 +1455,19 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         private String globalConfigEmail;
         private boolean createAccountBasedOnEmail;
 //        private GitClientType defaultClientType = GitClientType.GITCLI;
+        private boolean showEntireCommitSummaryInChanges;
 
         public DescriptorImpl() {
             super(GitSCM.class, GitRepositoryBrowser.class);
             load();
+        }
+
+        public boolean isShowEntireCommitSummaryInChanges() {
+            return showEntireCommitSummaryInChanges;
+        }
+
+        public void setShowEntireCommitSummaryInChanges(boolean showEntireCommitSummaryInChanges) {
+            this.showEntireCommitSummaryInChanges = showEntireCommitSummaryInChanges;
         }
 
         public String getDisplayName() {

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -75,6 +75,7 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
      * @return
      *      null if the browser doesn't have any suitable URL.
      * @throws IOException on input or output error
+     * @throws URISyntaxException on URI syntax error
      */
     public abstract URL getFileLink(GitChangeSet.Path path) throws IOException, URISyntaxException;
 

--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -11,6 +11,9 @@
     <f:entry title="${%Create new accounts based on author/committer's email}" field="createAccountBasedOnEmail">
            <f:checkbox name="createAccountBasedOnEmail" checked="${descriptor.createAccountBasedOnEmail}"/>
     </f:entry>
+    <f:entry title="${%Show the entire commit summary in changes}" field="showEntireCommitSummaryInChanges">
+      <f:checkbox name="showEntireCommitSummaryInChanges" checked="${descriptor.showEntireCommitSummaryInChanges}"/>
+    </f:entry>
     <!--
     <f:entry title="${%Default git client implementation}" field="defaultClientType">
         <select>

--- a/src/test/java/hudson/plugins/git/GitChangeSetBasicTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetBasicTest.java
@@ -2,6 +2,8 @@ package hudson.plugins.git;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import static hudson.plugins.git.GitChangeSet.TRUNCATE_LIMIT;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
 
@@ -17,7 +19,8 @@ public class GitChangeSetBasicTest {
 
     @Test
     public void testLegacyChangeSet() {
-        GitChangeSetUtil.assertChangeSet(genChangeSet(false, true));
+        GitChangeSet gitChangeSet = GitChangeSetUtil.genChangeSet(false, true, false, GitChangeSetUtil.COMMIT_TITLE ,false);
+        GitChangeSetUtil.assertChangeSet( gitChangeSet );
     }
 
     @Test
@@ -129,5 +132,121 @@ public class GitChangeSetBasicTest {
     @Test
     public void testSwedishTimestamp() {
         assertEquals(1363875404000L, genChangeSetForSwedCase(true).getTimestamp());
+    }
+
+    @Test
+    public void testChangeLogTruncationWithShortMessage(){
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                "Lorem ipsum dolor sit amet.",
+                false);
+        String msg = changeSet.getMsg();
+        assertThat("Title is correct ", msg, containsString("Lorem ipsum dolor sit amet.") );
+        assertThat("Title length is correct ", msg.length(), lessThanOrEqualTo(TRUNCATE_LIMIT));
+    }
+
+    @Test
+    public void testChangeLogTruncationWithNewLine(){
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                "Lorem ipsum dolor sit amet, "+System.lineSeparator()+"consectetur adipiscing elit.",
+                false);
+        String msg = changeSet.getMsg();
+        assertThat(msg, is("Lorem ipsum dolor sit amet,"));
+        assertThat("Title length is correct ", msg.length(), lessThanOrEqualTo(TRUNCATE_LIMIT));
+    }
+
+    @Test
+    public void testChangeLogRetainSummaryWithoutNewLine(){
+        String originalCommitMessage = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pellentesque ipsum non aliquam interdum. Integer metus orci, vulputate id turpis in, pharetra pretium magna. Fusce sollicitudin vehicula lectus. Nam ut eros purus. Mauris aliquam mi et nunc porta, non consectetur mauris pretium. Fusce a venenatis dolor. Sed commodo, dui ac posuere dignissim, dolor tortor semper eros, varius consequat nulla purus a lacus. Vestibulum egestas, orci vitae pellentesque laoreet, dolor lorem molestie tellus, nec luctus lorem ex quis orci. Phasellus interdum elementum luctus. Nam commodo, turpis in sollicitudin auctor, ipsum lectus finibus erat, in iaculis sapien neque ultrices sapien. In congue diam semper tortor laoreet aliquet. Mauris lacinia quis nunc vel accumsan. Nullam sed nisl eget orci porttitor venenatis. Lorem ipsum dolor sit amet, consectetur adipiscing elit";
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                originalCommitMessage,
+                true);
+        assertThat(changeSet.getMsg(), is(originalCommitMessage));
+    }
+
+    @Test
+    public void testChangeLogDoNotRetainSummaryWithoutNewLine(){
+        String msg = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pellentesque ipsum non aliquam interdum. Integer metus orci, vulputate id turpis in, pharetra pretium magna. Fusce sollicitudin vehicula lectus. Nam ut eros purus. Mauris aliquam mi et nunc porta, non consectetur mauris pretium. Fusce a venenatis dolor. Sed commodo, dui ac posuere dignissim, dolor tortor semper eros, varius consequat nulla purus a lacus. Vestibulum egestas, orci vitae pellentesque laoreet, dolor lorem molestie tellus, nec luctus lorem ex quis orci. Phasellus interdum elementum luctus. Nam commodo, turpis in sollicitudin auctor, ipsum lectus finibus erat, in iaculis sapien neque ultrices sapien. In congue diam semper tortor laoreet aliquet. Mauris lacinia quis nunc vel accumsan. Nullam sed nisl eget orci porttitor venenatis. Lorem ipsum dolor sit amet, consectetur adipiscing elit";
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                msg,
+                false);
+        assertThat(changeSet.getMsg(), is("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus"));
+    }
+
+    @Test
+    public void testChangeLogNoTruncationWithNewLine(){
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                "Lorem ipsum dolor sit amet, consectetur "+System.lineSeparator()+" adipiscing elit. Phasellus pellentesque ipsum non aliquam interdum. Integer metus orci, vulputate id turpis in, pharetra pretium magna. Fusce sollicitudin vehicula lectus. Nam ut eros purus. Mauris aliquam mi et nunc porta, non consectetur mauris pretium. Fusce a venenatis dolor. Sed commodo, dui ac posuere dignissim, dolor tortor semper eros, varius consequat nulla purus a lacus. Vestibulum egestas, orci vitae pellentesque laoreet, dolor lorem molestie tellus, nec luctus lorem ex quis orci. Phasellus interdum elementum luctus. Nam commodo, turpis in sollicitudin auctor, ipsum lectus finibus erat, in iaculis sapien neque ultrices sapien. In congue diam semper tortor laoreet aliquet. Mauris lacinia quis nunc vel accumsan. Nullam sed nisl eget orci porttitor venenatis. Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                true);
+        String msg = changeSet.getMsg();
+        assertThat("Title is correct ", msg, is("Lorem ipsum dolor sit amet, consectetur") );
+    }
+
+    @Test
+    public void testChangeLogEdgeCaseNotTruncating(){
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                "[JENKINS-012345] 8901 34567 90 23456 8901 34567 9012 4567890 2345678 0 2 4 5",
+                false);
+        String msg = changeSet.getMsg();
+        assertThat( msg.length(), lessThanOrEqualTo( TRUNCATE_LIMIT ));
+        assertThat( msg, is("[JENKINS-012345] 8901 34567 90 23456 8901 34567 9012 4567890 2345678 0 2") );
+    }
+
+    @Test
+    public void testChangeLogEdgeCaseTruncating(){
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                "[JENKINS-012345] 8901 34567 90 23456 8901 34567 9012 4567890 2345678 0 2 4 5",
+                true);
+        String msg = changeSet.getMsg();
+        assertThat( msg, is("[JENKINS-012345] 8901 34567 90 23456 8901 34567 9012 4567890 2345678 0 2 4 5") );
+    }
+
+    @Test
+    public void testChangeLogEdgeCaseTruncatingAndNewLine(){
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                "[JENKINS-012345] 8901 34567 " + System.lineSeparator() + "90 23456 8901 34567 9012 4567890 2345678 0 2 4 5",
+                true);
+        String msg = changeSet.getMsg();
+        assertThat( msg, is("[JENKINS-012345] 8901 34567") );
+    }
+
+    @Test
+    public void testLongString(){
+        GitChangeSet changeSet = GitChangeSetUtil.genChangeSet(true, false, true,
+                "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+                false);
+        String msg = changeSet.getMsg();
+        assertThat( msg, is("12345678901234567890123456789012345678901234567890123456789012345678901234567890") );
+    }
+
+    @Test
+    public void stringSplitter(){
+        String msg = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pellentesque ipsum non aliquam interdum. Integer metus orci, vulputate id turpis in, pharetra pretium magna. Fusce sollicitudin vehicula lectus. Nam ut eros purus. Mauris aliquam mi et nunc porta, non consectetur mauris pretium. Fusce a venenatis dolor. Sed commodo, dui ac posuere dignissim, dolor tortor semper eros, varius consequat nulla purus a lacus. Vestibulum egestas, orci vitae pellentesque laoreet, dolor lorem molestie tellus, nec luctus lorem ex quis orci. Phasellus interdum elementum luctus. Nam commodo, turpis in sollicitudin auctor, ipsum lectus finibus erat, in iaculis sapien neque ultrices sapien. In congue diam semper tortor laoreet aliquet. Mauris lacinia quis nunc vel accumsan. Nullam sed nisl eget orci porttitor venenatis. Lorem ipsum dolor sit amet, consectetur adipiscing elit";
+        assertThat(GitChangeSet.splitString(msg, 15), is("Lorem ipsum"));
+        assertThat(GitChangeSet.splitString(msg, 16), is("Lorem ipsum"));
+        assertThat(GitChangeSet.splitString(msg, 17), is("Lorem ipsum dolor"));
+        assertThat(GitChangeSet.splitString(msg, 18), is("Lorem ipsum dolor"));
+        assertThat(GitChangeSet.splitString(msg, 19), is("Lorem ipsum dolor"));
+        assertThat(GitChangeSet.splitString(msg, 20), is("Lorem ipsum dolor"));
+        assertThat(GitChangeSet.splitString(msg, 21), is("Lorem ipsum dolor sit"));
+        assertThat(GitChangeSet.splitString(msg, 22), is("Lorem ipsum dolor sit"));
+
+        msg = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pellentesque ipsum non aliquam interdum.";
+        assertThat(GitChangeSet.splitString(msg, TRUNCATE_LIMIT),
+                is("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus"));
+    }
+
+    @Test
+    public void splitingWithBrackets(){
+        assertThat(GitChangeSet.splitString("[task] Lorem ipsum dolor sit amet, consectetur adipiscing elit.", 25), is("[task] Lorem ipsum dolor"));
+    }
+
+    @Test
+    public void splitingEmptyString(){
+        assertThat(GitChangeSet.splitString("", 25), is(""));
+    }
+
+    @Test
+    public void splitingNullString(){
+        assertThat(GitChangeSet.splitString(null, 25), is(""));
     }
 }

--- a/src/test/java/hudson/plugins/git/GitChangeSetEuroTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetEuroTest.java
@@ -60,7 +60,7 @@ public class GitChangeSetEuroTest {
         gitChangeLog.add("    Tested-by: Jenkins <jenkins@no-mail.com>");
         gitChangeLog.add("    Reviewed-by: Mister Another <mister.another@ericsson.com>");
         gitChangeLog.add("");
-        changeSet = new GitChangeSet(gitChangeLog, useAuthorName);
+        changeSet = new GitChangeSet(gitChangeLog, useAuthorName, false);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/git/GitChangeSetTruncateTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTruncateTest.java
@@ -49,6 +49,8 @@ public class GitChangeSetTruncateTest {
 
     /* Computed in the constructor, used in tests */
     private final GitChangeSet changeSet;
+    private final GitChangeSet changeSetFullSummary;
+    private final GitChangeSet changeSetTruncatedSummary;
 
     private static class TestData {
 
@@ -94,6 +96,8 @@ public class GitChangeSetTruncateTest {
         gitClient.changelog().includes(head).to(changelogStringWriter).execute();
         List<String> changeLogList = Arrays.asList(changelogStringWriter.toString().split("\n"));
         changeSet = new GitChangeSet(changeLogList, random.nextBoolean());
+        changeSetFullSummary = new GitChangeSet(changeLogList, random.nextBoolean(), true);
+        changeSetTruncatedSummary = new GitChangeSet(changeLogList, random.nextBoolean(), false);
     }
 
     @Parameterized.Parameters(name = "{0} \"{1}\" --->>> \"{2}\"")
@@ -150,6 +154,23 @@ public class GitChangeSetTruncateTest {
     @Test
     @Issue("JENKINS-29977") // CLI git truncates first line of commit message in Changes page, JGit doesn't
     public void summaryTruncatedAtLastWord72CharactersOrLess() throws Exception {
-        assertThat(changeSet.getMsg(), is(gitImpl.equals("git") ? truncatedSummary : commitSummary));
+        /**
+         * Before git plugin 4.0, calls to GitChangeSet(x, y) truncated CLI git, did not truncate JGit.
+         * After git plugin 4.0, calls to GitChangeSet(x, y) truncates CLI git, truncates JGit.
+         * Callers after git plugin 4.0 must use the GitChangeSet(x, y, z) call to specify truncation behavior.
+         */
+        assertThat(changeSet.getMsg(), is(truncatedSummary));
+    }
+
+    @Test
+    @Issue("JENKINS-29977")
+    public void summaryAlwaysTruncatedAtLastWord72CharactersOrLess() throws Exception {
+        assertThat(changeSetTruncatedSummary.getMsg(), is(truncatedSummary));
+    }
+
+    @Test
+    @Issue("JENKINS-29977")
+    public void summaryNotTruncatedAtLastWord72CharactersOrLess() throws Exception {
+        assertThat(changeSetFullSummary.getMsg(), is(commitSummary));
     }
 }

--- a/src/test/java/hudson/plugins/git/GitChangeSetUtil.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetUtil.java
@@ -39,6 +39,14 @@ public class GitChangeSetUtil {
     }
 
     public static GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat, boolean hasParent) {
+        return genChangeSet(authorOrCommitter, useLegacyFormat, hasParent, COMMIT_TITLE);
+    }
+
+    public static GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat, boolean hasParent, String commitTitle) {
+       return genChangeSet(authorOrCommitter, useLegacyFormat, hasParent, commitTitle, false);
+    }
+
+    public static GitChangeSet genChangeSet(boolean authorOrCommitter, boolean useLegacyFormat, boolean hasParent, String commitTitle, boolean truncate) {
         ArrayList<String> lines = new ArrayList<>();
         lines.add("Some header junk we should ignore...");
         lines.add("header line 2");
@@ -52,7 +60,7 @@ public class GitChangeSetUtil {
         lines.add("author " + AUTHOR_NAME + " <" + AUTHOR_EMAIL + "> " + AUTHOR_DATE);
         lines.add("committer " + COMMITTER_NAME + " <" + COMMITTER_EMAIL + "> " + COMMITTER_DATE);
         lines.add("");
-        lines.add("    " + COMMIT_TITLE);
+        lines.add("    " + commitTitle);
         lines.add("    Commit extended description.");
         lines.add("");
         if (useLegacyFormat) {
@@ -65,7 +73,7 @@ public class GitChangeSetUtil {
         lines.add(":123456 789012 123abc456def789abc012def345abc678def901a bc234def567abc890def123abc456def789abc01 M\tsrc/test/modified.file");
         lines.add(":123456 789012 123abc456def789abc012def345abc678def901a bc234def567abc890def123abc456def789abc01 R012\tsrc/test/renamedFrom.file\tsrc/test/renamedTo.file");
         lines.add(":000000 123456 bc234def567abc890def123abc456def789abc01 123abc456def789abc012def345abc678def901a C100\tsrc/test/original.file\tsrc/test/copyOf.file");
-        return new GitChangeSet(lines, authorOrCommitter);
+        return new GitChangeSet(lines, authorOrCommitter, truncate);
     }
 
     static void assertChangeSet(GitChangeSet changeSet) {


### PR DESCRIPTION
## [JENKINS-29977](https://issues.jenkins-ci.org/browse/JENKINS-29977) - add option to retain full changelog summary

The command line git implementation inside git client plugin 2.0 and later will silently truncate the commit summary at the last word break prior to 73 characters.

The JGit implementation does not truncate the commit summary.

This change adds a global option which will retain the full commit summary in both the command line git implementation and the JGit implementation.

The command line git implementation continues to truncate by default so that behavioral compatibility is retained for existing users of the command line git implementation.

The JGit implementation continues to not truncate by default in the user interface so that behavioral compatibility is retained for existing users of the JGit implementation.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

Consumers of the git plugin API that use the previous two argument GitChangeSet constructor with the command line git implementation will continue to see truncated commit summary messages unless the global option has been set to retain the full commit summary.

Consumers of the git plugin API that use the previous two argument GitChangeSet constructor with the JGit  implementation will see truncated commit summary messages unless the global option has been set to retain the full commit summary.  This is a change of JGit behavior from previous use. If an API consumer needs the previous behavior, they will need to call the new three argument GitChangeSet constructor so that they can explicitly control the truncation.

This change relies on the git client plugin 3.0 change which moves the responsibility for commit message summary truncation from the git client plugin to the git plugin.
