### PR TITLE
[JENKINS-54972] Include the SCM name on changes pages

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSetList.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSetList.java
@@ -16,11 +16,17 @@ import java.util.List;
  */
 public class GitChangeSetList extends ChangeLogSet<GitChangeSet> {
     private final List<GitChangeSet> changeSets;
+    private final String scmName;
 
-    /*package*/ GitChangeSetList(Run build, RepositoryBrowser<?> browser, List<GitChangeSet> logs) {
+    /*package*/ GitChangeSetList(
+            Run build,
+            RepositoryBrowser<?> browser,
+            List<GitChangeSet> logs,
+            String scmName) {
         super(build, browser);
         Collections.reverse(logs);  // put new things first
         this.changeSets = Collections.unmodifiableList(logs);
+        this.scmName = scmName;
         for (GitChangeSet log : logs)
             log.setParent(this);
     }
@@ -35,6 +41,10 @@ public class GitChangeSetList extends ChangeLogSet<GitChangeSet> {
 
     public List<GitChangeSet> getLogs() {
         return changeSets;
+    }
+
+    public String getScmName() {
+        return scmName;
     }
 
     @Exported

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1444,11 +1444,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     public ChangeLogParser createChangeLogParser() {
         try {
             GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using(gitTool).getClient();
-            return new GitChangeLogParser(gitClient, getExtensions().get(AuthorInChangelog.class) != null);
+            return new GitChangeLogParser(gitClient, getExtensions().get(AuthorInChangelog.class) != null, getScmName());
         } catch (IOException | InterruptedException e) {
             LOGGER.log(Level.WARNING, "Git client using '" + gitTool + "' changelog parser failed, using deprecated changelog parser", e);
         }
-        return new GitChangeLogParser(getExtensions().get(AuthorInChangelog.class) != null);
+        return new GitChangeLogParser(null, getExtensions().get(AuthorInChangelog.class) != null, getScmName());
     }
 
     @Extension

--- a/src/main/resources/hudson/plugins/git/GitChangeSetList/digest.jelly
+++ b/src/main/resources/hudson/plugins/git/GitChangeSetList/digest.jelly
@@ -12,7 +12,7 @@
       ${%No changes.}
     </j:when>
     <j:otherwise>
-      ${%Changes}
+      ${%Changes}<j:if test="${!empty(it.scmName)}"> from <b>SCM:</b> ${it.scmName}</j:if>
       <ol>
         <j:forEach var="cs" items="${it.logs}" varStatus="loop">
           <li>

--- a/src/main/resources/hudson/plugins/git/GitChangeSetList/index.jelly
+++ b/src/main/resources/hudson/plugins/git/GitChangeSetList/index.jelly
@@ -5,7 +5,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="browser" value="${it.browser}"/>
 
-  <h2>${%Summary}</h2>
+  <h2>${%Summary} <j:if test="${!empty(it.scmName)}">for SCM: ${it.scmName}</j:if></h2>
   <ol>
     <j:forEach var="cs" items="${it.logs}">
       <li><j:out value="${cs.msgAnnotated}"/> (<a href="#${cs.id}">${%details}</a>)</li>

--- a/src/main/resources/hudson/plugins/git/GitSCM/project-changes.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/project-changes.jelly
@@ -44,9 +44,11 @@ THE SOFTWARE.
         <j:forEach var="changeSet" items="${b.changeSets}">
           <j:set var="browser" value="${changeSet.browser}"/>
           <j:set var="hadChanges" value="${true}"/>
-          <h2><a href="${b.number}/changes">${b.displayName}
-            (<i:formatDate value="${b.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)</a></h2>
-
+          <h2><a href="${b.number}/changes">
+            ${b.displayName}
+            (<i:formatDate value="${b.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)
+            <j:if test="${!empty(changeSet.scmName)}"> for SCM: ${changeSet.scmName}</j:if>
+          </a></h2>
           <ol>
             <j:forEach var="c" items="${changeSet.iterator()}">
               <li>

--- a/src/test/java/hudson/plugins/git/GitChangeLogParserTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeLogParserTest.java
@@ -45,7 +45,7 @@ public class GitChangeLogParserTest {
     }
 
     private void generateDuplicateChanges(GitClient gitClient, String expectedMessage) throws Exception {
-        GitChangeLogParser parser = new GitChangeLogParser(gitClient, true);
+        GitChangeLogParser parser = new GitChangeLogParser(gitClient, true, null);
         File log = tmpFolder.newFile();
         try (FileWriter writer = new FileWriter(log)) {
             writer.write("commit 123abc456def\n");

--- a/src/test/java/hudson/plugins/git/GitChangeSetListTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetListTest.java
@@ -43,7 +43,7 @@ public class GitChangeSetListTest {
     public GitChangeSetListTest() {
         RepositoryBrowser<?> browser = null;
         Run build = null;
-        emptyChangeSetList = new GitChangeSetList(build, browser, new ArrayList<>());
+        emptyChangeSetList = new GitChangeSetList(build, browser, new ArrayList<>(), null);
     }
 
     @Before
@@ -55,7 +55,7 @@ public class GitChangeSetListTest {
         changeSet = new GitChangeSet(changeSetText, true);
         assertTrue(logs.add(changeSet));
         assertThat(changeSet.getParent(), is(nullValue()));
-        changeSetList = new GitChangeSetList(build, browser, logs);
+        changeSetList = new GitChangeSetList(build, browser, logs, null);
         assertThat(changeSet.getParent(), is(changeSetList));
     }
 

--- a/src/test/java/hudson/plugins/git/browser/BitbucketWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/BitbucketWebTest.java
@@ -83,7 +83,7 @@ public class BitbucketWebTest {
     private GitChangeSet createChangeSet(String rawchangelogpath) throws Exception {
         /* Use randomly selected git client implementation since the client implementation should not change result */
         GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using(random.nextBoolean() ? "Default" : "jgit").getClient();
-        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false);
+        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false, null);
         final List<GitChangeSet> changeSetList = logParser.parse(BitbucketWebTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }

--- a/src/test/java/hudson/plugins/git/browser/GitLabTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitLabTest.java
@@ -158,7 +158,7 @@ public class GitLabTest {
     private GitChangeSet createChangeSet(String rawchangelogpath) throws Exception {
         /* Use randomly selected git client implementation since the client implementation should not change result */
         GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using(random.nextBoolean() ? "Default" : "jgit").getClient();
-        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false);
+        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false, null);
         final List<GitChangeSet> changeSetList = logParser.parse(GitLabTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }

--- a/src/test/java/hudson/plugins/git/browser/GitListTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitListTest.java
@@ -80,7 +80,7 @@ public class GitListTest {
     private GitChangeSet createChangeSet(String rawchangelogpath) throws Exception {
         /* Use randomly selected git client implementation since the client implementation should not change result */
         GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using(random.nextBoolean() ? null : "jgit").getClient();
-        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false);
+        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false, null);
         final List<GitChangeSet> changeSetList = logParser.parse(GitListTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }

--- a/src/test/java/hudson/plugins/git/browser/GitWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitWebTest.java
@@ -63,7 +63,7 @@ public class GitWebTest {
     private GitChangeSet createChangeSet(String rawchangelogpath) throws Exception {
         /* Use randomly selected git client implementation since the client implementation should not change result */
         GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using(random.nextBoolean() ? null : "jgit").getClient();
-        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, random.nextBoolean());
+        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, random.nextBoolean(), null);
         final List<GitChangeSet> changeSetList = logParser.parse(GitWebTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }

--- a/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
@@ -206,7 +206,7 @@ public class GithubWebTest {
     private GitChangeSet createChangeSet(String rawchangelogpath) throws Exception {
         /* Use randomly selected git client implementation since the client implementation should not change result */
         GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using(random.nextBoolean() ? null : "jgit").getClient();
-        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false);
+        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false, null);
         final List<GitChangeSet> changeSetList = logParser.parse(GithubWebTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }

--- a/src/test/java/hudson/plugins/git/browser/GitoriousWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitoriousWebTest.java
@@ -71,7 +71,7 @@ public class GitoriousWebTest {
     private GitChangeSet createChangeSet(String rawchangelogpath) throws Exception {
         /* Use randomly selected git client implementation since the client implementation should not change result */
         GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using(random.nextBoolean() ? null : "jgit").getClient();
-        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false);
+        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false, null);
         final List<GitChangeSet> changeSetList = logParser.parse(GitoriousWebTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }

--- a/src/test/java/hudson/plugins/git/browser/GogsGitTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GogsGitTest.java
@@ -75,7 +75,7 @@ public class GogsGitTest {
     private GitChangeSet createChangeSet(String rawchangelogpath) throws Exception {
         /* Use randomly selected git client implementation since the client implementation should not change result */
         GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using(random.nextBoolean() ? null : "jgit").getClient();
-        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false);
+        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false, null);
         final List<GitChangeSet> changeSetList = logParser.parse(GogsGitTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }

--- a/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
+++ b/src/test/java/hudson/plugins/git/browser/KilnGitTest.java
@@ -75,7 +75,7 @@ public class KilnGitTest {
     private GitChangeSet createChangeSet(String rawchangelogpath) throws Exception {
         /* Use randomly selected git client implementation since the client implementation should not change result */
         GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using(random.nextBoolean() ? null : "jgit").getClient();
-        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false);
+        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false, null);
         final List<GitChangeSet> changeSetList = logParser.parse(KilnGitTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }

--- a/src/test/java/hudson/plugins/git/browser/RedmineWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/RedmineWebTest.java
@@ -75,7 +75,7 @@ public class RedmineWebTest {
     private GitChangeSet createChangeSet(String rawchangelogpath) throws Exception {
         /* Use randomly selected git client implementation since the client implementation should not change result */
         GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using(random.nextBoolean() ? null : "jgit").getClient();
-        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false);
+        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false, null);
         final List<GitChangeSet> changeSetList = logParser.parse(RedmineWebTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }

--- a/src/test/java/hudson/plugins/git/browser/RhodeCodeTest.java
+++ b/src/test/java/hudson/plugins/git/browser/RhodeCodeTest.java
@@ -71,7 +71,7 @@ public class RhodeCodeTest {
     private GitChangeSet createChangeSet(String rawchangelogpath) throws Exception {
         /* Use randomly selected git client implementation since the client implementation should not change result */
         GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using(random.nextBoolean() ? null : "jgit").getClient();
-        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false);
+        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false, null);
         final List<GitChangeSet> changeSetList = logParser.parse(RhodeCodeTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }

--- a/src/test/java/hudson/plugins/git/browser/ViewGitWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/ViewGitWebTest.java
@@ -85,7 +85,7 @@ public class ViewGitWebTest {
     private GitChangeSet createChangeSet(String rawchangelogpath) throws Exception {
         /* Use randomly selected git client implementation since the client implementation should not change result */
         GitClient gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using(random.nextBoolean() ? null : "jgit").getClient();
-        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false);
+        final GitChangeLogParser logParser = new GitChangeLogParser(gitClient, false, null);
         final List<GitChangeSet> changeSetList = logParser.parse(ViewGitWebTest.class.getResourceAsStream(rawchangelogpath));
         return changeSetList.get(0);
     }


### PR DESCRIPTION
## [JENKINS-54972](https://issues.jenkins-ci.org/browse/JENKINS-54972) - Include SCM Name on changes pages

There's a bunch of places where it'd be useful to expose the custom SCM name if one is configured, especially when working with multi-repo build jobs.

This exposes it on `/job/<build>/changes` and on `/job/<build>/<build_number>/changes`.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [X] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [X] Unit tests pass locally with my changes
- [X] I have added documentation as necessary
- [X] No Javadoc warnings were introduced with my changes
- [X] No findbugs warnings were introduced with my changes
- [X] I have interactively tested my changes
- [X] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

The SCM name tests in `hudson.plugins.git.GitSCMTest.testCustomSCMName` appear to be commented out - I think that's the logical place to add a test if required (where the test would probably just do something along the lines of `expectedScmName == createChangeLogParser().parse().getScmName()` ).

I've tested it by installing a plugin with the changes on one of Jenkins servers.