### PR TITLE
Remove getBySHA1 REST API obsoleted by SECURITY-595

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -950,23 +950,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return tool.getGitExe();
     }
 
-    /**
-     * Web-bound method to let people look up a build by their SHA1 commit.
-     * @param sha1 SHA1 hash of commit
-     * @return most recent build of sha1
-     */
-    public AbstractBuild<?,?> getBySHA1(String sha1) {
-        AbstractProject<?,?> p = Stapler.getCurrentRequest().findAncestorObject(AbstractProject.class);
-        for (AbstractBuild b : p.getBuilds()) {
-            BuildData d = b.getAction(BuildData.class);
-            if (d!=null && d.lastBuild!=null) {
-                Build lb = d.lastBuild;
-                if (lb.isFor(sha1)) return b;
-            }
-        }
-        return null;
-    }
-
     /*package*/ static class BuildChooserContextImpl implements BuildChooserContext, Serializable {
         @SuppressFBWarnings(value="SE_BAD_FIELD", justification="known non-serializable field")
         final Job project;


### PR DESCRIPTION
## [SECURITY-595](https://issues.jenkins-ci.org/browse/SECURITY-595) - Remove obsolete REST API

The SECURITY-595 security fix for Jenkins core prevents access to the URL /job/<Job Name here>/scm/. That prevents access to …/scm/bySHA1/…. That change breaks this undocumented feature.

Since Git plugin 4.0 is a major release, let's use the major release to remove this unusable API.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary (will add to git plugin release notes / change log)
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If we find a critical need to provide this REST API, it can be reinstated on the Descriptor.  Descriptors are already involved in URL handling and will work out of the box.