### PR TITLE
[JENKINS-33238] Do not block builds in Git Publisher

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -130,7 +130,7 @@ public class GitPublisher extends Recorder implements Serializable {
     
     
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     private String replaceAdditionalEnvironmentalVariables(String input, AbstractBuild<?, ?> build){


### PR DESCRIPTION
## [JENKINS-33238](https://issues.jenkins-ci.org/browse/JENKINS-33238) Do not block builds in Git Publisher

The Git Publisher does not depend on the completion of preceding builds so it should not need to monitor BUILD.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
