### PR TITLE
[JENKINS-53346] fix for same env vars for different branches

### DIFF
--- a/src/main/java/hudson/plugins/git/BranchSpec.java
+++ b/src/main/java/hudson/plugins/git/BranchSpec.java
@@ -92,13 +92,25 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
      * @return true if repositoryName/branchName matches this BranchSpec
      */
     public boolean matchesRepositoryBranch(String repositoryName, String branchName) {
+        return matchesRepositoryBranch(new EnvVars(), repositoryName, branchName);
+    }
+
+    /**
+     * Compare the configured pattern to a git branch defined by the repository name and branch name.
+     * @param environment environment variables to use in comparison
+     * @param repositoryName git repository name
+     * @param branchName git branch name
+     * @return true if repositoryName/branchName matches this BranchSpec
+     */
+    public boolean matchesRepositoryBranch(EnvVars environment, String repositoryName, String branchName) {
         if (branchName == null) {
             return false;
         }
-        Pattern pattern = getPattern(new EnvVars(), repositoryName);
+        Pattern pattern = getPattern(environment, repositoryName);
         String branchWithoutRefs = cutRefs(branchName);
         return pattern.matcher(branchWithoutRefs).matches() || pattern.matcher(join(repositoryName, branchWithoutRefs)).matches();
     }
+
 
     /**
      * @deprecated use {@link #filterMatching(Collection, EnvVars)}
@@ -137,7 +149,7 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
         return items;
     }
 
-    private String getExpandedName(EnvVars env) {
+    String getExpandedName(EnvVars env) {
         String expandedName = env.expand(name);
         if (expandedName.length() == 0) {
             return "**";
@@ -229,7 +241,7 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
         return builder.toString();
     }
 
-    private String cutRefs(@NonNull String name) {
+    static String cutRefs(@NonNull String name) {
         Matcher matcher = GitSCM.GIT_REF.matcher(name);
         return matcher.matches() ? matcher.group(2) : name;
     }

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -2196,6 +2196,9 @@ public class GitSCMTest extends AbstractGitTestCase {
         BuildData buildData = Mockito.mock(BuildData.class);
         Mockito.when(buildData.getLastBuiltRevision()).thenReturn(revision);
         Mockito.when(buildData.hasBeenReferenced(anyString())).thenReturn(true);
+        Mockito.when(buildData.getBuildsByBranchName()).thenReturn(new HashMap() {{
+            put("refs/remotes/origin/master", null);
+        }});
 
         /* List of build data that will be returned by the mocked BuildData */
         List<BuildData> buildDataList = new ArrayList<>();
@@ -2231,6 +2234,9 @@ public class GitSCMTest extends AbstractGitTestCase {
        BuildData buildData = Mockito.mock(BuildData.class);
        Mockito.when(buildData.getLastBuiltRevision()).thenReturn(revision);
        Mockito.when(buildData.hasBeenReferenced(anyString())).thenReturn(true);
+       Mockito.when(buildData.getBuildsByBranchName()).thenReturn(new HashMap() {{
+           put("refs/remotes/origin/master", null);
+       }});
 
        /* List of build data that will be returned by the mocked BuildData */
        List<BuildData> buildDataList = new ArrayList<>();
@@ -2272,6 +2278,9 @@ public class GitSCMTest extends AbstractGitTestCase {
        BuildData buildData = Mockito.mock(BuildData.class);
        Mockito.when(buildData.getLastBuiltRevision()).thenReturn(revision);
        Mockito.when(buildData.hasBeenReferenced(anyString())).thenReturn(true);
+       Mockito.when(buildData.getBuildsByBranchName()).thenReturn(new HashMap() {{
+           put("refs/remotes/origin/master", null);
+       }});
 
        /* List of build data that will be returned by the mocked BuildData */
        List<BuildData> buildDataList = new ArrayList<>();
@@ -2313,6 +2322,9 @@ public class GitSCMTest extends AbstractGitTestCase {
        BuildData buildData = Mockito.mock(BuildData.class);
        Mockito.when(buildData.getLastBuiltRevision()).thenReturn(revision);
        Mockito.when(buildData.hasBeenReferenced(anyString())).thenReturn(true);
+       Mockito.when(buildData.getBuildsByBranchName()).thenReturn(new HashMap() {{
+           put("refs/remotes/origin/master", null);
+       }});
 
        /* List of build data that will be returned by the mocked BuildData */
        List<BuildData> buildDataList = new ArrayList<>();

--- a/src/test/java/hudson/plugins/git/MultipleSCMEnvVarsTest.java
+++ b/src/test/java/hudson/plugins/git/MultipleSCMEnvVarsTest.java
@@ -1,0 +1,115 @@
+package hudson.plugins.git;
+
+import hudson.EnvVars;
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.scm.SCM;
+import hudson.util.StreamTaskListener;
+import org.jenkinsci.plugins.multiplescms.MultiSCM;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class MultipleSCMEnvVarsTest {
+
+  @Rule public JenkinsRule r = new JenkinsRule();
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  protected TaskListener listener;
+
+  protected TestGitRepo repo0;
+
+  @Before public void setUp() throws Exception {
+    listener = StreamTaskListener.fromStderr();
+    repo0 = new TestGitRepo("repo0", tmp.newFolder(), listener);
+  }
+
+  @Issue("JENKINS-53346")
+  @Test public void testEnvVarsForSameRepo() throws Exception
+  {
+    FreeStyleProject project = setupBasicProject("same-repo",
+      new Tuple(repo0, Collections.singletonList(new BranchSpec("master"))),
+      new Tuple(repo0, Collections.singletonList(new BranchSpec("dev")))
+    );
+
+    String sha1 = repo0.commit("file", repo0.johnDoe, "message");
+    repo0.git.checkoutBranch("dev","master");
+    String sha2 = repo0.commit("file2", repo0.janeDoe, "message");
+
+    FreeStyleBuild b = build(project, Result.SUCCESS);
+
+    EnvVars env = new EnvVars();
+    project.getScm().buildEnvironment(b, env);
+
+    assertEquals("origin/master", env.get(GitSCM.GIT_BRANCH));
+    assertEquals(sha1, env.get(GitSCM.GIT_COMMIT));
+    assertEquals("origin/dev", env.get(GitSCM.GIT_BRANCH + "_1"));
+    assertEquals(sha2, env.get(GitSCM.GIT_COMMIT + "_1"));
+  }
+
+  private FreeStyleProject setupBasicProject(String name, Tuple... repos) throws IOException
+  {
+    FreeStyleProject project = r.createFreeStyleProject(name);
+
+    List<SCM> testScms = new ArrayList<>();
+
+    for (Tuple repo : repos) {
+      testScms.add(new GitSCM(
+        repo.getRepo().remoteConfigs(),
+        repo.getBranch(),
+        false,
+        Collections.<SubmoduleConfig>emptyList(),
+        null,
+        null,
+        Collections.<GitSCMExtension>emptyList()));
+    }
+
+    MultiSCM scm = new MultiSCM(testScms);
+
+    project.setScm(scm);
+    project.getBuildersList().add(new CaptureEnvironmentBuilder());
+    return project;
+  }
+
+  private FreeStyleBuild build(final FreeStyleProject project,
+                               final Result expectedResult) throws Exception {
+    final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserCause()).get();
+    if(expectedResult != null) {
+      r.assertBuildStatus(expectedResult, build);
+    }
+    return build;
+  }
+
+  private class Tuple {
+    TestGitRepo repo;
+    List<BranchSpec> branch;
+
+    public Tuple(TestGitRepo repo, List<BranchSpec> branch) {
+      this.repo = repo;
+      this.branch = branch;
+    }
+
+    public TestGitRepo getRepo() {
+      return repo;
+    }
+
+    public List<BranchSpec> getBranch() {
+      return branch;
+    }
+  }
+}


### PR DESCRIPTION
## [JENKINS-53346](https://issues.jenkins-ci.org/browse/JENKINS-53346) - attempting to fix checkout returning same values on second different call

The problem relies on the inability of GitSCM.getBuildData returning the right BuildData for the instance.  It was only comparing the urls, ignoring the branch name.  So in the end, a different branch name would get the first registered checkout's BuildData.

This change will make it search not only for the url but also for the branch name.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

~Although this seems to fix the mentioned issue, the changes causes other tests to start failing.  I did not have the time to look at them!~

@MarkEWaite could you please review my approach? 