### PR TITLE
JENKINS-30515 Adding messages for credentials use: empty, found and n…

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -117,6 +117,7 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.lang.String.format;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.isBlank;
 
@@ -830,7 +831,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         for (UserRemoteConfig uc : getUserRemoteConfigs()) {
             String ucCredentialsId = uc.getCredentialsId();
-            if (ucCredentialsId != null) {
+            if (ucCredentialsId == null) {
+                listener.getLogger().println("No credentials specified");
+            } else {
                 String url = getParameterString(uc.getUrl(), environment);
                 List<StandardUsernameCredentials> urlCredentials = CredentialsProvider.lookupCredentials(
                         StandardUsernameCredentials.class,
@@ -845,9 +848,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 StandardUsernameCredentials credentials = CredentialsMatchers.firstOrNull(urlCredentials, idMatcher);
                 if (credentials != null) {
                     c.addCredentials(url, credentials);
+                    listener.getLogger().println(format("using credential %s", credentials.getId()));
                     if (project != null && project.getLastBuild() != null) {
                         CredentialsProvider.track(project.getLastBuild(), credentials);
                     }
+                } else {
+                    listener.getLogger().println(format("Warning: CredentialId \"%s\" could not be found.", ucCredentialsId));
                 }
             }
         }

--- a/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
@@ -25,6 +25,7 @@ public class CredentialsUserRemoteConfigTest {
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
+
     @Rule
     public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
 

--- a/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
@@ -1,0 +1,144 @@
+package hudson.plugins.git;
+
+import com.cloudbees.plugins.credentials.*;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import jenkins.model.Jenkins;
+import jenkins.plugins.git.GitSampleRepoRule;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class CredentialsUserRemoteConfigTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+    private CredentialsStore store = null;
+
+    @Before
+    public void enableSystemCredentialsProvider() {
+        SystemCredentialsProvider.getInstance().setDomainCredentialsMap(
+                Collections.singletonMap(Domain.global(), Collections.<Credentials>emptyList()));
+        for (CredentialsStore s : CredentialsProvider.lookupStores(Jenkins.getInstance())) {
+            if (s.getProvider() instanceof SystemCredentialsProvider.ProviderImpl) {
+                store = s;
+                break;
+            }
+        }
+        assertThat("The system credentials provider is enabled", store, notNullValue());
+    }
+
+    @Issue("JENKINS-30515")
+    @Test
+    public void checkoutWithValidCredentials() throws Exception {
+        sampleRepo.init();
+        store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "github"));
+        store.save();
+
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                        + "  checkout(\n"
+                        + "    [$class: 'GitSCM', \n"
+                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$, branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false]]]\n"
+                        + "  )"
+                        + "}"));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("using credential github", b);
+    }
+
+    @Issue("JENKINS-30515")
+    @Test
+    public void checkoutWithDifferentCredentials() throws Exception {
+        sampleRepo.init();
+        store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "other"));
+        store.save();
+
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                        + "  checkout(\n"
+                        + "    [$class: 'GitSCM', \n"
+                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$, branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false]]]\n"
+                        + "  )"
+                        + "}"));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        System.out.println(JenkinsRule.getLog(b));
+        r.assertLogContains("Warning: CredentialId \"github\" could not be found", b);
+    }
+
+    @Issue("JENKINS-30515")
+    @Test
+    public void checkoutWithVInvalidCredentials() throws Exception {
+        sampleRepo.init();
+        store.addCredentials(Domain.global(), createCredential(CredentialsScope.SYSTEM, "github"));
+        store.save();
+
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                        + "  checkout(\n"
+                        + "    [$class: 'GitSCM', \n"
+                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$, branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false]]]\n"
+                        + "  )"
+                        + "}"));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        r.assertLogContains("Warning: CredentialId \"github\" could not be found", b);
+    }
+
+    @Issue("JENKINS-30515")
+    @Test
+    public void checkoutWithVNoCredentialsStoredButUsed() throws Exception {
+        sampleRepo.init();
+
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                        + "  checkout(\n"
+                        + "    [$class: 'GitSCM', \n"
+                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$, branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false]]]\n"
+                        + "  )"
+                        + "}"));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        System.out.println(JenkinsRule.getLog(b));
+        r.assertLogContains("Warning: CredentialId \"github\" could not be found", b);
+    }
+
+    @Issue("JENKINS-30515")
+    @Test
+    public void checkoutWithVNoCredentialsSpecified() throws Exception {
+        sampleRepo.init();
+
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                        + "  checkout(\n"
+                        + "    [$class: 'GitSCM', \n"
+                        + "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$, branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false]]]\n"
+                        + "  )"
+                        + "}"));
+        WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        System.out.println(JenkinsRule.getLog(b));
+        r.assertLogContains("No credentials specified", b);
+    }
+
+
+    private StandardCredentials createCredential(CredentialsScope scope, String id) {
+        return new UsernamePasswordCredentialsImpl(scope, id, "desc: " + id, "username", "password");
+    }
+}


### PR DESCRIPTION
…ot found

## [JENKINS-30515](https://issues.jenkins-ci.org/browse/JENKINS-30515) - scm (git) command does not fail correctly when it cannot look up credentials

This is a simple change that only show a message about the Credential use, basically show if it's used and if so, if it can be found within the Storage. It does not stop the build if the credential is not found.
## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)
