### PR TITLE
JENKINS-50366 - Implement --first-parent option in changelog

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.0.0-beta6-rc1890.1f6b1a87b5dd</version>
+      <version>3.0.0-beta6-rc1867.e1faf24eb816</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.0.0-beta5</version>
+      <version>3.0.0-beta6-rc1867.204c85557f8c</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.0.0-rc</version>
+      <version>3.0.1-rc-rc1899.506c77b9e006</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.0.0-beta6-rc1867.204c85557f8c</version>
+      <version>3.0.0-beta6-rc1867.e1faf24eb816</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -42,6 +42,7 @@ import hudson.plugins.git.extensions.impl.PathRestriction;
 import hudson.plugins.git.extensions.impl.LocalBranch;
 import hudson.plugins.git.extensions.impl.RelativeTargetDirectory;
 import hudson.plugins.git.extensions.impl.PreBuildMerge;
+import hudson.plugins.git.extensions.impl.ChangelogFirstParent;
 import hudson.plugins.git.opt.PreBuildMergeOptions;
 import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.*;
@@ -1317,6 +1318,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                         exclusion = true;
                     }
                 }
+            }
+            if (getExtensions().get(ChangelogFirstParent.class)!=null) {
+                changelog.firstParent();
+                listener.getLogger().println("Using '--first-parent' argument when determining changelog.");
             }
 
             if (!exclusion) {

--- a/src/main/java/hudson/plugins/git/extensions/impl/ChangelogFirstParent.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/ChangelogFirstParent.java
@@ -1,0 +1,62 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.FakeGitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import hudson.scm.ChangeLogSet.Entry;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * When calculating the changelog, if there are merge commits in the changelog,
+ * only follow the first parent, not any additional parents to keep the changelog
+ * limited to changes on the currently checked out branch only.
+ *
+ * @author Ben Sluis
+ */
+public class ChangelogFirstParent extends FakeGitSCMExtension {
+
+    @DataBoundConstructor
+    public ChangelogFirstParent() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return o instanceof ChangelogFirstParent;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return ChangelogFirstParent.class.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "ChangelogFirstParent{}";
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Use --first-parent when determining changelog";
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/git/traits/ChangelogFirstParentTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/ChangelogFirstParentTrait.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package jenkins.plugins.git.traits;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.impl.ChangelogFirstParent;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Exposes {@link ChangelogFirstParent} as a {@link SCMSourceTrait}.
+ *
+ * @since 3.4.0
+ */
+public class ChangelogFirstParentTrait extends GitSCMExtensionTrait<ChangelogFirstParent> {
+    /**
+     * Stapler constructor.
+     */
+    @DataBoundConstructor
+    public ChangelogFirstParentTrait() {
+        super(new ChangelogFirstParent());
+    }
+
+    /**
+     * Our {@link hudson.model.Descriptor}
+     */
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionTraitDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Use --first-parent when determining changelog";
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/ChangelogFirstParent/help.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/ChangelogFirstParent/help.html
@@ -1,0 +1,4 @@
+<div>
+  When determining the changelog that include merge commits, the default behavior is to walk the history of all the parents of the merge commit.
+  With this option, use the --first-parent argument to limit the changelog to the commits from the first parent history.  Effectively this means to only include commits made to the currently checked out branch.
+</div>


### PR DESCRIPTION
[JENKINS-50366](https://issues.jenkins-ci.org/browse/JENKINS-50366) - Implement --first-parent option in changelog

In some cases, the changelog on a branch should only show changes from that branch and not show any changes from the branch being merged in.  The --first-parent option limits the changelog to show only changes on the branch.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
