### PR TITLE
Fix git scm test on git 2.20 with latest git client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <revision>4.0.0</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.107.3</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <concurrency>1C</concurrency>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.0.0-beta6</version>
+      <version>3.0.0-beta7-rc1887.63cf3cdbaf54</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## [JENKINS-55284](https://issues.jenkins-ci.org/browse/JENKINS-55284) - GitSCMTest fails on CLI git 2.20

Command line git 2.20 fixed a long-standing bug in tag fetching.  Previously, a tag which existed locally and remotely would be updated by fetch if the remote changed the tag.  The git team fixed that bug in command line git 2.20 so that the `--force` argument is required to modify a local tag that already exists.

The change has been made in git client plugin 2.7.6 and will be made in git client plugin 3.0.0-beta7.  Until git client plugin 3.0.0-beta7 is released, this relies on the incrementals build to resolve the issue.

This also updates from requiring Jenkins 2.60.3 to now require Jenkins 2.107.3.  That is the new required Jenkins version for git client plugin 3.0.0-beta7 and is a good choice as the minimum Jenkins version for the git plugin as well.  Users running versions older than 2.107.3 will need to remain on git plugin 3.x. 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
