### PR TITLE
WIP: bump parent pom to test JTH 2.46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,18 @@
       <version>2.14</version>
       <scope>test</scope>
     </dependency>
+    <!-- exclude Xalan from the test classpath -->
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>xalan</groupId>
+          <artifactId>xalan</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -287,18 +287,6 @@
       <version>2.14</version>
       <scope>test</scope>
     </dependency>
-    <!-- exclude Xalan from the test classpath -->
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-test-harness</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>xalan</groupId>
-          <artifactId>xalan</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.32</version>
+    <version>3.33-20190110.085245-1</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
     <no-test-jar>false</no-test-jar>
     <concurrency>1C</concurrency>
     <scm-api-plugin.version>2.3.0</scm-api-plugin.version>
+    <!-- force JTH version 2.46, waiting for next version of the parent pom -->
+    <jenkins-test-harness.version>2.46</jenkins-test-harness.version>
   </properties>
 
   <build>

--- a/src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory
+++ b/src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory
@@ -1,0 +1,1 @@
+com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl

--- a/src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory
+++ b/src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory
@@ -1,1 +1,0 @@
-com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl


### PR DESCRIPTION
Following jenkinsci/jenkins-test-harness#89, jenkinsci/plugin-pom#93 and jenkinsci/git-client-plugin#393, here is a test PR to see how jenkinsci/git-plugin unit tests behave when there is a space character in their temporary workdir path.

Results are pretty good on my environment (Linux and recent git version), but for one worrisome test failure (`GitSCMTest.testDataCompatibility1`):
```
[ERROR] testDataCompatibility1(hudson.plugins.git.GitSCMTest)  Time elapsed: 9.92 s  <<< ERROR!
java.io.IOException: Failed to persist config.xml
	at hudson.model.ItemGroupMixIn.createProjectFromXML(ItemGroupMixIn.java:292)
	at jenkins.model.Jenkins.createProjectFromXML(Jenkins.java:3824)
	at hudson.plugins.git.GitSCMTest.testDataCompatibility1(GitSCMTest.java:1558)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:553)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
Caused by: javax.xml.transform.TransformerException: java.io.FileNotFoundException: /home/lwjs1183/git/jenkins-git-plugin/target/tmp/j%20h6664057865101334020/jobs/foo/config.xml (No such file or directory)
	at org.apache.xalan.transformer.TransformerIdentityImpl.createResultContentHandler(TransformerIdentityImpl.java:297)
	at org.apache.xalan.transformer.TransformerIdentityImpl.transform(TransformerIdentityImpl.java:330)
	at jenkins.util.xml.XMLUtils._transform(XMLUtils.java:212)
	at jenkins.util.xml.XMLUtils.safeTransform(XMLUtils.java:84)
	at hudson.model.ItemGroupMixIn.createProjectFromXML(ItemGroupMixIn.java:272)
	... 17 more
Caused by: java.io.FileNotFoundException: /home/.../jenkins-git-plugin/target/tmp/j%20h6664057865101334020/jobs/foo/config.xml (No such file or directory)
	at java.io.FileOutputStream.open0(Native Method)
	at java.io.FileOutputStream.open(FileOutputStream.java:270)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:101)
	at org.apache.xalan.transformer.TransformerIdentityImpl.createResultContentHandler(TransformerIdentityImpl.java:287)
	... 21 more
```

Note the URL-encoded space character in a Java `File` path.

I've not understood yet where it comes from, but at first glance it looks unlikely that it would be specific to this plugin unit tests, and it might rather be an issue in core...
I've tested with Jenkins 2.150.1 instead of 2.107.3, and got the same error.

Anyway, I'm opening this PR just to reproduce the issue and share with reviewers from jenkinsci/jenkins-test-harness#89.