### PR TITLE
[DO NOT MERGE][JENKINS-55456] Update Parent POM to use PowerMock 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.32</version>
+    <version>3.33-20190116.125555-4</version>
     <relativePath />
   </parent>
 
@@ -148,19 +148,16 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.8.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.7.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito2</artifactId>
-      <version>1.7.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## [JENKINS-55456](https://issues.jenkins-ci.org/browse/JENKINS-55456) - Validate that using new version of PowerMock is not a problem

In the new version of the library, the project removed some code. This is to validate that the tests environment for the git-plugin is still valid. This PR is to validate that the new version of the library, declared in jenkinsci/plugin-pom#148 is still usable for this project.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
    - there is no new code
- [x] Unit tests pass locally with my changes
    - no but I want make sure it's not related to my environment
- [x] I have added documentation as necessary
   - there is no new code
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
   - there is no new code
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)
   - not yet, this PR is to validate the modification in jenkinsci/plugin-pom#148

## Types of changes

- [x] Upgrading the Parent POM version
