### PR TITLE
Replace joda time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,11 +76,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.9.5</version>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
       <version>1.10</version>

--- a/src/main/java/hudson/plugins/git/util/AncestryBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/AncestryBuildChooser.java
@@ -17,9 +17,9 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.jenkinsci.plugins.gitclient.GitClient;
-import org.jenkinsci.plugins.gitclient.RepositoryCallback;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.google.common.base.Predicate;
@@ -103,16 +103,17 @@ public class AncestryBuildChooser extends DefaultBuildChooser {
     
     private static class CommitAgeFilter implements Predicate<RevCommit> {
         
-        private DateTime oldestAllowableCommitDate = null;
+        private LocalDateTime oldestAllowableCommitDate = null;
         
         public CommitAgeFilter(Integer oldestAllowableAgeInDays) {
             if (oldestAllowableAgeInDays != null && oldestAllowableAgeInDays >= 0) {
-                this.oldestAllowableCommitDate = new LocalDate().toDateTimeAtStartOfDay().minusDays(oldestAllowableAgeInDays);
+                this.oldestAllowableCommitDate = LocalDate.now().atStartOfDay().minusDays(oldestAllowableAgeInDays);
             }
         }
         
+        @Override
         public boolean apply(RevCommit rev) {
-            return new DateTime(rev.getCommitterIdent().getWhen()).isAfter(this.oldestAllowableCommitDate);
+            return LocalDateTime.ofInstant(rev.getCommitterIdent().getWhen().toInstant(), ZoneId.systemDefault()).isAfter(this.oldestAllowableCommitDate);
         }
         
         public boolean isEnabled() {

--- a/src/test/java/hudson/plugins/git/GitChangeSetTimestampTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTimestampTest.java
@@ -1,50 +1,101 @@
 package hudson.plugins.git;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
 import static org.junit.Assert.*;
-import org.junit.Before;
+import static org.hamcrest.Matchers.*;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.Issue;
 
 /**
  * JENKINS-30073 reports that the timestamp returns -1 for the typical timestamp
  * reported by the +%ci format to git log and git whatchanged. This test
- * duplicates the bug.
+ * duplicates the bug and tests many other date formatting cases.
+ * See JENKINS-55693 for more details on joda time replacement.
  *
  * @author Mark Waite
  */
+@RunWith(Parameterized.class)
 public class GitChangeSetTimestampTest {
 
-    private GitChangeSet changeSet = null;
+    private final String normalizedTimestamp;
+    private final long millisecondsSinceEpoch;
 
-    @Before
-    public void createChangeSet() {
-        changeSet = genChangeSetForJenkins30073(true);
+    private final GitChangeSet changeSet;
+
+    public GitChangeSetTimestampTest(String timestamp, String normalizedTimestamp, long millisecondsSinceEpoch) {
+        this.normalizedTimestamp = normalizedTimestamp == null ? timestamp : normalizedTimestamp;
+        this.millisecondsSinceEpoch = millisecondsSinceEpoch;
+        changeSet = genChangeSet(timestamp);
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection createSampleChangeSets() {
+        Object[][] samples = {
+            /* git whatchanged dates from various time zones, months, & days */
+            {"2015-10-06 19:29:47 +0300", null, 1444148987000L},
+            {"2017-10-23 23:43:29 +0100", null, 1508798609000L},
+            {"2017-09-21 17:35:24 -0400", null, 1506029724000L},
+            {"2017-07-18 08:34:48 -0800", null, 1500395688000L},
+            {"2007-12-19 01:59:25 +0000", null, 1198029565000L},
+            {"2007-12-19 01:59:25 -0000", null, 1198029565000L},
+            {"2017-01-13 16:20:12 -0500", null, 1484342412000L},
+            {"2016-12-24 20:08:55 +0900", null, 1482577735000L},
+            /* nearly ISO 8601 formatted dates from various time zones, months, & days */
+            {"2013-03-21T15:16:44+0100", null, 1363875404000L},
+            {"2014-11-13T01:42:14-0700", null, 1415868134000L},
+            {"2010-06-24T20:08:27+0200", null, 1277402907000L},
+            /* Seconds since epoch dates from various time zones, months, & days */
+            {"1363879004 +0100", "2013-03-21T15:16:44+0100", 1363875404000L},
+            {"1415842934 -0700", "2014-11-13T01:42:14-0700", 1415868134000L},
+            {"1277410107 +0200", "2010-06-24T20:08:27+0200", 1277402907000L},
+            {"1234567890 +0000", "2009-02-13T23:31:30+0000", 1234567890000L},
+            /* ISO 8601 formatted dates from various time zones, months, & days */
+            {"2013-03-21T15:16:44+01:00", null, 1363875404000L},
+            {"2014-11-13T01:42:14-07:00", null, 1415868134000L},
+            {"2010-06-24T20:08:27+02:00", null, 1277402907000L},
+            /* Invalid date */
+            {"2010-06-24 20:08:27am +02:00", null, -1L}
+        };
+        List<Object[]> values = new ArrayList<>(samples.length);
+        values.addAll(Arrays.asList(samples));
+        return values;
     }
 
     @Test
     public void testChangeSetDate() {
-        assertEquals("2015-10-06 19:29:47 +0300", changeSet.getDate());
+        assertThat(changeSet.getDate(), is(normalizedTimestamp));
     }
 
     @Test
     @Issue("JENKINS-30073")
     public void testChangeSetTimeStamp() {
-        assertEquals(1444148987000L, changeSet.getTimestamp());
+        assertThat(changeSet.getTimestamp(), is(millisecondsSinceEpoch));
     }
 
-    private GitChangeSet genChangeSetForJenkins30073(boolean authorOrCommitter) {
-        ArrayList<String> lines = new ArrayList<>();
-        lines.add("commit 302548f75c3eb6fa1db83634e4061d0ded416e5a");
-        lines.add("tree e1bd430d3f45b7aae54a3061b7895ee1858ec1f8");
-        lines.add("parent c74f084d8f9bc9e52f0b3fe9175ad27c39947a73");
-        lines.add("author Viacheslav Kopchenin <vkopchenin@odin.com> 2015-10-06 19:29:47 +0300");
-        lines.add("committer Viacheslav Kopchenin <vkopchenin@odin.com> 2015-10-06 19:29:47 +0300");
-        lines.add("");
-        lines.add("    pom.xml");
-        lines.add("    ");
-        lines.add("    :100644 100644 bb32d78c69a7bf79849217bc02b1ba2c870a5a66 343a844ad90466d8e829896c1827ca7511d0d1ef M	modules/platform/pom.xml");
-        lines.add("");
+    private final Random random = new Random();
+
+    private GitChangeSet genChangeSet(String timestamp) {
+        boolean authorOrCommitter = random.nextBoolean();
+        String[] linesArray = {
+            "commit 302548f75c3eb6fa1db83634e4061d0ded416e5a",
+            "tree e1bd430d3f45b7aae54a3061b7895ee1858ec1f8",
+            "parent c74f084d8f9bc9e52f0b3fe9175ad27c39947a73",
+            "author Viacheslav Kopchenin <vkopchenin@odin.com> " + timestamp,
+            "committer Viacheslav Kopchenin <vkopchenin@odin.com> " + timestamp,
+            "",
+            "    pom.xml",
+            "    ",
+            "    :100644 100644 bb32d78c69a7bf79849217bc02b1ba2c870a5a66 343a844ad90466d8e829896c1827ca7511d0d1ef M	modules/platform/pom.xml",
+            ""
+        };
+        ArrayList<String> lines = new ArrayList<>(linesArray.length);
+        lines.addAll(Arrays.asList(linesArray));
         return new GitChangeSet(lines, authorOrCommitter);
     }
 }

--- a/src/test/java/hudson/plugins/git/util/AncestryBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/AncestryBuildChooserTest.java
@@ -21,8 +21,10 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.jenkinsci.plugins.gitclient.GitClient;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -42,9 +44,9 @@ public class AncestryBuildChooserTest extends AbstractGitRepository {
     private String tenDaysAgoCommit = null;
     private String twentyDaysAgoCommit = null;
     
-    private final DateTime fiveDaysAgo = new LocalDate().toDateTimeAtStartOfDay().minusDays(5);
-    private final DateTime tenDaysAgo = new LocalDate().toDateTimeAtStartOfDay().minusDays(10);
-    private final DateTime twentyDaysAgo = new LocalDate().toDateTimeAtStartOfDay().minusDays(20);
+    private final LocalDateTime fiveDaysAgo = LocalDate.now().atStartOfDay().minusDays(5);
+    private final LocalDateTime tenDaysAgo = LocalDate.now().atStartOfDay().minusDays(10);
+    private final LocalDateTime twentyDaysAgo = LocalDate.now().atStartOfDay().minusDays(20);
     
     private final PersonIdent johnDoe = new PersonIdent("John Doe", "john@example.com");
 
@@ -69,17 +71,23 @@ public class AncestryBuildChooserTest extends AbstractGitRepository {
         
         testGitClient.branch("20-days-old-branch");
         testGitClient.checkoutBranch("20-days-old-branch", ancestorCommit);
-        this.commit("20 days ago commit message", new PersonIdent(johnDoe, twentyDaysAgo.toDate()), new PersonIdent(johnDoe, twentyDaysAgo.toDate()));
+        Date twentyDaysAgoDate = Date.from(twentyDaysAgo.atZone(ZoneId.systemDefault()).toInstant());
+        PersonIdent johnDoeTwentyDaysAgo = new PersonIdent(johnDoe, twentyDaysAgoDate);
+        this.commit("20 days ago commit message", johnDoeTwentyDaysAgo, johnDoeTwentyDaysAgo);
         twentyDaysAgoCommit = getLastCommitSha1(prevBranches);
         
         testGitClient.checkout().ref(ancestorCommit).execute();
         testGitClient.checkoutBranch("10-days-old-branch", ancestorCommit);
-        this.commit("10 days ago commit message", new PersonIdent(johnDoe, tenDaysAgo.toDate()), new PersonIdent(johnDoe, tenDaysAgo.toDate()));
+        Date tenDaysAgoDate = Date.from(tenDaysAgo.atZone(ZoneId.systemDefault()).toInstant());
+        PersonIdent johnDoeTenDaysAgo = new PersonIdent(johnDoe, tenDaysAgoDate);
+        this.commit("10 days ago commit message", johnDoeTenDaysAgo, johnDoeTenDaysAgo);
         tenDaysAgoCommit = getLastCommitSha1(prevBranches);
         
         testGitClient.checkout().ref(rootCommit).execute();
         testGitClient.checkoutBranch("5-days-old-branch", rootCommit);
-        this.commit("5 days ago commit message", new PersonIdent(johnDoe, fiveDaysAgo.toDate()), new PersonIdent(johnDoe, fiveDaysAgo.toDate()));
+        Date fiveDaysAgoDate = Date.from(fiveDaysAgo.atZone(ZoneId.systemDefault()).toInstant());
+        PersonIdent johnDoeFiveDaysAgo = new PersonIdent(johnDoe, fiveDaysAgoDate);
+        this.commit("5 days ago commit message", johnDoeFiveDaysAgo, johnDoeFiveDaysAgo);
         fiveDaysAgoCommit = getLastCommitSha1(prevBranches);
     }
     


### PR DESCRIPTION
## [JENKINS-55693](https://issues.jenkins-ci.org/browse/JENKINS-55693) - Replace joda time with java.time

Joda-time was the defacto time implementation for Java 6 and Java 7 due to limitations in the Java date and time classes.  Java 8 provides the java.time package which is based on the design and concepts of Joda-time.  The maintainer of Joda-time recommends that Java 8 users [switch from Joda-time to java.time](https://www.joda.org/joda-time/).  The maintainer says:

> Note that from Java SE 8 onwards, users are asked to migrate to java.time (JSR-310) - a core part of the JDK which replaces this project.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

I would like to have @reviewbybees or by @darxriggs just in case I've missed something in the changes.
