### PR TITLE
Extend GitTagActionTest for more cases

### DIFF
--- a/src/test/java/hudson/plugins/git/GitTagActionTest.java
+++ b/src/test/java/hudson/plugins/git/GitTagActionTest.java
@@ -119,7 +119,7 @@ public class GitTagActionTest {
         waitForTagCreation(tagOneAction, "v1");
         waitForTagCreation(tagTwoAction, "v2");
 
-        // assertThat(getMatchingTagNames(), hasItems(getTagValue("v1"), getTagValue("v2")));
+        assertThat(getMatchingTagNames(), hasItems(getTagValue("v1"), getTagValue("v2")));
     }
 
     private static String getTagName(String message) {
@@ -176,7 +176,7 @@ public class GitTagActionTest {
             String tagComment = getTagComment(message);
             Map<String, String> tagMap = new HashMap<>();
             tagMap.put(tagName, tagValue);
-            // tagAction.scheduleTagCreation(tagMap, tagComment);
+            tagAction.scheduleTagCreation(tagMap, tagComment);
         }
         return tagAction;
     }
@@ -193,14 +193,13 @@ public class GitTagActionTest {
     }
 
     private static void waitForTagCreation(GitTagAction tagAction, String message) throws Exception {
-        return;
-        // long backoffDelay = 499L;
-        // while (tagAction.getLastTagName() == null && tagAction.getLastTagException() == null && backoffDelay < 8000L) {
-        //     backoffDelay = backoffDelay * 2;
-        //     Thread.sleep(backoffDelay); // Allow some time for tag creation
-        // }
-        // assertThat(tagAction.getLastTagName(), is(getTagValue(message)));
-        // assertThat(tagAction.getLastTagException(), is(nullValue()));
+        long backoffDelay = 499L;
+        while (tagAction.getLastTagName() == null && tagAction.getLastTagException() == null && backoffDelay < 8000L) {
+            backoffDelay = backoffDelay * 2;
+            Thread.sleep(backoffDelay); // Allow some time for tag creation
+        }
+        assertThat(tagAction.getLastTagName(), is(getTagValue(message)));
+        assertThat(tagAction.getLastTagException(), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
## [SECURITY-1095](https://issues.jenkins-ci.org/browse/SECURITY-1095) - Add more tests of GitTagAction

Tests are imperfect but better than no tests.  The tests are able to run a Freestyle project and create two different tags in the workspace of the project.

The tests are not able to create the tags from the doSubmit method and thus are still unable to assert several important cases.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Non-breaking change to improve an existing test

## Further comments

Fixes for the original security issue (no CSRF protection on Git Tag Action) are included in git plugin 3.9.2.