### PR TITLE
Assert specific tag creation in sequence

### DIFF
--- a/src/test/java/hudson/plugins/git/GitTagActionTest.java
+++ b/src/test/java/hudson/plugins/git/GitTagActionTest.java
@@ -112,11 +112,13 @@ public class GitTagActionTest {
         /* Run with first tag action defined */
         tagOneAction = createTagAction("v1");
 
+        /* Wait for tag creation threads to complete, then assert conditions */
+        waitForTagCreation(tagOneAction, "v1");
+
         /* Run with second tag action defined */
         tagTwoAction = createTagAction("v2");
 
         /* Wait for tag creation threads to complete, then assert conditions */
-        waitForTagCreation(tagOneAction, "v1");
         waitForTagCreation(tagTwoAction, "v2");
 
         assertThat(getMatchingTagNames(), hasItems(getTagValue("v1"), getTagValue("v2")));


### PR DESCRIPTION
## [SECURITY-1095](https://issues.jenkins-ci.org/browse/SECURITY-1095) - test improvement

@romenrg noted that the assertion checks for the last tag namne and if they
are created out of order, then the last tag name may be wrong.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Non-breaking change

