### PR TITLE
Fix [JENKINS-55827] - local tool definition ignored on agent

### DIFF
--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -10,7 +10,6 @@ import hudson.plugins.git.Branch;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitObject;
-import hudson.plugins.git.GitTool;
 import hudson.plugins.git.Revision;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.NodeProperty;
@@ -30,7 +29,6 @@ import java.text.MessageFormat;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 public class GitUtils implements Serializable {
@@ -44,56 +42,6 @@ public class GitUtils implements Serializable {
     public GitUtils(@Nonnull TaskListener listener, @Nonnull GitClient git) {
         this.git = git;
         this.listener = listener;
-    }
-
-    /**
-     * Resolves Git Tool by name.
-     * @param gitTool Tool name. If {@code null}, default tool will be used (if exists)
-     * @param builtOn Node for which the tool should be resolved
-     *                Can be {@link Jenkins#getInstance()} when running on master
-     * @param env Additional environment variables
-     * @param listener Event listener
-     * @return Tool installation or {@code null} if it cannot be resolved
-     * @since TODO
-     */
-    @CheckForNull
-    public static GitTool resolveGitTool(@CheckForNull String gitTool,
-                                  @CheckForNull Node builtOn,
-                                  @CheckForNull EnvVars env,
-                                  @Nonnull TaskListener listener) {
-        GitTool git = gitTool == null
-                ? GitTool.getDefaultInstallation()
-                : Jenkins.getActiveInstance().getDescriptorByType(GitTool.DescriptorImpl.class).getInstallation(gitTool);
-        if (git == null) {
-            listener.getLogger().println("Selected Git installation does not exist. Using Default");
-            git = GitTool.getDefaultInstallation();
-        }
-        if (git != null) {
-            if (builtOn != null) {
-                try {
-                    git = git.forNode(builtOn, listener);
-                } catch (IOException | InterruptedException e) {
-                    listener.getLogger().println("Failed to get git executable");
-                }
-            }
-            if (env != null) {
-                git = git.forEnvironment(env);
-            }
-        }
-        return git;
-    }
-
-    /**
-     * Resolves Git Tool by name in a node-agnostic way.
-     * Use {@link #resolveGitTool(String, Node, EnvVars, TaskListener)} when the node is known
-     * @param gitTool Tool name. If {@code null}, default tool will be used (if exists)
-     * @param listener Event listener
-     * @return Tool installation or {@code null} if it cannot be resolved
-     * @since TODO
-     */
-    @CheckForNull
-    public static GitTool resolveGitTool(@CheckForNull String gitTool, @Nonnull TaskListener listener) {
-        return resolveGitTool(gitTool, null, null, listener);
     }
 
     public static Node workspaceToNode(FilePath workspace) { // TODO https://trello.com/c/doFFMdUm/46-filepath-getcomputer

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -40,7 +40,6 @@ import hudson.Util;
 import hudson.model.Action;
 import hudson.model.Actionable;
 import hudson.model.Item;
-import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
@@ -55,7 +54,6 @@ import hudson.plugins.git.util.BuildChooser;
 import hudson.plugins.git.util.BuildChooserContext;
 import hudson.plugins.git.util.BuildChooserDescriptor;
 import hudson.plugins.git.util.BuildData;
-import hudson.plugins.git.util.GitUtils;
 import hudson.scm.SCM;
 import hudson.security.ACL;
 import java.io.File;
@@ -300,17 +298,14 @@ public abstract class AbstractGitSCMSource extends SCMSource {
      * @param gitTool the {@link GitTool#getName()} to resolve.
      * @return the {@link GitTool}
      * @since 3.4.0
-     * @deprecated Use {@link #resolveGitTool(String, TaskListener)} instead
      */
     @CheckForNull
-    @Deprecated
     protected GitTool resolveGitTool(String gitTool) {
-        return resolveGitTool(gitTool, TaskListener.NULL);
-    }
-
-    protected GitTool resolveGitTool(String gitTool, TaskListener listener) {
-        final Jenkins jenkins = Jenkins.getInstance();
-        return GitUtils.resolveGitTool(gitTool, jenkins, null, TaskListener.NULL);
+        return StringUtils.isBlank(gitTool)
+                ? GitTool.getDefaultInstallation()
+                : Jenkins.getActiveInstance()
+                        .getDescriptorByType(GitTool.DescriptorImpl.class)
+                        .getInstallation(gitTool);
     }
 
     private interface Retriever<T> {
@@ -329,7 +324,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         try {
             File cacheDir = getCacheDir(cacheEntry);
             Git git = Git.with(listener, new EnvVars(EnvVars.masterEnvVars)).in(cacheDir);
-            GitTool tool = resolveGitTool(context.gitTool(), listener);
+            GitTool tool = resolveGitTool(context.gitTool());
             if (tool != null) {
                 git.using(tool.getGitExe());
             }
@@ -799,7 +794,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         // 8.  A short/full revision hash that is not the head revision of a branch (we'll need to fetch everything to
         // try and resolve the hash from the history of one of the heads)
         Git git = Git.with(listener, new EnvVars(EnvVars.masterEnvVars));
-        GitTool tool = resolveGitTool(context.gitTool(), listener);
+        GitTool tool = resolveGitTool(context.gitTool());
         if (tool != null) {
             git.using(tool.getGitExe());
         }
@@ -1022,7 +1017,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             return result;
         }
         Git git = Git.with(listener, new EnvVars(EnvVars.masterEnvVars));
-        GitTool tool = resolveGitTool(context.gitTool(), listener);
+        GitTool tool = resolveGitTool(context.gitTool());
         if (tool != null) {
             git.using(tool.getGitExe());
         }
@@ -1089,7 +1084,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         final GitSCMSourceContext context =
                 new GitSCMSourceContext<>(null, SCMHeadObserver.none()).withTraits(getTraits());
         Git git = Git.with(listener, new EnvVars(EnvVars.masterEnvVars));
-        GitTool tool = resolveGitTool(context.gitTool(), listener);
+        GitTool tool = resolveGitTool(context.gitTool());
         if (tool != null) {
             git.using(tool.getGitExe());
         }

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -371,7 +371,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
             try {
                 File cacheDir = AbstractGitSCMSource.getCacheDir(cacheEntry);
                 Git git = Git.with(listener, new EnvVars(EnvVars.masterEnvVars)).in(cacheDir);
-                GitTool tool = gitSCMSource.resolveGitTool(builder.gitTool(), listener);
+                GitTool tool = gitSCMSource.resolveGitTool(builder.gitTool());
                 if (tool != null) {
                     git.using(tool.getGitExe());
                 }

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceRetrieveHeadsTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceRetrieveHeadsTest.java
@@ -56,7 +56,7 @@ public class AbstractGitSCMSourceRetrieveHeadsTest {
         // Partial mock our AbstractGitSCMSourceImpl
         gitSCMSource = PowerMockito.spy(new AbstractGitSCMSourceImpl());
         // Always resolve to mocked GitTool
-        PowerMockito.doReturn(mockedTool).when(gitSCMSource).resolveGitTool(EXPECTED_GIT_EXE, TaskListener.NULL);
+        PowerMockito.doReturn(mockedTool).when(gitSCMSource).resolveGitTool(EXPECTED_GIT_EXE);
     }
 
     /**

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
@@ -2,25 +2,15 @@ package jenkins.plugins.git;
 
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.EnvVars;
-import hudson.FilePath;
 import hudson.model.Action;
 import hudson.model.Item;
-import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.model.TopLevelItem;
 import hudson.plugins.git.GitStatus;
-import hudson.plugins.git.GitTool;
-import hudson.remoting.Launcher;
-import hudson.tools.CommandInstaller;
-import hudson.tools.InstallSourceProperty;
-import hudson.tools.ToolInstallation;
-import hudson.tools.ToolInstaller;
 import hudson.util.LogTaskListener;
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
@@ -30,8 +20,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import hudson.util.StreamTaskListener;
 import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.plugins.git.traits.TagDiscoveryTrait;
 import jenkins.scm.api.SCMEventListener;
@@ -47,7 +35,6 @@ import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.api.metadata.PrimaryInstanceMetadataAction;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import org.hamcrest.Matchers;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,7 +50,6 @@ import org.mockito.Mockito;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
@@ -73,7 +59,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -346,46 +331,6 @@ public class GitSCMSourceTest {
                 instanceOf(PrimaryInstanceMetadataAction.class)));
         assertThat(instance.fetchActions(new GitTagSCMHead("v1.0.0", 0L), null, null),
                 is(Collections.<Action>emptyList()));
-    }
-
-
-    @Issue("JENKINS-52754")
-    @Test
-    public void gitSCMSourceShouldResolveToolsForMaster() throws Exception {
-        Assume.assumeTrue("Runs on Unix only", !Launcher.isWindows());
-        TaskListener log = StreamTaskListener.fromStdout();
-        HelloToolInstaller inst = new HelloToolInstaller("master", "echo Hello", "git");
-        GitTool t = new GitTool("myGit", null, Collections.singletonList(
-                new InstallSourceProperty(Collections.singletonList(inst))));
-        t.getDescriptor().setInstallations(t);
-
-        GitTool defaultTool = GitTool.getDefaultInstallation();
-        GitTool resolved = (GitTool) defaultTool.translate(jenkins.jenkins, new EnvVars(), TaskListener.NULL);
-        assertThat(resolved.getGitExe(), org.hamcrest.CoreMatchers.containsString("git"));
-
-        GitSCMSource instance = new GitSCMSource("http://git.test/telescope.git");
-        instance.retrieveRevisions(log);
-        assertTrue("Installer should be invoked", inst.isInvoked());
-    }
-
-    private static class HelloToolInstaller extends CommandInstaller {
-
-        private boolean invoked;
-
-        public HelloToolInstaller(String label, String command, String toolHome) {
-            super(label, command, toolHome);
-        }
-
-        public boolean isInvoked() {
-            return invoked;
-        }
-
-        @Override
-        public FilePath performInstallation(ToolInstallation toolInstallation, Node node, TaskListener taskListener) throws IOException, InterruptedException {
-            taskListener.error("Hello, world!");
-            invoked = true;
-            return super.performInstallation(toolInstallation, node, taskListener);
-        }
     }
 
     @TestExtension


### PR DESCRIPTION
## [JENKINS-55827](https://issues.jenkins-ci.org/browse/JENKINS-55827) - Honor local tool definition

Revert "[JENKINS-52754] - GitBranchSource should consult with GitTools node-specific tool installers"

This reverts commit 77967dbb349c8d1df02e4a21e0ff9d9e107e94ee.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

This is an intentionally short term fix that reverts the fix for [JENKINS-52754](https://issues.jenkins-ci.org/browse/JENKINS-52754) (GitBranchSource should consult with GitTools node-specific tool installers) in order to resolve the more serious problem of [JENKINS-55827](https://issues.jenkins-ci.org/browse/JENKINS-55827) (local tool definition ignored on agent).

