### PR TITLE
[JENKINS-55876] Recursively update submodules

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -130,7 +130,10 @@ public class SubmoduleOption extends GitSCMExtension {
             if (!disableSubmodules && git.hasGitModules()) {
                 // This ensures we don't miss changes to submodule paths and allows
                 // seamless use of bare and non-bare superproject repositories.
-                git.setupSubmoduleUrls(revToBuild.lastBuild.getRevision(), listener);
+                git.setupSubmoduleUrls(
+                        revToBuild.lastBuild.getRevision(),
+                        listener,
+                        recursiveSubmodules);
                 SubmoduleUpdateCommand cmd = git.submoduleUpdate()
                         .recursive(recursiveSubmodules)
                         .remoteTracking(trackingSubmodules)


### PR DESCRIPTION
## [JENKINS-55876](https://issues.jenkins-ci.org/browse/JENKINS-55876) - Recursively synchronize submodule URLs

Currently Jenkins only synchronizes submodule URLs for top level submodules. This means checkout can fail, if a submodule URL of a submodule changes, because the old second level submodule may not have the revision referenced by the submodule.

This change resolves that by indicating whether submodules should be handled recursively when synchronizing submodule URLs.

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [X] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [X] Unit tests pass locally with my changes
- [X] I have added documentation as necessary - none believed to be necessary.
- [X] No Javadoc warnings were introduced with my changes
- [X] No findbugs warnings were introduced with my changes
- [X] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin). This is dependent on https://github.com/jenkinsci/git-client-plugin/pull/405 which is not yet merged

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
