### PR TITLE
[JENKINS-55787] Switch labels from entry to checkbox

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
@@ -1,18 +1,21 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:entry field="pushOnlyIfSuccess"
-             title="${%Push Only If Build Succeeds}">
-      <f:checkbox />
+    <f:entry>
+      <f:checkbox field="pushOnlyIfSuccess"
+                  title="${%Push Only If Build Succeeds}"
+                  />
     </f:entry>
-    <f:entry field="pushMerge"
-             title="${%Merge Results}"
-             description="${%If pre-build merging is configured, push the result back to the origin}">
-      <f:checkbox />
+    <f:entry>
+      <f:checkbox field="pushMerge"
+                  title="${%Merge Results}"
+                  description="${%If pre-build merging is configured, push the result back to the origin}"
+                  />
     </f:entry>
-    <f:entry field="forcePush"
-             title="${%Force Push}"
-             description="${%Add force option to git push}">
-      <f:checkbox />
+    <f:entry>
+      <f:checkbox field="forcePush"
+                  title="${%Force Push}"
+                  description="${%Add force option to git push}"
+                  />
     </f:entry>
     <f:entry field="tagsToPush"
              title="${%Tags}"
@@ -29,13 +32,13 @@
                    title="${%Tag message}">
             <f:textarea/>
           </f:entry>
-          <f:entry field="createTag"
-                   title="${%Create new tag}">
-            <f:checkbox />
+          <f:entry>
+            <f:checkbox field="createTag"
+                        title="${%Create new tag}"/>
           </f:entry>
-          <f:entry field="updateTag"
-                   title="${%Update new tag}">
-            <f:checkbox />
+          <f:entry>
+            <f:checkbox field="updateTag"
+                        title="${%Update new tag}"/>
           </f:entry>
           <f:entry field="targetRepoName"
                    title="${%Target remote name}">
@@ -89,8 +92,8 @@
             <f:textbox/>
           </f:entry>
           
-          <f:entry title="${%Abort if note exists}" field="noteReplace" >
-            <f:checkbox />
+          <f:entry>
+            <f:checkbox title="${%Abort if note exists}" field="noteReplace"/>
           </f:entry>
           
         </table>

--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -9,12 +9,20 @@
       <f:textbox />
     </f:entry>
     <f:optionalBlock title="${%Create new accounts based on author/committer's email}" field="createAccountBasedOnEmail" checked="${descriptor.createAccountBasedOnEmail}" inline="true">
-      <f:entry title="${%Use existing account with same email if found}" field="useExistingAccountWithSameEmail">
-        <f:checkbox name="useExistingAccountWithSameEmail" checked="${descriptor.useExistingAccountWithSameEmail}" />
+      <f:entry>
+        <f:checkbox name="useExistingAccountWithSameEmail"
+            checked="${descriptor.useExistingAccountWithSameEmail}"
+            field="useExistingAccountWithSameEmail"
+            title="${%Use existing account with same email if found}"
+            />
       </f:entry>
     </f:optionalBlock>
-    <f:entry title="${%Show the entire commit summary in changes}" field="showEntireCommitSummaryInChanges">
-      <f:checkbox name="showEntireCommitSummaryInChanges" checked="${descriptor.showEntireCommitSummaryInChanges}"/>
+    <f:entry>
+      <f:checkbox name="showEntireCommitSummaryInChanges"
+          checked="${descriptor.showEntireCommitSummaryInChanges}"
+          title="${%Show the entire commit summary in changes}"
+          field="showEntireCommitSummaryInChanges"
+          />
     </f:entry>
     <!--
     <f:entry title="${%Default git client implementation}" field="defaultClientType">

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
@@ -2,14 +2,14 @@ package hudson.plugins.git.extensions.impl.CloneOption;
 
 def f = namespace(lib.FormTagLib);
 
-f.entry(title:_("Fetch tags"), field:"noTags") {
-    f.checkbox(negative:true, checked:(instance==null||!instance.noTags))
+f.entry() {
+    f.checkbox(title:_("Fetch tags"), field:"noTags", negative:true, checked:(instance==null||!instance.noTags))
 }
-f.entry(title:_("Honor refspec on initial clone"), field:"honorRefspec") {
-    f.checkbox()
+f.entry() {
+    f.checkbox(title:_("Honor refspec on initial clone"), field:"honorRefspec")
 }
-f.entry(title:_("Shallow clone"), field:"shallow") {
-    f.checkbox()
+f.entry() {
+    f.checkbox(title:_("Shallow clone"), field:"shallow")
 }
 f.entry(title:_("Shallow clone depth"), field:"depth") {
     f.number(clazz:"number", min:1, step:1)

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
@@ -2,20 +2,20 @@ package hudson.plugins.git.extensions.impl.SubmoduleOption;
 
 def f = namespace(lib.FormTagLib);
 
-f.entry(title:_("Disable submodules processing"), field:"disableSubmodules") {
-    f.checkbox()
+f.entry() {
+    f.checkbox(title:_("Disable submodules processing"), field:"disableSubmodules")
 }
-f.entry(title:_("Recursively update submodules"), field:"recursiveSubmodules") {
-    f.checkbox()
+f.entry() {
+    f.checkbox(title:_("Recursively update submodules"), field:"recursiveSubmodules")
 }
-f.entry(title:_("Update tracking submodules to tip of branch"), field:"trackingSubmodules") {
-    f.checkbox()
+f.entry() {
+    f.checkbox(title:_("Update tracking submodules to tip of branch"), field:"trackingSubmodules")
 }
-f.entry(title:_("Use credentials from default remote of parent repository"), field:"parentCredentials") {
-    f.checkbox()
+f.entry() {
+    f.checkbox(title:_("Use credentials from default remote of parent repository"), field:"parentCredentials")
 }
-f.entry(title:_("Shallow clone"), field:"shallow") {
-    f.checkbox()
+f.entry() {
+    f.checkbox(title:_("Shallow clone"), field:"shallow")
 }
 f.entry(title:_("Shallow clone depth"), field:"depth") {
     f.number(clazz:"number", min:1, step:1)
@@ -33,9 +33,8 @@ f.entry(title:_("Number of threads to use when updating submodules"), field:"thr
 /*
   This needs more thought
 
-  <f:entry title="Autogenerate submodule configurations">
-    <f:checkbox name="git.generate" checked="${scm.doGenerate}"/>
-    <label class="attach-previous">Generate submodule configurations</label>
+  <f:entry>
+    <f:checkbox title="Autogenerate submodule configurations" name="git.generate" checked="${scm.doGenerate}">
 
     <f:repeatable var="smcfg" name="smcfg" varStatus="cfgStatus" items="${scm.submoduleCfg}" noAddButton="false">
            <table width="100%">


### PR DESCRIPTION
## [JENKINS-55787](https://issues.jenkins-ci.org/browse/JENKINS-55787) - Use checkbox for labels, not entry

Basically checkboxes should have labels, splitting the labels away from their checkboxes is poor UX, poor accessibility. This change brings the layout more inline with how normal settings UIs lay out checkboxes.

This supersedes #675 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix - Non-breaking change which fixes an issue
