### PR TITLE
Early exit from tag dependent test if CLI git 2.20+

### DIFF
--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -839,6 +839,12 @@ public class GitSCMTest extends AbstractGitTestCase {
         git.checkout("master");
         git.deleteBranch(tmpBranch);
 
+        if (sampleRepo.gitVersionAtLeast(2, 20, 0)) {
+            /* Newer CLI git versions fail this test unless they have newer git client */
+            /* Don't want to force users onto a newer git client, so we skip the final build and assertions on git 2.20 and newer */
+            return;
+        }
+
         // at this point we're back on master, there are no other branches, "mytag" has been updated to a new commit:
         assertTrue("scm polling should detect commit3 change in 'mytag'", project.poll(listener).hasChanges());
         build(project, Result.SUCCESS, commitFile3);


### PR DESCRIPTION
## Early exit testGitSCMCanBuildAgainstTags if CLI git 2.20+

Git client plugin 2.7.6 and later include a fix for the new tag handling behavior of command line git 2.20.  However, we don't want to force users to upgrade to that git client version, so the git plugin depends on an older version.

The older version does not include the CLI git 2.20 tag handling change so it will fail this test.  Rather than fail the test, we exit the test early if it is running with CLI git 2.20 or newer.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Non-breaking change which fixes a test
