### PR TITLE
Prevent submodule NPE on null BuildData

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -127,7 +127,7 @@ public class SubmoduleOption extends GitSCMExtension {
         BuildData revToBuild = scm.getBuildData(build);
 
         try {
-            if (!disableSubmodules && git.hasGitModules()) {
+            if (!disableSubmodules && git.hasGitModules() && revToBuild != null && revToBuild.lastBuild != null) {
                 // This ensures we don't miss changes to submodule paths and allows
                 // seamless use of bare and non-bare superproject repositories.
                 git.setupSubmoduleUrls(revToBuild.lastBuild.getRevision(), listener);


### PR DESCRIPTION
## [JENKINS-56150](https://issues.jenkins-ci.org/browse/JENKINS-56150) - null pointer exception in git plugin

Only reference build data if not null.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

No test written.  I haven't been able to deduce a way to duplicate the bug interactively or programatically.

@jacob-keller, could you review and comment?