### PR TITLE
[JENKINS-56189] Add Sparse Checkout SCM trait

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPaths.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPaths.java
@@ -16,6 +16,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class SparseCheckoutPaths extends GitSCMExtension {
     private List<SparseCheckoutPath> sparseCheckoutPaths = Collections.emptyList();
@@ -48,5 +49,40 @@ public class SparseCheckoutPaths extends GitSCMExtension {
         public String getDisplayName() {
             return "Sparse Checkout paths";
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        
+        SparseCheckoutPaths that = (SparseCheckoutPaths) o;
+        return Objects.equals(getSparseCheckoutPaths(), that.getSparseCheckoutPaths());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(getSparseCheckoutPaths());
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "SparseCheckoutPaths{" +
+                "sparseCheckoutPaths=" + sparseCheckoutPaths +
+                '}';
     }
 }

--- a/src/main/java/jenkins/plugins/git/traits/SparseCheckoutPathsTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/SparseCheckoutPathsTrait.java
@@ -1,0 +1,37 @@
+package jenkins.plugins.git.traits;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.impl.SparseCheckoutPaths;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Exposes {@link SparseCheckoutPaths} as a {@link SCMSourceTrait}.
+ *
+ * @since 4.0.0
+ */
+public class SparseCheckoutPathsTrait extends GitSCMExtensionTrait<SparseCheckoutPaths> {
+    /**
+     * Stapler constructor.
+     *
+     * @param extension the {@link SparseCheckoutPaths}
+     */
+    @DataBoundConstructor
+    public SparseCheckoutPathsTrait(SparseCheckoutPaths extension) {
+        super(extension);
+    }
+
+    /**
+     * Our {@link hudson.model.Descriptor}
+     */
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionTraitDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Sparse Checkout paths";
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/git/traits/SparseCheckoutPathsTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/SparseCheckoutPathsTrait.java
@@ -8,7 +8,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 /**
  * Exposes {@link SparseCheckoutPaths} as a {@link SCMSourceTrait}.
  *
- * @since 4.0.0
+ * @since 4.0.1
  */
 public class SparseCheckoutPathsTrait extends GitSCMExtensionTrait<SparseCheckoutPaths> {
     /**

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
@@ -10,9 +10,11 @@ import hudson.plugins.git.extensions.impl.CloneOption;
 import hudson.plugins.git.extensions.impl.GitLFSPull;
 import hudson.plugins.git.extensions.impl.LocalBranch;
 import hudson.plugins.git.extensions.impl.PruneStaleBranch;
+import hudson.plugins.git.extensions.impl.SparseCheckoutPaths;
 import hudson.plugins.git.extensions.impl.SubmoduleOption;
 import hudson.plugins.git.extensions.impl.UserIdentity;
 import hudson.plugins.git.extensions.impl.WipeWorkspace;
+
 import java.util.Collections;
 import jenkins.model.Jenkins;
 
@@ -213,8 +215,8 @@ public class GitSCMSourceTraitsTest {
                         Matchers.<GitSCMExtension>instanceOf(PruneStaleBranch.class),
                         Matchers.<GitSCMExtension>instanceOf(AuthorInChangelog.class),
                         Matchers.<GitSCMExtension>instanceOf(WipeWorkspace.class),
-                        Matchers.<SCMSourceTrait>allOf(
-                                instanceOf(SparseCheckoutPathsTrait.class),
+                        Matchers.<GitSCMExtension>allOf(
+                                instanceOf(SparseCheckoutPaths.class),
                                 hasProperty("sparseCheckoutPaths", hasSize(2))
                         )
                 )

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
@@ -15,6 +15,7 @@ import hudson.plugins.git.extensions.impl.UserIdentity;
 import hudson.plugins.git.extensions.impl.WipeWorkspace;
 import java.util.Collections;
 import jenkins.model.Jenkins;
+
 import jenkins.plugins.git.traits.AuthorInChangelogTrait;
 import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.plugins.git.traits.CheckoutOptionTrait;
@@ -28,6 +29,7 @@ import jenkins.plugins.git.traits.LocalBranchTrait;
 import jenkins.plugins.git.traits.PruneStaleBranchTrait;
 import jenkins.plugins.git.traits.RefSpecsSCMSourceTrait;
 import jenkins.plugins.git.traits.RemoteNameSCMSourceTrait;
+import jenkins.plugins.git.traits.SparseCheckoutPathsTrait;
 import jenkins.plugins.git.traits.SubmoduleOptionTrait;
 import jenkins.plugins.git.traits.UserIdentityTrait;
 import jenkins.plugins.git.traits.WipeWorkspaceTrait;
@@ -45,6 +47,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -156,6 +159,14 @@ public class GitSCMSourceTraitsTest {
                                                 hasProperty("repoUrl", is("foo"))
                                         )
                                 )
+                        ),
+                        Matchers.<SCMSourceTrait>allOf(
+                                instanceOf(SparseCheckoutPathsTrait.class),
+                                hasProperty("extension",
+                                        allOf(
+                                                hasProperty("sparseCheckoutPaths", hasSize(2))
+                                        )
+                                )
                         )
                 )
         );
@@ -201,7 +212,11 @@ public class GitSCMSourceTraitsTest {
                         Matchers.<GitSCMExtension>instanceOf(GitLFSPull.class),
                         Matchers.<GitSCMExtension>instanceOf(PruneStaleBranch.class),
                         Matchers.<GitSCMExtension>instanceOf(AuthorInChangelog.class),
-                        Matchers.<GitSCMExtension>instanceOf(WipeWorkspace.class)
+                        Matchers.<GitSCMExtension>instanceOf(WipeWorkspace.class),
+                        Matchers.<SCMSourceTrait>allOf(
+                                instanceOf(SparseCheckoutPathsTrait.class),
+                                hasProperty("sparseCheckoutPaths", hasSize(2))
+                        )
                 )
         );
         assertThat(instance.getBrowser(), allOf(


### PR DESCRIPTION
## [JENKINS-56189](https://issues.jenkins-ci.org/browse/JENKINS-56189) - Add Sparse Checkout as a Git SCM Trait

This is simply adding the existing Sparse Checkout extension as a Git SCM Trait to make it configurable From Git SCM Source and Navigator implementations.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
