### PR TITLE
JENKINS-56284 Make compute changelog extensible

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/GitSCMChangelogExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMChangelogExtension.java
@@ -1,0 +1,33 @@
+package hudson.plugins.git.extensions;
+
+import java.io.IOException;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.Revision;
+import org.jenkinsci.plugins.gitclient.ChangelogCommand;
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+/**
+ * FIXME JavaDoc
+ * @author Zhenlei Huang
+ */
+public abstract class GitSCMChangelogExtension extends FakeGitSCMExtension {
+
+    /**
+     * Called before a {@link ChangelogCommand} is executed to allow extensions to alter its behaviour.
+     * @param scm GitSCM object
+     * @param build run context
+     * @param git GitClient
+     * @param listener build log
+     * @param cmd changelog command to be decorated
+     * @param revToBuild The revision selected for this build
+     * @return true in case decorated, false otherwise
+     * @throws IOException on input or output error
+     * @throws InterruptedException when interrupted
+     * @throws GitException on git error
+     */
+    public abstract boolean decorateChangelogCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, ChangelogCommand cmd, Revision revToBuild) throws IOException, InterruptedException, GitException;
+}

--- a/src/main/java/jenkins/plugins/git/ChangelogToPreviousBuild.java
+++ b/src/main/java/jenkins/plugins/git/ChangelogToPreviousBuild.java
@@ -1,0 +1,95 @@
+package jenkins.plugins.git;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.Revision;
+import hudson.plugins.git.extensions.GitSCMChangelogExtension;
+import hudson.plugins.git.util.Build;
+import hudson.plugins.git.util.BuildChooserContext;
+import hudson.remoting.Channel;
+import org.jenkinsci.plugins.gitclient.ChangelogCommand;
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+/**
+ * FIXME JavaDoc
+ * @author Zhenlei Huang
+ */
+public class ChangelogToPreviousBuild extends GitSCMChangelogExtension {
+
+    @Override
+    public boolean decorateChangelogCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, ChangelogCommand cmd, Revision revToBuild) throws IOException, InterruptedException, GitException {
+        boolean decorated = false;
+
+        for (Branch b : revToBuild.getBranches()) {
+            Build lastRevWas = scm.getBuildChooser().prevBuildForChangelog(b.getName(), scm.getBuildData(build.getPreviousBuild()), git, new BuildChooserContextImpl(build.getParent(), build, build.getEnvironment(listener)));
+            if (lastRevWas != null && lastRevWas.revision != null && git.isCommitInRepo(lastRevWas.getSHA1())) {
+                cmd.includes(revToBuild.getSha1());
+                cmd.excludes(lastRevWas.getSHA1());
+                decorated = true;
+            }
+        }
+
+        return decorated;
+    }
+
+    // Copy of GitSCM.BuildChooserContextImpl
+    /*package*/ static class BuildChooserContextImpl implements BuildChooserContext, Serializable {
+        @SuppressFBWarnings(value="SE_BAD_FIELD", justification="known non-serializable field")
+        final Job project;
+        @SuppressFBWarnings(value="SE_BAD_FIELD", justification="known non-serializable field")
+        final Run build;
+        final EnvVars environment;
+
+        BuildChooserContextImpl(Job project, Run build, EnvVars environment) {
+            this.project = project;
+            this.build = build;
+            this.environment = environment;
+        }
+
+        public <T> T actOnBuild(ContextCallable<Run<?,?>, T> callable) throws IOException, InterruptedException {
+            return callable.invoke(build, FilePath.localChannel);
+        }
+
+        public <T> T actOnProject(ContextCallable<Job<?,?>, T> callable) throws IOException, InterruptedException {
+            return callable.invoke(project, FilePath.localChannel);
+        }
+
+        public Run<?, ?> getBuild() {
+            return build;
+        }
+
+        public EnvVars getEnvironment() {
+            return environment;
+        }
+
+        private Object writeReplace() {
+            return Channel.current().export(BuildChooserContext.class,new BuildChooserContext() {
+                public <T> T actOnBuild(ContextCallable<Run<?,?>, T> callable) throws IOException, InterruptedException {
+                    return callable.invoke(build,Channel.current());
+                }
+
+                public <T> T actOnProject(ContextCallable<Job<?,?>, T> callable) throws IOException, InterruptedException {
+                    return callable.invoke(project,Channel.current());
+                }
+
+                public Run<?, ?> getBuild() {
+                    return build;
+                }
+
+                public EnvVars getEnvironment() {
+                    return environment;
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/git/LegacyGitSCMChangelogExtension.java
+++ b/src/main/java/jenkins/plugins/git/LegacyGitSCMChangelogExtension.java
@@ -1,0 +1,46 @@
+package jenkins.plugins.git;
+
+import java.io.IOException;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.Revision;
+import hudson.plugins.git.extensions.GitSCMChangelogExtension;
+import hudson.plugins.git.extensions.impl.ChangelogToBranch;
+import org.jenkinsci.plugins.gitclient.ChangelogCommand;
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+
+/**
+ * FIXME JavaDoc
+ * Legacy changelog impl.
+ */
+public class LegacyGitSCMChangelogExtension extends GitSCMChangelogExtension {
+
+
+    @Override
+    public boolean decorateChangelogCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, ChangelogCommand cmd, Revision revToBuild) throws IOException, InterruptedException, GitException {
+        boolean exclusion = false;
+
+        // TODO Refactor ChangelogToBranch
+        ChangelogToBranch changelogToBranch = scm.getExtensions().get(ChangelogToBranch.class);
+        if (changelogToBranch != null) {
+            listener.getLogger().println("Using 'Changelog to branch' strategy.");
+            cmd.includes(revToBuild.getSha1());
+            cmd.excludes(changelogToBranch.getOptions().getRef());
+            exclusion = true;
+        } else {
+            exclusion = new ChangelogToPreviousBuild().decorateChangelogCommand(scm, build, git, listener, cmd, revToBuild);
+        }
+
+        if (!exclusion) {
+            // this is the first time we are building this branch, so there's no base line to compare against.
+            // if we force the changelog, it'll contain all the changes in the repo, which is not what we want.
+            listener.getLogger().println("First time build. Skipping changelog.");
+        }
+
+        return exclusion;
+    }
+}


### PR DESCRIPTION
## [JENKINS-56284](https://issues.jenkins-ci.org/browse/JENKINS-56284) - Make compute changelog extensible

Describe the big picture of your changes here to explain to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, include a link to the issue.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
