### PR TITLE
Skip truncation test on ancient git versions

### DIFF
--- a/src/test/java/hudson/plugins/git/GitChangeSetTruncateTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTruncateTest.java
@@ -18,6 +18,8 @@ import org.eclipse.jgit.lib.ObjectId;
 
 import hudson.EnvVars;
 import hudson.model.TaskListener;
+import jenkins.plugins.git.CliGitCommand;
+import jenkins.plugins.git.GitSampleRepoRule;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 
@@ -36,6 +38,9 @@ public class GitChangeSetTruncateTest {
 
     @ClassRule
     public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @ClassRule
+    public static GitSampleRepoRule versionCheckRepo = new GitSampleRepoRule();
 
     private static File repoRoot = null;
 
@@ -96,9 +101,12 @@ public class GitChangeSetTruncateTest {
 
     @Parameterized.Parameters(name = "{0} \"{1}\" --->>> \"{2}\"")
     public static Collection gitObjects() {
-        String[] implementations = {"git", "jgit"};
+        /* If CLI git is older than 1.8.3, don't test CLI git message truncation */
+        /* CLI git 1.7.1 (CentOS 6) does not support the message truncation command line flags */
+        String[] bothGitImplementations = {"git", "jgit"};
+        String[] jgitImplementation = {"jgit"};
         List<Object[]> arguments = new ArrayList<>();
-        for (String implementation : implementations) {
+        for (String implementation : versionCheckRepo.gitVersionAtLeast(1, 8, 3) ? bothGitImplementations : jgitImplementation) {
             for (TestData sample : TEST_DATA) {
                 /* Expect truncated message from git, full message from JGit */
                 String expected = implementation.equals("git") ? sample.testDataExpectedSummary : sample.testDataCommitSummary;


### PR DESCRIPTION
## [JENKINS-56116](https://issues.jenkins-ci.org/browse/JENKINS-56116) - Skip truncation tests on old CLI git

Do not attempt to test truncation on command line git versions older than git 1.8.3 like CentOS 6.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix
