### PR TITLE
[JENKINS-56176] - GIT_COMMIT not available for build name setter

### DIFF
--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -773,6 +773,12 @@ public class GitSCMTest extends AbstractGitTestCase {
         rule.assertLogContains(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build1);
     }
 
+    @Issue("JENKINS-56176")
+    @Test
+    public void buildNameSetterMacroNotDefined() {
+        fail("JENKINS-56176 needs to be fixed before git plugin 4.0.0 is released");
+    }
+
     @Issue("HUDSON-7411")
     @Test
     public void testNodeEnvVarsAvailable() throws Exception {


### PR DESCRIPTION
## [JENKINS-56176](https://issues.jenkins-ci.org/browse/JENKINS-56176) - GIT_COMMIT not available for build name setter

Git plugin 3.x releases provide the GIT_COMMIT token macro that can be used in the build name setter plugin and elsewhere to provide the SHA1 of the commit that was built in a Jenkins job context.

Git plugin 4.x pre-releases lost that token macro.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)