### PR TITLE
[JENKINS-55939] lastBuiltRevision API investigation

### DIFF
--- a/src/test/java/hudson/plugins/git/util/BuildDataTest.java
+++ b/src/test/java/hudson/plugins/git/util/BuildDataTest.java
@@ -491,4 +491,10 @@ public class BuildDataTest {
         emptyData.remoteUrls = null;
         assertEquals(emptyData.hashCode(), emptyData.hashCode());
     }
+
+    @Test
+    @Issue("JENKINS-55939")
+    public void testBuildDataLastBuiltRevisionAPI() {
+        fail("Last built revision REST API needs to be reviewed, retained if possible");
+    }
 }


### PR DESCRIPTION
## [JENKINS-55939](https://issues.jenkins-ci.org/browse/JENKINS-55939) - review lastBuiltRevision API

Need to review the git plugin 3.9 REST API and compare it to the git plugin 4.0 REST API.  We don't want the waste of storing every SHA1 of every build in the history of every build in a job.  However, we would like to retain API compatibility if that can be done, or at least retain API data elements where they make sense.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

May not be possible.  This pull request is a placeholder for an investigation,p not a commitment to any specific course of action.