### PR TITLE
Replace <tt> by <code> to fix javadoc failure on Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 // Test plugin compatibility to recent Jenkins LTS
 // Allow failing tests to retry execution
-buildPlugin(jenkinsVersions: [null, '2.150.1'],
+buildPlugin(configurations: buildPlugin.recommendedConfigurations(),
             findbugs: [run:true, archive:true, unstableTotalAll: '0'],
             failFast: false)
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.39</version>
+    <version>3.40</version>
     <relativePath />
   </parent>
 

--- a/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java
@@ -17,14 +17,14 @@ import java.util.*;
  * Git build chooser which will select all branches <b>except</b> for those which match the
  * configured branch specifiers.
  * <p>
- * e.g. If <tt>&#x2a;&#x2a;/master</tt> and <tt>&#x2a;&#x2a;/release-&#x2a;</tt> are configured as
+ * e.g. If <code>&#x2a;&#x2a;/master</code> and <code>&#x2a;&#x2a;/release-&#x2a;</code> are configured as
  * "Branches to build" then any branches matching those patterns <b>will not</b> be built, unless
  * another branch points to the same revision.
  * <p>
- * This is useful, for example, when you have jobs building your <tt>master</tt> and various
- * <tt>release</tt> branches and you want a second job which builds all new feature branches &mdash;
+ * This is useful, for example, when you have jobs building your <code>master</code> and various
+ * <code>release</code> branches and you want a second job which builds all new feature branches &mdash;
  * i.e. branches which do not match these patterns &mdash; without redundantly building
- * <tt>master</tt> and the release branches again each time they change.
+ * <code>master</code> and the release branches again each time they change.
  *
  * @author Christopher Orr
  */


### PR DESCRIPTION
New commit for https://github.com/jenkinsci/git-plugin/pull/685 which I cannot push directly to.

cc @oleg-nenashev 


Build failure when using JDK 11.0.2:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:jar (attach-javadocs) on project git: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1 - /home/tiste/dev/github/jenkinsci/git-plugin/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java:20: error: tag not supported in the generated HTML version: tt
[ERROR]  * e.g. If <tt>&#x2a;&#x2a;/master</tt> and <tt>&#x2a;&#x2a;/release-&#x2a;</tt> are configured as
[ERROR]            ^
[ERROR] /home/tiste/dev/github/jenkinsci/git-plugin/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java:20: error: tag not supported in the generated HTML version: tt
[ERROR]  * e.g. If <tt>&#x2a;&#x2a;/master</tt> and <tt>&#x2a;&#x2a;/release-&#x2a;</tt> are configured as
[ERROR]                                             ^
[ERROR] /home/tiste/dev/github/jenkinsci/git-plugin/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java:24: error: tag not supported in the generated HTML version: tt
[ERROR]  * This is useful, for example, when you have jobs building your <tt>master</tt> and various
[ERROR]                                                                  ^
[ERROR] /home/tiste/dev/github/jenkinsci/git-plugin/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java:25: error: tag not supported in the generated HTML version: tt
[ERROR]  * <tt>release</tt> branches and you want a second job which builds all new feature branches &mdash;
[ERROR]    ^
[ERROR] /home/tiste/dev/github/jenkinsci/git-plugin/src/main/java/hudson/plugins/git/util/InverseBuildChooser.java:27: error: tag not supported in the generated HTML version: tt
[ERROR]  * <tt>master</tt> and the release branches again each time they change.
[ERROR]    ^
[ERROR] /home/tiste/dev/github/jenkinsci/git-plugin/src/main/java/hudson/plugins/git/util/BuildChooser.java:190: warning: @return has already been specified
[ERROR]      * @return
[ERROR]        ^
[ERROR]
[ERROR] Command line was: /home/tiste/.tools/JDKs/jdk-11.0.2/bin/javadoc @options @packages
[ERROR]
[ERROR] Refer to the generated Javadoc files in '/home/tiste/dev/github/jenkinsci/git-plugin/target/apidocs' dir.
```