### PR TITLE
[JENKINS-56176] GIT_REVISION token macro lost

### DIFF
--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1072,6 +1072,12 @@ public class GitSCMTest extends AbstractGitTestCase {
         rule.assertLogContains(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build1);
     }
 
+    @Issue("JENKINS-56176")
+    @Test
+    public void buildNameSetterMacroNotDefined() {
+        fail("JENKINS-56176 needs to be fixed before git plugin 4.0.0 is released");
+    }
+
     @Issue("HUDSON-7411")
     @Test
     public void testNodeEnvVarsAvailable() throws Exception {


### PR DESCRIPTION
## [JENKINS-56176](https://issues.jenkins-ci.org/browse/JENKINS-56176) - GIT_REVISION token macro unavailable

This failing test is the placeholder so that I can use GitHub milestones to track progress towards completion of git plugin 4.0.0 release without forcing myself to look at a list of tagged bug reports in Jira.

JENKINS-56176 is a blocker for the git plugin 4.0.0 release.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

Needs further investigation.  This is only a placeholder. I confirmed by interactive testing that the #689 pull request also resolves this regression.  Still needs a test to prevent the same regression from reappearing in the future, but the problem is resolved by that revert.