### PR TITLE
Make GitSCMSource aware of PruneStaleBranchTrait

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -920,6 +920,8 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         if (candidateOtherRef != null) {
             return candidateOtherRef;
         }
+        //if PruneStaleBranches it should take affect on the following retrievals
+        boolean pruneRefs = context.pruneRefs();
         if (tagName != null) {
             listener.getLogger().println(
                     "Resolving tag commit... (remote references may be a lightweight tag or an annotated tag)");
@@ -941,7 +943,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                   }
                               },
                     context,
-                    listener, false);
+                    listener, pruneRefs);
         }
         // Pokémon!... Got to catch them all
         listener.getLogger().printf("Could not find %s in remote references. "
@@ -987,7 +989,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                               }
                           },
                 context,
-                listener, false);
+                listener, pruneRefs);
     }
 
     /**

--- a/src/main/java/jenkins/plugins/git/GitSCMSourceContext.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSourceContext.java
@@ -68,6 +68,10 @@ public class GitSCMSourceContext<C extends GitSCMSourceContext<C, R>, R extends 
      */
     private boolean wantTags;
     /**
+     * {@code true} if the {@link GitSCMSourceRequest} needs to be prune aware.
+     */
+    private boolean pruneRefs;
+    /**
      * A list of other references to discover and search
      */
     private Set<RefNameMapping> refNameMappings;
@@ -117,6 +121,15 @@ public class GitSCMSourceContext<C extends GitSCMSourceContext<C, R>, R extends 
      */
     public final boolean wantTags() {
         return wantTags;
+    }
+
+    /**
+     * Returns {@code true} if the {@link GitSCMSourceRequest} needs to be prune aware.
+     *
+     * @return {@code true} if the {@link GitSCMSourceRequest} needs to be prune aware.
+     */
+    public final boolean pruneRefs() {
+        return pruneRefs;
     }
 
     /**
@@ -204,6 +217,20 @@ public class GitSCMSourceContext<C extends GitSCMSourceContext<C, R>, R extends 
     @NonNull
     public C wantTags(boolean include) {
         wantTags = wantTags || include;
+        return (C) this;
+    }
+
+    /**
+     * Adds a requirement for git ref pruning to any {@link GitSCMSourceRequest} for this context.
+     *
+     * @param include {@code true} to add the requirement or {@code false} to leave the requirement as is (makes
+     *                simpler with method chaining)
+     * @return {@code this} for method chaining.
+     */
+    @SuppressWarnings("unchecked")
+    @NonNull
+    public C pruneRefs(boolean include) {
+        pruneRefs = pruneRefs || include;
         return (C) this;
     }
 

--- a/src/main/java/jenkins/plugins/git/traits/PruneStaleBranchTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/PruneStaleBranchTrait.java
@@ -27,6 +27,8 @@ package jenkins.plugins.git.traits;
 
 import hudson.Extension;
 import hudson.plugins.git.extensions.impl.PruneStaleBranch;
+import jenkins.plugins.git.GitSCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -42,6 +44,15 @@ public class PruneStaleBranchTrait extends GitSCMExtensionTrait<PruneStaleBranch
     @DataBoundConstructor
     public PruneStaleBranchTrait() {
         super(new PruneStaleBranch());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        GitSCMSourceContext<?,?> ctx = (GitSCMSourceContext<?, ?>) context;
+        ctx.pruneRefs(true);
     }
 
     /**


### PR DESCRIPTION
When using this [retrieve](https://github.com/jenkinsci/git-plugin/blob/6cdc97e0081276470bb96535e65bd0b4cb195ec9/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java#L768) entrypoint and attempting to find a Tag with the TagDiscoveryTrait enabled or attempting to find something without the appropriate DiscoveryTrait enabled, a doRetrieve call is processed. These two calls do not prune even if the PruneStaleBranchTrait is present. This code makes these two calls aware of said trait and therefore avoid any tag ref lock exception

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments
This fix is brought about by a heavy use of the Pipeline global library plugin, and while adding the PruneStaleBranchTrait avoids most of the issues caused by:
branch x created, build run, branch x deleted, build run, branch x/x created
If the branch run between branch x deleted and branch x/x created is not performed the error is encountered
