### PR TITLE
[JENKINS-51638] Documenting current behaior in a unit test

### DIFF
--- a/src/test/java/hudson/plugins/git/UserMergeOptionsTest.java
+++ b/src/test/java/hudson/plugins/git/UserMergeOptionsTest.java
@@ -2,14 +2,18 @@ package hudson.plugins.git;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.Issue;
 
 @RunWith(Parameterized.class)
 public class UserMergeOptionsTest {
@@ -195,4 +199,32 @@ public class UserMergeOptionsTest {
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }
+
+    @Issue("JENKINS-51638")
+    @Test
+    public void mergeStrategyCase() throws Exception {
+        Map<String, Object> args = new HashMap<>();
+        if (expectedMergeTarget != null) {
+            args.put("mergeTarget", expectedMergeTarget);
+        }
+        if (expectedMergeRemote != null) {
+            args.put("mergeRemote", expectedMergeRemote);
+        }
+        if (expectedMergeStrategy != null) {
+            // Recommend syntax as of JENKINS-34070:
+            args.put("mergeStrategy", expectedMergeStrategy.name());
+        }
+        if (expectedFastForwardMode != null) {
+            args.put("fastForwardMode", expectedFastForwardMode.name());
+        }
+        assertEquals(options, new DescribableModel<>(UserMergeOptions.class).instantiate(args));
+        /* TODO JENKINS-51638
+        if (expectedMergeStrategy != null) {
+            // Historically accepted lowercase strings here:
+            args.put("mergeStrategy", expectedMergeStrategy.toString());
+            assertEquals(options, new DescribableModel<>(UserMergeOptions.class).instantiate(args));
+        }
+        */
+    }
+
 }


### PR DESCRIPTION
Documents a regression from #580: [JENKINS-51638](https://issues.jenkins-ci.org/browse/JENKINS-51638). Safe to merge as is; if and when I come up with a satisfactory fix, I would amend this PR if is still open, else file a follow-up.