### PR TITLE
ChangelogToBranch extension doesn't allow to specify revision

### DIFF
--- a/src/main/java/hudson/plugins/git/ChangelogToBranchOptions.java
+++ b/src/main/java/hudson/plugins/git/ChangelogToBranchOptions.java
@@ -1,6 +1,8 @@
 package hudson.plugins.git;
 
 import java.io.Serializable;
+
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
@@ -35,6 +37,12 @@ public class ChangelogToBranchOptions extends AbstractDescribableImpl<ChangelogT
     }
 
     public String getRef() {
+        if (StringUtils.isBlank(compareRemote)) {
+            return compareTarget;
+        }
+        if (StringUtils.isBlank(compareTarget)) {
+            return compareRemote;
+        }
         return compareRemote + "/" + compareTarget;
     }
 


### PR DESCRIPTION
Currently git plugin supports two strategies to compute changelog:
- against last build
- against branch specified using ChangelogToBranch extension 

The first one does not work as expected when our builds fail - plugin does not pick up changelog records, related to the failed build. As a workaround we would like to implement something like:

```
String getLastSuccessfulRevision() {
    def job = Jenkins.instance.getItemByFullName(env.JOB_NAME)
    def build = job.getLastSuccessfulBuild()
    return build?.getAction(hudson.plugins.git.util.BuildData)
            ?.lastBuild?.revision?.sha1?.getName()
}

String lastSuccessfulRevision = getLastSuccessfulRevision()
if (lastSuccessfulRevision) {
    extensions << [
            $class : 'ChangelogToBranch',
            options: [
                    compareTarget: "${lastSuccessfulRevision}"
            ]
    ]
}
```
in our pipeline, unfortunately ChangelogToBranch extension forcibly adds '/' symbol to the git ref and our workaround does not work. This RP adds possibility to specify git revision when using ChangelogToBranch extension.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

