### PR TITLE
Fix AbstractGitSCMSourceTest for git 2.7 and earlier

### DIFF
--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -951,7 +951,7 @@ public class AbstractGitSCMSourceTest {
 
         //Remove branch x
         sampleRepo.git("checkout", "master");
-        sampleRepo.git("push", source.getRemote(), "-d", branch);
+        sampleRepo.git("push", source.getRemote(), "--delete", branch);
 
         //Create branch x/x (ref lock engaged)
         sampleRepo.git("checkout", "-b", branchRefLock);


### PR DESCRIPTION
## Fix AbstractGitSCMSourceTest for git 2.7 and earlier

Git 1.7.0 added the `--delete` flag to push as a way to delete a remote branch.  The `-d` alias for `--delete` was not added until git 2.8.  Use the old argument format since that works with git versions as old as CentOS 6 provides.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

If an even older syntax were desired, we could use:

```
git push origin :remote-branch-name-to-delete
```