### PR TITLE
[JENKINS-50394] Get remote references before fetching to cache when discoverX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.0.0-beta8</version>
+      <version>3.0.0-beta9-rc1944.926401690c63</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -314,7 +314,13 @@ public abstract class AbstractGitSCMSource extends SCMSource {
     }
 
     private interface Retriever<T> {
-        T run(GitClient client, String remoteName) throws IOException, InterruptedException;
+        default T run(GitClient client, String remoteName) throws IOException, InterruptedException {
+            throw new AbstractMethodError("Not implemented");
+        }
+    }
+
+    private interface Retriever2<T> extends Retriever<T> {
+        T run(GitClient client, String remoteName, FetchCommand fetch) throws IOException, InterruptedException;
     }
 
     @NonNull
@@ -322,6 +328,15 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                                                                                  @NonNull C context,
                                                                                                  @NonNull TaskListener listener,
                                                                                                  boolean prune)
+            throws IOException, InterruptedException {
+        return doRetrieve(retriever, context, listener, prune, false);
+    }
+
+    @NonNull
+    private <T, C extends GitSCMSourceContext<C, R>, R extends GitSCMSourceRequest> T doRetrieve(Retriever<T> retriever,
+                                                                                                 @NonNull C context,
+                                                                                                 @NonNull TaskListener listener,
+                                                                                                 boolean prune, boolean delayFetch)
             throws IOException, InterruptedException {
         String cacheEntry = getCacheEntry();
         Lock cacheLock = getCacheLock(cacheEntry);
@@ -344,16 +359,20 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             client.setRemoteUrl(remoteName, getRemote());
             listener.getLogger().println((prune ? "Fetching & pruning " : "Fetching ") + remoteName + "...");
             FetchCommand fetch = client.fetch_();
-            if (prune) {
-                fetch = fetch.prune();
-            }
+            fetch = fetch.prune(prune);
+
             URIish remoteURI = null;
             try {
                 remoteURI = new URIish(remoteName);
             } catch (URISyntaxException ex) {
                 listener.getLogger().println("URI syntax exception for '" + remoteName + "' " + ex);
             }
-            fetch.from(remoteURI, context.asRefSpecs()).execute();
+            final FetchCommand fetchCommand = fetch.from(remoteURI, context.asRefSpecs());
+            if (!delayFetch) {
+                fetchCommand.execute();
+            } else if (retriever instanceof Retriever2) {
+                return ((Retriever2<T>)retriever).run(client, remoteName, fetchCommand);
+            }
             return retriever.run(client, remoteName);
         } finally {
             cacheLock.unlock();
@@ -541,21 +560,25 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                 return;
             }
         }
-        doRetrieve(new Retriever<Void>() {
+        doRetrieve(new Retriever2<Void>() {
             @Override
-            public Void run(GitClient client, String remoteName) throws IOException, InterruptedException {
+            public Void run(GitClient client, String remoteName, FetchCommand fetch) throws IOException, InterruptedException {
+                final Map<String, ObjectId> remoteReferences;
+                if (context.wantBranches() || context.wantTags() || context.wantOtherRefs()) {
+                    listener.getLogger().println("Listing remote references...");
+                    boolean headsOnly = !context.wantOtherRefs() && context.wantBranches();
+                    boolean tagsOnly = !context.wantOtherRefs() && context.wantTags();
+                    remoteReferences = client.getRemoteReferences(
+                            client.getRemoteUrl(remoteName), null, headsOnly, tagsOnly
+                    );
+                } else {
+                    remoteReferences = Collections.emptyMap();
+                }
+                fetch.execute();
                 final Repository repository = client.getRepository();
                 try (RevWalk walk = new RevWalk(repository);
                      GitSCMSourceRequest request = context.newRequest(AbstractGitSCMSource.this, listener)) {
-                    Map<String, ObjectId> remoteReferences = null;
-                    if (context.wantBranches() || context.wantTags() || context.wantOtherRefs()) {
-                        listener.getLogger().println("Listing remote references...");
-                        boolean headsOnly = !context.wantOtherRefs() && context.wantBranches();
-                        boolean tagsOnly = !context.wantOtherRefs() && context.wantTags();
-                        remoteReferences = client.getRemoteReferences(
-                                client.getRemoteUrl(remoteName), null, headsOnly, tagsOnly
-                        );
-                    }
+
                     if (context.wantBranches()) {
                         discoverBranches(repository, walk, request, remoteReferences);
                     }
@@ -757,7 +780,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                 }
                 listener.getLogger().format("Processed %d tags%n", count);
             }
-        }, context, listener, true);
+        }, context, listener, true, true);
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/gitclient/TestJGitAPIImpl.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/TestJGitAPIImpl.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.model.TaskListener;
+import jenkins.plugins.git.AbstractGitSCMSourceTest;
+import org.jenkinsci.plugins.gitclient.jgit.PreemptiveAuthHttpClientConnectionFactory;
+
+import java.io.File;
+
+/**
+ * This is just here to make the constructors public
+ * @see AbstractGitSCMSourceTest#when_commits_added_during_discovery_we_do_not_crash()
+ */
+public class TestJGitAPIImpl extends JGitAPIImpl {
+    public TestJGitAPIImpl(File workspace, TaskListener listener) {
+        super(workspace, listener);
+    }
+
+    public TestJGitAPIImpl(File workspace, TaskListener listener, PreemptiveAuthHttpClientConnectionFactory httpConnectionFactory) {
+        super(workspace, listener, httpConnectionFactory);
+    }
+}


### PR DESCRIPTION
## [JENKINS-50394](https://issues.jenkins-ci.org/browse/JENKINS-50394) - Get remote references before fetching to local cache when discovering branches et.al.

This is the same as #702 cherry-picked and modified for the master/4.x branch.

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [X] I have referenced the Jira issue related to my changes in one or more commit messages
- [X] I have added tests that verify my changes
- [X] Unit tests pass locally with my changes
- [X] I have added documentation as necessary
- [X] No Javadoc warnings were introduced with my changes
- [X] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

## Further comments

See https://github.com/jenkinsci/git-plugin/pull/702
Needs corresponding master release of git-client.