### PR TITLE
Skip 2 prune tests on old CLI git versions

### DIFF
--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -74,6 +74,7 @@ import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
 import static org.hamcrest.number.OrderingComparison.lessThanOrEqualTo;
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.when;
 
 /**
@@ -937,6 +938,8 @@ public class AbstractGitSCMSourceTest {
 
     @Test
     public void refLockAvoidedIfPruneTraitPresentOnNotFoundRetrieval() throws Exception {
+        /* Older git versions have unexpected behaviors with prune */
+        assumeTrue(sampleRepo.gitVersionAtLeast(1, 9, 0));
         TaskListener listener = StreamTaskListener.fromStderr();
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits((Arrays.asList(new TagDiscoveryTrait(), new PruneStaleBranchTrait())));
@@ -950,6 +953,8 @@ public class AbstractGitSCMSourceTest {
 
     @Test
     public void refLockAvoidedIfPruneTraitPresentOnTagRetrieval() throws Exception {
+        /* Older git versions have unexpected behaviors with prune */
+        assumeTrue(sampleRepo.gitVersionAtLeast(1, 9, 0));
         TaskListener listener = StreamTaskListener.fromStderr();
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits((Arrays.asList(new TagDiscoveryTrait(), new PruneStaleBranchTrait())));


### PR DESCRIPTION
## Skip 2 prune tests on old CLI git versions

Users running on CentOS 7 and Red Hat Enterprise Linux 7 will either
need to not enable the prune trait for Pipelines or they will need to
update to a newer version of command line git.

Command line git prune behavior before git 1.9.0 does not handle these
two prune test cases correctly.  Rather than be distracted by failing
tests, acknowledge that the tests are known to fail in that environment.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.