### PR TITLE
Fix JENKINS-51638 - allow lower case 'default' UserMergeStrategy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>3.1.8</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.19</version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <jenkins.version>2.121.1</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
+    <useBeta>true</useBeta>
     <concurrency>1C</concurrency>
     <findbugs.failOnError>false</findbugs.failOnError>
     <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
@@ -68,7 +69,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.14</version>
+      <version>1.18</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/UserMergeOptions.java
+++ b/src/main/java/hudson/plugins/git/UserMergeOptions.java
@@ -9,6 +9,11 @@ import org.jenkinsci.plugins.gitclient.MergeCommand;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import org.jenkinsci.plugins.structs.describable.CustomDescribableModel;
 import org.kohsuke.stapler.DataBoundSetter;
 
 /**
@@ -121,52 +126,51 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
         return "UserMergeOptions{" +
                 "mergeRemote='" + mergeRemote + '\'' +
                 ", mergeTarget='" + mergeTarget + '\'' +
-                ", mergeStrategy='" + mergeStrategy + '\'' +
-                ", fastForwardMode='" + fastForwardMode + '\'' +
+                ", mergeStrategy='" + getMergeStrategy().name() + '\'' +
+                ", fastForwardMode='" + getFastForwardMode().name() + '\'' +
                 '}';
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (this == other) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (other instanceof UserMergeOptions) {
-            UserMergeOptions that = (UserMergeOptions) other;
-            if ((mergeRemote != null && mergeRemote.equals(that.mergeRemote))
-                    || (mergeRemote == null && that.mergeRemote == null)) {
-                if ((mergeTarget != null && mergeTarget.equals(that.mergeTarget))
-                        || (mergeTarget == null && that.mergeTarget == null)) {
-                    if ((mergeStrategy != null && mergeStrategy.equals(that.mergeStrategy))
-                            || (mergeStrategy == null && that.mergeStrategy == null)) {
-                        if ((fastForwardMode != null && fastForwardMode.equals(that.fastForwardMode))
-                                || (fastForwardMode == null && that.fastForwardMode == null)) {
-                            return true;
-                        }
-                    }
-                }
-            }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
         }
 
-        return false;
+        UserMergeOptions that = (UserMergeOptions) o;
+
+        return Objects.equals(mergeRemote, that.mergeRemote)
+                && Objects.equals(mergeTarget, that.mergeTarget)
+                && Objects.equals(mergeStrategy, that.mergeStrategy)
+                && Objects.equals(fastForwardMode, that.fastForwardMode);
     }
 
     @Override
     public int hashCode() {
-        int result = mergeRemote != null ? mergeRemote.hashCode() : 0;
-        result = 31 * result + (mergeTarget != null ? mergeTarget.hashCode() : 0);
-        result = 31 * result + (mergeStrategy != null ? mergeStrategy.hashCode() : 0);
-        result = 31 * result + (fastForwardMode != null ? fastForwardMode.hashCode() : 0);
-        return result;
+        return Objects.hash(mergeRemote, mergeTarget, mergeStrategy, fastForwardMode);
     }
 
     @Extension
-    public static class DescriptorImpl extends Descriptor<UserMergeOptions> {
+    public static class DescriptorImpl extends Descriptor<UserMergeOptions> implements CustomDescribableModel {
 
         @Override
         public String getDisplayName() {
             return "";
         }
 
+        @Override
+        public Map<String, Object> customInstantiate(Map<String, Object> arguments) {
+            Map<String, Object> r = new HashMap<>(arguments);
+            Object mergeStrategy = r.get("mergeStrategy");
+            if (mergeStrategy instanceof String) {
+                r.put("mergeStrategy", ((String) mergeStrategy).toUpperCase(Locale.ROOT));
+            }
+            return r;
+        }
+
     }
+
 }


### PR DESCRIPTION
## [JENKINS-56138](https://issues.jenkins-ci.org/browse/JENKINS-51638) - Handle lower case 'default' UserMergeStrategy value

Some users upgrading from prior git plugin versions to git plugin 3.9.x received error messages that their merge strategy value was not recognized.  They had used 'default' as the value instead of 'DEFAULT' and the new code only accepted 'default'.  This code now accepts all case variants of 'default'.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

Relies on structs 1.18 for an API enhancement.  Requires Jenkins 2.121.1 or newer.  Backport of #699