### PR TITLE
Disable javadoc because JDK 11.0.3 broke it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <concurrency>1C</concurrency>
     <findbugs.failOnError>false</findbugs.failOnError>
     <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <repositories>


### PR DESCRIPTION
## JDK 11.0.3 breaks maven javadoc build

Changes in JDK 11.0.3 break javadoc creation.  The break has been confirmed on Amazon Corretto JDK 11.0.3 and Debian Buster OpenJDK 11.03.  It is expected to be a problem on Oracle JDK 11.0.3 as well.

This disables Javadoc generation on all builds.  It is more important that we compile and test on JDK 11.0.3 than that we generate javadoc.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)