### PR TITLE
Fix JDK 11 javadoc with parent pom 3.43

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.42</version>
+    <version>3.43</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
     <concurrency>1C</concurrency>
     <findbugs.failOnError>false</findbugs.failOnError>
     <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
-    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <repositories>


### PR DESCRIPTION
## Fix JDK 11 javadoc with parent pom 3.43

Jesse Glick fixed the root of my problem with javadoc generation on JDK 11.0.3 with his fix in parent pom 3.43.  Use the fix.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)