### PR TITLE
[JENKINS-21896] Merge commit message style can now be changed

### DIFF
--- a/src/main/java/hudson/plugins/git/UserMergeOptions.java
+++ b/src/main/java/hudson/plugins/git/UserMergeOptions.java
@@ -68,7 +68,6 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
     @DataBoundConstructor
     public UserMergeOptions(String mergeTarget) {
         this.mergeTarget = mergeTarget;
-        this.commitMessageStyle = CommitMessageStyle.NONE;
     }
 
     /**
@@ -135,7 +134,12 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
     }
 
     public CommitMessageStyle getCommitMessageStyle() {
-        return commitMessageStyle;
+        for (CommitMessageStyle commitMessageStyle : CommitMessageStyle.values()) {
+            if (commitMessageStyle.equals(this.commitMessageStyle)) {
+                return commitMessageStyle;
+            }
+        }
+        return CommitMessageStyle.NONE;
     }
 
     @DataBoundSetter

--- a/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
@@ -7,6 +7,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.UserMergeOptions;
+import hudson.plugins.git.UserMergeOptions.CommitMessageStyle;
 import hudson.plugins.git.extensions.GitClientType;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
@@ -28,8 +29,6 @@ import static hudson.model.Result.FAILURE;
 import static java.text.MessageFormat.format;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import static org.apache.commons.lang.StringUtils.contains;
-import static org.apache.commons.lang.StringUtils.substringAfterLast;
 import static org.eclipse.jgit.lib.Constants.HEAD;
 
 /**
@@ -76,7 +75,8 @@ public class PreBuildMerge extends GitSCMExtension {
         checkoutCommand.execute();
 
         try {
-            MergeCommand cmd = git.merge().setRevisionToMerge(rev.getSha1()).setMessage(getMessage(rev, remoteBranchRef));
+            MergeCommand cmd = git.merge().setRevisionToMerge(rev.getSha1());
+            cmd.setMessage(options.getCommitMessageStyle().message(rev, remoteBranchRef));
             for (GitSCMExtension ext : scm.getExtensions())
                 ext.decorateMergeCommand(scm, build, git, listener, cmd);
             cmd.execute();
@@ -123,26 +123,6 @@ public class PreBuildMerge extends GitSCMExtension {
         Revision mergeRevision = new GitUtils(listener,git).getRevisionForSHA1(git.revParse(HEAD));
         mergeRevision.getBranches().add(new Branch(remoteBranchRef, target));
         return mergeRevision;
-    }
-
-    private String getMessage(Revision rev, String remoteBranchRef) {
-        return format("Merge branch {0} into {1}", getShortBranchName(rev), getShortBranchName(remoteBranchRef));
-    }
-
-    private String getShortBranchName(Revision revision) {
-        Iterator<Branch> branchIterator = revision.getBranches().iterator();
-        if (branchIterator.hasNext()) {
-            return getShortBranchName(branchIterator.next().getName());
-        }
-        return null;
-    }
-
-    private String getShortBranchName(String branchName) {
-        String forwardSlash = "/";
-        if (contains(branchName, forwardSlash)) {
-            return substringAfterLast(branchName, forwardSlash);
-        }
-        return branchName;
     }
 
     @Override

--- a/src/main/resources/hudson/plugins/git/UserMergeOptions/config.jelly
+++ b/src/main/resources/hudson/plugins/git/UserMergeOptions/config.jelly
@@ -16,4 +16,9 @@
           ${it.toString()}
       </f:enum>
   </f:entry>
+  <f:entry title="${%Commit message style}" field="commitMessageStyle">
+      <f:enum>
+          ${it.toString()}
+      </f:enum>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/git/UserMergeOptions/help-commitMessageStyle.html
+++ b/src/main/resources/hudson/plugins/git/UserMergeOptions/help-commitMessageStyle.html
@@ -1,0 +1,5 @@
+<div>
+    Merge commit message style.</br>
+    The default, <b>none</b>, sets no specific message i.e. lets the GIT implementation handle it</br>
+    If <b>gitlab</b> is selected it sets a more human readable message in Gitlab style e.g. Merge branch 'stable-3.9' into 'stable-3.10' 
+</div>

--- a/src/test/java/hudson/plugins/git/extensions/impl/PreBuildMergeMessageTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/PreBuildMergeMessageTest.java
@@ -27,6 +27,7 @@ import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.UserMergeOptions;
+import hudson.plugins.git.UserMergeOptions.CommitMessageStyle;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.util.DescribableList;
@@ -75,6 +76,7 @@ public class PreBuildMergeMessageTest {
         Revision rev = new Revision(branch.getSHA1(), Arrays.asList(branch));
 
         UserMergeOptions userMergeOptions = new UserMergeOptions(mergeToBranch);
+        userMergeOptions.setCommitMessageStyle(CommitMessageStyle.GITLAB);
         PreBuildMerge preBuildMerge = new PreBuildMerge(userMergeOptions);
         preBuildMerge.decorateRevisionToBuild(gitSCM, build, git, listener, marked, rev);
     }
@@ -83,21 +85,21 @@ public class PreBuildMergeMessageTest {
     public void branchNameSingleForwardSlash() throws InterruptedException, IOException {
         decorateRevisionToBuild("origin/stable-3.9", "origin/stable-3.10");
 
-        verify(mergeCommand).setMessage("Merge branch stable-3.9 into stable-3.10");
+        verify(mergeCommand).setMessage("Merge branch 'stable-3.9' into 'stable-3.10'");
     }
 
     @Test
     public void branchNameMultipleForwardSlashes() throws InterruptedException, IOException {
         decorateRevisionToBuild("refs/remotes/origin/stable-3.9", "refs/remotes/origin/stable-3.10");
 
-        verify(mergeCommand).setMessage("Merge branch stable-3.9 into stable-3.10");
+        verify(mergeCommand).setMessage("Merge branch 'stable-3.9' into 'stable-3.10'");
     }
 
     @Test
     public void branchNameNoForwardSlashes() throws InterruptedException, IOException {
         decorateRevisionToBuild("stable-3.9", "stable-3.10");
 
-        verify(mergeCommand).setMessage("Merge branch stable-3.9 into stable-3.10");
+        verify(mergeCommand).setMessage("Merge branch 'stable-3.9' into 'stable-3.10'");
     }
 
     @Test
@@ -105,10 +107,22 @@ public class PreBuildMergeMessageTest {
         Revision rev = new Revision(fromString("2cec153f34767f7638378735dc2b907ed251a67d"));
 
         UserMergeOptions userMergeOptions = new UserMergeOptions("123");
+        userMergeOptions.setCommitMessageStyle(CommitMessageStyle.GITLAB);
         PreBuildMerge preBuildMerge = new PreBuildMerge(userMergeOptions);
         preBuildMerge.decorateRevisionToBuild(gitSCM, build, git, listener, marked, rev);
 
-        verify(mergeCommand).setMessage("Merge branch null into 123");
+        verify(mergeCommand).setMessage("Merge branch 'null' into '123'");
+    }
+    
+    @Test
+    public void noneCommitMessageStyle() throws InterruptedException, IOException {
+        Revision rev = new Revision(fromString("2cec153f34767f7638378735dc2b907ed251a67d"));
+
+        UserMergeOptions userMergeOptions = new UserMergeOptions("123");
+        PreBuildMerge preBuildMerge = new PreBuildMerge(userMergeOptions);
+        preBuildMerge.decorateRevisionToBuild(gitSCM, build, git, listener, marked, rev);
+
+        verify(mergeCommand).setMessage(null);
     }
 
 }


### PR DESCRIPTION
## [JENKINS-21896](https://issues.jenkins-ci.org/browse/JENKINS-21896) - Merge commit message style can now be changed

**N.B.** There is another [pull request](https://github.com/jenkinsci/git-plugin/pull/628) from me which actually changes the default behavior. This one does not.

If we want to actually push the merged changes to the repository the default message doesn't give us enough meaningful information which branches had been merged. This changes gives the possibility to set a more descriptive commit message to the merge.

This is done by introducing a new merge option "Commit message style". It has two values:
- none - the default, keeps the current plugin behavior i.e. does not set a specific message
- gitlab - sets a specific merge commit message in Gitlab style

For example if two branches are being merged:
- refs/remotes/origin/stable-3.9
- origin/stable-3.10

If 'gitlab' is selected, then the commit message will be: Merge branch 'stable-3.9' into 'stable-3.10'

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] There are no dependent changes in upstream modules

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
