### PR TITLE
[JENKINS-57683] Fix class cast exception scanning multibranch pipeline

### DIFF
--- a/src/main/java/jenkins/plugins/git/traits/PruneStaleBranchTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/PruneStaleBranchTrait.java
@@ -51,8 +51,10 @@ public class PruneStaleBranchTrait extends GitSCMExtensionTrait<PruneStaleBranch
      */
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
-        GitSCMSourceContext<?,?> ctx = (GitSCMSourceContext<?, ?>) context;
-        ctx.pruneRefs(true);
+        if (context instanceof GitSCMSourceContext) {
+            GitSCMSourceContext<?, ?> ctx = (GitSCMSourceContext<?, ?>) context;
+            ctx.pruneRefs(true);
+        }
     }
 
     /**

--- a/src/test/java/jenkins/plugins/git/traits/PruneStaleBranchTraitTest.java
+++ b/src/test/java/jenkins/plugins/git/traits/PruneStaleBranchTraitTest.java
@@ -1,0 +1,56 @@
+package jenkins.plugins.git.traits;
+
+import hudson.model.TaskListener;
+import jenkins.plugins.git.GitSCMSourceContext;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceCriteria;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceRequest;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * Test for JENKINS-57683 - Class cast exception when an SCMSource or
+ * SCMSourceContext was passed that was not a GitSCMSource.
+ *
+ * @author Mark Waite
+ */
+public class PruneStaleBranchTraitTest {
+
+    public PruneStaleBranchTraitTest() {
+    }
+
+    @Test
+    public void testDecorateContextWithGitSCMSourceContent() {
+        GitSCMSourceContext context = new GitSCMSourceContext(null, null);
+        assertThat(context.pruneRefs(), is(false));
+        PruneStaleBranchTrait pruneStaleBranchTrait = new PruneStaleBranchTrait();
+        pruneStaleBranchTrait.decorateContext(context);
+        assertThat(context.pruneRefs(), is(true));
+    }
+
+    @Test
+    @Issue("JENKINS-57683")
+    public void testDecorateContextWithNonGitSCMSourceContent() {
+        SCMSourceContext context = new FakeSCMSourceContext(null, null);
+        PruneStaleBranchTrait pruneStaleBranchTrait = new PruneStaleBranchTrait();
+        pruneStaleBranchTrait.decorateContext(context);
+        /* JENKINS-57683 would cause this test to throw an exception */
+    }
+
+    private static class FakeSCMSourceContext extends SCMSourceContext {
+
+        public FakeSCMSourceContext(SCMSourceCriteria scmsc, SCMHeadObserver scmho) {
+            super(scmsc, scmho);
+        }
+
+        @Override
+        public SCMSourceRequest newRequest(SCMSource scms, TaskListener tl) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+    }
+}


### PR DESCRIPTION
## [JENKINS-57683](https://issues.jenkins-ci.org/browse/JENKINS-57683) - Fix class cast exception scanning multibranch pipeline

PruneStaleBranchTrait implementation did not handle SCMSource which was not a GitSCMSource.
Added a failing test, then fixed the failing test.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes (I won't merge this until I've tested interactively)
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)