### PR TITLE
[JENKINS-57603] CasC is now able to configure submodules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <concurrency>1C</concurrency>
     <findbugs.failOnError>false</findbugs.failOnError>
     <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
+    <jcasc.version>1.20</jcasc.version>
   </properties>
 
   <repositories>
@@ -264,6 +265,20 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
       <version>3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- JCasC compatibility -->
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${jcasc.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${jcasc.version}</version>
+      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/hudson/plugins/git/SubmoduleConfig.java
+++ b/src/main/java/hudson/plugins/git/SubmoduleConfig.java
@@ -20,10 +20,7 @@ public class SubmoduleConfig implements java.io.Serializable {
     }
 
     public SubmoduleConfig(String submoduleName, String[] branches) {
-        this.submoduleName = submoduleName;
-        if (branches != null) {
-            this.branches = Arrays.copyOf(branches, branches.length);
-        }
+        this(submoduleName, branches != null ? Arrays.asList(branches) : Collections.emptySet());
     }
 
     @DataBoundConstructor

--- a/src/main/java/hudson/plugins/git/SubmoduleConfig.java
+++ b/src/main/java/hudson/plugins/git/SubmoduleConfig.java
@@ -1,6 +1,8 @@
 package hudson.plugins.git;
 
 import com.google.common.base.Joiner;
+import org.kohsuke.stapler.DataBoundConstructor;
+
 import java.util.Arrays;
 
 import java.util.regex.Pattern;
@@ -9,6 +11,18 @@ public class SubmoduleConfig implements java.io.Serializable {
     private static final long serialVersionUID = 1L;
     String   submoduleName;
     String[] branches;
+
+    public SubmoduleConfig() {
+        this(null, null);
+    }
+
+    @DataBoundConstructor
+    public SubmoduleConfig(String submoduleName, String[] branches) {
+        this.submoduleName = submoduleName;
+        if (branches != null) {
+            this.branches = Arrays.copyOf(branches, branches.length);
+        }
+    }
 
     public String getSubmoduleName() {
         return submoduleName;

--- a/src/main/java/hudson/plugins/git/SubmoduleConfig.java
+++ b/src/main/java/hudson/plugins/git/SubmoduleConfig.java
@@ -1,10 +1,13 @@
 package hudson.plugins.git;
 
 import com.google.common.base.Joiner;
+import org.apache.commons.collections.CollectionUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Arrays;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.regex.Pattern;
 
 public class SubmoduleConfig implements java.io.Serializable {
@@ -13,14 +16,21 @@ public class SubmoduleConfig implements java.io.Serializable {
     String[] branches;
 
     public SubmoduleConfig() {
-        this(null, null);
+        this(null, Collections.emptySet());
     }
 
-    @DataBoundConstructor
     public SubmoduleConfig(String submoduleName, String[] branches) {
         this.submoduleName = submoduleName;
         if (branches != null) {
             this.branches = Arrays.copyOf(branches, branches.length);
+        }
+    }
+
+    @DataBoundConstructor
+    public SubmoduleConfig(String submoduleName, Collection<String> branches) {
+        this.submoduleName = submoduleName;
+        if (CollectionUtils.isNotEmpty(branches)) {
+            this.branches = branches.toArray(new String[branches.size()]);
         }
     }
 

--- a/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java
@@ -1,16 +1,40 @@
 package jenkins.plugins.git;
 
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.SubmoduleConfig;
+import hudson.scm.SCM;
 import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import org.hamcrest.CoreMatchers;
+import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
+import org.jenkinsci.plugins.workflow.libs.LibraryRetriever;
+import org.jenkinsci.plugins.workflow.libs.SCMRetriever;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class GitJCasCCompatibilityTest extends RoundTripAbstractTest {
     @Override
     protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+        LibraryRetriever retriever = GlobalLibraries.get().getLibraries().get(0).getRetriever();
+        assertThat(retriever, CoreMatchers.instanceOf(SCMRetriever.class));
+        SCM scm =  ((SCMRetriever) retriever).getScm();
+        assertThat(scm, CoreMatchers.instanceOf(GitSCM.class));
 
+        Collection<SubmoduleConfig> submodulesConfig = ((GitSCM) scm).getSubmoduleCfg();
+
+        assertThat(submodulesConfig.size(), is(2));
+        assertTrue(submodulesConfig.stream().anyMatch(m -> m.getSubmoduleName().equals("submodule-1")));
+        assertTrue(submodulesConfig.stream().anyMatch(m -> m.getSubmoduleName().equals("submodule-2")));
+        assertTrue(submodulesConfig.stream().anyMatch(m -> m.getBranchesString().equals("mybranch-1,mybranch-2")));
+        assertTrue(submodulesConfig.stream().anyMatch(m -> m.getBranchesString().equals("mybranch-3,mybranch-4")));
     }
 
     @Override
     protected String stringInLogExpected() {
-        return "hudson.plugins.git.UserRemoteConfig.url = https://git.acmecorp/myGitLib.git";
+        return "Setting class hudson.plugins.git.GitSCM.submoduleCfg = [{}, {}]";
     }
 }

--- a/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java
@@ -1,0 +1,16 @@
+package jenkins.plugins.git;
+
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class GitJCasCCompatibilityTest extends RoundTripAbstractTest {
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+
+    }
+
+    @Override
+    protected String stringInLogExpected() {
+        return "hudson.plugins.git.UserRemoteConfig.url = https://git.acmecorp/myGitLib.git";
+    }
+}

--- a/src/test/resources/jenkins/plugins/git/configuration-as-code.yaml
+++ b/src/test/resources/jenkins/plugins/git/configuration-as-code.yaml
@@ -1,0 +1,41 @@
+unclassified:
+  globalLibraries:
+    libraries:
+      - defaultVersion: "1.2.3"
+        name: "My Git Lib"
+        retriever:
+          legacySCM:
+            scm:
+              git:
+                branches:
+                  - name: "*/myprodbranch"
+                browser:
+                  assemblaWeb:
+                    repoUrl: "assembla.acmecorp.com"
+                buildChooser: "default"
+                doGenerateSubmoduleConfigurations: false
+                extensions:
+                  - "cleanCheckout"
+                  - "gitLFSPull"
+                  - checkoutOption:
+                      timeout: 60
+                  - userIdentity:
+                      email: "customuser@acmecorp.com"
+                      name: "custom user"
+                  - preBuildMerge:
+                      options:
+                        mergeRemote: "myrepo"
+                        mergeStrategy: RECURSIVE
+                        mergeTarget: "master"
+                submoduleCfg:
+                  - submoduleName: "submodule-1"
+                    branches:
+                    - "mybranch-1"
+                    - "mybranch-2"
+                  - submoduleName: "submodule-2"
+                    branches:
+                    - "mybranch-3"
+                    - "mybranch-4"
+                userRemoteConfigs:
+                  - credentialsId: "acmeuser-cred-Id"
+                    url: "https://git.acmecorp/myGitLib.git"

--- a/src/test/resources/jenkins/plugins/git/configuration-as-code.yaml
+++ b/src/test/resources/jenkins/plugins/git/configuration-as-code.yaml
@@ -9,9 +9,6 @@ unclassified:
               git:
                 branches:
                   - name: "*/myprodbranch"
-                browser:
-                  assemblaWeb:
-                    repoUrl: "assembla.acmecorp.com"
                 buildChooser: "default"
                 doGenerateSubmoduleConfigurations: false
                 extensions:


### PR DESCRIPTION
## [JENKINS-57603](https://issues.jenkins-ci.org/browse/JENKINS-57603) - CasC is now able to configure submodules

Submodules configuration could not be applied by CasC. Resumes some work done by @fcojfernandez 

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [X] I have referenced the Jira issue related to my changes in one or more commit messages
- [X] I have added tests that verify my changes
- [X] Unit tests pass locally with my changes
- [X] I have added documentation as necessary
- [X] No Javadoc warnings were introduced with my changes
- [X] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [X] Dependency or infrasrtructure update
- [X] Bug fix (non-breaking change which fixes an issue)
