### PR TITLE
Feature/message exclusion trait

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
@@ -16,6 +16,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -39,6 +40,41 @@ public class MessageExclusion extends GitSCMExtension {
 	public boolean requiresWorkspaceForPolling() { return true; }
 
 	public String getExcludedMessage() { return excludedMessage; }
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		MessageExclusion that = (MessageExclusion) o;
+
+		return Objects.equals(excludedMessage, that.excludedMessage);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public int hashCode() {
+		return Objects.hash(excludedMessage);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String toString() {
+		return "MessageExclusion{" +
+				"excludedMessage='" + excludedMessage + '\'' +
+				'}';
+	}
 
 	@Override
 	@SuppressFBWarnings(value="NP_BOOLEAN_RETURN_NULL", justification="null used to indicate other extensions should decide")

--- a/src/main/java/jenkins/plugins/git/traits/MessageExclusionTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/MessageExclusionTrait.java
@@ -1,0 +1,32 @@
+package jenkins.plugins.git.traits;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.impl.MessageExclusion;
+
+public class MessageExclusionTrait extends GitSCMExtensionTrait<MessageExclusion> {
+    /**
+     * Stapler constructor.
+     *
+     * @param extension the {@link MessageExclusion}.
+     */
+    @DataBoundConstructor
+    public MessageExclusionTrait(MessageExclusion extension) {
+        super(extension);
+    }
+
+    /**
+     * Our {@link hudson.model.Descriptor}
+     */
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionTraitDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Message exclusion";
+        }
+    }
+}

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
@@ -9,6 +9,7 @@ import hudson.plugins.git.extensions.impl.CleanCheckout;
 import hudson.plugins.git.extensions.impl.CloneOption;
 import hudson.plugins.git.extensions.impl.GitLFSPull;
 import hudson.plugins.git.extensions.impl.LocalBranch;
+import hudson.plugins.git.extensions.impl.MessageExclusion;
 import hudson.plugins.git.extensions.impl.PruneStaleBranch;
 import hudson.plugins.git.extensions.impl.SubmoduleOption;
 import hudson.plugins.git.extensions.impl.UserIdentity;
@@ -25,6 +26,7 @@ import jenkins.plugins.git.traits.GitBrowserSCMSourceTrait;
 import jenkins.plugins.git.traits.GitLFSPullTrait;
 import jenkins.plugins.git.traits.IgnoreOnPushNotificationTrait;
 import jenkins.plugins.git.traits.LocalBranchTrait;
+import jenkins.plugins.git.traits.MessageExclusionTrait;
 import jenkins.plugins.git.traits.PruneStaleBranchTrait;
 import jenkins.plugins.git.traits.RefSpecsSCMSourceTrait;
 import jenkins.plugins.git.traits.RemoteNameSCMSourceTrait;
@@ -134,6 +136,12 @@ public class GitSCMSourceTraitsTest {
                         ),
                         Matchers.<SCMSourceTrait>instanceOf(CleanAfterCheckoutTrait.class),
                         Matchers.<SCMSourceTrait>instanceOf(CleanBeforeCheckoutTrait.class),
+                        Matchers.allOf(
+                                instanceOf(MessageExclusionTrait.class),
+                                hasProperty("extension",
+                                        hasProperty("excludedMessage", is("does not work"))
+                                )
+                        ),
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(UserIdentityTrait.class),
                                 hasProperty("extension",
@@ -197,6 +205,10 @@ public class GitSCMSourceTraitsTest {
                                 instanceOf(UserIdentity.class),
                                 hasProperty("name", is("bob")),
                                 hasProperty("email", is("bob@example.com"))
+                        ),
+                        Matchers.allOf(
+                                instanceOf(MessageExclusion.class),
+                                hasProperty("excludedMessage", is("does not work"))
                         ),
                         Matchers.<GitSCMExtension>instanceOf(GitLFSPull.class),
                         Matchers.<GitSCMExtension>instanceOf(PruneStaleBranch.class),

--- a/src/test/resources/jenkins/plugins/git/configuration-as-code.yaml
+++ b/src/test/resources/jenkins/plugins/git/configuration-as-code.yaml
@@ -19,6 +19,8 @@ unclassified:
                   - userIdentity:
                       email: "customuser@acmecorp.com"
                       name: "custom user"
+                  - messageExclusion:
+                      excludedMessage: ".*\[ci skip\].*"
                   - preBuildMerge:
                       options:
                         mergeRemote: "myrepo"

--- a/src/test/resources/jenkins/plugins/git/configuration-as-code.yaml
+++ b/src/test/resources/jenkins/plugins/git/configuration-as-code.yaml
@@ -20,7 +20,7 @@ unclassified:
                       email: "customuser@acmecorp.com"
                       name: "custom user"
                   - messageExclusion:
-                      excludedMessage: ".*\[ci skip\].*"
+                      excludedMessage: "does not work"
                   - preBuildMerge:
                       options:
                         mergeRemote: "myrepo"


### PR DESCRIPTION
## [JENKINS-46081](https://issues.jenkins-ci.org/browse/JENKINS-46081) - Add MessageExclusion trait

Add a corresponding trait for the `MessageExclusion` extension.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Further comments

I have tried to test this interactively by running a noddy build job with an example Jenkinsfile, but I’m not sure that the MessageExclusion itself actually works.
