### PR TITLE
Bump xmlunit-matchers from 2.6.2 to 2.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-matchers</artifactId>
-      <version>2.6.2</version>
+      <version>2.6.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Update xmlunit-matchers in tests

Bumps [xmlunit-matchers](https://github.com/xmlunit/xmlunit) from 2.6.2 to 2.6.3.
- [Release notes](https://github.com/xmlunit/xmlunit/releases)
- [Changelog](https://github.com/xmlunit/xmlunit/blob/master/RELEASE_NOTES.md)
- [Commits](https://github.com/xmlunit/xmlunit/compare/v2.6.2...v2.6.3)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency or infrastructure update