### PR TITLE
Use latest parent pom - 3.47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <concurrency>1C</concurrency>
     <findbugs.failOnError>false</findbugs.failOnError>
     <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
-    <jcasc.version>1.20</jcasc.version>
+    <jcasc.version>1.22</jcasc.version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.46</version>
+    <version>3.47</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Use parent pom 3.47

Use latest parent pom and test with latest configuration as code plugin.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency or infrastructure update