### PR TITLE
Correct links to changeset details

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitChangeSetList/digest.jelly
+++ b/src/main/resources/hudson/plugins/git/GitChangeSetList/digest.jelly
@@ -14,10 +14,10 @@
     <j:otherwise>
       ${%Changes}
       <ol>
-        <j:forEach var="cs" items="${it.logs}" varStatus="loop">
+        <j:forEach var="cs" items="${it.logs}">
           <li>
             <j:out value="${cs.msgAnnotated}"/>
-            (<a href="changes#detail${loop.index}">${%detail}</a>
+            (<a href="changes#${cs.id}">${%details}</a>
             <j:set var="cslink" value="${browser.getChangeSetLink(cs)}"/>
             <j:if test="${cslink!=null}">
               <j:text> / </j:text>

--- a/src/main/resources/hudson/plugins/git/GitChangeSetList/digest_it.properties
+++ b/src/main/resources/hudson/plugins/git/GitChangeSetList/digest_it.properties
@@ -1,3 +1,3 @@
 No\ changes.=Nessun cambiamenti.
 Changes=Cambiamenti
-detail=dettaglio
+details=dettagli

--- a/src/main/resources/hudson/plugins/git/GitChangeSetList/index.jelly
+++ b/src/main/resources/hudson/plugins/git/GitChangeSetList/index.jelly
@@ -15,8 +15,7 @@
     <j:forEach var="cs" items="${it.logs}">
       <tr class="pane">
         <td colspan="2" class="changeset">
-          <a name="${cs.id}"></a>
-          <div class="changeset-message">
+          <div class="changeset-message" id="${cs.id}">
             <b>
               ${%Commit}
               <j:set var="cslink" value="${browser.getChangeSetLink(cs)}"/>
@@ -40,10 +39,10 @@
           <td width="16"><t:editTypeIcon type="${p.editType}"/></td>
           <td>
             <a href="${browser.getFileLink(p)}">${p.path}</a>
-            <j:set var="diff" value="${browser.getDiffLink(p)}"/>
-            <j:if test="${diff!=null}">
+            <j:set var="difflink" value="${browser.getDiffLink(p)}"/>
+            <j:if test="${difflink!=null}">
               <st:nbsp/>
-              <a href="${diff}">(${%diff})</a>
+              <a href="${difflink}">(${%diff})</a>
             </j:if>
           </td>
         </tr>


### PR DESCRIPTION
Because the fix and issue are trivial I did not create an issue on https://issues.jenkins-ci.org/ to avoid generating unnecessary noise.

## Summary

Build summary page displays the list of changelog entries with commit message and link to the detailed view. The mentioned links are not correct as they points to a page containing all chaneset details but does not scroll to the matching element because of invalid identifier. This patch fixes the issue and now when clicking on the "details" we will be taken exactly to the matching entry.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![build_summary_changelog](https://user-images.githubusercontent.com/2482753/61542616-37aa9380-aa42-11e9-92d0-e2a552a3a35f.png)
