### PR TITLE
Backport pr 708

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <inceptionYear>2007</inceptionYear>
 
   <properties>
-    <revision>3.10.2</revision>
+    <revision>3.11.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.121.1</jenkins.version>
     <java.level>8</java.level>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
     <concurrency>1C</concurrency>
-    <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
+    <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
     <jcasc.version>1.23</jcasc.version>
     <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
     <maven.checkstyle.version>8.22</maven.checkstyle.version>

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -43,6 +43,7 @@ import hudson.plugins.git.GitTool;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.remoting.VirtualChannel;
 import hudson.scm.SCM;
+import hudson.scm.SCMDescriptor;
 import hudson.security.ACL;
 import hudson.util.LogTaskListener;
 import java.io.File;
@@ -281,7 +282,13 @@ public class GitSCMFileSystem extends SCMFileSystem {
         }
 
         @Override
-        public boolean supports(SCMSourceDescriptor descriptor) {
+        public boolean supportsDescriptor(SCMDescriptor descriptor) {
+            // Assume by default that we don't support GitSCM since we can't tell how it would be configured.
+            return false;
+        }
+
+        @Override
+        public boolean supportsDescriptor(SCMSourceDescriptor descriptor) {
             return AbstractGitSCMSource.class.isAssignableFrom(descriptor.clazz);
         }
 

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -61,6 +61,7 @@ import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceDescriptor;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
@@ -277,6 +278,11 @@ public class GitSCMFileSystem extends SCMFileSystem {
         @Override
         public boolean supports(SCMSource source) {
             return source instanceof AbstractGitSCMSource;
+        }
+
+        @Override
+        public boolean supports(SCMSourceDescriptor descriptor) {
+            return AbstractGitSCMSource.class.isAssignableFrom(descriptor.clazz);
         }
 
         @Override

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -283,8 +283,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
 
         @Override
         public boolean supportsDescriptor(SCMDescriptor descriptor) {
-            // Assume by default that we don't support GitSCM since we can't tell how it would be configured.
-            return false;
+            return descriptor instanceof GitSCM.DescriptorImpl;
         }
 
         @Override

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -44,6 +44,7 @@ import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceDescriptor;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
@@ -345,6 +346,13 @@ public class GitSCMFileSystemTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         assertTrue(gitPlugin260FS.changesSince(rev261, out));
         assertThat(out.toString(), is(""));
+    }
+
+    @Issue("JENKINS-52964")
+    @Test
+    public void filesystem_supports_descriptor() throws Exception {
+        SCMSourceDescriptor descriptor = r.jenkins.getDescriptorByType(GitSCMSource.DescriptorImpl.class);
+        assertTrue(SCMFileSystem.supports(descriptor));
     }
 
     /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
@@ -8,6 +8,7 @@ import hudson.model.TaskListener;
 import hudson.model.TopLevelItem;
 import hudson.plugins.git.GitStatus;
 import hudson.util.LogTaskListener;
+import hudson.scm.SCMDescriptor;
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
@@ -31,6 +32,7 @@ import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
+import jenkins.scm.api.SCMSourceDescriptor;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.api.metadata.PrimaryInstanceMetadataAction;
 import jenkins.scm.api.trait.SCMSourceTrait;
@@ -338,6 +340,16 @@ public class GitSCMSourceTest {
         @Override
         public boolean supports(@NonNull String remote) {
             return "http://git.test/telescope.git".equals(remote);
+        }
+
+        @Override
+        public boolean supportsDescriptor(SCMDescriptor descriptor) {
+            return false;
+        }
+
+        @Override
+        public boolean supportsDescriptor(SCMSourceDescriptor descriptor) {
+            return false;
         }
 
         @Override

--- a/src/test/java/jenkins/plugins/git/GitSCMTelescopeTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMTelescopeTest.java
@@ -38,6 +38,7 @@ import hudson.plugins.git.browser.GitWeb;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.scm.NullSCM;
 import hudson.scm.SCM;
+import hudson.scm.SCMDescriptor;
 import hudson.search.Search;
 import hudson.search.SearchIndex;
 import hudson.security.ACL;
@@ -496,6 +497,16 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
                 return false;
             }
             return allowedRemote.equals(remote);
+        }
+
+        @Override
+        public boolean supportsDescriptor(SCMDescriptor descriptor) {
+            return false;
+        }
+
+        @Override
+        public boolean supportsDescriptor(SCMSourceDescriptor descriptor) {
+            return false;
         }
 
         @Override


### PR DESCRIPTION
## Backport of PR-708

#708 fixes JENKINS-43802.  This a backport of the that change to the 3.10 line.  It pulls in JENKINS-52964 and requires scm-api v2.6.3. 
@jglick @MarkEWaite 
