### PR TITLE
Fix pipeline syntax errors in test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.61</version>
+      <version>1.62</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
@@ -56,7 +56,7 @@ public class CredentialsUserRemoteConfigTest {
                 "node {\n"
                         + "  checkout(\n"
                         + "    [$class: 'GitSCM', \n"
-                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$, branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false]]]\n"
+                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$]]]\n"
                         + "  )"
                         + "}"));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
@@ -75,7 +75,7 @@ public class CredentialsUserRemoteConfigTest {
                 "node {\n"
                         + "  checkout(\n"
                         + "    [$class: 'GitSCM', \n"
-                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$, branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false]]]\n"
+                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$]]]\n"
                         + "  )"
                         + "}"));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
@@ -95,7 +95,7 @@ public class CredentialsUserRemoteConfigTest {
                 "node {\n"
                         + "  checkout(\n"
                         + "    [$class: 'GitSCM', \n"
-                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$, branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false]]]\n"
+                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$]]]\n"
                         + "  )"
                         + "}"));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
@@ -112,7 +112,7 @@ public class CredentialsUserRemoteConfigTest {
                 "node {\n"
                         + "  checkout(\n"
                         + "    [$class: 'GitSCM', \n"
-                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$, branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false]]]\n"
+                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$]]]\n"
                         + "  )"
                         + "}"));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
@@ -130,7 +130,7 @@ public class CredentialsUserRemoteConfigTest {
                 "node {\n"
                         + "  checkout(\n"
                         + "    [$class: 'GitSCM', \n"
-                        + "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$, branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false]]]\n"
+                        + "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]]\n"
                         + "  )"
                         + "}"));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));


### PR DESCRIPTION
## Remove incorrect extra args from pipeline test job

Plugin compatibility tester detected an error in the automated test definition of a Pipeline job.  Unrecognized extra arguments were included in the userRemoteConfig value in the tests.  Fix the tests by removing those unrecognized extra arguments.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)