### PR TITLE
Fix JENKINS-58964 - Lost modern SCM with older workflow cps global lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.18</version>
+      <version>1.19</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.14</version>
+      <version>2.1.18</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -123,12 +123,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.13</version>
+      <version>2.20</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <version>2.4</version>
+      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -212,7 +212,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.13</version>
+      <version>2.20</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -226,7 +226,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.52</version>
+      <version>2.71</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -256,7 +256,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps-global-lib</artifactId>
-      <version>2.10</version>
+      <version>2.14</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -274,13 +274,13 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <version>2.30</version>
+      <version>2.33</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>3.1</version>
+      <version>3.3</version>
       <scope>test</scope>
     </dependency>
     <!-- JCasC compatibility -->

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@
   <inceptionYear>2007</inceptionYear>
 
   <properties>
-    <revision>3.11.1</revision>
+    <revision>3.12.0</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.121.1</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>

--- a/src/test/java/jenkins/plugins/git/ModernScmTest.java
+++ b/src/test/java/jenkins/plugins/git/ModernScmTest.java
@@ -1,0 +1,47 @@
+/*
+ *
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.plugins.git;
+
+import hudson.ExtensionList;
+import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class ModernScmTest {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    public void gitIsModernScm() {
+        SCMSourceRetriever.DescriptorImpl descriptor = ExtensionList.lookupSingleton(SCMSourceRetriever.DescriptorImpl.class);
+        assertThat(descriptor.getSCMDescriptors(), contains(instanceOf(GitSCMSource.DescriptorImpl.class)));
+    }
+}


### PR DESCRIPTION
## [JENKINS-58964](https://issues.jenkins-ci.org/browse/JENKINS-58964) - Require workflow cps global lib 2.14

The fix for [JENKINS-43802](https://issues.jenkins-ci.org/browse/JENKINS-43802) made in git plugin 3.11.0 changes the SCM implementation inside the git plugin to use a newer API.  The API is available in older plugin versions but workflow cps global lib 2.14 changes are needed to allow the git plugin to continue to act as a modern SCM implementation instead of regressing to only be a legacy SCM implementation.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

This fix allows git plugin 3.11.0 and later to continue to provide a modern SCM implementation in addition to the legacy SCM implementation by requiring that the Jenkins installation must have workflow cps global lib 2.14 or newer.  Users with older versions of workflow cps global lib will be upgraded to at least 2.14 by this dependency change.

This is a stable-3.x version of pull request https://github.com/jenkinsci/git-plugin/pull/741 submitted by @olivergondza , with some edits.