### PR TITLE
Test with JCasC 1.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <useBeta>true</useBeta>
     <concurrency>1C</concurrency>
     <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
-    <jcasc.version>1.25</jcasc.version>
+    <jcasc.version>1.27</jcasc.version>
     <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
     <maven.checkstyle.version>8.23</maven.checkstyle.version>
   </properties>

--- a/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java
@@ -35,6 +35,6 @@ public class GitJCasCCompatibilityTest extends RoundTripAbstractTest {
 
     @Override
     protected String stringInLogExpected() {
-        return "Setting class hudson.plugins.git.GitSCM.submoduleCfg = [{}, {}]";
+        return "Setting class hudson.plugins.git.SubmoduleConfig. branches = [mybranch-3, mybranch-4]";
     }
 }


### PR DESCRIPTION
## Test with JCasC 1.27

Adjust expected log string to match JCasC 1.27 logging details level.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update

## Further comments

In JCasC 1.25, logging in the test was set to 'INFO' and the assertion was testing that the 'INFO' level logging in that version of JCasC was reporting that the submodule configuration contained two empty members. The submodule configuration should not have contained two empty members, but there was a bug in submodule configuration setting. That bug was fixed earlier, but the bug fix did not change the INFO level logging of configuration as code plugin 1.25.

In JCasC 1.27, test logging is set to 'FINER' and the logged statements have changed significantly.  This assertion can now check that specific values from the resource jenkins/plugins/git/configuration-as-code.yaml are correctly reported in the JCasC 1.27 log file.

JCasC 1.27 allows much more precise checks that the submodule config detail is correct.  The revised stringInLogExpected return value provides that more precise confirmation.  Refer to 'mybranch-3' and 'mybranch-4' in the resource jenkins/plugins/git/configuration-as-code.yaml