### PR TITLE
Add Issue annotations to some existing tests

### DIFF
--- a/src/test/java/hudson/plugins/git/BranchSpecTest.java
+++ b/src/test/java/hudson/plugins/git/BranchSpecTest.java
@@ -158,6 +158,7 @@ public class BranchSpecTest {
     }
 
     @Test
+    @Issue("JENKINS-26842")
     public void testUsesJavaPatternWithRepetition() {
     	// match pattern from JENKINS-26842
     	BranchSpec m = new BranchSpec(":origin/release-\\d{8}");

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1832,6 +1832,7 @@ public class GitSCMTest extends AbstractGitTestCase {
      * @throws Exception
      */
     @Test
+    @Issue("JENKINS-22009")
     public void testPolling_environmentValueInBranchSpec() throws Exception {
         // create parameterized project with environment value in branch specification
         FreeStyleProject project = createFreeStyleProject();

--- a/src/test/java/hudson/plugins/git/UserMergeOptionsTest.java
+++ b/src/test/java/hudson/plugins/git/UserMergeOptionsTest.java
@@ -204,7 +204,7 @@ public class UserMergeOptionsTest {
                 .verify();
     }
 
-    @Issue("JENKINS-51638")
+    @Issue({"JENKINS-51638", "JENKINS-34070"})
     @Test
     public void mergeStrategyCase() throws Exception {
         Map<String, Object> args = new HashMap<>();

--- a/src/test/java/jenkins/plugins/git/ModernScmTest.java
+++ b/src/test/java/jenkins/plugins/git/ModernScmTest.java
@@ -28,6 +28,7 @@ import hudson.ExtensionList;
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.Matchers.contains;
@@ -40,6 +41,7 @@ public class ModernScmTest {
     public JenkinsRule jenkins = new JenkinsRule();
 
     @Test
+    @Issue("JENKINS-58964")
     public void gitIsModernScm() {
         SCMSourceRetriever.DescriptorImpl descriptor = ExtensionList.lookupSingleton(SCMSourceRetriever.DescriptorImpl.class);
         assertThat(descriptor.getSCMDescriptors(), contains(instanceOf(GitSCMSource.DescriptorImpl.class)));


### PR DESCRIPTION
## Add Issue annotations to existing tests

Some bug specific tests were missing the Issue annotation.  Add them.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update