### PR TITLE
Reduce test configurations by 50%

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,12 @@
 
 // Test plugin compatibility to recommended configurations
 // Allow failing tests to retry execution
-buildPlugin(configurations: buildPlugin.recommendedConfigurations(), failFast: false)
+subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                      ],
+                        [ jdk: '8',  platform: 'linux',   jenkins: '2.164.1', javaLevel: '8' ],
+                        [ jdk: '11', platform: 'linux',   jenkins: '2.164.1', javaLevel: '8' ]
+                      ]
+
+buildPlugin(configurations: subsetConfiguration, failFast: false)
 
 def branches = [:]
 


### PR DESCRIPTION
## Reduce test resource use by testing fewer configurations

Have not seen a failure on Windows specific to Java 11.  Since Windows tests run slower and I have fewer Windows machines available, reduce the Windows cases from 3 to 1, testing Java 8 with the default Jenkins
(2.138.1).

Have not seen failures on Linux with the default Jenkins that are not also visible on Windows with default Jenkins.  Test Linux with Java 8 and Java 11 using the recent LTS release.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.