### PR TITLE
Replace JGit 4.5 getRef with findRef or exactRef

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -113,12 +113,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
         cacheEntry = AbstractGitSCMSource.getCacheEntry(remote);
         listener = new LogTaskListener(LOGGER, Level.FINER);
         this.client = client;
-        commitId = rev == null ? invoke(new FSFunction<ObjectId>() {
-            @Override
-            public ObjectId invoke(Repository repository) throws IOException, InterruptedException {
-                return repository.getRef(head).getObjectId();
-            }
-        }) : ObjectId.fromString(rev.getHash());
+        commitId = rev == null ? invoke((Repository repository) -> repository.findRef(head).getObjectId()) : ObjectId.fromString(rev.getHash());
     }
 
     @Override

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1603,7 +1603,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitClient gc = Git.with(StreamTaskListener.fromStdout(),null).in(b.getWorkspace()).getClient();
         gc.withRepository(new RepositoryCallback<Void>() {
             public Void invoke(Repository repo, VirtualChannel channel) throws IOException, InterruptedException {
-                Ref head = repo.getRef("HEAD");
+                Ref head = repo.findRef("HEAD");
                 assertTrue("Detached HEAD",head.isSymbolic());
                 Ref t = head.getTarget();
                 assertEquals(t.getName(),"refs/heads/master");


### PR DESCRIPTION
## Replace JGit 4.5 getRef with findRef or exactRef

JGit 5.x deprecates and removes the getRef method on repositories, replacing it with two methods, findRef and exactRef.  No reason to use the JGit 4.5 method even with JGit 4.5, since the new methods are available.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update