### PR TITLE
Bump checkstyle from 8.23 to 8.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
     <jcasc.version>1.29</jcasc.version>
     <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
-    <maven.checkstyle.version>8.23</maven.checkstyle.version>
+    <maven.checkstyle.version>8.24</maven.checkstyle.version>
   </properties>
 
   <build>


### PR DESCRIPTION
## Bump checkstyle from 8.23 to 8.24

Bumps [checkstyle](https://github.com/checkstyle/checkstyle) from 8.23 to 8.24.
- [Release notes](https://github.com/checkstyle/checkstyle/releases)
- [Commits](https://github.com/checkstyle/checkstyle/compare/checkstyle-8.23...checkstyle-8.24)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update