### PR TITLE
Fix un-needed nullchecks

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -101,8 +101,7 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                 return FormValidation.ok();
             }
             // Connect to URL and check content only if we have admin permission
-            Jenkins jenkins = Jenkins.getInstanceOrNull();
-            if (jenkins == null || !jenkins.hasPermission(Jenkins.ADMINISTER))
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
                 return FormValidation.ok();
             return new URLCheck() {
                 protected FormValidation check() throws IOException, ServletException {

--- a/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
@@ -87,8 +87,7 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
                 return FormValidation.ok();
             }
             // Connect to URL and check content only if we have admin permission
-            Jenkins jenkins = Jenkins.getInstanceOrNull();
-            if (jenkins == null || !jenkins.hasPermission(Jenkins.ADMINISTER))
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
                 return FormValidation.ok();
             return new URLCheck() {
                 protected FormValidation check() throws IOException, ServletException {

--- a/src/main/java/hudson/plugins/git/browser/Gitiles.java
+++ b/src/main/java/hudson/plugins/git/browser/Gitiles.java
@@ -74,8 +74,7 @@ public class Gitiles extends GitRepositoryBrowser {
             if (url == null) // nothing entered yet
                 return FormValidation.ok();
             // Connect to URL and check content only if we have admin permission
-            Jenkins jenkins = Jenkins.getInstanceOrNull();
-            if (jenkins == null || !jenkins.hasPermission(Jenkins.ADMINISTER))
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
                 return FormValidation.ok();
             return new URLCheck() {
                 protected FormValidation check() throws IOException, ServletException {

--- a/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
@@ -113,8 +113,7 @@ public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
                 ServletException {
 
             // Connect to URL and check content only if we have admin permission
-            Jenkins jenkins = Jenkins.getInstanceOrNull();
-            if (jenkins == null || !jenkins.hasPermission(Jenkins.ADMINISTER))
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
                 return FormValidation.ok();
 
             if (value == null) // nothing entered yet

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -93,8 +93,7 @@ public class ViewGitWeb extends GitRepositoryBrowser {
             if (url == null) // nothing entered yet
                 return FormValidation.ok();
             // Connect to URL and check content only if we have admin permission
-            Jenkins jenkins = Jenkins.getInstanceOrNull();
-            if (jenkins == null || !jenkins.hasPermission(Jenkins.ADMINISTER))
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
                 return FormValidation.ok();
             return new URLCheck() {
                 protected FormValidation check() throws IOException, ServletException {


### PR DESCRIPTION
## Fix un-needed nullchecks

Issue raised against 7d59ac5743f41aa0f5a39413ef8d246ab2eca3bf of #748  regarding null checks during form validation where the Jenkins object should never be null so simply using `get()` is a valid operation. Functionally it should behave as before.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [x] Dependency or infrastructure update

