### PR TITLE
Disable maven source cross references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <jcasc.version>1.29</jcasc.version>
     <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
     <maven.checkstyle.version>8.24</maven.checkstyle.version>
+    <linkXRef>false</linkXRef>
   </properties>
 
   <build>


### PR DESCRIPTION
## Dsiable maven source cross references

Disable the maven source cross reference feature, not used and not needed. Allow next generation warnings plugin to confirm there are 0 maven warnings.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency or infrastructure update