### PR TITLE
[JENKINS-57694] Fix IncompatibleClassChangeError when running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,12 @@
       <artifactId>git-tag-message</artifactId>
       <version>1.6.1</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>git</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- Satisfy upper bounds dependency warnings -->
     <dependency>


### PR DESCRIPTION
## [JENKINS-57694](https://issues.jenkins-ci.org/browse/JENKINS-57694) - Fix IncompatibleClassChangeError when running tests

When running the tests the following error was shown for every test that used `JenkinsRule`:
> Error injecting constructor, java.lang.IncompatibleClassChangeError:
> jenkins.plugins.git.AbstractGitSCMSource$SpecificRevisionBuildChooser and jenkins.plugins.git.AbstractGitSCMSource$SpecificRevisionBuildChooser$DescriptorImpl disagree on InnerClasses attribute
> at jenkins.plugins.git.AbstractGitSCMSource$SpecificRevisionBuildChooser$DescriptorImpl.<init>(AbstractGitSCMSource.java:416)

The error was introduced in commit db3e063c59f81d1cc78e77c075e8acd92f7b1b83 when _org.jenkins-ci.plugins:git-tag-message_ was added as dependency. It contains _org.jenkins-ci.plugins:git_ as dependency itself. Therefore 2 versions appeared on the classpath causing trouble.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency or infrastructure update

## Further comments

These tests fail locally but also on the _master_ branch:
- AbstractGitSCMSourceTest.refLockEncounteredIfPruneTraitNotPresentOnNotFoundRetrieval
- AbstractGitSCMSourceTest.refLockEncounteredIfPruneTraitNotPresentOnTagRetrieval