### PR TITLE
fix space in expected log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <useBeta>true</useBeta>
     <concurrency>1C</concurrency>
     <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
-    <jcasc.version>1.29</jcasc.version>
+    <jcasc.version>1.30-rc906.86de0756937e</jcasc.version>
     <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
     <maven.checkstyle.version>8.24</maven.checkstyle.version>
     <linkXRef>false</linkXRef>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <useBeta>true</useBeta>
     <concurrency>1C</concurrency>
     <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
-    <jcasc.version>1.30-rc906.86de0756937e</jcasc.version>
+    <jcasc.version>1.30</jcasc.version>
     <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
     <maven.checkstyle.version>8.24</maven.checkstyle.version>
     <linkXRef>false</linkXRef>

--- a/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java
@@ -35,6 +35,6 @@ public class GitJCasCCompatibilityTest extends RoundTripAbstractTest {
 
     @Override
     protected String stringInLogExpected() {
-        return "Setting class hudson.plugins.git.SubmoduleConfig. branches = [mybranch-3, mybranch-4]";
+        return "Setting class hudson.plugins.git.SubmoduleConfig.branches = [mybranch-3, mybranch-4]";
     }
 }


### PR DESCRIPTION
https://github.com/jenkinsci/configuration-as-code-plugin/pull/1049

Fix a silly space in the name 🤣

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the GitHub issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
- [x] Bug fix (non-breaking change which fixes an issue)
as expected)