### PR TITLE
[JENKINS-57694] Fix SpecificRevisionBuildChooser#getDisplayName()

### DIFF
--- a/src/main/java/hudson/plugins/git/util/BuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooser.java
@@ -7,6 +7,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
+import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
 import hudson.model.Item;
 import hudson.model.TaskListener;
@@ -46,9 +47,10 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
      * @return display name of this build chooser
      */
     public final String getDisplayName() {
-        return getDescriptor().getDisplayName();
+        Descriptor<?> descriptor = Jenkins.get().getDescriptor(getClass());
+        return descriptor != null ? descriptor.getDisplayName() : getClass().getSimpleName();
     }
-    
+
     /**
      * Get a list of revisions that are candidates to be built.
      *


### PR DESCRIPTION
## [JENKINS-57694](https://issues.jenkins-ci.org/browse/JENKINS-57694) - Fix SpecificRevisionBuildChooser#getDisplayName()

**old description**
~~All other `BuildChooser`s already have a `Descriptor`. This missing `Descriptor` was causing an exception when `BuildChooser#getDisplayName()` was called within `GitSCM#compareRemoteRevisionWithImpl()` to log its name.~~

~~The `Descriptor` was once already in place but then removed in commit 75e78800 because the `SpecificRevisionBuildChooser` is not meant to be selectable by a user in the UI.~~

~~The better way (because a `Describable` should have a `Descriptor`) to describe this fact is to overwrite `isApplicable()` to always return `false`.~~

**new description**
There may be `BuildChooser`s that don't have a `Descriptor` because they are not meant to be selectable by a user in the UI. Currently `SpecificRevisionBuildChooser` is such a `BuildChooser`.

This missing `Descriptor` was causing an exception when `BuildChooser#getDisplayName()` was called within `GitSCM#compareRemoteRevisionWithImpl()` to log its name.

The `Descriptor` was once already in place but then removed in commit 75e78800 because the `SpecificRevisionBuildChooser` is not meant to be selectable by a user in the UI.

Therefore the absence of a `Descriptor` has to be handled.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)