### PR TITLE
Fix the markdown syntax error in contribution document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Contributing to the Git Plugin
 ==============================
 
 The git plugin implements the [Jenkins SCM API](https://plugins.jenkins.io/scm-api).
-Refer to the SCM API documentation for [plugin naming conventions]https://github.com/jenkinsci/scm-api-plugin/blob/master/docs/implementation.adoc#naming-your-plugin(),
+Refer to the SCM API documentation for [plugin naming conventions](mvn spotbugs:checkhttps://github.com/jenkinsci/scm-api-plugin/blob/master/docs/implementation.adoc#naming-your-plugin),
 and for the [preferred locations of new functionality](https://github.com/jenkinsci/scm-api-plugin/blob/master/CONTRIBUTING.md#add-to-core-or-create-extension-plugin).
 
 Plugin source code is hosted on [GitHub](https://github.com/jenkinsci/git-plugin).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Contributing to the Git Plugin
 ==============================
 
 The git plugin implements the [Jenkins SCM API](https://plugins.jenkins.io/scm-api).
-Refer to the SCM API documentation for [plugin naming conventions](mvn spotbugs:checkhttps://github.com/jenkinsci/scm-api-plugin/blob/master/docs/implementation.adoc#naming-your-plugin),
+Refer to the SCM API documentation for [plugin naming conventions](https://github.com/jenkinsci/scm-api-plugin/blob/master/docs/implementation.adoc#naming-your-plugin),
 and for the [preferred locations of new functionality](https://github.com/jenkinsci/scm-api-plugin/blob/master/CONTRIBUTING.md#add-to-core-or-create-extension-plugin).
 
 Plugin source code is hosted on [GitHub](https://github.com/jenkinsci/git-plugin).


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
