### PR TITLE
[JENKINS-59415] run context for GitSCMExtension

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -781,7 +781,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
             // Fetch updates
             for (RemoteConfig remoteRepository : getParamExpandedRepos(lastBuild, listener)) {
-                fetchFrom(git, listener, remoteRepository);
+                fetchFrom(git, null, listener, remoteRepository);
             }
 
             listener.getLogger().println("Polling for changes in");
@@ -876,12 +876,14 @@ public class GitSCM extends GitSCMBackwardCompatibility {
      * Fetch information from a particular remote repository.
      *
      * @param git git client
+     * @param run run context if it's running for build
      * @param listener build log
      * @param remoteRepository remote git repository
      * @throws InterruptedException when interrupted
      * @throws IOException on input or output error
      */
     private void fetchFrom(GitClient git,
+            @CheckForNull Run<?, ?> run,
             TaskListener listener,
             RemoteConfig remoteRepository) throws InterruptedException, IOException {
 
@@ -897,7 +899,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
                 FetchCommand fetch = git.fetch_().from(url, remoteRepository.getFetchRefSpecs());
                 for (GitSCMExtension extension : extensions) {
-                    extension.decorateFetchCommand(this, git, listener, fetch);
+                    extension.decorateFetchCommand(this, run, git, listener, fetch);
                 }
                 fetch.execute();
             } catch (GitException ex) {
@@ -1116,7 +1118,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         for (RemoteConfig remoteRepository : repos) {
             try {
-                fetchFrom(git, listener, remoteRepository);
+                fetchFrom(git, build, listener, remoteRepository);
             } catch (GitException ex) {
                 /* Allow retry by throwing AbortException instead of
                  * GitException. See JENKINS-20531. */

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -266,6 +266,7 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
      * @throws IOException on input or output error
      * @throws InterruptedException when interrupted
      * @throws GitException on git error
+     * @deprecated use {@link #decorateCheckoutCommand(GitSCM, Run, GitClient, TaskListener, CheckoutCommand)}
      */
     @Deprecated
     public void decorateFetchCommand(GitSCM scm, GitClient git, TaskListener listener, FetchCommand cmd) throws IOException, InterruptedException, GitException {

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -267,7 +267,13 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
      * @throws InterruptedException when interrupted
      * @throws GitException on git error
      */
+    @Deprecated
     public void decorateFetchCommand(GitSCM scm, GitClient git, TaskListener listener, FetchCommand cmd) throws IOException, InterruptedException, GitException {
+    }
+
+    public void decorateFetchCommand(GitSCM scm, @CheckForNull Run<?,?> run, GitClient git, TaskListener listener, FetchCommand cmd)
+            throws IOException, InterruptedException, GitException {
+        decorateFetchCommand(scm, git, listener, cmd);
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -271,6 +271,17 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
     public void decorateFetchCommand(GitSCM scm, GitClient git, TaskListener listener, FetchCommand cmd) throws IOException, InterruptedException, GitException {
     }
 
+    /**
+     * Called before a {@link FetchCommand} is executed to allow extensions to alter its behaviour.
+     * @param scm GitSCM object
+     * @param run Run when fetch is called for Run. null during Job polling.
+     * @param git GitClient
+     * @param listener build log
+     * @param cmd fetch command to be decorated
+     * @throws IOException on input or output error
+     * @throws InterruptedException when interrupted
+     * @throws GitException on git error
+     */
     public void decorateFetchCommand(GitSCM scm, @CheckForNull Run<?,?> run, GitClient git, TaskListener listener, FetchCommand cmd)
             throws IOException, InterruptedException, GitException {
         decorateFetchCommand(scm, git, listener, cmd);


### PR DESCRIPTION
## [JENKINS-59415](https://issues.jenkins-ci.org/browse/JENKINS-59415) 

Seems run is historically missing in fetch because logic was reused for polling. Trying to pass build context into extension. Hopefully `fetchFrom` is private method and only extension method is affected.
Possibly the other variant could be to call old and new method?..
PoC for discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/git-plugin/766)
<!-- Reviewable:end -->
