### PR TITLE
[JENKINS-59540] Add annotation to getUrl

### DIFF
--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -68,6 +68,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
     }
 
     @Exported
+    @CheckForNull
     public String getUrl() {
         return url;
     }

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -286,12 +286,14 @@ public class GitSCMFileSystem extends SCMFileSystem {
             UserRemoteConfig config = gitSCM.getUserRemoteConfigs().get(0);
             BranchSpec branchSpec = gitSCM.getBranches().get(0);
             String remote = config.getUrl();
+            LogTaskListener listener = new LogTaskListener(LOGGER, Level.FINE);
             if (remote == null) {
+                listener.getLogger().println("Git remote url is null");
+                listener.close();
                 return null;
             }
             String cacheEntry = AbstractGitSCMSource.getCacheEntry(remote);
             Lock cacheLock = AbstractGitSCMSource.getCacheLock(cacheEntry);
-            TaskListener listener = new LogTaskListener(LOGGER, Level.FINE);
             cacheLock.lock();
             try {
                 File cacheDir = AbstractGitSCMSource.getCacheDir(cacheEntry);

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -282,13 +282,16 @@ public class GitSCMFileSystem extends SCMFileSystem {
             if (rev != null && !(rev instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
                 return null;
             }
-            TaskListener listener = new LogTaskListener(LOGGER, Level.FINE);
             GitSCM gitSCM = (GitSCM) scm;
             UserRemoteConfig config = gitSCM.getUserRemoteConfigs().get(0);
             BranchSpec branchSpec = gitSCM.getBranches().get(0);
             String remote = config.getUrl();
+            if (remote == null) {
+                return null;
+            }
             String cacheEntry = AbstractGitSCMSource.getCacheEntry(remote);
             Lock cacheLock = AbstractGitSCMSource.getCacheLock(cacheEntry);
+            TaskListener listener = new LogTaskListener(LOGGER, Level.FINE);
             cacheLock.lock();
             try {
                 File cacheDir = AbstractGitSCMSource.getCacheDir(cacheEntry);

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -286,10 +286,9 @@ public class GitSCMFileSystem extends SCMFileSystem {
             UserRemoteConfig config = gitSCM.getUserRemoteConfigs().get(0);
             BranchSpec branchSpec = gitSCM.getBranches().get(0);
             String remote = config.getUrl();
-            LogTaskListener listener = new LogTaskListener(LOGGER, Level.FINE);
+            TaskListener listener = new LogTaskListener(LOGGER, Level.FINE);
             if (remote == null) {
                 listener.getLogger().println("Git remote url is null");
-                listener.close();
                 return null;
             }
             String cacheEntry = AbstractGitSCMSource.getCacheEntry(remote);


### PR DESCRIPTION
## [JENKINS-59540](https://issues.jenkins-ci.org/browse/JENKINS-59540) Null check getUrl references

Make it clear to callers that getUrl may return null.

Adding an annotation for what I suspect was the cause of [JENKINS-50014](https://issues.jenkins-ci.org/browse/JENKINS-50014). Filed jenkinsci/git-parameter-plugin#83 against that plugin but circling back here to ensure that other plugins can catch this issue with the annotation added.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
