### PR TITLE
Bump equalsverifier from 3.1.9 to 3.1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.1.9</version>
+      <version>3.1.10</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
## Bump equalsverifier from 3.1.9 to 3.1.10

Bumps [equalsverifier](https://github.com/jqno/equalsverifier) from 3.1.9 to 3.1.10.
- [Release notes](https://github.com/jqno/equalsverifier/releases)
- [Changelog](https://github.com/jqno/equalsverifier/blob/master/CHANGELOG.md)
- [Commits](https://github.com/jqno/equalsverifier/compare/equalsverifier-3.1.9...equalsverifier-3.1.10)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [x] Dependency or infrastructure update