### PR TITLE
Use JCasC version from BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
     <concurrency>1C</concurrency>
-    <jcasc.version>1.30</jcasc.version>
     <linkXRef>false</linkXRef>
   </properties>
 
@@ -215,13 +214,11 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${jcasc.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${jcasc.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
## Use JCasC version from BOM

Let the BOM manage the version instead of dependabot.

Test dependency, good to update regularly.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [ ] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Dependency or infrastructure update