### PR TITLE
Depend on promoted builds 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>promoted-builds</artifactId>
-      <version>3.3</version>
+      <version>3.4</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
+++ b/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
@@ -59,7 +59,7 @@ public class GitRevisionBuildParameters extends AbstractBuildParameters {
 		if (data == null && Jenkins.getInstance().getPlugin("promoted-builds") != null) {
             if (build instanceof hudson.plugins.promoted_builds.Promotion) {
                 // We are running as a build promotion, so have to retrieve the git scm from target job
-                data = ((hudson.plugins.promoted_builds.Promotion) build).getTarget().getAction(BuildData.class);
+                data = ((hudson.plugins.promoted_builds.Promotion) build).getTargetBuild().getAction(BuildData.class);
             }
         }
         if (data == null) {


### PR DESCRIPTION
## Optional dependency on promoted builds 3.4 instead of 3.3

The git plugin can optionally use the promoted builds plugin. Promoted builds plugin 3.4 replaced the Promotions.getTarget() method with Promotions.getTargetBuild(). Adapt to the API change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update