### PR TITLE
Revert "Depend on promoted builds 3.4"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>promoted-builds</artifactId>
-      <version>3.4</version>
+      <version>3.3</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
+++ b/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
@@ -59,7 +59,7 @@ public class GitRevisionBuildParameters extends AbstractBuildParameters {
 		if (data == null && Jenkins.getInstance().getPlugin("promoted-builds") != null) {
             if (build instanceof hudson.plugins.promoted_builds.Promotion) {
                 // We are running as a build promotion, so have to retrieve the git scm from target job
-                data = ((hudson.plugins.promoted_builds.Promotion) build).getTargetBuild().getAction(BuildData.class);
+                data = ((hudson.plugins.promoted_builds.Promotion) build).getTarget().getAction(BuildData.class);
             }
         }
         if (data == null) {


### PR DESCRIPTION
Reverts jenkinsci/git-plugin#774 so that we do not force users to prematurely install the latest promoted builds plugin.  See [comment](https://github.com/jenkinsci/promoted-builds-plugin/commit/cf1128c914f2d84260c202ce58f6e559384761c6#commitcomment-35537086) on promoted builds [PR 140](https://github.com/jenkinsci/promoted-builds-plugin/pull/140)