### PR TITLE
Depend on promoted builds 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,10 +155,11 @@
       <version>0.6</version>
       <scope>test</scope>
     </dependency>
+    <!-- intentionally staying with promoted-builds 3.2 on advice of Oleg Nenashev -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>promoted-builds</artifactId>
-      <version>3.3</version>
+      <version>3.2</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Use optional promoted builds 3.2, not 3.3 or 3.4

Oleg Nenashev has detected issues with promoted builds plugin versions 3.3 and 3.4.  He recommends remaining with 3.2 for now.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency or infrastructure update