### PR TITLE
Cleanup config Groovy files

### DIFF
--- a/src/main/resources/hudson/plugins/git/BranchSpec/config.groovy
+++ b/src/main/resources/hudson/plugins/git/BranchSpec/config.groovy
@@ -1,4 +1,4 @@
-package hudson.plugins.git.BranchSpec;
+package hudson.plugins.git.BranchSpec
 
 f = namespace(lib.FormTagLib)
 

--- a/src/main/resources/hudson/plugins/git/GitSCM/buildEnv.groovy
+++ b/src/main/resources/hudson/plugins/git/GitSCM/buildEnv.groovy
@@ -1,4 +1,4 @@
-package hudson.plugins.git.GitSCM;
+package hudson.plugins.git.GitSCM
 
 def l = namespace(lib.JenkinsTagLib)
 

--- a/src/main/resources/hudson/plugins/git/UserRemoteConfig/config.groovy
+++ b/src/main/resources/hudson/plugins/git/UserRemoteConfig/config.groovy
@@ -1,4 +1,4 @@
-package hudson.plugins.git.UserRemoteConfig;
+package hudson.plugins.git.UserRemoteConfig
 
 f = namespace(lib.FormTagLib)
 c = namespace(lib.CredentialsTagLib)

--- a/src/main/resources/hudson/plugins/git/extensions/GitSCMExtension/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/GitSCMExtension/config.groovy
@@ -1,3 +1,3 @@
-package hudson.plugins.git.extensions.GitSCMExtension;
+package hudson.plugins.git.extensions.GitSCMExtension
 
 // no configuration

--- a/src/main/resources/hudson/plugins/git/extensions/impl/BuildChooserSetting/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/BuildChooserSetting/config.groovy
@@ -1,6 +1,6 @@
 package hudson.plugins.git.extensions.impl.BuildChooserSetting
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.entry() {
     f.dropdownDescriptorSelector(title:_("Choosing strategy"), field:"buildChooser",

--- a/src/main/resources/hudson/plugins/git/extensions/impl/ChangelogToBranch/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/ChangelogToBranch/config.groovy
@@ -1,5 +1,5 @@
-package hudson.plugins.git.extensions.impl.ChangelogToBranch;
+package hudson.plugins.git.extensions.impl.ChangelogToBranch
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.property(field:"options")

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CheckoutOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CheckoutOption/config.groovy
@@ -1,6 +1,6 @@
-package hudson.plugins.git.extensions.impl.CheckoutOption;
+package hudson.plugins.git.extensions.impl.CheckoutOption
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.entry(title:_("Timeout (in minutes) for checkout operation"), field:"timeout") {
     f.number(clazz:"number", min:1, step:1)

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
@@ -1,6 +1,6 @@
-package hudson.plugins.git.extensions.impl.CloneOption;
+package hudson.plugins.git.extensions.impl.CloneOption
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.entry(title:_("Fetch tags"), field:"noTags") {
     f.checkbox(negative:true, checked:(instance==null||!instance.noTags))

--- a/src/main/resources/hudson/plugins/git/extensions/impl/LocalBranch/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/LocalBranch/config.groovy
@@ -1,6 +1,6 @@
-package hudson.plugins.git.extensions.impl.LocalBranch;
+package hudson.plugins.git.extensions.impl.LocalBranch
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.entry(title:_("Branch name"), field:"localBranch") {
     f.textbox()

--- a/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/config.groovy
@@ -1,6 +1,6 @@
-package hudson.plugins.git.extensions.impl.MessageExclusion;
+package hudson.plugins.git.extensions.impl.MessageExclusion
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.entry(title:_("Excluded Messages"), field:"excludedMessage") {
     f.textbox()

--- a/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/config.groovy
@@ -1,6 +1,6 @@
-package hudson.plugins.git.extensions.impl.PathRestriction;
+package hudson.plugins.git.extensions.impl.PathRestriction
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.entry(title:_("Included Regions"), field:"includedRegions") {
     f.textarea()

--- a/src/main/resources/hudson/plugins/git/extensions/impl/PreBuildMerge/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/PreBuildMerge/config.groovy
@@ -1,5 +1,5 @@
-package hudson.plugins.git.extensions.impl.PreBuildMerge;
+package hudson.plugins.git.extensions.impl.PreBuildMerge
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.property(field:"options")

--- a/src/main/resources/hudson/plugins/git/extensions/impl/RelativeTargetDirectory/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/RelativeTargetDirectory/config.groovy
@@ -1,6 +1,6 @@
-package hudson.plugins.git.extensions.impl.RelativeTargetDirectory;
+package hudson.plugins.git.extensions.impl.RelativeTargetDirectory
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.entry(title:_("Local subdirectory for repo"), field:"relativeTargetDir") {
     f.textbox()

--- a/src/main/resources/hudson/plugins/git/extensions/impl/ScmName/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/ScmName/config.groovy
@@ -1,6 +1,6 @@
-package hudson.plugins.git.extensions.impl.ScmName;
+package hudson.plugins.git.extensions.impl.ScmName
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.entry(title:_("Unique SCM name"), field:"name") {
     f.textbox()

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
@@ -1,6 +1,6 @@
-package hudson.plugins.git.extensions.impl.SubmoduleOption;
+package hudson.plugins.git.extensions.impl.SubmoduleOption
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.entry(title:_("Disable submodules processing"), field:"disableSubmodules") {
     f.checkbox()

--- a/src/main/resources/hudson/plugins/git/extensions/impl/UserExclusion/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/UserExclusion/config.groovy
@@ -1,6 +1,6 @@
-package hudson.plugins.git.extensions.impl.UserExclusion;
+package hudson.plugins.git.extensions.impl.UserExclusion
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.entry(title:_("Excluded Users"), field:"excludedUsers") {
     f.textarea()

--- a/src/main/resources/hudson/plugins/git/extensions/impl/UserIdentity/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/UserIdentity/config.groovy
@@ -1,6 +1,6 @@
-package hudson.plugins.git.extensions.impl.UserIdentity;
+package hudson.plugins.git.extensions.impl.UserIdentity
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.entry(title:_("user.name"), field:"name") {
     f.textbox()

--- a/src/main/resources/hudson/plugins/git/util/AncestryBuildChooser/config.groovy
+++ b/src/main/resources/hudson/plugins/git/util/AncestryBuildChooser/config.groovy
@@ -1,6 +1,6 @@
-package hudson.plugins.git.util.AncestryBuildChooser;
+package hudson.plugins.git.util.AncestryBuildChooser
 
-def f = namespace(lib.FormTagLib);
+def f = namespace(lib.FormTagLib)
 
 f.description {
     raw(_("maximum_age_of_commit_blurb"))

--- a/src/main/resources/hudson/plugins/git/util/BuildChooser/config.groovy
+++ b/src/main/resources/hudson/plugins/git/util/BuildChooser/config.groovy
@@ -1,3 +1,3 @@
-package hudson.plugins.git.util.BuildChooser;
+package hudson.plugins.git.util.BuildChooser
 
 // no configuration

--- a/src/main/resources/hudson/plugins/git/util/InverseBuildChooser/config.groovy
+++ b/src/main/resources/hudson/plugins/git/util/InverseBuildChooser/config.groovy
@@ -1,4 +1,4 @@
-package hudson.plugins.git.util.InverseBuildChooser;
+package hudson.plugins.git.util.InverseBuildChooser
 
 def f = namespace(lib.FormTagLib)
 


### PR DESCRIPTION
- consistently don't use optional semicolons
- consistently use a newline at the end of a file