### PR TITLE
Improve nested lists in HTML

### DIFF
--- a/src/main/resources/hudson/plugins/git/BranchSpec/help-name.html
+++ b/src/main/resources/hudson/plugins/git/BranchSpec/help-name.html
@@ -19,40 +19,50 @@
            Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily
            the expected one. Better use <tt>refs/heads/&lt;branchName&gt;</tt>.<br/>
            E.g. <tt>master</tt>, <tt>feature1</tt>,...
+      </li>
       <li> <b><tt>refs/heads/&lt;branchName&gt;</tt></b><br/>
            Tracks/checks out the specified branch.<br/>
            E.g. <tt>refs/heads/master</tt>, <tt>refs/heads/feature1/master</tt>,...
+      </li>
       <li> <b><tt>&lt;remoteRepoName&gt;/&lt;branchName&gt;</tt></b><br/>
            Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily
            the expected one.<br/>
            Better use <tt>refs/heads/&lt;branchName&gt;</tt>.<br/>
            E.g. <tt>origin/master</tt>
+      </li>
       <li> <b><tt>remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</tt></b><br/>
            Tracks/checks out the specified branch.<br/>
            E.g. <tt>remotes/origin/master</tt>
+      </li>
       <li> <b><tt>refs/remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</tt></b><br/>
            Tracks/checks out the specified branch.<br/>
            E.g. <tt>refs/remotes/origin/master</tt>
+      </li>
       <li> <b><tt>&lt;tagName&gt;</tt></b><br/>
            This does not work since the tag will not be recognized as tag.<br/>
            Use <tt>refs/tags/&lt;tagName&gt;</tt> instead.<br/>
            E.g. <tt>git-2.3.0</tt>
+      </li>
       <li> <b><tt>refs/tags/&lt;tagName&gt;</tt></b><br/>
            Tracks/checks out the specified tag.<br/>
            E.g. <tt>refs/tags/git-2.3.0</tt>
+      </li>
       <li> <b><tt>&lt;commitId&gt;</tt></b><br/>
            Checks out the specified commit.<br/>
            E.g. <tt>5062ac843f2b947733e6a3b105977056821bd352</tt>, <tt>5062ac84</tt>, ...
+      </li>
       <li> <b><tt>${ENV_VARIABLE}</tt></b><br/>
            It is also possible to use environment variables. In this case the variables are evaluated and the
            result is used as described above.<br/>
            E.g. <tt>${TREEISH}</tt>, <tt>refs/tags/${TAGNAME}</tt>,...
+      </li>
       <li> <b><tt>&lt;Wildcards&gt;</tt></b><br/>
            The syntax is of the form: <tt>REPOSITORYNAME/BRANCH</tt>.
            In addition, <tt>BRANCH</tt> is recognized as a shorthand of <tt>*/BRANCH</tt>, '*' is recognized as a wildcard,
            and '**' is recognized as wildcard that includes the separator '/'. Therefore, <tt>origin/branches*</tt> would
            match <tt>origin/branches-foo</tt> but not <tt>origin/branches/foo</tt>, while <tt>origin/branches**</tt> would
            match both <tt>origin/branches-foo</tt> and <tt>origin/branches/foo</tt>.
+      </li>
       <li> <b><tt>:&lt;regular expression&gt;</tt></b><br/>
            The syntax is of the form: <tt>:regexp</tt>.
            Regular expression syntax in branches to build will only
@@ -60,22 +70,26 @@
            expression.<br/>
            Examples:<br/>
             <ul>
-                <li><tt>:^(?!(origin/prefix)).*</tt></li>
-                <ul>
+                <li><tt>:^(?!(origin/prefix)).*</tt>
+                  <ul>
                     <li>matches: <tt>origin</tt> or <tt>origin/master</tt> or <tt>origin/feature</tt></li>
                     <li>does not match: <tt>origin/prefix</tt> or <tt>origin/prefix_123</tt> or <tt>origin/prefix-abc</tt></li>
-                </ul>
-                <li><tt>:origin/release-\d{8}</tt></li>
-                <ul>
+                  </ul>
+                </li>
+                <li><tt>:origin/release-\d{8}</tt>
+                  <ul>
                     <li>matches: <tt>origin/release-20150101</tt></li>
                     <li>does not match: <tt>origin/release-2015010</tt> or <tt>origin/release-201501011</tt> or <tt>origin/release-20150101-something</tt></li>
-                </ul>
-                <li><tt>:^(?!origin/master$|origin/develop$).*</tt></li>
-                <ul>
+                  </ul>
+                </li>
+                <li><tt>:^(?!origin/master$|origin/develop$).*</tt>
+                  <ul>
                     <li>matches: <tt>origin/branch1</tt> or <tt>origin/branch-2</tt> or <tt>origin/master123</tt> or <tt>origin/develop-123</tt></li>
                     <li>does not match: <tt>origin/master</tt> or <tt>origin/develop</tt></li>
-                </ul>
+                  </ul>
+                </li>
             </ul>
+      </li>
     </ul>
   </p>
 </div>

--- a/src/main/resources/hudson/plugins/git/BranchSpec/help-name_ja.html
+++ b/src/main/resources/hudson/plugins/git/BranchSpec/help-name_ja.html
@@ -17,29 +17,37 @@
            指定したブランチを追跡します。もし、取得した結果があいまいで、必ずしも期待しているものではない場合、
            <tt>refs/heads/&lt;ブランチ名&gt;</tt>を使ってみてください。<br/>
            例: <tt>master</tt>, <tt>feature1</tt>,...
+      </li>
       <li> <b><tt>refs/heads/&lt;ブランチ名&gt;</tt></b><br/>
            指定したブランチ名を追跡します。<br/>
            例: <tt>refs/heads/master</tt>, <tt>refs/heads/feature1/master</tt>,...
+      </li>
       <li> <b><tt>&lt;リモートリポジトリ名&gt;/&lt;ブランチ名&gt;</tt></b><br/>
            指定したブランチを追跡します。もし、取得した結果があいまいで、必ずしも期待しているものではない場合、
            <tt>refs/heads/&lt;ブランチ名&gt;</tt>を使ってみてください。<br/>
            例: <tt>origin/master</tt>
+      </li>
       <li> <b><tt>remotes/&lt;リモートリポジトリ名&gt;/&lt;ブランチ名&gt;</tt></b><br/>
            指定したブランチを追跡します。<br/>
            例: <tt>remotes/origin/master</tt>
+      </li>
       <li> <b><tt>refs/remotes/&lt;リモートリポジトリ名&gt;/&lt;ブランチ名&gt;</tt></b><br/>
            指定したブランチを追跡します。<br/>
            例: <tt>refs/remotes/origin/master</tt>
+      </li>
       <li> <b><tt>&lt;タグ名&gt;</tt></b><br/>
            タグを認識できないため、動作しません。<br/> 
            代わりに、<tt>refs/tags/&lt;タグ名&gt;</tt>を使用してください。<br/>
            例: <tt>git-2.3.0</tt>
+      </li>
       <li> <b><tt>refs/tags/&lt;タグ名&gt;</tt></b><br/>
            指定したタグを追跡します。<br/>
            例: <tt>refs/tags/git-2.3.0</tt>
+      </li>
       <li> <b><tt>&lt;コミットID&gt;</tt></b><br/>
            指定したコミットIDをチェックアウトします。<br/>
            例: <tt>5062ac843f2b947733e6a3b105977056821bd352</tt>, <tt>5062ac84</tt>, ...
+      </li>
       <li> <b><tt>${ENV_VARIABLE}</tt></b><br/>
            環境変数も使用可能です。この場合、変数は評価され、結果は上記で説明したような値として使用されます。<br/>
            例: <tt>${TREEISH}</tt>, <tt>refs/tags/${TAGNAME}</tt>,...
@@ -49,29 +57,31 @@
            '**'はセパレータ'/'を含むワルドカードとして扱われます。それゆえ、<tt>origin/branches*</tt>は、<tt>origin/branches-foo</tt>に合致しますが、
            <tt>origin/branches/foo</tt>には合致しません。
            一方、<tt>origin/branches**</tt>は、<tt>origin/branches-foo</tt>と<tt>origin/branches/foo</tt>の両方に一致します。
+      </li>
       <li> <b><tt>:&lt;正規表現&gt;</tt></b><br/>
            文法は、<tt>:regexp</tt>の形式です。
            ここでの正規表現は、ブランチ名がその正規表現に合致するブランチだけをビルドします。<br/>
            例:<br/>
             <ul>
                 <li><tt>:^(?!(origin/prefix)).*</tt>
-                <ul>
+                  <ul>
                     <li>合致する: <tt>origin</tt> 、 <tt>origin/master</tt> 、 <tt>origin/feature</tt></li>
                     <li>合致しない: <tt>origin/prefix</tt> 、 <tt>origin/prefix_123</tt> 、 <tt>origin/prefix-abc</tt></li>
-                </ul>
+                  </ul>
                 </li>
                 <li><tt>:origin/release-\d{8}</tt>
-                <ul>
+                  <ul>
                     <li>合致する: <tt>origin/release-20150101</tt></li>
                     <li>合致しない: <tt>origin/release-2015010</tt> 、 <tt>origin/release-201501011</tt> 、<tt>origin/release-20150101-something</tt></li>
-                </ul>
+                  </ul>
                 </li>
                 <li><tt>:^(?!origin/master$|origin/develop$).*</tt>
-                <ul>
+                  <ul>
                     <li>合致する: <tt>origin/branch1</tt> 、 <tt>origin/branch-2</tt> 、 <tt>origin/master123</tt> 、 <tt>origin/develop-123</tt></li>
                     <li>合致しない: <tt>origin/master</tt> 、 <tt>origin/develop</tt></li>
-                </ul>
+                  </ul>
                 </li>
             </ul>
+      </li>
     </ul>
  </div>


### PR DESCRIPTION
They may have already been rendered somehow properly before this change in most browsers but the usage was not correct.

- use the `</li>` end tag to make the end of big list items more explicit
- contain `<ul>` elements inside `<li>` elements so that they are correctly part of the list item

Also see https://developer.mozilla.org/docs/Web/HTML/Element/li.