### PR TITLE
Bump bom-2.138.x from 3 to 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.138.x</artifactId>
-        <version>3</version>
+        <version>4</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
## Bump bom-2.138.x from 3 to 4

Bumps [bom-2.138.x](https://github.com/jenkinsci/bom) from 3 to 4.
- [Release notes](https://github.com/jenkinsci/bom/releases)
- [Commits](https://github.com/jenkinsci/bom/commits)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update