### PR TITLE
Restrict test to fork a single process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
-    <forkCount>1C</forkCount>
+    <forkCount>1</forkCount>
     <linkXRef>false</linkXRef>
   </properties>
 


### PR DESCRIPTION
## Restrict test to fork a single process

Setting forkCount to `1C` causes the tests to hang completely on systems with a large number of available CPU cores.  Rather than risk being unable to test on a full range of computers, limit the forkCount to 1.

Eventually it would be best to identify the root causes of the hanging tests, but that's far beyond what I can do now.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update