### PR TITLE
[JENKINS-26660] Expose 'cleanSubmodules' functionality to Jenkins UI

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/CleanBeforeCheckout.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CleanBeforeCheckout.java
@@ -7,9 +7,12 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import java.io.IOException;
+import java.util.Objects;
+
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * git-clean before the checkout.
@@ -17,8 +20,19 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @author David S Wang
  */
 public class CleanBeforeCheckout extends GitSCMExtension {
+    private boolean deleteUntrackedNestedRepositories;
+
     @DataBoundConstructor
     public CleanBeforeCheckout() {
+    }
+
+    public boolean isDeleteUntrackedNestedRepositories() {
+        return deleteUntrackedNestedRepositories;
+    }
+
+    @DataBoundSetter
+    public void setDeleteUntrackedNestedRepositories(boolean deleteUntrackedNestedRepositories) {
+        this.deleteUntrackedNestedRepositories = deleteUntrackedNestedRepositories;
     }
 
     /**
@@ -27,7 +41,7 @@ public class CleanBeforeCheckout extends GitSCMExtension {
     @Override
     public void decorateFetchCommand(GitSCM scm, GitClient git, TaskListener listener, FetchCommand cmd) throws IOException, InterruptedException, GitException {
         listener.getLogger().println("Cleaning workspace");
-        git.clean();
+        git.clean(deleteUntrackedNestedRepositories);
         // TODO: revisit how to hand off to SubmoduleOption
         for (GitSCMExtension ext : scm.getExtensions()) {
             ext.onClean(scm, git);
@@ -45,7 +59,8 @@ public class CleanBeforeCheckout extends GitSCMExtension {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        return o instanceof CleanBeforeCheckout;
+        CleanBeforeCheckout that = (CleanBeforeCheckout) o;
+        return deleteUntrackedNestedRepositories == that.deleteUntrackedNestedRepositories;
     }
 
     /**
@@ -53,7 +68,7 @@ public class CleanBeforeCheckout extends GitSCMExtension {
      */
     @Override
     public int hashCode() {
-        return CleanBeforeCheckout.class.hashCode();
+        return Objects.hash(deleteUntrackedNestedRepositories);
     }
 
     /**
@@ -61,7 +76,9 @@ public class CleanBeforeCheckout extends GitSCMExtension {
      */
     @Override
     public String toString() {
-        return "CleanBeforeCheckout{}";
+        return "CleanBeforeCheckout{" +
+                "deleteUntrackedNestedRepositories=" + deleteUntrackedNestedRepositories +
+                '}';
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/extensions/impl/CleanCheckout.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CleanCheckout.java
@@ -8,8 +8,11 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import java.io.IOException;
+import java.util.Objects;
+
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * git-clean after the checkout.
@@ -17,8 +20,19 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @author Kohsuke Kawaguchi
  */
 public class CleanCheckout extends GitSCMExtension {
+    private boolean deleteUntrackedNestedRepositories;
+
     @DataBoundConstructor
     public CleanCheckout() {
+    }
+
+    public boolean isDeleteUntrackedNestedRepositories() {
+        return deleteUntrackedNestedRepositories;
+    }
+
+    @DataBoundSetter
+    public void setDeleteUntrackedNestedRepositories(boolean deleteUntrackedNestedRepositories) {
+        this.deleteUntrackedNestedRepositories = deleteUntrackedNestedRepositories;
     }
 
     /**
@@ -27,7 +41,7 @@ public class CleanCheckout extends GitSCMExtension {
     @Override
     public void onCheckoutCompleted(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener) throws IOException, InterruptedException, GitException {
         listener.getLogger().println("Cleaning workspace");
-        git.clean();
+        git.clean(deleteUntrackedNestedRepositories);
         // TODO: revisit how to hand off to SubmoduleOption
         for (GitSCMExtension ext : scm.getExtensions()) {
             ext.onClean(scm, git);
@@ -45,7 +59,8 @@ public class CleanCheckout extends GitSCMExtension {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        return o instanceof CleanCheckout;
+        CleanCheckout that = (CleanCheckout) o;
+        return deleteUntrackedNestedRepositories == that.deleteUntrackedNestedRepositories;
     }
 
     /**
@@ -53,7 +68,7 @@ public class CleanCheckout extends GitSCMExtension {
      */
     @Override
     public int hashCode() {
-        return CleanCheckout.class.hashCode();
+        return Objects.hash(deleteUntrackedNestedRepositories);
     }
 
     /**
@@ -61,7 +76,9 @@ public class CleanCheckout extends GitSCMExtension {
      */
     @Override
     public String toString() {
-        return "CleanCheckout{}";
+        return "CleanCheckout{" +
+                "deleteUntrackedNestedRepositories=" + deleteUntrackedNestedRepositories +
+                '}';
     }
 
     @Extension

--- a/src/main/java/jenkins/plugins/git/traits/CleanAfterCheckoutTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/CleanAfterCheckoutTrait.java
@@ -30,18 +30,30 @@ import hudson.plugins.git.extensions.impl.CleanCheckout;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 /**
  * Exposes {@link CleanCheckout} as a {@link SCMSourceTrait}.
  *
  * @since 3.4.0
  */
 public class CleanAfterCheckoutTrait extends GitSCMExtensionTrait<CleanCheckout> {
+
+    /**
+     * @deprecated Use constructor that accepts extension instead.
+     */
+    @Deprecated
+    public CleanAfterCheckoutTrait() {
+        this(null);
+    }
+
     /**
      * Stapler constructor.
      */
     @DataBoundConstructor
-    public CleanAfterCheckoutTrait() {
-        super(new CleanCheckout());
+    public CleanAfterCheckoutTrait(@CheckForNull CleanCheckout extension) {
+        super(extension == null ? new CleanCheckout() : extension);
     }
 
     /**

--- a/src/main/java/jenkins/plugins/git/traits/CleanBeforeCheckoutTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/CleanBeforeCheckoutTrait.java
@@ -30,18 +30,30 @@ import hudson.plugins.git.extensions.impl.CleanBeforeCheckout;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 /**
  * Exposes {@link CleanBeforeCheckout} as a {@link SCMSourceTrait}.
  *
  * @since 3.4.0
  */
 public class CleanBeforeCheckoutTrait extends GitSCMExtensionTrait<CleanBeforeCheckout> {
+
+    /**
+     * @deprecated Use constructor that accepts extension instead.
+     */
+    @Deprecated
+    public CleanBeforeCheckoutTrait() {
+        this(null);
+    }
+
     /**
      * Stapler constructor.
      */
     @DataBoundConstructor
-    public CleanBeforeCheckoutTrait() {
-        super(new CleanBeforeCheckout());
+    public CleanBeforeCheckoutTrait(@CheckForNull CleanBeforeCheckout extension) {
+        super(extension == null ? new CleanBeforeCheckout() : extension);
     }
 
     /**

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CleanBeforeCheckout/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CleanBeforeCheckout/config.groovy
@@ -1,0 +1,7 @@
+package hudson.plugins.git.extensions.impl.CleanBeforeCheckout
+
+def f = namespace(lib.FormTagLib)
+
+f.entry(title: _("Delete untracked nested repositories"), field: "deleteUntrackedNestedRepositories") {
+    f.checkbox()
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CleanBeforeCheckout/help-deleteUntrackedNestedRepositories.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CleanBeforeCheckout/help-deleteUntrackedNestedRepositories.html
@@ -1,0 +1,3 @@
+<div>
+  Deletes untracked submodules and any other subdirectories which contain <code>.git</code> directories.
+</div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CleanCheckout/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CleanCheckout/config.groovy
@@ -1,0 +1,7 @@
+package hudson.plugins.git.extensions.impl.CleanCheckout
+
+def f = namespace(lib.FormTagLib)
+
+f.entry(title: _("Delete untracked nested repositories"), field: "deleteUntrackedNestedRepositories") {
+    f.checkbox()
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CleanCheckout/help-deleteUntrackedNestedRepositories.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CleanCheckout/help-deleteUntrackedNestedRepositories.html
@@ -1,0 +1,3 @@
+<div>
+  Deletes untracked submodules and any other subdirectories which contain <code>.git</code> directories.
+</div>

--- a/src/test/java/hudson/plugins/git/extensions/impl/CleanBeforeCheckoutTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CleanBeforeCheckoutTest.java
@@ -1,6 +1,7 @@
 package hudson.plugins.git.extensions.impl;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
 public class CleanBeforeCheckoutTest {
@@ -9,6 +10,7 @@ public class CleanBeforeCheckoutTest {
     public void equalsContract() {
         EqualsVerifier.forClass(CleanBeforeCheckout.class)
                 .usingGetClass()
+                .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }
 }

--- a/src/test/java/hudson/plugins/git/extensions/impl/CleanCheckoutTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CleanCheckoutTest.java
@@ -1,6 +1,7 @@
 package hudson.plugins.git.extensions.impl;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
 public class CleanCheckoutTest {
@@ -9,6 +10,7 @@ public class CleanCheckoutTest {
     public void equalsContract() {
         EqualsVerifier.forClass(CleanCheckout.class)
                 .usingGetClass()
+                .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }
 }

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
@@ -48,6 +48,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -81,6 +82,56 @@ public class GitSCMSourceTraitsTest {
         assertThat(instance.getRemote(), is("git://git.test/example.git"));
         assertThat(instance.getCredentialsId(), is(nullValue()));
         assertThat(instance.getTraits(), is(Collections.<SCMSourceTrait>emptyList()));
+    }
+
+    @Test
+    public void cleancheckout_v1_extension() {
+        verifyCleanCheckoutTraits(false);
+    }
+
+    @Test
+    public void cleancheckout_v1_trait() {
+        verifyCleanCheckoutTraits(false);
+    }
+
+    @Test
+    public void cleancheckout_v2_extension() {
+        verifyCleanCheckoutTraits(true);
+    }
+
+    @Test
+    public void cleancheckout_v2_trait() {
+        verifyCleanCheckoutTraits(true);
+    }
+
+    /**
+     * Tests loading of {@link CleanCheckout}/{@link CleanBeforeCheckout}.
+     */
+    private void verifyCleanCheckoutTraits(boolean deleteUntrackedNestedRepositories) {
+        GitSCMSource instance = load();
+
+        assertThat(instance.getTraits(),
+                hasItems(
+                        allOf(
+                                instanceOf(CleanBeforeCheckoutTrait.class),
+                                hasProperty("extension",
+                                        hasProperty(
+                                                "deleteUntrackedNestedRepositories",
+                                                is(deleteUntrackedNestedRepositories)
+                                        )
+                                )
+                        ),
+                        allOf(
+                                instanceOf(CleanAfterCheckoutTrait.class),
+                                hasProperty("extension",
+                                        hasProperty(
+                                                "deleteUntrackedNestedRepositories",
+                                                is(deleteUntrackedNestedRepositories)
+                                        )
+                                )
+                        )
+                )
+        );
     }
 
     @Test
@@ -137,8 +188,18 @@ public class GitSCMSourceTraitsTest {
                                         hasProperty("localBranch", is("**"))
                                 )
                         ),
-                        Matchers.<SCMSourceTrait>instanceOf(CleanAfterCheckoutTrait.class),
-                        Matchers.<SCMSourceTrait>instanceOf(CleanBeforeCheckoutTrait.class),
+                        Matchers.<SCMSourceTrait>allOf(
+                                instanceOf(CleanBeforeCheckoutTrait.class),
+                                hasProperty("extension",
+                                        hasProperty("deleteUntrackedNestedRepositories", is(true))
+                                )
+                        ),
+                        Matchers.<SCMSourceTrait>allOf(
+                                instanceOf(CleanAfterCheckoutTrait.class),
+                                hasProperty("extension",
+                                        hasProperty("deleteUntrackedNestedRepositories", is(true))
+                                )
+                        ),
                         Matchers.<SCMSourceTrait>allOf(
                                 instanceOf(UserIdentityTrait.class),
                                 hasProperty("extension",

--- a/src/test/resources/jenkins/plugins/git/GitSCMSourceTraitsTest/cleancheckout_v1_extension.xml
+++ b/src/test/resources/jenkins/plugins/git/GitSCMSourceTraitsTest/cleancheckout_v1_extension.xml
@@ -1,0 +1,6 @@
+<jenkins.plugins.git.GitSCMSource>
+  <extensions>
+    <hudson.plugins.git.extensions.impl.CleanCheckout/>
+    <hudson.plugins.git.extensions.impl.CleanBeforeCheckout/>
+  </extensions>
+</jenkins.plugins.git.GitSCMSource>

--- a/src/test/resources/jenkins/plugins/git/GitSCMSourceTraitsTest/cleancheckout_v1_trait.xml
+++ b/src/test/resources/jenkins/plugins/git/GitSCMSourceTraitsTest/cleancheckout_v1_trait.xml
@@ -1,0 +1,10 @@
+<jenkins.plugins.git.GitSCMSource>
+  <traits>
+    <jenkins.plugins.git.traits.CleanAfterCheckoutTrait>
+      <extension class="hudson.plugins.git.extensions.impl.CleanCheckout"/>
+    </jenkins.plugins.git.traits.CleanAfterCheckoutTrait>
+    <jenkins.plugins.git.traits.CleanBeforeCheckoutTrait>
+      <extension class="hudson.plugins.git.extensions.impl.CleanBeforeCheckout"/>
+    </jenkins.plugins.git.traits.CleanBeforeCheckoutTrait>
+  </traits>
+</jenkins.plugins.git.GitSCMSource>

--- a/src/test/resources/jenkins/plugins/git/GitSCMSourceTraitsTest/cleancheckout_v2_extension.xml
+++ b/src/test/resources/jenkins/plugins/git/GitSCMSourceTraitsTest/cleancheckout_v2_extension.xml
@@ -1,0 +1,10 @@
+<jenkins.plugins.git.GitSCMSource>
+  <extensions>
+    <hudson.plugins.git.extensions.impl.CleanBeforeCheckout>
+      <deleteUntrackedNestedRepositories>true</deleteUntrackedNestedRepositories>
+    </hudson.plugins.git.extensions.impl.CleanBeforeCheckout>
+    <hudson.plugins.git.extensions.impl.CleanCheckout>
+      <deleteUntrackedNestedRepositories>true</deleteUntrackedNestedRepositories>
+    </hudson.plugins.git.extensions.impl.CleanCheckout>
+  </extensions>
+</jenkins.plugins.git.GitSCMSource>

--- a/src/test/resources/jenkins/plugins/git/GitSCMSourceTraitsTest/cleancheckout_v2_trait.xml
+++ b/src/test/resources/jenkins/plugins/git/GitSCMSourceTraitsTest/cleancheckout_v2_trait.xml
@@ -1,0 +1,14 @@
+<jenkins.plugins.git.GitSCMSource>
+  <traits>
+    <jenkins.plugins.git.traits.CleanAfterCheckoutTrait>
+      <extension class="hudson.plugins.git.extensions.impl.CleanCheckout">
+        <deleteUntrackedNestedRepositories>true</deleteUntrackedNestedRepositories>
+      </extension>
+    </jenkins.plugins.git.traits.CleanAfterCheckoutTrait>
+    <jenkins.plugins.git.traits.CleanBeforeCheckoutTrait>
+      <extension class="hudson.plugins.git.extensions.impl.CleanBeforeCheckout">
+        <deleteUntrackedNestedRepositories>true</deleteUntrackedNestedRepositories>
+      </extension>
+    </jenkins.plugins.git.traits.CleanBeforeCheckoutTrait>
+  </traits>
+</jenkins.plugins.git.GitSCMSource>

--- a/src/test/resources/jenkins/plugins/git/GitSCMSourceTraitsTest/pimpped_out.xml
+++ b/src/test/resources/jenkins/plugins/git/GitSCMSourceTraitsTest/pimpped_out.xml
@@ -45,8 +45,12 @@
     <hudson.plugins.git.extensions.impl.LocalBranch>
       <localBranch>**</localBranch>
     </hudson.plugins.git.extensions.impl.LocalBranch>
-    <hudson.plugins.git.extensions.impl.CleanCheckout/>
-    <hudson.plugins.git.extensions.impl.CleanBeforeCheckout/>
+    <hudson.plugins.git.extensions.impl.CleanCheckout>
+      <deleteUntrackedNestedRepositories>true</deleteUntrackedNestedRepositories>
+    </hudson.plugins.git.extensions.impl.CleanCheckout>
+    <hudson.plugins.git.extensions.impl.CleanBeforeCheckout>
+      <deleteUntrackedNestedRepositories>true</deleteUntrackedNestedRepositories>
+    </hudson.plugins.git.extensions.impl.CleanBeforeCheckout>
     <hudson.plugins.git.extensions.impl.PerBuildTag/>
     <hudson.plugins.git.extensions.impl.ScmName>
       <name>irrelevant</name>


### PR DESCRIPTION
[JENKINS-26660](https://issues.jenkins-ci.org/browse/JENKINS-26660) - add UI for cleaning of nested repositories/submodules

This PR exposes functionality created in jenkinsci/git-client-plugin#222 to Jenkins UI so it is possible to actually use it.

![image](https://user-images.githubusercontent.com/92637/69475939-4afcaf80-0de4-11ea-942e-13397ec4b244.png)

#449 attempted to do the same thing but was closed for various reasons.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] New feature (~non~-breaking change which adds functionality)
