### PR TITLE
[JENKINS-60267] Document limitations of git step

### DIFF
--- a/src/main/resources/jenkins/plugins/git/GitStep/help-branch.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help-branch.html
@@ -1,0 +1,11 @@
+<div>
+    <p>
+    Branch to be checked out in the workspace.  Default is the remote repository's default branch (typically '<code>master</code>').
+    </p>
+    <p>
+    Note that this must be a local branch name like 'master' or 'develop' or a tag name.
+    Remote branch names like 'origin/master' and 'origin/develop' are <b>not supported</b> as the branch argument.
+    SHA-1 hashes are <b>not supported</b> as the branch argument.
+    Remote branch names and SHA-1 hashes are supported by the general purpose <code>checkout</code> step.
+    </p>
+</div>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help-changelog.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help-changelog.html
@@ -1,0 +1,9 @@
+<div>
+    <p>
+    Compute changelog for this job. Default is '<code>true</code>'.
+    </p>
+    <p>
+    If <code>changelog</code> is false, then the changelog will not be computed for this job.
+    If <code>changelog</code> is true or is not set, then the changelog will be computed.
+    </p>
+</div>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help-credentialsId.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help-credentialsId.html
@@ -1,0 +1,9 @@
+<div>
+    <p>
+    Identifier of the credential used to access the remote git repository.  Default is '&lt;empty&gt;'.
+    </p>
+    <p>
+    The credential must be a private key credential if the remote git repository is accessed with the ssh protocol.
+    The credential must be a username / password credential if the remote git repository is accessed with http or https protocol.
+    </p>
+</div>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help-poll.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help-poll.html
@@ -1,0 +1,9 @@
+<div>
+    <p>
+    Poll remote repository for changes. Default is '<code>true</code>'.
+    </p>
+    <p>
+    If <code>poll</code> is false, then the remote repository will not be polled for changes.
+    If <code>poll</code> is true or is not set, then the remote repository will be polled for changes.
+    </p>
+</div>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help-url.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help-url.html
@@ -1,0 +1,10 @@
+<div>
+    <p>
+    URL of the repository to be checked out in the workspace.  Required parameter.
+    </p>
+    <p>
+    Repository URL's should follow the <a href="https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a">git URL guidelines</a>.
+    Git steps to access a secured repository should provide a Jenkins credential with the <code>credentialsId</code> argument rather than embedding credentials in the URL.
+    Credentials embedded in a repository URL may be visible in console logs or in other log files.
+    </p>
+</div>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help.html
@@ -4,8 +4,28 @@
     </p>
     <p>
     Note that this step is shorthand for the generic SCM step:<pre>
-checkout([$class: 'GitSCM', branches: [[name: '*/master']], 
+checkout([$class: 'GitSCM', branches: [[name: '*/master']],
      userRemoteConfigs: [[url: 'http://git-server/user/repository.git']]])
     </pre>
+    The <code>checkout</code> step is the preferred step for SCM checkout.
+    The <code>checkout</code> step provides significantly more functionality and can be used in many cases where the <code>git</code> step cannot be used.
+    For example, the <code>git</code> step does <b>not</b> support:
+    <ul>
+      <li>SHA-1 checkout</li>
+      <li>Tag checkout</li>
+      <li>Submodule checkout</li>
+      <li>Sparse checkout</li>
+      <li>Large file checkout (LFS)</li>
+      <li>Branch merges</li>
+      <li>Repository tagging</li>
+      <li>Reference repositories</li>
+      <!-- Less commonly used features that are also not supported by the git step -->
+      <!--
+      <li>Custom refspecs</li>
+      <li>Timeout configuration</li>
+      <li>Changelog calculation against a non-default reference</li>
+      <li>Stale branch pruning</li>
+      -->
+    </ul>
     </p>
 </div>


### PR DESCRIPTION
## [JENKINS-60267](https://issues.jenkins-ci.org/browse/JENKINS-60267)  Document limitations of git step

This git step is a limited functionality shorthand for a portion of the generic SCM step.

The checkout step is the preferred step for SCM checkout.

The checkout step provides significantly more functionality and can be used in many cases where the git step cannot be used.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)