### PR TITLE
Fix repository leak in AbstractGitSCMSource.retrieve

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -573,8 +573,8 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                     remoteReferences = Collections.emptyMap();
                 }
                 fetch.execute();
-                final Repository repository = client.getRepository();
-                try (RevWalk walk = new RevWalk(repository);
+                try (Repository repository = client.getRepository();
+                     RevWalk walk = new RevWalk(repository);
                      GitSCMSourceRequest request = context.newRequest(AbstractGitSCMSource.this, listener)) {
 
                     if (context.wantBranches()) {


### PR DESCRIPTION
This bug is detected by AbstractGitSCMSourceTest.when_commits_added_during_discovery_we_do_not_crash to if run against newer JTH.
## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Tests verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
