### PR TITLE
Don't use pre-sized arrays on array conversion

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -278,7 +278,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
             List<RefSpec> rs = new ArrayList<>();
             rs.add(new RefSpec("+refs/heads/*:refs/remotes/origin/*"));
-            remoteRepositories.add(newRemoteConfig("origin", source, rs.toArray(new RefSpec[rs.size()])));
+            remoteRepositories.add(newRemoteConfig("origin", source, rs.toArray(new RefSpec[0])));
             if (branch != null) {
                 branches.add(new BranchSpec(branch));
             } else {
@@ -504,7 +504,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     	return newRemoteConfig(
                 getParameterString(remoteRepository.getName(), env),
                 getParameterString(remoteRepository.getURIs().get(0).toPrivateString(), env),
-                refSpecs.toArray(new RefSpec[refSpecs.size()]));
+                refSpecs.toArray(new RefSpec[0]));
     }
 
     public RemoteConfig getRepositoryByName(String repoName) {

--- a/src/main/java/hudson/plugins/git/RemoteConfigConverter.java
+++ b/src/main/java/hudson/plugins/git/RemoteConfigConverter.java
@@ -93,13 +93,13 @@ public class RemoteConfigConverter implements Converter {
                 if (null != key)
                     switch (key) {
                     case KEY_URL:
-                        uris = values.toArray(new String[values.size()]);
+                        uris = values.toArray(new String[0]);
                         break;
                     case KEY_FETCH:
-                        fetch = values.toArray(new String[values.size()]);
+                        fetch = values.toArray(new String[0]);
                         break;
                     case KEY_PUSH:
-                        push = values.toArray(new String[values.size()]);
+                        push = values.toArray(new String[0]);
                         break;
                     case KEY_UPLOADPACK:
                         for (String value : values)

--- a/src/main/java/hudson/plugins/git/SubmoduleConfig.java
+++ b/src/main/java/hudson/plugins/git/SubmoduleConfig.java
@@ -27,7 +27,7 @@ public class SubmoduleConfig implements java.io.Serializable {
     public SubmoduleConfig(String submoduleName, Collection<String> branches) {
         this.submoduleName = submoduleName;
         if (CollectionUtils.isNotEmpty(branches)) {
-            this.branches = branches.toArray(new String[branches.size()]);
+            this.branches = branches.toArray(new String[0]);
         }
     }
 

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -275,7 +275,7 @@ public class GitSCMSource extends AbstractGitSCMSource {
                     }
                 }
                 if (!templates.isEmpty()) {
-                    return new RefSpecsSCMSourceTrait(templates.toArray(new String[templates.size()]));
+                    return new RefSpecsSCMSourceTrait(templates.toArray(new String[0]));
                 }
             }
         }


### PR DESCRIPTION
On modern JVMs using an empty array is faster and even simpler to use:
https://shipilev.net/blog/2016/arrays-wisdom-ancients/