### PR TITLE
Avoid cleanup failures in GitStatusTest & GitSCMTest 

### DIFF
--- a/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
@@ -247,7 +247,6 @@ public abstract class AbstractGitTestCase {
 
     protected FreeStyleBuild build(final FreeStyleProject project, final Result expectedResult, final String...expectedNewlyCommittedFiles) throws Exception {
         final FreeStyleBuild build = project.scheduleBuild2(0).get();
-        System.out.println(build.getLog());
         for(final String expectedNewlyCommittedFile : expectedNewlyCommittedFiles) {
             assertTrue(expectedNewlyCommittedFile + " file not found in workspace", build.getWorkspace().child(expectedNewlyCommittedFile).exists());
         }
@@ -259,7 +258,6 @@ public abstract class AbstractGitTestCase {
 
     protected FreeStyleBuild build(final FreeStyleProject project, final String parentDir, final Result expectedResult, final String...expectedNewlyCommittedFiles) throws Exception {
         final FreeStyleBuild build = project.scheduleBuild2(0).get();
-        System.out.println(build.getLog());
         for(final String expectedNewlyCommittedFile : expectedNewlyCommittedFiles) {
             assertTrue(build.getWorkspace().child(parentDir).child(expectedNewlyCommittedFile).exists());
         }
@@ -271,7 +269,6 @@ public abstract class AbstractGitTestCase {
     
     protected MatrixBuild build(final MatrixProject project, final Result expectedResult, final String...expectedNewlyCommittedFiles) throws Exception {
         final MatrixBuild build = project.scheduleBuild2(0).get();
-        System.out.println(build.getLog());
         for(final String expectedNewlyCommittedFile : expectedNewlyCommittedFiles) {
             assertTrue(expectedNewlyCommittedFile + " file not found in workspace", build.getWorkspace().child(expectedNewlyCommittedFile).exists());
         }
@@ -310,15 +307,6 @@ public abstract class AbstractGitTestCase {
                 }
 
             });
-    }
-
-    /* A utility method that displays a git repo. Useful to visualise merges. */
-    public void showRepo(TestGitRepo repo, String msg) throws Exception {
-        System.out.println("*********** "+msg+" ***********");
-        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            int returnCode = new Launcher.LocalLauncher(listener).launch().cmds("git", "log","--all","--graph","--decorate","--oneline").pwd(repo.gitDir.getCanonicalPath()).stdout(out).join();
-            System.out.println(out.toString());
-        }
     }
 
     public static class HasCredentialBuilder extends Builder {

--- a/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
@@ -78,7 +78,6 @@ public class CredentialsUserRemoteConfigTest {
                         + "  )"
                         + "}"));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        System.out.println(JenkinsRule.getLog(b));
         r.assertLogContains("Warning: CredentialId \"github\" could not be found", b);
     }
 
@@ -115,7 +114,6 @@ public class CredentialsUserRemoteConfigTest {
                         + "  )"
                         + "}"));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        System.out.println(JenkinsRule.getLog(b));
         r.assertLogContains("Warning: CredentialId \"github\" could not be found", b);
     }
 
@@ -133,7 +131,6 @@ public class CredentialsUserRemoteConfigTest {
                         + "  )"
                         + "}"));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        System.out.println(JenkinsRule.getLog(b));
         r.assertLogContains("No credentials specified", b);
     }
 

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -533,6 +534,7 @@ public class GitStatusTest extends AbstractGitProject {
     }
 
     private void doNotifyCommitWithDefaultParameter(final boolean allowed, String safeParameters) throws Exception {
+        assumeTrue(runUnreliableTests()); // Test cleanup is unreliable in some cases
         if (allowed) {
             GitStatus.setAllowNotifyCommitParameters(true);
         }
@@ -574,6 +576,18 @@ public class GitStatusTest extends AbstractGitProject {
                 + (allowedExtra ? "extra='" + extraValue + "'," : "")
                 + "A='aaa',C='ccc',B='$A$C'";
         assertEquals(expected, this.gitStatus.toString());
+    }
+
+    /** Returns true if unreliable tests should be run */
+    private boolean runUnreliableTests() {
+        if (!isWindows()) {
+            return true; // Always run tests on non-Windows platforms
+        }
+        String jobUrl = System.getenv("JOB_URL");
+        if (jobUrl == null) {
+            return true; // Always run tests when not inside a CI environment
+        }
+        return !jobUrl.contains("ci.jenkins.io"); // Skip some tests on ci.jenkins.io, windows cleanup is unreliable on those machines
     }
 
     /**


### PR DESCRIPTION
## Avoid cleanup failures in GitStatusTest & GitSCMTest 

GitSCMTest and GitStatusTest both fail intermittently on ci.jenkins.io Windows computers.  The failures are due to a busy log file or a busy job directory.  The failures are **not** due to busy git files or busy git directories.  I assume some component is holding a file open at that point in the test.

Rather than spend significant time trying to find the component of JenkinsRule that is holding the build log open, it is simpler to use a "sleep" variant in one test and to skip the tests on the ci.jenkins.io Windows computers in the other test.

Tests continue to execute when run by developers.  Tests continue to execute in my Windows and Linux and FreeBSD test environment.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency or infrastructure update