### PR TITLE
[JENKINS-60617] Include git step examples

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -413,7 +413,7 @@ Excluded Users::
   If set and Jenkins is configured to poll for changes, Jenkins will ignore any revisions committed by users in this list when determining if a build should be triggered.
   This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct SCM user.
   Using this behaviour prevents the faster `git ls-remote` polling mechanism.
-  It forces polling to require a workspace, as if you had selected the xxxx Force polling using workspace extension.
+  It forces polling to require a workspace, as if you had selected the <<force-polling-using-workspace,Force polling using workspace>> extension.
 
   Each exclusion uses literal pattern matching, and must be separated by a new line.
 
@@ -422,9 +422,9 @@ Excluded Users::
 
 If set and Jenkins is configured to poll for changes, Jenkins will pay attention to included and/or excluded files and/or folders when determining if a build needs to be triggered.
 
-Using this behaviour will preclude the faster remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the Force polling using workspace extension as well.
+Using this behaviour will preclude the faster remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <<force-polling-using-workspace,Force polling using workspace>> extension as well.
 This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct SCM user.
-Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace, as if you had selected the Force polling using workspace extension as well.
+Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace, as if you had selected the <<force-polling-using-workspace,Force polling using workspace>> extension as well.
 
 Included Regions::
 

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,18 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <!-- Exclude JTH dependency commons-net - otherwise it is included in hpi file as a transient dependency -->
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help.html
@@ -3,12 +3,36 @@
     Git step. It performs a clone from the specified repository.
     </p>
     <p>
-    Note that this step is shorthand for the generic SCM step:<pre>
+    Use the <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> to generate a sample pipeline script for the git step.
+    More advanced checkout operations require the <code>checkout</code> step rather than the <code>git</code> step.
+    Examples of the <code>git</code> step include:
+    <ul>
+      <li><a href="#git-step-with-defaults">Git step with defaults</a></li>
+      <li><a href="#git-step-with-https-and-branch">Git step with https and a specific branch</a></li>
+      <li><a href="#git-step-with-ssh-and-credential">Git step with ssh and a private key credential</a></li>
+      <li><a href="#git-step-with-https-and-changelog">Git step with https and changelog disabled</a></li>
+      <li><a href="#git-step-with-git-and-polling">Git step with git protocol and polling disabled</a></li>
+    </ul>
+    </p>
+
+    <p>
+    The <code>git</code> step is a simplified shorthand for a subset of the more powerful <code>checkout</code> step:
+<pre>
 checkout([$class: 'GitSCM', branches: [[name: '*/master']],
-     userRemoteConfigs: [[url: 'http://git-server/user/repository.git']]])
-    </pre>
-    The <code>checkout</code> step is the preferred step for SCM checkout.
-    The <code>checkout</code> step provides significantly more functionality and can be used in many cases where the <code>git</code> step cannot be used.
+    userRemoteConfigs: [[url: 'http://git-server/user/repository.git']]])
+</pre>
+    </p>
+
+    <hr>
+
+    <p>
+    <strong>NOTE:</strong> The <code>checkout</code> step is the <strong>preferred SCM checkout method</strong>.
+    It provides significantly more functionality than the <code>git</code> step.
+    </p>
+    <p>Use the <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> to generate a sample pipeline script for the checkout step.
+    </p>
+    <p>
+    The <code>checkout</code> step can be used in many cases where the <code>git</code> step cannot be used.
     For example, the <code>git</code> step does <strong>not</strong> support:
     <ul>
       <li>SHA-1 checkout</li>
@@ -16,9 +40,9 @@ checkout([$class: 'GitSCM', branches: [[name: '*/master']],
       <li>Submodule checkout</li>
       <li>Sparse checkout</li>
       <li>Large file checkout (LFS)</li>
+      <li>Reference repositories</li>
       <li>Branch merges</li>
       <li>Repository tagging</li>
-      <li>Reference repositories</li>
       <!-- Less commonly used features that are also not supported by the git step -->
       <!--
       <li>Custom refspecs</li>
@@ -28,4 +52,54 @@ checkout([$class: 'GitSCM', branches: [[name: '*/master']],
       -->
     </ul>
     </p>
+
+    <hr>
+
+    <strong><a name="git-step-with-defaults">Example: Git step with defaults</a></strong>
+    <p>
+    Checkout from the git plugin source repository using https protocol, no credentials, and the master branch.
+    </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
+<pre>
+git 'https://github.com/jenkinsci/git-plugin'
+</pre>
+    </p>
+
+    <strong><a name="git-step-with-https-and-branch">Example: Git step with https and a specific branch</a></strong>
+    <p>
+    Checkout from the Jenkins source repository using https protocol, no credentials, and a specific branch (stable-2.204).
+    </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
+<pre>
+git branch: 'stable-2.204', url: 'https://github.com/jenkinsci/jenkins.git'
+</pre>
+    </p>
+
+    <strong><a name="git-step-with-ssh-and-credential">Example: Git step with ssh and a private key credential</a></strong>
+    <p>
+    Checkout from the git client plugin source repository using ssh protocol, private key credentials, and the master branch.
+    </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
+<pre>
+git credentialsId: 'my-private-key-credential-id', url: 'git@github.com:jenkinsci/git-client-plugin.git'
+</pre>
+    </p>
+
+    <strong><a name="git-step-with-https-and-changelog">Example: Git step with https and changelog disabled</a></strong>
+    <p>
+    Checkout from the Jenkins source repository using https protocol, no credentials, the master branch, and changelog calculation disabled.
+    See the <a href="https://github.com/jenkinsci/workflow-scm-step-plugin/blob/master/README.md#changelogs">workflow scm step documentation</a> for more changelog details.
+    </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
+<pre>
+git changelog: false, url: 'https://github.com/jenkinsci/credentials-plugin.git'
+</pre>
+    </p>
+
+    <strong><a name="git-step-with-git-and-polling">Example: Git step with git protocol and polling disabled</a></strong>
+    <p>
+    Checkout from the Jenkins platform labeler repository using git protocol, no credentials, the master branch, and no polling for changes.
+    See the <a href="https://github.com/jenkinsci/workflow-scm-step-plugin/blob/master/README.md#polling">workflow scm step documentation</a> for more polling details.
+    </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
+<pre>
+git poll: false, url: 'git://github.com/jenkinsci/platformlabeler-plugin.git'
+</pre>
+    </p>
+
 </div>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help.html
@@ -74,7 +74,8 @@ git 'https://github.com/jenkinsci/git-plugin'
     Remote branch names and SHA-1 hashes <strong>are supported</strong> by the general purpose <code>checkout</code> step.
     </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
-git branch: 'stable-2.204', url: 'https://github.com/jenkinsci/jenkins.git'
+git branch: 'stable-2.204',
+    url: 'https://github.com/jenkinsci/jenkins.git'
 </pre>
     </p>
 
@@ -85,7 +86,8 @@ git branch: 'stable-2.204', url: 'https://github.com/jenkinsci/jenkins.git'
     The credential must be a username / password credential if the remote git repository is accessed with http or https protocol.
     </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
-git credentialsId: 'my-private-key-credential-id', url: 'git@github.com:jenkinsci/git-client-plugin.git'
+git credentialsId: 'my-private-key-credential-id',
+    url: 'git@github.com:jenkinsci/git-client-plugin.git'
 </pre>
     </p>
 
@@ -97,7 +99,8 @@ git credentialsId: 'my-private-key-credential-id', url: 'git@github.com:jenkinsc
     See the <a href="https://github.com/jenkinsci/workflow-scm-step-plugin/blob/master/README.md#changelogs">workflow scm step documentation</a> for more changelog details.
     </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
-git changelog: false, url: 'https://github.com/jenkinsci/credentials-plugin.git'
+git changelog: false,
+    url: 'https://github.com/jenkinsci/credentials-plugin.git'
 </pre>
     </p>
 
@@ -109,7 +112,8 @@ git changelog: false, url: 'https://github.com/jenkinsci/credentials-plugin.git'
     See the <a href="https://github.com/jenkinsci/workflow-scm-step-plugin/blob/master/README.md#polling">workflow scm step documentation</a> for more polling details.
     </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
-git poll: false, url: 'git://github.com/jenkinsci/platformlabeler-plugin.git'
+git poll: false,
+    url: 'git://github.com/jenkinsci/platformlabeler-plugin.git'
 </pre>
     </p>
 

--- a/src/main/resources/jenkins/plugins/git/GitStep/help.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help.html
@@ -68,6 +68,10 @@ git 'https://github.com/jenkinsci/git-plugin'
     <strong><a name="git-step-with-https-and-branch">Example: Git step with https and a specific branch</a></strong>
     <p>
     Checkout from the Jenkins source repository using https protocol, no credentials, and a specific branch (stable-2.204).
+    Note that this must be a local branch name like 'master' or 'develop' or a tag name.
+    Remote branch names like 'origin/master' and 'origin/develop' are <strong>not supported</strong> as the branch argument.
+    SHA-1 hashes are <strong>not supported</strong> as the branch argument.
+    Remote branch names and SHA-1 hashes <strong>are supported</strong> by the general purpose <code>checkout</code> step.
     </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
 git branch: 'stable-2.204', url: 'https://github.com/jenkinsci/jenkins.git'
@@ -77,6 +81,8 @@ git branch: 'stable-2.204', url: 'https://github.com/jenkinsci/jenkins.git'
     <strong><a name="git-step-with-ssh-and-credential">Example: Git step with ssh and a private key credential</a></strong>
     <p>
     Checkout from the git client plugin source repository using ssh protocol, private key credentials, and the master branch.
+    The credential must be a private key credential if the remote git repository is accessed with the ssh protocol.
+    The credential must be a username / password credential if the remote git repository is accessed with http or https protocol.
     </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
 git credentialsId: 'my-private-key-credential-id', url: 'git@github.com:jenkinsci/git-client-plugin.git'
@@ -86,6 +92,8 @@ git credentialsId: 'my-private-key-credential-id', url: 'git@github.com:jenkinsc
     <strong><a name="git-step-with-https-and-changelog">Example: Git step with https and changelog disabled</a></strong>
     <p>
     Checkout from the Jenkins source repository using https protocol, no credentials, the master branch, and changelog calculation disabled.
+    If changelog is <code>false</code>, then the changelog will not be computed for this job.
+    If changelog is <code>true</code> or is not set, then the changelog will be computed.
     See the <a href="https://github.com/jenkinsci/workflow-scm-step-plugin/blob/master/README.md#changelogs">workflow scm step documentation</a> for more changelog details.
     </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
@@ -96,6 +104,8 @@ git changelog: false, url: 'https://github.com/jenkinsci/credentials-plugin.git'
     <strong><a name="git-step-with-git-and-polling">Example: Git step with git protocol and polling disabled</a></strong>
     <p>
     Checkout from the Jenkins platform labeler repository using git protocol, no credentials, the master branch, and no polling for changes.
+    If poll is <code>false</code>, then the remote repository will not be polled for changes.
+    If poll is <code>true</code> or is not set, then the remote repository will be polled for changes.
     See the <a href="https://github.com/jenkinsci/workflow-scm-step-plugin/blob/master/README.md#polling">workflow scm step documentation</a> for more polling details.
     </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help.html
@@ -33,6 +33,7 @@ checkout([$class: 'GitSCM', branches: [[name: '*/master']],
     </p>
     <p>
     The <code>checkout</code> step can be used in many cases where the <code>git</code> step cannot be used.
+    Refer to the <a href="https://plugins.jenkins.io/git#extensions">git plugin documentation</a> for detailed descriptions of options available to the checkout step.
     For example, the <code>git</code> step does <strong>not</strong> support:
     <ul>
       <li>SHA-1 checkout</li>


### PR DESCRIPTION
## [JENKINS-60617](https://issues.jenkins-ci.org/browse/JENKINS-60617) - Include git step examples

This page is displayed at https://jenkins.io/doc/pipeline/steps/git/. That page has received the most negative reviews of any page on https://jenkins.io/ .  The most frequently requested enhancement for the page is to include examples.  This change includes examples.  

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

This file is displayed as help for the git step when using the pipeline syntax generator.

A high frequency complaint is that the git step is missing functionality.  That will not change.

The checkout step is the replacement for the git step.  The checkout step provides all the functionality of the git step and all the functionality available from the git plugin. It is more maintainable and better prepared for use in realistic pipelines.

This page also includes strong guidance to use the checkout step.