### PR TITLE
[JENKINS-59868] Add information about missing working directory to Polling logs

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -763,6 +763,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         // (Re)build if the working directory doesn't exist
         if (workingDirectory == null || !workingDirectory.exists()) {
+            listener.getLogger().println("[poll] Working Directory does not exist");
             return BUILD_NOW;
         }
 


### PR DESCRIPTION
## [JENKINS-59868](https://issues.jenkins-ci.org/browse/JENKINS-59868) - Improve logging details in cases where the working directory does not exist. 

The polling log should print the reason why the GitSCM decides to trigger a build. In that particular case, nothing useful is logged and one can spend a lot of time trying to understand what causes a build.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
