### PR TITLE
[JENKINS-60574] Fix InjectedTest hang from JTH 2.57

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,10 @@
     <forkCount>1</forkCount>
     <linkXRef>false</linkXRef>
     <configuration-as-code.version>1.35</configuration-as-code.version>
-  </properties>
+   <!-- Fix InjectedTest hang on multi-core machines and InjectedTest failures on ci.jenkins.io -->
+    <!-- Remove when parent pom 3.56 is used -->
+    <jenkins-test-harness.version>2.60</jenkins-test-harness.version>
+   </properties>
 
   <build>
     <plugins>
@@ -205,6 +208,12 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps-global-lib</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>


### PR DESCRIPTION
## [JENKINS-60574](https://issues.jenkins-ci.org/browse/JENKINS-60574) - Fix InjectedTest hang from JTH 2.57

Use JTH 2.60 instead of 2.57 to resolve test failures and test hangs on multi-core machines.

* See [JENKINS-60574](https://issues.jenkins-ci.org/browse/JENKINS-60754)
* See [JENKINS-60694](https://issues.jenkins-ci.org/browse/JENKINS-60694)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update