### PR TITLE
Use parent pom 3.56 to fix JTH test issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.55</version>
+    <version>3.56</version>
     <relativePath />
   </parent>
 
@@ -31,13 +31,10 @@
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
-    <forkCount>1</forkCount>
+    <forkCount>1C</forkCount>
     <linkXRef>false</linkXRef>
     <configuration-as-code.version>1.35</configuration-as-code.version>
-   <!-- Fix InjectedTest hang on multi-core machines and InjectedTest failures on ci.jenkins.io -->
-    <!-- Remove when parent pom 3.56 is used -->
-    <jenkins-test-harness.version>2.60</jenkins-test-harness.version>
-   </properties>
+  </properties>
 
   <build>
     <plugins>


### PR DESCRIPTION
## Use parent pom 3.56 to fix JTH test issue

Now allowed to run parallel tests on multi-core machines without hanging.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update