### PR TITLE
[JENKINS-42860] Whitelist pipeline safe getters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,10 @@
       <artifactId>scm-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
     </dependency>
@@ -119,11 +123,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>script-security</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/plugins/git/BranchSpec.java
+++ b/src/main/java/hudson/plugins/git/BranchSpec.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -38,6 +39,7 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
     private String name;
 
     @Exported
+    @Whitelisted
     public String getName() {
         return name;
     }

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -73,6 +73,7 @@ import org.jenkinsci.plugins.gitclient.CloneCommand;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
@@ -161,6 +162,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     @SuppressFBWarnings(value="SE_BAD_FIELD", justification="Known non-serializable field")
     private DescribableList<GitSCMExtension,GitSCMExtensionDescriptor> extensions;
 
+    @Whitelisted
     public Collection<SubmoduleConfig> getSubmoduleCfg() {
         return submoduleCfg;
     }
@@ -236,6 +238,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
      *
      * @since 2.0
      */
+    @Whitelisted
     public DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> getExtensions() {
         return extensions;
     }
@@ -347,6 +350,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     }
 
     @Override
+    @Whitelisted
     public GitRepositoryBrowser getBrowser() {
         return browser;
     }
@@ -429,6 +433,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return (gitDescriptor != null && gitDescriptor.isUseExistingAccountWithSameEmail());
     }
 
+    @Whitelisted
     public BuildChooser getBuildChooser() {
         BuildChooser bc;
 
@@ -518,6 +523,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     }
 
     @Exported
+    @Whitelisted
     public List<UserRemoteConfig> getUserRemoteConfigs() {
         if (userRemoteConfigs == null) {
             /* Prevent NPE when no remote config defined */
@@ -526,6 +532,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return Collections.unmodifiableList(userRemoteConfigs);
     }
 
+    @Whitelisted
     public List<RemoteConfig> getRepositories() {
         // Handle null-value to ensure backwards-compatibility, ie project configuration missing the <repositories/> XML element
         if (remoteRepositories == null) {
@@ -570,6 +577,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     }
 
     @CheckForNull
+    @Whitelisted
     public String getGitTool() {
         return gitTool;
     }
@@ -1694,11 +1702,13 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
     private static final long serialVersionUID = 1L;
 
+    @Whitelisted
     public boolean isDoGenerateSubmoduleConfigurations() {
         return this.doGenerateSubmoduleConfigurations;
     }
 
     @Exported
+    @Whitelisted
     public List<BranchSpec> getBranches() {
         return branches;
     }

--- a/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
+++ b/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
@@ -17,6 +17,7 @@ import java.io.Serializable;
 import java.util.Set;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 /**
  * This is a portion of {@link GitSCM} for the stuff that's used to be in {@link GitSCM}
@@ -178,6 +179,7 @@ public abstract class GitSCMBackwardCompatibility extends SCM implements Seriali
     private transient BuildChooser buildChooser;
 
 
+    @Whitelisted
     abstract DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> getExtensions();
 
     @Override

--- a/src/main/java/hudson/plugins/git/SubmoduleConfig.java
+++ b/src/main/java/hudson/plugins/git/SubmoduleConfig.java
@@ -2,6 +2,7 @@ package hudson.plugins.git;
 
 import com.google.common.base.Joiner;
 import org.apache.commons.collections.CollectionUtils;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Arrays;
@@ -31,6 +32,7 @@ public class SubmoduleConfig implements java.io.Serializable {
         }
     }
 
+    @Whitelisted
     public String getSubmoduleName() {
         return submoduleName;
     }

--- a/src/main/java/hudson/plugins/git/UserMergeOptions.java
+++ b/src/main/java/hudson/plugins/git/UserMergeOptions.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.structs.describable.CustomDescribableModel;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -70,6 +71,7 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
      * Repository name, such as 'origin' that designates which repository the branch lives in.
      * @return repository name
      */
+    @Whitelisted
     public String getMergeRemote() {
         return mergeRemote;
     }
@@ -84,6 +86,7 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
      * Normally a branch name like 'master'.
      * @return branch name from which merge will be performed
      */
+    @Whitelisted
     public String getMergeTarget() {
         return mergeTarget;
     }

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -39,6 +39,7 @@ import org.apache.commons.lang.StringUtils;
 import static hudson.Util.fixEmpty;
 import static hudson.Util.fixEmptyAndTrim;
 import hudson.model.FreeStyleProject;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 @ExportedBean
@@ -58,27 +59,32 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
     }
 
     @Exported
+    @Whitelisted
     public String getName() {
         return name;
     }
 
     @Exported
+    @Whitelisted
     public String getRefspec() {
         return refspec;
     }
 
     @Exported
     @CheckForNull
+    @Whitelisted
     public String getUrl() {
         return url;
     }
 
     @Exported
+    @Whitelisted
     @CheckForNull
     public String getCredentialsId() {
         return credentialsId;
     }
 
+    @Override
     public String toString() {
         return getRefspec() + " => " + getUrl() + " (" + getName() + ")";
     }

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -21,6 +21,7 @@ import org.eclipse.jgit.transport.RemoteConfig;
 import org.jenkinsci.plugins.gitclient.CloneCommand;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -48,10 +49,12 @@ public class CloneOption extends GitSCMExtension {
         this.honorRefspec = false;
     }
 
+    @Whitelisted
     public boolean isShallow() {
         return shallow;
     }
 
+    @Whitelisted
     public boolean isNoTags() {
         return noTags;
     }
@@ -94,14 +97,17 @@ public class CloneOption extends GitSCMExtension {
      *
      * @return true if initial clone will honor the user defined refspec
      */
+    @Whitelisted
     public boolean isHonorRefspec() {
         return honorRefspec;
     }
 
+    @Whitelisted
     public String getReference() {
         return reference;
     }
 
+    @Whitelisted
     public Integer getTimeout() {
         return timeout;
     }
@@ -111,6 +117,7 @@ public class CloneOption extends GitSCMExtension {
         this.depth = depth;
     }
 
+    @Whitelisted
     public Integer getDepth() {
         return depth;
     }

--- a/src/main/java/hudson/plugins/git/extensions/impl/LocalBranch.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/LocalBranch.java
@@ -7,6 +7,7 @@ import hudson.plugins.git.Messages;
 import hudson.plugins.git.extensions.FakeGitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import java.util.Objects;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -28,6 +29,7 @@ public class LocalBranch extends FakeGitSCMExtension {
     }
 
     @CheckForNull
+    @Whitelisted
     public String getLocalBranch() {
         return localBranch;
     }

--- a/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
@@ -18,6 +18,7 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.gitclient.CheckoutCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
@@ -47,6 +48,7 @@ public class PreBuildMerge extends GitSCMExtension {
         this.options = options;
     }
 
+    @Whitelisted
     public UserMergeOptions getOptions() {
         return options;
     }

--- a/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPath.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPath.java
@@ -5,6 +5,7 @@ import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.Serializable;
@@ -23,6 +24,7 @@ public class SparseCheckoutPath extends AbstractDescribableImpl<SparseCheckoutPa
         this.path = path;
     }
 
+    @Whitelisted
     public String getPath() {
         return path;
     }

--- a/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPaths.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPaths.java
@@ -11,6 +11,7 @@ import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import org.jenkinsci.plugins.gitclient.CheckoutCommand;
 import org.jenkinsci.plugins.gitclient.CloneCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
@@ -26,6 +27,7 @@ public class SparseCheckoutPaths extends GitSCMExtension {
         this.sparseCheckoutPaths = sparseCheckoutPaths == null ? Collections.<SparseCheckoutPath>emptyList() : sparseCheckoutPaths;
     }
 
+    @Whitelisted
     public List<SparseCheckoutPath> getSparseCheckoutPaths() {
         return sparseCheckoutPaths;
     }

--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.Objects;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -59,26 +60,32 @@ public class SubmoduleOption extends GitSCMExtension {
         this.timeout = timeout;
     }
 
+    @Whitelisted
     public boolean isDisableSubmodules() {
         return disableSubmodules;
     }
 
+    @Whitelisted
     public boolean isRecursiveSubmodules() {
         return recursiveSubmodules;
     }
 
+    @Whitelisted
     public boolean isTrackingSubmodules() {
         return trackingSubmodules;
     }
 
+    @Whitelisted
     public boolean isParentCredentials() {
         return parentCredentials;
     }
 
+    @Whitelisted
     public String getReference() {
         return reference;
     }
 
+    @Whitelisted
     public Integer getTimeout() {
         return timeout;
     }
@@ -88,6 +95,7 @@ public class SubmoduleOption extends GitSCMExtension {
         this.shallow = shallow;
     }
 
+    @Whitelisted
     public boolean getShallow() {
         return shallow;
     }
@@ -97,10 +105,12 @@ public class SubmoduleOption extends GitSCMExtension {
         this.depth = depth;
     }
 
+    @Whitelisted
     public Integer getDepth() {
         return depth;
     }
 
+    @Whitelisted
     public Integer getThreads() {
         return threads;
     }


### PR DESCRIPTION
## [JENKINS-42860](https://issues.jenkins-ci.org/browse/JENKINS-42860) - Whitelist pipeline safe getters

Pipelines are not allowed to reference plugin fields unless those fields are whitelisted.  Allow plugin access to many fields in the git plugin.

Test automation of this change uses an acceptance test rather than a test included inside this repository. There are suggestions from the community that test automation of a whitelisted method should be feasible, but I didn't want to delay the release of git plugin 4.1.0 for that automation inside the plugin when there is already automation outside the plugin.

See the [acceptance test docker image](https://github.com/MarkEWaite/docker-lfs/tree/lts-with-plugins) and the [acceptance test source code](https://github.com/MarkEWaite/jenkins-bugs/blob/JENKINS-42860/Jenkinsfile) for more details of the test.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.