### PR TITLE
Use docs from tagged release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
   <name>Jenkins Git plugin</name>
-  <description>Integrates Jenkins with GIT SCM</description>
+  <description>Integrates Jenkins with Git SCM</description>
   <!-- Use documentation from tagged release -->
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin/tree/${project.artifactId}-${revision}/README.adoc</url>
   <inceptionYear>2007</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,8 @@
   <packaging>hpi</packaging>
   <name>Jenkins Git plugin</name>
   <description>Integrates Jenkins with GIT SCM</description>
-  <url>https://github.com/jenkinsci/git-plugin/blob/master/README.adoc</url>
+  <!-- Use documentation from tagged release -->
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin/tree/${project.artifactId}-${revision}/README.adoc</url>
   <inceptionYear>2007</inceptionYear>
 
   <properties>


### PR DESCRIPTION
## Use docs from tagged release

Don't use the docs file from the master branch, since it usually contains unreleased content. Special thanks to jenkins.io docs for describing how to do this.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update