### PR TITLE
[JENKINS-38608] Fix to allow null value in 'GIT_URL_n'

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1376,16 +1376,24 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
         }
 
+        /* Check all repository URLs are not empty */
+        /* JENKINS-38608 reports an unhelpful error message when a repository URL is empty */
+        /* Throws an IllegalArgumentException because that exception is thrown by env.put() on a null argument */
+        int repoCount = 1;
+        for (UserRemoteConfig config:userRemoteConfigs) {
+            if (config.getUrl() == null) {
+                throw new IllegalArgumentException("Git repository URL " + repoCount + " is an empty string in job definition. Checkout requires a valid repository URL");
+            }
+            repoCount++;
+        }
 
         if (userRemoteConfigs.size()==1){
             env.put("GIT_URL", userRemoteConfigs.get(0).getUrl());
         } else {
             int count=1;
-            for(UserRemoteConfig config:userRemoteConfigs)   {
-               	if(config.getUrl()!=null) {
-                    env.put("GIT_URL_" + count, config.getUrl());
-                    count++;
-                }
+            for (UserRemoteConfig config:userRemoteConfigs) {
+                env.put("GIT_URL_" + count, config.getUrl());
+                count++;
             }
         }
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1382,10 +1382,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         } else {
             int count=1;
             for(UserRemoteConfig config:userRemoteConfigs)   {
-               	if(config.getUrl()!=null){
-		env.put("GIT_URL_"+count, config.getUrl());
-                count++; 
-		}
+               	if(config.getUrl()!=null) {
+                    env.put("GIT_URL_" + count, config.getUrl());
+                    count++;
+                }
             }
         }
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1382,8 +1382,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         } else {
             int count=1;
             for(UserRemoteConfig config:userRemoteConfigs)   {
-                env.put("GIT_URL_"+count, config.getUrl());
-                count++;
+               	if(config.getUrl()!=null){
+		env.put("GIT_URL_"+count, config.getUrl());
+                count++; 
+		}
             }
         }
 

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -312,6 +312,26 @@ public class GitSCMTest extends AbstractGitTestCase {
         build(projectWithMaster, Result.SUCCESS); /* If clone refspec had been honored, this would fail */
         build(projectWithFoo, Result.SUCCESS, commitFile1);
     }
+    
+    /**
+     * This test confirm the behaviour of not allowing null values as environment variables and hence has been fixed
+     * with a null check. If the second repo is added accidentally but not filled in the text field, the build won't fail.
+     * @throws Exception on error
+     */
+    @Test
+    @Issue("JENKINS-38608")
+    public void testAddSecondRepositoryWithNULLValue() throws Exception{
+        String repoURL = "https://github.com/jenkinsci/git-plugin";
+        List<UserRemoteConfig> repos = new ArrayList<>();
+        repos.add(new UserRemoteConfig(repoURL, null, null, null));
+        repos.add(new UserRemoteConfig(null, null, null, null));
+        FreeStyleProject project = setupProject(repos, Collections.singletonList(new BranchSpec("master")), null, false, null);
+        EnvVars vars = project.getCharacteristicEnvVars();
+        FreeStyleBuild build = build(project, Result.SUCCESS);
+        GitSCM scm = (GitSCM) project.getScm();
+        scm.getExtensions().add(new LocalBranch("master"));
+        scm.buildEnvironment(build, vars);
+    }
 
     @Test
     public void testBranchSpecWithRemotesHierarchical() throws Exception {

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -312,25 +312,51 @@ public class GitSCMTest extends AbstractGitTestCase {
         build(projectWithMaster, Result.SUCCESS); /* If clone refspec had been honored, this would fail */
         build(projectWithFoo, Result.SUCCESS, commitFile1);
     }
-    
+
     /**
-     * This test confirm the behaviour of not allowing null values as environment variables and hence has been fixed
-     * with a null check. If the second repo is added accidentally but not filled in the text field, the build won't fail.
+     * An empty remote repo URL failed the job as expected but provided
+     * a poor diagnostic message. The fix for JENKINS-38608 improves
+     * the error message to be clear and helpful. This test checks for
+     * that error message.
      * @throws Exception on error
      */
     @Test
     @Issue("JENKINS-38608")
-    public void testAddSecondRepositoryWithNULLValue() throws Exception{
-        String repoURL = "https://github.com/jenkinsci/git-plugin";
+    public void testAddFirstRepositoryWithNullRepoURL() throws Exception{
+        List<UserRemoteConfig> repos = new ArrayList<>();
+        repos.add(new UserRemoteConfig(null, null, null, null));
+        FreeStyleProject project = setupProject(repos, Collections.singletonList(new BranchSpec("master")), null, false, null);
+        FreeStyleBuild build = build(project, Result.FAILURE);
+        // Before JENKINS-38608 fix
+        assertFalse("Build log reports 'Null value not allowed'",
+                build.getLog().contains("Null value not allowed as an environment variable: GIT_URL"));
+        // After JENKINS-38608 fix
+        assertTrue("Build log did not report empty string in job definition",
+                build.getLog().contains("Git repository URL 1 is an empty string in job definition. Checkout requires a valid repository URL"));
+    }
+
+    /**
+     * An empty remote repo URL failed the job as expected but provided
+     * a poor diagnostic message. The fix for JENKINS-38608 improves
+     * the error message to be clear and helpful. This test checks for
+     * that error message when the second URL is empty.
+     * @throws Exception on error
+     */
+    @Test
+    @Issue("JENKINS-38608")
+    public void testAddSecondRepositoryWithNullRepoURL() throws Exception{
+        String repoURL = "https://example.com/non-empty/repo/url";
         List<UserRemoteConfig> repos = new ArrayList<>();
         repos.add(new UserRemoteConfig(repoURL, null, null, null));
         repos.add(new UserRemoteConfig(null, null, null, null));
         FreeStyleProject project = setupProject(repos, Collections.singletonList(new BranchSpec("master")), null, false, null);
-        EnvVars vars = project.getCharacteristicEnvVars();
-        FreeStyleBuild build = build(project, Result.SUCCESS);
-        GitSCM scm = (GitSCM) project.getScm();
-        scm.getExtensions().add(new LocalBranch("master"));
-        scm.buildEnvironment(build, vars);
+        FreeStyleBuild build = build(project, Result.FAILURE);
+        // Before JENKINS-38608 fix
+        assertFalse("Build log reports 'Null value not allowed'",
+                build.getLog().contains("Null value not allowed as an environment variable: GIT_URL_2"));
+        // After JENKINS-38608 fix
+        assertTrue("Build log did not report empty string in job definition for URL 2",
+                build.getLog().contains("Git repository URL 2 is an empty string in job definition. Checkout requires a valid repository URL"));
     }
 
     @Test


### PR DESCRIPTION
## [JENKINS-38608](https://issues.jenkins-ci.org/browse/JENKINS-38608)

<img width="1440" alt="Screenshot 2020-01-22 at 1 15 44 AM" src="https://user-images.githubusercontent.com/31189405/72837604-bb289400-3cb4-11ea-97f9-e4bf2b71dab3.png">

The issue belongs to the **Source Code Management section**, whereupon the addition of a secondary repository URL and leaving it empty caused something like this `java.lang.IllegalArgumentException: Null value not allowed as an environment variable: GIT_URL_2`. 


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [x] Bug fix (non-breaking change which fixes an issue)
