### PR TITLE
[JENKINS-38608] Report clearly if the Repo URL is empty

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1392,7 +1392,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         } else {
             int count=1;
             for(UserRemoteConfig config:userRemoteConfigs)   {
-                env.put("GIT_URL_" + count, config.getUrl());
+                env.put("GIT_URL_"+count, config.getUrl());
                 count++;
             }
         }

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1376,16 +1376,24 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
         }
 
+        /* Check all repository URLs are not empty */
+        /* JENKINS-38608 reports an unhelpful error message when a repository URL is empty */
+        /* Throws an IllegalArgumentException because that exception is thrown by env.put() on a null argument */
+        int repoCount = 1;
+        for (UserRemoteConfig config:userRemoteConfigs) {
+            if (config.getUrl() == null) {
+                throw new IllegalArgumentException("Git repository URL " + repoCount + " is an empty string in job definition. Checkout requires a valid repository URL");
+            }
+            repoCount++;
+        }
 
         if (userRemoteConfigs.size()==1){
             env.put("GIT_URL", userRemoteConfigs.get(0).getUrl());
         } else {
             int count=1;
-            for(UserRemoteConfig config:userRemoteConfigs)   {
-               	if(config.getUrl()!=null) {
-                    env.put("GIT_URL_" + count, config.getUrl());
-                    count++;
-                }
+            for (UserRemoteConfig config:userRemoteConfigs) {
+                env.put("GIT_URL_" + count, config.getUrl());
+                count++;
             }
         }
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1382,10 +1382,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         } else {
             int count=1;
             for(UserRemoteConfig config:userRemoteConfigs)   {
-               	if(config.getUrl()!=null){
-		env.put("GIT_URL_"+count, config.getUrl());
-                count++; 
-		}
+               	if(config.getUrl()!=null) {
+                    env.put("GIT_URL_" + count, config.getUrl());
+                    count++;
+                }
             }
         }
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1382,8 +1382,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         } else {
             int count=1;
             for(UserRemoteConfig config:userRemoteConfigs)   {
-                env.put("GIT_URL_"+count, config.getUrl());
-                count++;
+               	if(config.getUrl()!=null){
+		env.put("GIT_URL_"+count, config.getUrl());
+                count++; 
+		}
             }
         }
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1391,7 +1391,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             env.put("GIT_URL", userRemoteConfigs.get(0).getUrl());
         } else {
             int count=1;
-            for (UserRemoteConfig config:userRemoteConfigs) {
+            for(UserRemoteConfig config:userRemoteConfigs)   {
                 env.put("GIT_URL_" + count, config.getUrl());
                 count++;
             }

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -312,6 +312,26 @@ public class GitSCMTest extends AbstractGitTestCase {
         build(projectWithMaster, Result.SUCCESS); /* If clone refspec had been honored, this would fail */
         build(projectWithFoo, Result.SUCCESS, commitFile1);
     }
+    
+    /**
+     * This test confirm the behaviour of not allowing null values as environment variables and hence has been fixed
+     * with a null check. If the second repo is added accidentally but not filled in the text field, the build won't fail.
+     * @throws Exception on error
+     */
+    @Test
+    @Issue("JENKINS-38608")
+    public void testAddSecondRepositoryWithNULLValue() throws Exception{
+        String repoURL = "https://github.com/jenkinsci/git-plugin";
+        List<UserRemoteConfig> repos = new ArrayList<>();
+        repos.add(new UserRemoteConfig(repoURL, null, null, null));
+        repos.add(new UserRemoteConfig(null, null, null, null));
+        FreeStyleProject project = setupProject(repos, Collections.singletonList(new BranchSpec("master")), null, false, null);
+        EnvVars vars = project.getCharacteristicEnvVars();
+        FreeStyleBuild build = build(project, Result.SUCCESS);
+        GitSCM scm = (GitSCM) project.getScm();
+        scm.getExtensions().add(new LocalBranch("master"));
+        scm.buildEnvironment(build, vars);
+    }
 
     @Test
     public void testBranchSpecWithRemotesHierarchical() throws Exception {

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -312,25 +312,51 @@ public class GitSCMTest extends AbstractGitTestCase {
         build(projectWithMaster, Result.SUCCESS); /* If clone refspec had been honored, this would fail */
         build(projectWithFoo, Result.SUCCESS, commitFile1);
     }
-    
+
     /**
-     * This test confirm the behaviour of not allowing null values as environment variables and hence has been fixed
-     * with a null check. If the second repo is added accidentally but not filled in the text field, the build won't fail.
+     * An empty remote repo URL failed the job as expected but provided
+     * a poor diagnostic message. The fix for JENKINS-38608 improves
+     * the error message to be clear and helpful. This test checks for
+     * that error message.
      * @throws Exception on error
      */
     @Test
     @Issue("JENKINS-38608")
-    public void testAddSecondRepositoryWithNULLValue() throws Exception{
-        String repoURL = "https://github.com/jenkinsci/git-plugin";
+    public void testAddFirstRepositoryWithNullRepoURL() throws Exception{
+        List<UserRemoteConfig> repos = new ArrayList<>();
+        repos.add(new UserRemoteConfig(null, null, null, null));
+        FreeStyleProject project = setupProject(repos, Collections.singletonList(new BranchSpec("master")), null, false, null);
+        FreeStyleBuild build = build(project, Result.FAILURE);
+        // Before JENKINS-38608 fix
+        assertFalse("Build log reports 'Null value not allowed'",
+                build.getLog().contains("Null value not allowed as an environment variable: GIT_URL"));
+        // After JENKINS-38608 fix
+        assertTrue("Build log did not report empty string in job definition",
+                build.getLog().contains("Git repository URL 1 is an empty string in job definition. Checkout requires a valid repository URL"));
+    }
+
+    /**
+     * An empty remote repo URL failed the job as expected but provided
+     * a poor diagnostic message. The fix for JENKINS-38608 improves
+     * the error message to be clear and helpful. This test checks for
+     * that error message when the second URL is empty.
+     * @throws Exception on error
+     */
+    @Test
+    @Issue("JENKINS-38608")
+    public void testAddSecondRepositoryWithNullRepoURL() throws Exception{
+        String repoURL = "https://example.com/non-empty/repo/url";
         List<UserRemoteConfig> repos = new ArrayList<>();
         repos.add(new UserRemoteConfig(repoURL, null, null, null));
         repos.add(new UserRemoteConfig(null, null, null, null));
         FreeStyleProject project = setupProject(repos, Collections.singletonList(new BranchSpec("master")), null, false, null);
-        EnvVars vars = project.getCharacteristicEnvVars();
-        FreeStyleBuild build = build(project, Result.SUCCESS);
-        GitSCM scm = (GitSCM) project.getScm();
-        scm.getExtensions().add(new LocalBranch("master"));
-        scm.buildEnvironment(build, vars);
+        FreeStyleBuild build = build(project, Result.FAILURE);
+        // Before JENKINS-38608 fix
+        assertFalse("Build log reports 'Null value not allowed'",
+                build.getLog().contains("Null value not allowed as an environment variable: GIT_URL_2"));
+        // After JENKINS-38608 fix
+        assertTrue("Build log did not report empty string in job definition for URL 2",
+                build.getLog().contains("Git repository URL 2 is an empty string in job definition. Checkout requires a valid repository URL"));
     }
 
     @Test


### PR DESCRIPTION
## [JENKINS-38608](https://issues.jenkins-ci.org/browse/JENKINS-38608) Report clearly if repo URL is empty

See https://github.com/jenkinsci/git-plugin/pull/820 for the original discussion related to fixing this particular bug.

See https://github.com/jenkinsci/git-plugin/pull/820#issuecomment-576981707 to understand the fix. 
Since UserRemoteConfig URL can't be null for many reasons, we arrived at the conclusion of improving the error message to 
> Git repository URL 1 is an empty string in job definition. Checkout requires a valid repository URL
