### PR TITLE
[JENKINS-57660] Addition of a doCheck validation method for invalid refSpec

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1392,7 +1392,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         } else {
             int count=1;
             for(UserRemoteConfig config:userRemoteConfigs)   {
-                env.put("GIT_URL_" + count, config.getUrl());
+                env.put("GIT_URL_"+count, config.getUrl());
                 count++;
             }
         }

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -230,7 +230,8 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
             String refSpec = Util.fixEmptyAndTrim(value);
 
             if(refSpec == null){
-                return FormValidation.error(Messages.UserRemoteConfig_CheckUrl_UrlIsNull());
+                // We fix empty field value with a default refspec, hence we send ok.
+                return FormValidation.ok();
             }
 
             if(refSpec.contains("$")){

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -248,7 +248,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
             try {
                 RemoteConfig.getAllRemoteConfigs(repoConfig);
             } catch (Exception e) {
-                return FormValidation.error("Specification is wrong");
+                return FormValidation.error("Specification is invalid");
             }
 
             return FormValidation.ok();

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -34,7 +34,6 @@ import org.kohsuke.stapler.export.ExportedBean;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.List;
 import java.util.regex.Pattern;
 import java.util.UUID;
 import org.apache.commons.lang.StringUtils;
@@ -231,7 +230,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
             String refSpec = Util.fixEmptyAndTrim(value);
 
             if(refSpec==null){
-                return FormValidation.error(Messages.UserRemoteConfig_CheckUrl_UrlIsNull());
+                return FormValidation.error(Messages.UserRemoteConfig_CheckRefSpec_RefSpecIsNull());
             }
 
             if(refSpec.contains("$")){
@@ -248,7 +247,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
             try {
                 RemoteConfig.getAllRemoteConfigs(repoConfig);
             } catch (Exception e) {
-                return FormValidation.error("Specification is invalid");
+                return FormValidation.error(Messages.UserRemoteConfig_CheckRefSpec_InvalidRefSpec());
             }
 
             return FormValidation.ok();

--- a/src/main/resources/hudson/plugins/git/Messages.properties
+++ b/src/main/resources/hudson/plugins/git/Messages.properties
@@ -5,7 +5,6 @@ BuildChooser_Ancestry=Ancestry
 BuildChooser_BuildingLastRevision=No new revisions were found; the most-recently built branch will be built again.
 UserRemoteConfig.FailedToConnect=Failed to connect to repository : {0}
 UserRemoteConfig.CheckUrl.UrlIsNull=Please enter Git repository.
-UserRemoteConfig.CheckRefSpec.RefSpecIsNull=Please enter valid RefSpec.
 UserRemoteConfig.CheckRefSpec.InvalidRefSpec=Specification is invalid.
 
 GitPublisher.Check.TagName=Tag Name

--- a/src/main/resources/hudson/plugins/git/Messages.properties
+++ b/src/main/resources/hudson/plugins/git/Messages.properties
@@ -5,6 +5,8 @@ BuildChooser_Ancestry=Ancestry
 BuildChooser_BuildingLastRevision=No new revisions were found; the most-recently built branch will be built again.
 UserRemoteConfig.FailedToConnect=Failed to connect to repository : {0}
 UserRemoteConfig.CheckUrl.UrlIsNull=Please enter Git repository.
+UserRemoteConfig.CheckRefSpec.RefSpecIsNull=Please enter valid RefSpec.
+UserRemoteConfig.CheckRefSpec.InvalidRefSpec=Specification is invalid.
 
 GitPublisher.Check.TagName=Tag Name
 GitPublisher.Check.BranchName=Branch Name

--- a/src/test/java/hudson/plugins/git/UserRemoteConfigRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/UserRemoteConfigRefSpecTest.java
@@ -4,6 +4,9 @@ import hudson.util.FormValidation;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 
@@ -11,11 +14,78 @@ public class UserRemoteConfigRefSpecTest {
 
     @Issue("JENKINS-57660")
     @Test
-    public void testdoCheckRefspec(){
-        String url = "https://github.com/daytonpa/pipeline_test_example.git";
+    public void testdoCheckRefspecSuccessWithoutWildcards(){
+        String url = "git://git.example.com/repository-that-does-not-exist";
         String name = "origin";
-        String refSpec = "refs/heads/master";
+        List<String> refSpec = new ArrayList<>();
+        refSpec.add("+refs/heads/master:refs/remotes/origin/master");
+        refSpec.add("+refs/heads/JENKINS-57660:refs/remotes/origin/JENKINS-57660");
+        refSpec.add("master:refs/remotes/origin/mymaster");
+        refSpec.add("master:refs/remotes/origin/mymaster topic:refs/remotes/origin/topic");
+
         UserRemoteConfig.DescriptorImpl descriptor = new UserRemoteConfig.DescriptorImpl();
-        assertEquals(FormValidation.ok(), descriptor.doCheckRefspec(url, name, refSpec));
+        for (String ref:refSpec) {
+            assertEquals(FormValidation.ok(), descriptor.doCheckRefspec(url, name, ref));
+        }
+    }
+
+    @Issue("JENKINS-57660")
+    @Test
+    public void testdoCheckRefspecSuccessWithMatchedWildCards(){
+        String url = "git://git.example.com/repository-that-does-not-exist";
+        String name = "origin";
+        List<String> refSpec = new ArrayList<>();
+        refSpec.add("+refs/heads/qa/*:refs/remotes/origin/qa/*");
+        refSpec.add("+refs/pull/*/head:refs/remotes/origin/pr/*");
+
+        UserRemoteConfig.DescriptorImpl descriptor = new UserRemoteConfig.DescriptorImpl();
+        for (String ref:refSpec) {
+            assertEquals(FormValidation.ok(), descriptor.doCheckRefspec(url, name, ref));
+        }
+    }
+
+    @Issue("JENKINS-57660")
+    @Test
+    public void testdoCheckRefspecFailureWithUnMatchedWildCards(){
+        String url = "git://git.example.com/repository-that-does-not-exist";
+        String name = "origin";
+        List<String> refSpec = new ArrayList<>();
+        refSpec.add("+refs/heads/qa:refs/remotes/origin/qa/*");
+        refSpec.add("+refs/heads/qa/*:refs/remotes/origin/qa");
+
+        UserRemoteConfig.DescriptorImpl descriptor = new UserRemoteConfig.DescriptorImpl();
+        for (String ref:refSpec) {
+            assertEquals("Specification is invalid.",
+                    descriptor.doCheckRefspec(url, name, ref).getLocalizedMessage());
+        }
+    }
+
+    @Issue("JENKINS-57660")
+    @Test
+    public void testdoCheckRefspecFailureWithEmptyString(){
+        String url = "git://git.example.com/repository-that-does-not-exist";
+        String name = "origin";
+        List<String> refSpec = new ArrayList<>();
+        refSpec.add("");
+
+        UserRemoteConfig.DescriptorImpl descriptor = new UserRemoteConfig.DescriptorImpl();
+        for (String ref:refSpec) {
+            assertEquals("Please enter valid RefSpec.",
+                    descriptor.doCheckRefspec(url, name, ref).getLocalizedMessage());
+        }
+    }
+
+    @Issue("JENKINS-57660")
+    @Test
+    public void testdoCheckRefspecSuccessWithPartialGlobs(){
+        String url = "git://git.example.com/repository-that-does-not-exist";
+        String name = "origin";
+        List<String> refSpec = new ArrayList<>();
+        refSpec.add("+refs/heads/qa*:refs/remotes/origin/qa*");
+        UserRemoteConfig.DescriptorImpl descriptor = new UserRemoteConfig.DescriptorImpl();
+        for (String ref:refSpec) {
+            assertEquals(FormValidation.ok(),
+                    descriptor.doCheckRefspec(url, name, ref));
+        }
     }
 }

--- a/src/test/java/hudson/plugins/git/UserRemoteConfigRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/UserRemoteConfigRefSpecTest.java
@@ -88,4 +88,18 @@ public class UserRemoteConfigRefSpecTest {
                     descriptor.doCheckRefspec(url, name, ref));
         }
     }
+
+    @Issue("JENKINS-57660")
+    @Test
+    public void testdoCheckRefspecSuccessWithEnvironmentVariable(){
+        String url = "git://git.example.com/repository-that-does-not-exist";
+        String name = "origin";
+        List<String> refSpec = new ArrayList<>();
+        refSpec.add("$REFSPEC");
+        UserRemoteConfig.DescriptorImpl descriptor = new UserRemoteConfig.DescriptorImpl();
+        for (String ref:refSpec) {
+            assertEquals(FormValidation.ok(),
+                    descriptor.doCheckRefspec(url, name, ref));
+        }
+    }
 }

--- a/src/test/java/hudson/plugins/git/UserRemoteConfigRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/UserRemoteConfigRefSpecTest.java
@@ -1,0 +1,21 @@
+package hudson.plugins.git;
+
+import hudson.util.FormValidation;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class UserRemoteConfigRefSpecTest {
+
+    @Issue("JENKINS-57660")
+    @Test
+    public void testdoCheckRefspec(){
+        String url = "https://github.com/daytonpa/pipeline_test_example.git";
+        String name = "origin";
+        String refSpec = "refs/heads/master";
+        UserRemoteConfig.DescriptorImpl descriptor = new UserRemoteConfig.DescriptorImpl();
+        assertEquals(FormValidation.ok(), descriptor.doCheckRefspec(url, name, refSpec));
+    }
+}

--- a/src/test/java/hudson/plugins/git/UserRemoteConfigRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/UserRemoteConfigRefSpecTest.java
@@ -62,7 +62,7 @@ public class UserRemoteConfigRefSpecTest {
 
     @Issue("JENKINS-57660")
     @Test
-    public void testdoCheckRefspecFailureWithEmptyString(){
+    public void testdoCheckRefspecSuccessWithEmptyString(){
         String url = "git://git.example.com/repository-that-does-not-exist";
         String name = "origin";
         List<String> refSpec = new ArrayList<>();
@@ -70,8 +70,8 @@ public class UserRemoteConfigRefSpecTest {
 
         UserRemoteConfig.DescriptorImpl descriptor = new UserRemoteConfig.DescriptorImpl();
         for (String ref:refSpec) {
-            assertEquals("Please enter valid RefSpec.",
-                    descriptor.doCheckRefspec(url, name, ref).getLocalizedMessage());
+            assertEquals(FormValidation.ok(),
+                    descriptor.doCheckRefspec(url, name, ref));
         }
     }
 


### PR DESCRIPTION
## [JENKINS-57660](https://issues.jenkins-ci.org/browse/JENKINS-57660)

While adding a Git source in the **Source Code Management**, adding an invalid refSpec produces a confusing/complex stack trace upon applying/saving the configuration changes.

Upon discussion on this issue, a good way to inform the user about the invalid refSpec is to check the correctness of the values entered by the user on the fly (Done on the server-side). Hence, a `doCheckRefspec` method has been added to create a form validation logic.

Here is a screenshot of the UI result of the new method:
<img width="1440" alt="Screenshot 2020-01-26 at 6 10 06 PM" src="https://user-images.githubusercontent.com/31189405/73136011-110f8a00-406f-11ea-8225-874ac768b6be.png">

**Note: The message has been changed to "Specification is invalid"**

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
