### PR TITLE
Allow disabling of multi candidate scheduling

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -33,6 +33,7 @@ import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.plugins.git.extensions.impl.AuthorInChangelog;
 import hudson.plugins.git.extensions.impl.BuildChooserSetting;
+import hudson.plugins.git.extensions.impl.BuildSingleRevisionOnly;
 import hudson.plugins.git.extensions.impl.ChangelogToBranch;
 import hudson.plugins.git.extensions.impl.PathRestriction;
 import hudson.plugins.git.extensions.impl.LocalBranch;
@@ -1067,17 +1068,24 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         if (buildData.getBuildsByBranchName().size() >= 100) {
             log.println("JENKINS-19022: warning: possible memory leak due to Git plugin usage; see: https://wiki.jenkins.io/display/JENKINS/Remove+Git+Plugin+BuildsByBranch+BuildData");
         }
+        boolean checkForMultipleRevisions = true;
+        BuildSingleRevisionOnly ext = extensions.get(BuildSingleRevisionOnly.class);
+        if (ext != null) {
+            checkForMultipleRevisions = ext.enableMultipleRevisionDetection();
+        }
 
         if (candidates.size() > 1) {
             log.println("Multiple candidate revisions");
-            Job<?, ?> job = build.getParent();
-            if (job instanceof AbstractProject) {
-                AbstractProject project = (AbstractProject) job;
-                if (!project.isDisabled()) {
-                    log.println("Scheduling another build to catch up with " + project.getFullDisplayName());
-                    if (!project.scheduleBuild(0, new SCMTrigger.SCMTriggerCause("This build was triggered by build "
-                            + build.getNumber() + " because more than one build candidate was found."))) {
-                        log.println("WARNING: multiple candidate revisions, but unable to schedule build of " + project.getFullDisplayName());
+            if (checkForMultipleRevisions) {
+                Job<?, ?> job = build.getParent();
+                if (job instanceof AbstractProject) {
+                    AbstractProject project = (AbstractProject) job;
+                    if (!project.isDisabled()) {
+                        log.println("Scheduling another build to catch up with " + project.getFullDisplayName());
+                        if (!project.scheduleBuild(0, new SCMTrigger.SCMTriggerCause("This build was triggered by build "
+                                + build.getNumber() + " because more than one build candidate was found."))) {
+                            log.println("WARNING: multiple candidate revisions, but unable to schedule build of " + project.getFullDisplayName());
+                        }
                     }
                 }
             }

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -352,6 +352,15 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
         return GitClientType.ANY;
     }
 
+    /**
+     *
+     * @return <code>true</code> to disable the scheduling of another build to catch up
+     * when multiple revisions are detected
+     */
+    public boolean enableMultipleRevisionDetection() {
+        return true;
+    }
+
     @Override
     public GitSCMExtensionDescriptor getDescriptor() {
         return (GitSCMExtensionDescriptor) super.getDescriptor();

--- a/src/main/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnly.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnly.java
@@ -1,0 +1,30 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Don't trigger another build to catch up
+ *
+ * @author Sven Hickstein
+ */
+public class BuildSingleRevisionOnly extends GitSCMExtension {
+    @DataBoundConstructor
+    public BuildSingleRevisionOnly() {
+    }
+
+    @Override
+    public boolean enableMultipleRevisionDetection() {
+        return false;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Build single revision only";
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnly/help.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnly/help.html
@@ -1,0 +1,10 @@
+<div>
+    Disable scheduling for multiple candidate revisions.<br>
+    If we have 3 branches:<br>
+    ----A--.---.--- B<br>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\-----C<br>
+    jenkins would try to build (B) and (C).<br>
+    This behaviour disables this and only builds one of them.<br>
+    It is helpful to reduce the load of the Jenkins infrastructure when the
+    SCM system like Bitbucket or GitHub should decide what commits to build.
+</div>

--- a/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
@@ -1,0 +1,80 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.plugins.git.AbstractGitTestCase;
+import hudson.plugins.git.BranchSpec;
+
+import hudson.plugins.git.GitSCM;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BuildSingleRevisionOnlyTest extends AbstractGitTestCase {
+
+    @Test
+    public void testSingleRevision() throws Exception {
+        // This is the additional behaviour
+        List<BranchSpec> branchSpec = new ArrayList<>();
+        branchSpec.add(new BranchSpec("master"));
+        branchSpec.add(new BranchSpec("foo"));
+        branchSpec.add(new BranchSpec("bar"));
+        FreeStyleProject project = setupProject(branchSpec, false, "",
+                "","",
+                "", false, "");
+
+        ((GitSCM) project.getScm()).getExtensions().add(new BuildSingleRevisionOnly());
+        final String commitFile = "commitFile1";
+        // create the initial master commit
+        commit(commitFile, johnDoe, "Initial commit in master");
+
+        // create additional branches and commits
+        git.branch("foo");
+        git.branch("bar");
+        git.checkoutBranch("foo", "master");
+        commit(commitFile, johnDoe, "Commit in foo");
+        git.checkoutBranch("bar", "master");
+        commit(commitFile, johnDoe, "Commit in bar");
+
+        final FreeStyleBuild build = build(project, Result.SUCCESS, commitFile);
+
+        rule.assertBuildStatusSuccess(build);
+        boolean result = build.getLog(100).contains(
+                String.format("Scheduling another build to catch up with %s", project.getName()));
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testMultiRevision() throws Exception {
+        // This is the old and now default behaviour
+        List<BranchSpec> branchSpec = new ArrayList<>();
+        branchSpec.add(new BranchSpec("master"));
+        branchSpec.add(new BranchSpec("foo"));
+        branchSpec.add(new BranchSpec("bar"));
+        FreeStyleProject project = setupProject(branchSpec, false, "",
+                "","",
+                "", false, "");
+
+        final String commitFile = "commitFile1";
+        // create the initial master commit
+        commit(commitFile, johnDoe, "Initial commit in master");
+
+        // create additional branches and commits
+        git.branch("foo");
+        git.branch("bar");
+        git.checkoutBranch("foo", "master");
+        commit(commitFile, johnDoe, "Commit in foo");
+        git.checkoutBranch("bar", "master");
+        commit(commitFile, johnDoe, "Commit in bar");
+
+        final FreeStyleBuild build = build(project, Result.SUCCESS, commitFile);
+
+        rule.assertBuildStatusSuccess(build);
+        boolean result = build.getLog(100).contains(
+                String.format("Scheduling another build to catch up with %s", project.getName()));
+        Assert.assertTrue(result);
+    }
+}


### PR DESCRIPTION
Add an additional behaviour that disables the multi candidate scheduling.

The default behaviour of the git plugin is to check for new changes and trigger a new build for every tip of every branch. When working with big repositories, high build times and many independent branches, this behaviour leads to an unnecessary high resource consumption.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Further comments

I tried to get this change into the upstream in #509 . That is over two years ago, was pre 4.0.0 and got the label later. So I'll try it again :)

We're patching this feature in every release since 2,5 years. It would be nice to see it in the official plugin.
