### PR TITLE
[JENKINS-56063] (Expansion of variables in refspec in case of honor refspec on initial clone)

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -149,20 +149,12 @@ public class CloneOption extends GitSCMExtension {
             // in a single job definition.
             RemoteConfig rc = scm.getRepositories().get(0);
             List<RefSpec> refspecs = rc.getFetchRefSpecs();
-            List<RefSpec> expandedrefSpecs = new ArrayList<>();
-            Boolean check = false;
+            List<RefSpec> expandedRefSpecs = new ArrayList<>();
+            EnvVars env = build.getEnvironment(listener);
             for (RefSpec ref:refspecs) {
-                if(ref.toString().contains("$")){
-                    EnvVars env = build.getEnvironment(listener);
-                    expandedrefSpecs.add(new RefSpec(env.expand(ref.toString())));
-                    check = true;
-                }
+                expandedRefSpecs.add(new RefSpec(env.expand(ref.toString())));
             }
-            if(!check) {
-                cmd.refspecs(refspecs);
-            } else{
-                cmd.refspecs(expandedrefSpecs);
-            }
+                cmd.refspecs(expandedRefSpecs);
         }
         cmd.timeout(timeout);
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -14,6 +14,7 @@ import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.plugins.git.util.GitUtils;
 import hudson.slaves.NodeProperty;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.eclipse.jgit.transport.RefSpec;
@@ -148,7 +149,20 @@ public class CloneOption extends GitSCMExtension {
             // in a single job definition.
             RemoteConfig rc = scm.getRepositories().get(0);
             List<RefSpec> refspecs = rc.getFetchRefSpecs();
-            cmd.refspecs(refspecs);
+            List<RefSpec> expandedrefSpecs = new ArrayList<>();
+            Boolean check = false;
+            for (RefSpec ref:refspecs) {
+                if(ref.toString().contains("$")){
+                    EnvVars env = build.getEnvironment(listener);
+                    expandedrefSpecs.add(new RefSpec(env.expand(ref.toString())));
+                    check = true;
+                }
+            }
+            if(!check) {
+                cmd.refspecs(refspecs);
+            } else{
+                cmd.refspecs(expandedrefSpecs);
+            }
         }
         cmd.timeout(timeout);
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -151,10 +151,10 @@ public class CloneOption extends GitSCMExtension {
             List<RefSpec> refspecs = rc.getFetchRefSpecs();
             List<RefSpec> expandedRefSpecs = new ArrayList<>();
             EnvVars env = build.getEnvironment(listener);
-            for (RefSpec ref:refspecs) {
+            for (RefSpec ref : refspecs) {
                 expandedRefSpecs.add(new RefSpec(env.expand(ref.toString())));
             }
-                cmd.refspecs(expandedRefSpecs);
+            cmd.refspecs(expandedRefSpecs);
         }
         cmd.timeout(timeout);
 

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
@@ -38,7 +38,7 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
     @Parameterized.Parameters(name = "{0}")
     public static Collection permuteRefSpecVariable() {
         List<Object[]> values = new ArrayList<>();
-        String[] allowed = {"${BUILD_NO}","${BUILD_ID}",
+        String[] allowed = {"${BUILD_NUMBER}","${BUILD_ID}",
                 "${GIT_COMMIT}"};
         for (String refSpecValue : allowed) {
             Object[] combination = {refSpecValue};

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
@@ -1,0 +1,85 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.plugins.git.AbstractGitTestCase;
+import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
+import org.eclipse.jgit.transport.RefSpec;
+import org.jenkinsci.plugins.gitclient.CloneCommand;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(Parameterized.class)
+public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
+
+    private GitSCM gitSCM;
+    private FreeStyleBuild build;
+    private String refSpecVar;
+    private TaskListener listener;
+
+    public CloneOptionHonorRefSpecTest(String useRefSpecVariable) {
+        this.refSpecVar = useRefSpecVariable;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection permuteRefSpecVariable() {
+        List<Object[]> values = new ArrayList<>();
+        String[] allowed = {"${BUILD_NO}","${BUILD_ID}",
+                "${GIT_COMMIT}"};
+        for (String refSpecValue : allowed) {
+            Object[] combination = {refSpecValue};
+            values.add(combination);
+        }
+        return values;
+    }
+
+    @Before
+    public void setupProjectAndDependencies() throws Exception{
+        listener = mock(TaskListener.class);
+        // create initial commit
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit in master");
+
+        List<UserRemoteConfig> repos = new ArrayList<>();
+        repos.add(new UserRemoteConfig(testRepo.gitDir.getAbsolutePath(), "origin", "+refs/heads/master:refs/remotes/origin/master" + refSpecVar, null));
+
+        /* Creating a project */
+        FreeStyleProject project = setupProject(repos, Collections.singletonList(new BranchSpec("master" + refSpecVar)), null, false, null);
+        build = build(project, Result.SUCCESS, commitFile1);
+        gitSCM = (GitSCM) project.getScm();
+    }
+
+    @Test
+    public void decorateCloneCommandWithHonorRefSpec() throws Exception {
+        List<RefSpec> refSpecs = new ArrayList<>();
+        String envKey = refSpecVar.substring(refSpecVar.indexOf("{")+1, refSpecVar.indexOf("}"));
+        String refSpecVariable = build.getEnvironment(listener).get(envKey);
+        refSpecs.add(new RefSpec("+refs/heads/master:refs/remotes/origin/master" + refSpecVariable));
+
+        PrintStream logger = mock(PrintStream.class);
+        when(listener.getLogger()).thenReturn(logger);
+
+        CloneCommand cloneCommand = mock(CloneCommand.class);
+
+        /* Creating a clone option which would honor refspec for initial clone */
+        CloneOption cloneOption = new CloneOption(false, false, null, null);
+        cloneOption.setHonorRefspec(true);
+        cloneOption.decorateCloneCommand(gitSCM, build, git, listener, cloneCommand);
+
+        verify(cloneCommand).refspecs(refSpecs);
+    }
+}


### PR DESCRIPTION

## [JENKINS-56063](https://issues.jenkins-ci.org/browse/JENKINS-56063) - Addition of variable expansion in refspec in case of _Honoring refspec on initial clone_


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

