### PR TITLE
Restore Push notification documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -90,6 +90,29 @@ https://plugins.jenkins.io/credentials[Jenkins credentials plugin].
 It does not support other credential types like secret text, secret file, or certificates.
 Select credentials from the job definition drop down menu or enter their identifiers in Pipeline job definitions.
 
+[[GitPlugin-Pushnotificationfromrepository]]
+=== Push notification from repository
+
+To minimize the delay between a push and a build, it is recommended to set up the post-receive hook in the repository to poke Jenkins when a new push occurs. To do this, add the following line in your hooks/post-receive file, where <URL of the Git repository> is the fully qualified URL you use when cloning this repository.
+
+....
+curl http://yourserver/git/notifyCommit?url=<URL of the Git repository>[&branches=branch1[,branch2]*][&sha1=<commit ID>]
+....
+
+This will scan all the jobs that:
+
+* Have Build Triggers > Poll SCM enabled.  No polling Schedule is required.
+* Are configured to build the repository at the specified URL
+* Are configured to build the optionally specified branches or commit ID
+
+For jobs that meet these conditions, polling will be immediately triggered.  If polling finds a change worthy of a build, a build will in turn be triggered.
+
+This allows a script to remain the same when jobs come and go in Jenkins. Or if you have multiple repositories under a single repository host application (such as Gitosis), you can share a single post-receive hook script with all the repositories. Finally, this URL doesn't require authentication even for secured Jenkins, because the server doesn't directly use anything that the client is sending. It runs polling to verify that there is a change, before it actually starts a build.
+
+When successful, the list of projects that were triggered is returned.
+
+`<commit ID>` is optional. If set, it will trigger a build immediately, without polling for changes. The advantage of this is that you then can have all pushes tested by jenkins, even when developers push at the same time.
+
 [[enabling-jgit]]
 === Enabling JGit
 


### PR DESCRIPTION
For unknown reason, the documentation chapter about "Push notification
from repository" has disappeared. Currently we are forced to retrieve it
via the wayback machine:
https://web.archive.org/web/20190905084011/https://wiki.jenkins.io/display/JENKINS/Git+Plugin#GitPlugin-Pushnotificationfromrepository

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Documentation