### PR TITLE
Refine the web hook and notify commit docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -103,7 +103,7 @@ Refer to webhook documentation for your repository:
 * link:https://github.com/jenkinsci/gitea-plugin/blob/master/docs/README.md[Gitea]
 
 Other git repositories can use a link:https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks[post-receive hook] in the remote repository to notify Jenkins of changes.
-Add the following line in your hooks/post-receive file on the git server, replacing <URL of the Git repository> with the fully qualified URL you use when cloning the repository.
+Add the following line in your `hooks/post-receive` file on the git server, replacing <URL of the Git repository> with the fully qualified URL you use when cloning the repository.
 
 ....
 curl http://yourserver/git/notifyCommit?url=<URL of the Git repository>

--- a/README.adoc
+++ b/README.adoc
@@ -102,7 +102,7 @@ Refer to webhook documentation for your repository:
 * link:https://plugins.jenkins.io/gitlab-branch-source[GitLab]
 * link:https://github.com/jenkinsci/gitea-plugin/blob/master/docs/README.md[Gitea]
 
-Other git repositories can notify Jenkins with a post-receive hook in the repository to poke Jenkins when a new push occurs.
+Other git repositories can use a link:https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks[post-receive hook] in the remote repository to notify Jenkins of changes.
 Add the following line in your hooks/post-receive file on the git server, replacing <URL of the Git repository> with the fully qualified URL you use when cloning the repository.
 
 ....

--- a/README.adoc
+++ b/README.adoc
@@ -90,28 +90,38 @@ https://plugins.jenkins.io/credentials[Jenkins credentials plugin].
 It does not support other credential types like secret text, secret file, or certificates.
 Select credentials from the job definition drop down menu or enter their identifiers in Pipeline job definitions.
 
+[[push-notification-from-repository]]
 [[GitPlugin-Pushnotificationfromrepository]]
 === Push notification from repository
 
-To minimize the delay between a push and a build, it is recommended to set up the post-receive hook in the repository to poke Jenkins when a new push occurs. To do this, add the following line in your hooks/post-receive file, where <URL of the Git repository> is the fully qualified URL you use when cloning this repository.
+To minimize the delay between a push and a build, configure the remote repository to use a Webhook to notify Jenkins of changs to the repository.
+Refer to webhook documentation for your repository:
+* link:https://plugins.jenkins.io/github#GitHubPlugin-GitHubhooktriggerforGITScmpolling[GitHub]
+* link:https://plugins.jenkins.io/bitbucket[Bitbucket]
+* link:https://plugins.jenkins.io/gitlab-branch-source[GitLab]
+* link:https://github.com/jenkinsci/gitea-plugin/blob/master/docs/README.md[Gitea]
+
+Other git repositories can notify Jenkins with a post-receive hook in the repository to poke Jenkins when a new push occurs.
+Add the following line in your hooks/post-receive file on the git server, replacing <URL of the Git repository> with the fully qualified URL you use when cloning the repository.
 
 ....
-curl http://yourserver/git/notifyCommit?url=<URL of the Git repository>[&branches=branch1[,branch2]*][&sha1=<commit ID>]
+curl http://yourserver/git/notifyCommit?url=<URL of the Git repository>
 ....
 
 This will scan all the jobs that:
 
-* Have Build Triggers > Poll SCM enabled.  No polling Schedule is required.
+* Have Build Triggers > Poll SCM enabled.  No polling schedule is required.
 * Are configured to build the repository at the specified URL
-* Are configured to build the optionally specified branches or commit ID
 
-For jobs that meet these conditions, polling will be immediately triggered.  If polling finds a change worthy of a build, a build will in turn be triggered.
+For jobs that meet these conditions, polling will be triggered.
+If polling finds a change worthy of a build, a build will be triggered.
 
-This allows a script to remain the same when jobs come and go in Jenkins. Or if you have multiple repositories under a single repository host application (such as Gitosis), you can share a single post-receive hook script with all the repositories. Finally, this URL doesn't require authentication even for secured Jenkins, because the server doesn't directly use anything that the client is sending. It runs polling to verify that there is a change, before it actually starts a build.
+This allows a script to remain the same when jobs come and go in Jenkins. 
+Or if you have multiple repositories under a single repository host application (such as Gitosis, gitweb, or ), you can share a single post-receive hook script with all the repositories.
+Finally, this URL doesn't require authentication even for secured Jenkins, because the server doesn't directly use anything that the client is sending.
+It runs polling to verify that there is a change before it actually starts a build.
 
-When successful, the list of projects that were triggered is returned.
-
-`<commit ID>` is optional. If set, it will trigger a build immediately, without polling for changes. The advantage of this is that you then can have all pushes tested by jenkins, even when developers push at the same time.
+When notifyCommit is successful, the list of triggered projects is returned.
 
 [[enabling-jgit]]
 === Enabling JGit

--- a/README.adoc
+++ b/README.adoc
@@ -96,6 +96,7 @@ Select credentials from the job definition drop down menu or enter their identif
 
 To minimize the delay between a push and a build, configure the remote repository to use a Webhook to notify Jenkins of changs to the repository.
 Refer to webhook documentation for your repository:
+
 * link:https://plugins.jenkins.io/github#GitHubPlugin-GitHubhooktriggerforGITScmpolling[GitHub]
 * link:https://plugins.jenkins.io/bitbucket[Bitbucket]
 * link:https://plugins.jenkins.io/gitlab-branch-source[GitLab]

--- a/README.adoc
+++ b/README.adoc
@@ -118,7 +118,7 @@ For jobs that meet these conditions, polling will be triggered.
 If polling finds a change worthy of a build, a build will be triggered.
 
 This allows a script to remain the same when jobs come and go in Jenkins. 
-Or if you have multiple repositories under a single repository host application (such as Gitosis, gitweb, or ), you can share a single post-receive hook script with all the repositories.
+Or if you have multiple repositories under a single repository host application (such as Gitosis), you can share a single post-receive hook script with all the repositories.
 Finally, this URL doesn't require authentication even for secured Jenkins, because the server doesn't directly use anything that the client is sending.
 It runs polling to verify that there is a change before it actually starts a build.
 


### PR DESCRIPTION
## Improve web hook and notifyCommit docs

Transition from wiki to GitHub docs did not transfer the notifyCommit documentation.  #835 added the documentation from the wiki to the README.  This refines that documentation.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Documentation

