### PR TITLE
[JENKINS-48625] Restore binding of doCheckUrl methods and add some initial checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,17 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+      <version>1.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-digester</groupId>
+          <artifactId>commons-digester</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -107,7 +107,6 @@ public class AssemblaWeb extends GitRepositoryBrowser {
             if (initialChecksAndReturnOk(project, cleanUrl)) {
                 return FormValidation.ok();
             }
-            FormValidation response;
             if (checkURIFormatAndHostName(cleanUrl, "assembla")) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
@@ -128,9 +127,8 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                     }
                 }.check();
             } else {
-                response = FormValidation.error(Messages.invalidUrl());
+                return FormValidation.error(Messages.invalidUrl());
             }
-            return response;
         }
 
         private boolean checkURIFormatAndHostName(String url, String browserName) throws URISyntaxException {

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -11,7 +11,6 @@ import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.URLCheck;
-import org.apache.commons.validator.routines.UrlValidator;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -22,7 +21,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
@@ -104,21 +102,11 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                 throws IOException, ServletException, URISyntaxException {
 
             String cleanUrl = Util.fixEmptyAndTrim(repoUrl);
-
-            if (cleanUrl == null) {
-                return FormValidation.ok();
-            }
-
-            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
-                return FormValidation.ok();
-            }
-
-            if (cleanUrl.contains("$")) {
-                // set by variable, can't validate
+            if (initialChecksAndReturnOk(project, cleanUrl)) {
                 return FormValidation.ok();
             }
             FormValidation response;
-            if (checkURIFormat(cleanUrl)) {
+            if (checkURIFormat(cleanUrl, "assembla")) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
                         String v = cleanUrl;
@@ -141,14 +129,6 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                 response = FormValidation.error(Messages.invalidUrl());
             }
             return response;
-        }
-
-        private boolean checkURIFormat(String url) throws URISyntaxException {
-            //https://app.assembla.com/spaces/git-plugin/git/source
-            URI uri = new URI(url);
-            String[] schemes = {"http", "https"};
-            UrlValidator urlValidator = new UrlValidator(schemes);
-            return urlValidator.isValid(uri.toString()) && uri.getHost().contains("assembla");
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -104,31 +104,32 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                 throws IOException, ServletException, URISyntaxException {
 
             String cleanUrl = Util.fixEmptyAndTrim(repoUrl);
-            if (initialChecksAndReturnOk(project, cleanUrl)) {
+            if (initialChecksAndReturnOk(project, cleanUrl))
+            {
                 return FormValidation.ok();
             }
-            if (checkURIFormatAndHostName(cleanUrl, "assembla")) {
-                return new URLCheck() {
-                    protected FormValidation check() throws IOException, ServletException {
-                        String v = cleanUrl;
-                        if (!v.endsWith("/")) {
-                            v += '/';
-                        }
-
-                        try {
-                            if (findText(open(new URL(v)), "Assembla")) {
-                                return FormValidation.ok();
-                            } else {
-                                return FormValidation.error("This is a valid URL but it does not look like Assembla");
-                            }
-                        } catch (IOException e) {
-                            return handleIOException(v, e);
-                        }
-                    }
-                }.check();
-            } else {
+            // Connect to URL and check content only if we have permission
+            if (!checkURIFormatAndHostName(cleanUrl, "assembla")) {
                 return FormValidation.error(Messages.invalidUrl());
             }
+            return new URLCheck() {
+                protected FormValidation check() throws IOException, ServletException {
+                    String v = cleanUrl;
+                    if (!v.endsWith("/")) {
+                        v += '/';
+                    }
+
+                    try {
+                        if (findText(open(new URL(v)), "Assembla")) {
+                            return FormValidation.ok();
+                        } else {
+                            return FormValidation.error("This is a valid URL but it does not look like Assembla");
+                        }
+                    } catch (IOException e) {
+                        return handleIOException(v, e);
+                    }
+                }
+            }.check();
         }
 
         private boolean checkURIFormatAndHostName(String url, String browserName) throws URISyntaxException {

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -130,7 +130,7 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                             if (findText(open(new URL(v)), "Assembla")) {
                                 return FormValidation.ok();
                             } else {
-                                return FormValidation.error("This is a valid URL but it doesn't look like Assembla");
+                                return FormValidation.error("This is a valid URL but it does not look like Assembla");
                             }
                         } catch (IOException e) {
                             return handleIOException(v, e);

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -132,12 +132,12 @@ public class AssemblaWeb extends GitRepositoryBrowser {
             }.check();
         }
 
-        private boolean checkURIFormatAndHostName(String url, String browserName) throws URISyntaxException {
+        private boolean checkURIFormatAndHostName(String url, String hostNameFragment) throws URISyntaxException {
             URI uri = new URI(url);
             String[] schemes = {"http", "https"};
             UrlValidator urlValidator = new UrlValidator(schemes);
-            browserName = browserName + ".";
-            return urlValidator.isValid(uri.toString()) && uri.getHost().contains(browserName);
+            hostNameFragment = hostNameFragment + ".";
+            return urlValidator.isValid(uri.toString()) && uri.getHost().contains(hostNameFragment);
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -12,7 +12,6 @@ import hudson.scm.RepositoryBrowser;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.URLCheck;
 import net.sf.json.JSONObject;
-import org.apache.commons.validator.routines.UrlValidator;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -22,7 +21,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
@@ -108,7 +106,7 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                 return FormValidation.ok();
             }
             FormValidation response;
-            if (checkURIFormatAndHostName(cleanUrl, "assembla")) {
+            if (checkURIFormat(cleanUrl, "assembla")) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
                         String v = cleanUrl;
@@ -131,14 +129,6 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                 response = FormValidation.error(Messages.invalidUrl());
             }
             return response;
-        }
-
-        private boolean checkURIFormatAndHostName(String url, String browserName) throws URISyntaxException {
-            URI uri = new URI(url);
-            String[] schemes = {"http", "https"};
-            UrlValidator urlValidator = new UrlValidator(schemes);
-            browserName = browserName + ".";
-            return urlValidator.isValid(uri.toString()) && uri.getHost().contains(browserName);
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -12,6 +12,7 @@ import hudson.scm.RepositoryBrowser;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.URLCheck;
 import net.sf.json.JSONObject;
+import org.apache.commons.validator.routines.UrlValidator;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -21,6 +22,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
@@ -106,7 +108,7 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                 return FormValidation.ok();
             }
             FormValidation response;
-            if (checkURIFormat(cleanUrl, "assembla")) {
+            if (checkURIFormatAndHostName(cleanUrl, "assembla")) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
                         String v = cleanUrl;
@@ -129,6 +131,14 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                 response = FormValidation.error(Messages.invalidUrl());
             }
             return response;
+        }
+
+        private boolean checkURIFormatAndHostName(String url, String browserName) throws URISyntaxException {
+            URI uri = new URI(url);
+            String[] schemes = {"http", "https"};
+            UrlValidator urlValidator = new UrlValidator(schemes);
+            browserName = browserName + ".";
+            return urlValidator.isValid(uri.toString()) && uri.getHost().contains(browserName);
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -1,15 +1,19 @@
 package hudson.plugins.git.browser;
 
 import hudson.Extension;
+import hudson.Util;
 import hudson.model.Descriptor;
+import hudson.model.Item;
 import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSet.Path;
+import hudson.plugins.git.Messages;
 import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.URLCheck;
-import jenkins.model.Jenkins;
+import org.apache.commons.validator.routines.UrlValidator;
 import net.sf.json.JSONObject;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
@@ -18,6 +22,8 @@ import org.kohsuke.stapler.StaplerRequest;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 /**
@@ -94,33 +100,55 @@ public class AssemblaWeb extends GitRepositoryBrowser {
         }
 
         @RequirePOST
-        public FormValidation doCheckUrl(@QueryParameter(fixEmpty = true) final String url)
-                throws IOException, ServletException {
-            if (url == null) // nothing entered yet
-            {
+        public FormValidation doCheckRepoUrl(@AncestorInPath Item project, @QueryParameter(fixEmpty = true) final String repoUrl)
+                throws IOException, ServletException, URISyntaxException {
+
+            String cleanUrl = Util.fixEmptyAndTrim(repoUrl);
+
+            if (cleanUrl == null) {
                 return FormValidation.ok();
             }
-            // Connect to URL and check content only if we have admin permission
-            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
-                return FormValidation.ok();
-            return new URLCheck() {
-                protected FormValidation check() throws IOException, ServletException {
-                    String v = url;
-                    if (!v.endsWith("/")) {
-                        v += '/';
-                    }
 
-                    try {
-                        if (findText(open(new URL(v)), "Assembla")) {
-                            return FormValidation.ok();
-                        } else {
-                            return FormValidation.error("This is a valid URL but it doesn't look like Assembla");
+            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
+                return FormValidation.ok();
+            }
+
+            if (cleanUrl.contains("$")) {
+                // set by variable, can't validate
+                return FormValidation.ok();
+            }
+            FormValidation response;
+            if (checkURIFormat(cleanUrl)) {
+                return new URLCheck() {
+                    protected FormValidation check() throws IOException, ServletException {
+                        String v = cleanUrl;
+                        if (!v.endsWith("/")) {
+                            v += '/';
                         }
-                    } catch (IOException e) {
-                        return handleIOException(v, e);
+
+                        try {
+                            if (findText(open(new URL(v)), "Assembla")) {
+                                return FormValidation.ok();
+                            } else {
+                                return FormValidation.error("This is a valid URL but it doesn't look like Assembla");
+                            }
+                        } catch (IOException e) {
+                            return handleIOException(v, e);
+                        }
                     }
-                }
-            }.check();
+                }.check();
+            } else {
+                response = FormValidation.error(Messages.invalidUrl());
+            }
+            return response;
+        }
+
+        private boolean checkURIFormat(String url) throws URISyntaxException {
+            //https://app.assembla.com/spaces/git-plugin/git/source
+            URI uri = new URI(url);
+            String[] schemes = {"http", "https"};
+            UrlValidator urlValidator = new UrlValidator(schemes);
+            return urlValidator.isValid(uri.toString()) && uri.getHost().contains("assembla");
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
@@ -12,7 +12,6 @@ import hudson.scm.RepositoryBrowser;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.URLCheck;
 import net.sf.json.JSONObject;
-import org.apache.commons.validator.routines.UrlValidator;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -23,7 +22,6 @@ import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -105,7 +103,7 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
                 return FormValidation.ok();
             }
             FormValidation response;
-            if (checkURIFormat(cleanUrl)) {
+            if (checkURIFormat(cleanUrl, "gitblit")) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
                         String v = cleanUrl;
@@ -128,13 +126,6 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
                 response = FormValidation.error(Messages.invalidUrl());
             }
             return response;
-        }
-
-        private boolean checkURIFormat(String url) throws URISyntaxException {
-            URI uri = new URI(url);
-            String[] schemes = {"http", "https"};
-            UrlValidator urlValidator = new UrlValidator(schemes);
-            return urlValidator.isValid(uri.toString()) && uri.getHost().contains("gitblit");
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
@@ -67,7 +67,7 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
         return projectName;
     }
 
-    private String encodeString(final String s) throws UnsupportedEncodingException {
+     private String encodeString(final String s) throws UnsupportedEncodingException {
         return URLEncoder.encode(s, "UTF-8").replaceAll("\\+", "%20");
     }
 
@@ -89,20 +89,9 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
                 throws IOException, ServletException, URISyntaxException {
 
             String cleanUrl = Util.fixEmptyAndTrim(repoUrl);
-
-            if (cleanUrl == null) {
+            if(initialChecksAndReturnOk(project, cleanUrl)){
                 return FormValidation.ok();
             }
-
-            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
-                return FormValidation.ok();
-            }
-
-            if (cleanUrl.contains("$")) {
-                // set by variable, can't validate
-                return FormValidation.ok();
-            }
-            FormValidation response;
             if (checkURIFormat(cleanUrl)) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
@@ -123,9 +112,8 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
                     }
                 }.check();
             } else {
-                response = FormValidation.error(Messages.invalidUrl());
+                return FormValidation.error(Messages.invalidUrl());
             }
-            return response;
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
@@ -103,7 +103,7 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
                 return FormValidation.ok();
             }
             FormValidation response;
-            if (checkURIFormat(cleanUrl, "gitblit")) {
+            if (checkURIFormat(cleanUrl)) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
                         String v = cleanUrl;

--- a/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
@@ -89,31 +89,32 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
                 throws IOException, ServletException, URISyntaxException {
 
             String cleanUrl = Util.fixEmptyAndTrim(repoUrl);
-            if(initialChecksAndReturnOk(project, cleanUrl)){
+            if (initialChecksAndReturnOk(project, cleanUrl))
+            {
                 return FormValidation.ok();
             }
-            if (checkURIFormat(cleanUrl)) {
-                return new URLCheck() {
-                    protected FormValidation check() throws IOException, ServletException {
-                        String v = cleanUrl;
-                        if (!v.endsWith("/")) {
-                            v += '/';
-                        }
-
-                        try {
-                            if (findText(open(new URL(v)), "Gitblit")) {
-                                return FormValidation.ok();
-                            } else {
-                                return FormValidation.error("This is a valid URL but it doesn't look like Gitblit");
-                            }
-                        } catch (IOException e) {
-                            return handleIOException(v, e);
-                        }
-                    }
-                }.check();
-            } else {
+            if (!checkURIFormat(cleanUrl))
+            {
                 return FormValidation.error(Messages.invalidUrl());
             }
+            return new URLCheck() {
+                protected FormValidation check() throws IOException, ServletException {
+                    String v = cleanUrl;
+                    if (!v.endsWith("/")) {
+                        v += '/';
+                    }
+
+                    try {
+                        if (findText(open(new URL(v)), "Gitblit")) {
+                            return FormValidation.ok();
+                        } else {
+                            return FormValidation.error("This is a valid URL but it doesn't look like Gitblit");
+                        }
+                    } catch (IOException e) {
+                        return handleIOException(v, e);
+                    }
+                }
+            }.check();
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -1,12 +1,14 @@
 package hudson.plugins.git.browser;
 
 import hudson.EnvVars;
+import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSet.Path;
 import hudson.scm.RepositoryBrowser;
 
+import org.apache.commons.validator.routines.UrlValidator;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -115,6 +117,28 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
         } catch (URISyntaxException e) {
             throw new IOException(e);
         }
+    }
+
+    public static boolean initialChecksAndReturnOk(Item project, String cleanUrl){
+        if (cleanUrl == null) {
+            return true;
+        }
+        if (project == null || !project.hasPermission(Item.CONFIGURE)) {
+            return true;
+        }
+        if (cleanUrl.contains("$")) {
+            // set by variable, can't validate
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean checkURIFormat(String url, String browserName) throws URISyntaxException {
+        URI uri = new URI(url);
+        String[] schemes = {"http", "https"};
+        UrlValidator urlValidator = new UrlValidator(schemes);
+        browserName = browserName + ".";
+        return urlValidator.isValid(uri.toString()) && uri.getHost().contains(browserName);
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -134,10 +134,9 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
     }
 
     protected static boolean checkURIFormat(String url) throws URISyntaxException {
-        URI uri = new URI(url);
         String[] schemes = {"http", "https"};
         UrlValidator urlValidator = new UrlValidator(schemes);
-        return urlValidator.isValid(uri.toString());
+        return urlValidator.isValid(url);
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -133,11 +133,12 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
         return false;
     }
 
-    protected static boolean checkURIFormat(String url) throws URISyntaxException {
+    protected static boolean checkURIFormat(String url, String browserName) throws URISyntaxException {
         URI uri = new URI(url);
         String[] schemes = {"http", "https"};
         UrlValidator urlValidator = new UrlValidator(schemes);
-        return urlValidator.isValid(uri.toString());
+        browserName = browserName + ".";
+        return urlValidator.isValid(uri.toString()) && uri.getHost().contains(browserName);
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -133,12 +133,11 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
         return false;
     }
 
-    protected static boolean checkURIFormat(String url, String browserName) throws URISyntaxException {
+    protected static boolean checkURIFormat(String url) throws URISyntaxException {
         URI uri = new URI(url);
         String[] schemes = {"http", "https"};
         UrlValidator urlValidator = new UrlValidator(schemes);
-        browserName = browserName + ".";
-        return urlValidator.isValid(uri.toString()) && uri.getHost().contains(browserName);
+        return urlValidator.isValid(uri.toString());
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -119,7 +119,7 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
         }
     }
 
-    public static boolean initialChecksAndReturnOk(Item project, String cleanUrl){
+    protected static boolean initialChecksAndReturnOk(Item project, String cleanUrl){
         if (cleanUrl == null) {
             return true;
         }
@@ -133,7 +133,7 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
         return false;
     }
 
-    public static boolean checkURIFormat(String url, String browserName) throws URISyntaxException {
+    protected static boolean checkURIFormat(String url, String browserName) throws URISyntaxException {
         URI uri = new URI(url);
         String[] schemes = {"http", "https"};
         UrlValidator urlValidator = new UrlValidator(schemes);

--- a/src/main/java/hudson/plugins/git/browser/Gitiles.java
+++ b/src/main/java/hudson/plugins/git/browser/Gitiles.java
@@ -80,7 +80,6 @@ public class Gitiles extends GitRepositoryBrowser {
             if(initialChecksAndReturnOk(project, cleanUrl)){
                 return FormValidation.ok();
             }
-            FormValidation response;
             if (checkURIFormat(cleanUrl)) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
@@ -101,9 +100,8 @@ public class Gitiles extends GitRepositoryBrowser {
                     }
                 }.check();
             } else {
-                response = FormValidation.error(Messages.invalidUrl());
+                return FormValidation.error(Messages.invalidUrl());
             }
-            return response;
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/Gitiles.java
+++ b/src/main/java/hudson/plugins/git/browser/Gitiles.java
@@ -81,7 +81,7 @@ public class Gitiles extends GitRepositoryBrowser {
                 return FormValidation.ok();
             }
             FormValidation response;
-            if (checkURIFormat(cleanUrl, "gerrit")) {
+            if (checkURIFormat(cleanUrl)) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
                         String v = cleanUrl;

--- a/src/main/java/hudson/plugins/git/browser/Gitiles.java
+++ b/src/main/java/hudson/plugins/git/browser/Gitiles.java
@@ -12,7 +12,6 @@ import hudson.util.FormValidation;
 import hudson.util.FormValidation.URLCheck;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
@@ -21,7 +20,6 @@ import javax.servlet.ServletException;
 
 import net.sf.json.JSONObject;
 
-import org.apache.commons.validator.routines.UrlValidator;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -79,21 +77,11 @@ public class Gitiles extends GitRepositoryBrowser {
                 throws IOException, ServletException, URISyntaxException {
 
             String cleanUrl = Util.fixEmptyAndTrim(repoUrl);
-
-            if (cleanUrl == null) {
-                return FormValidation.ok();
-            }
-
-            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
-                return FormValidation.ok();
-            }
-
-            if (cleanUrl.contains("$")) {
-                // set by variable, can't validate
+            if(initialChecksAndReturnOk(project, cleanUrl)){
                 return FormValidation.ok();
             }
             FormValidation response;
-            if (checkURIFormat(cleanUrl)) {
+            if (checkURIFormat(cleanUrl, "gerrit")) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
                         String v = cleanUrl;
@@ -116,13 +104,6 @@ public class Gitiles extends GitRepositoryBrowser {
                 response = FormValidation.error(Messages.invalidUrl());
             }
             return response;
-        }
-
-        private boolean checkURIFormat(String url) throws URISyntaxException {
-            URI uri = new URI(url);
-            String[] schemes = {"http", "https"};
-            UrlValidator urlValidator = new UrlValidator(schemes);
-            return urlValidator.isValid(uri.toString()) && uri.getHost().contains("gerrit");
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/Gitiles.java
+++ b/src/main/java/hudson/plugins/git/browser/Gitiles.java
@@ -80,28 +80,27 @@ public class Gitiles extends GitRepositoryBrowser {
             if(initialChecksAndReturnOk(project, cleanUrl)){
                 return FormValidation.ok();
             }
-            if (checkURIFormat(cleanUrl)) {
-                return new URLCheck() {
-                    protected FormValidation check() throws IOException, ServletException {
-                        String v = cleanUrl;
-                        if (!v.endsWith("/")) {
-                            v += '/';
-                        }
-
-                        try {
-                            if (findText(open(new URL(v)), "git clone")) {
-                                return FormValidation.ok();
-                            } else {
-                                return FormValidation.error("This is a valid URL but it doesn't look like Gitiles");
-                            }
-                        } catch (IOException e) {
-                            return handleIOException(v, e);
-                        }
-                    }
-                }.check();
-            } else {
+            if (!checkURIFormat(cleanUrl)) {
                 return FormValidation.error(Messages.invalidUrl());
             }
+            return new URLCheck() {
+                protected FormValidation check() throws IOException, ServletException {
+                    String v = cleanUrl;
+                    if (!v.endsWith("/"))
+                        v += '/';
+
+                    try {
+                        // gitiles has a line in main page indicating how to clone the project
+                        if (findText(open(new URL(v)), "git clone")) {
+                            return FormValidation.ok();
+                        } else {
+                            return FormValidation.error("This is a valid URL but it doesn't look like Gitiles");
+                        }
+                    } catch (IOException e) {
+                        return handleIOException(v, e);
+                    }
+                }
+            }.check();
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/Gitiles.java
+++ b/src/main/java/hudson/plugins/git/browser/Gitiles.java
@@ -1,16 +1,19 @@
 package hudson.plugins.git.browser;
 
 import hudson.Extension;
+import hudson.Util;
 import hudson.model.Descriptor;
+import hudson.model.Item;
 import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSet.Path;
+import hudson.plugins.git.Messages;
 import hudson.scm.RepositoryBrowser;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.URLCheck;
 
-import jenkins.model.Jenkins;
-
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import javax.annotation.Nonnull;
@@ -18,6 +21,8 @@ import javax.servlet.ServletException;
 
 import net.sf.json.JSONObject;
 
+import org.apache.commons.validator.routines.UrlValidator;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
@@ -70,30 +75,54 @@ public class Gitiles extends GitRepositoryBrowser {
         }
 
         @RequirePOST
-        public FormValidation doCheckUrl(@QueryParameter(fixEmpty = true) final String url) throws IOException, ServletException {
-            if (url == null) // nothing entered yet
-                return FormValidation.ok();
-            // Connect to URL and check content only if we have admin permission
-            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
-                return FormValidation.ok();
-            return new URLCheck() {
-                protected FormValidation check() throws IOException, ServletException {
-                    String v = url;
-                    if (!v.endsWith("/"))
-                        v += '/';
+        public FormValidation doCheckRepoUrl(@AncestorInPath Item project, @QueryParameter(fixEmpty = true) final String repoUrl)
+                throws IOException, ServletException, URISyntaxException {
 
-                    try {
-                        // gitiles has a line in main page indicating how to clone the project
-                        if (findText(open(new URL(v)), "git clone")) {
-                            return FormValidation.ok();
-                        } else {
-                            return FormValidation.error("This is a valid URL but it doesn't look like Gitiles");
+            String cleanUrl = Util.fixEmptyAndTrim(repoUrl);
+
+            if (cleanUrl == null) {
+                return FormValidation.ok();
+            }
+
+            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
+                return FormValidation.ok();
+            }
+
+            if (cleanUrl.contains("$")) {
+                // set by variable, can't validate
+                return FormValidation.ok();
+            }
+            FormValidation response;
+            if (checkURIFormat(cleanUrl)) {
+                return new URLCheck() {
+                    protected FormValidation check() throws IOException, ServletException {
+                        String v = cleanUrl;
+                        if (!v.endsWith("/")) {
+                            v += '/';
                         }
-                    } catch (IOException e) {
-                        return handleIOException(v, e);
+
+                        try {
+                            if (findText(open(new URL(v)), "git clone")) {
+                                return FormValidation.ok();
+                            } else {
+                                return FormValidation.error("This is a valid URL but it doesn't look like Gitiles");
+                            }
+                        } catch (IOException e) {
+                            return handleIOException(v, e);
+                        }
                     }
-                }
-            }.check();
+                }.check();
+            } else {
+                response = FormValidation.error(Messages.invalidUrl());
+            }
+            return response;
+        }
+
+        private boolean checkURIFormat(String url) throws URISyntaxException {
+            URI uri = new URI(url);
+            String[] schemes = {"http", "https"};
+            UrlValidator urlValidator = new UrlValidator(schemes);
+            return urlValidator.isValid(uri.toString()) && uri.getHost().contains("gerrit");
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -44,7 +44,7 @@ public class ViewGitWeb extends GitRepositoryBrowser {
         if (path.getEditType() == EditType.EDIT) {
             URL url = getUrl();
             String spec = buildCommitDiffSpec(url, path);
-            return new URL(url, url.getPath() + spec);
+              return new URL(url, url.getPath() + spec);
         }
         return null;
     }
@@ -56,14 +56,14 @@ public class ViewGitWeb extends GitRepositoryBrowser {
             String spec = buildCommitDiffSpec(url, path);
             return encodeURL(new URL(url, url.getPath() + spec));
         }
-        String spec = param(url).add("p=" + projectName).add("a=viewblob").add("h=" + path.getDst()).add("f=" + path.getPath()).toString();
+        String spec = param(url).add("p=" + projectName).add("a=viewblob").add("h=" + path.getDst()).add("f=" +  path.getPath()).toString();
         return encodeURL(new URL(url, url.getPath() + spec));
     }
 
-    private String buildCommitDiffSpec(URL url, Path path)
-            throws UnsupportedEncodingException {
-        return param(url).add("p=" + projectName).add("a=commitdiff").add("h=" + path.getChangeSet().getId()) + "#" + URLEncoder.encode(path.getPath(), "UTF-8").toString();
-    }
+      private String buildCommitDiffSpec(URL url, Path path)
+                      throws UnsupportedEncodingException {
+        return param(url).add("p=" + projectName).add("a=commitdiff").add("h=" + path.getChangeSet().getId()) + "#" +  URLEncoder.encode(path.getPath(), "UTF-8").toString();
+      }
 
     @Override
     public URL getChangeSetLink(GitChangeSet changeSet) throws IOException {
@@ -100,7 +100,6 @@ public class ViewGitWeb extends GitRepositoryBrowser {
             if(initialChecksAndReturnOk(project, cleanUrl)){
                 return FormValidation.ok();
             }
-            FormValidation response;
             if (checkURIFormat(cleanUrl)) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
@@ -121,9 +120,8 @@ public class ViewGitWeb extends GitRepositoryBrowser {
                     }
                 }.check();
             } else {
-                response = FormValidation.error(Messages.invalidUrl());
+                return FormValidation.error(Messages.invalidUrl());
             }
-            return response;
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -101,7 +101,7 @@ public class ViewGitWeb extends GitRepositoryBrowser {
                 return FormValidation.ok();
             }
             FormValidation response;
-            if (checkURIFormat(cleanUrl, "viewgit")) {
+            if (checkURIFormat(cleanUrl)) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
                         String v = cleanUrl;

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -1,16 +1,20 @@
 package hudson.plugins.git.browser;
 
 import hudson.Extension;
+import hudson.Util;
 import hudson.model.Descriptor;
+import hudson.model.Item;
 import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSet.Path;
+import hudson.plugins.git.Messages;
 import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import hudson.scm.browsers.QueryBuilder;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.URLCheck;
-import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+import org.apache.commons.validator.routines.UrlValidator;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
@@ -20,6 +24,8 @@ import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 
@@ -40,7 +46,7 @@ public class ViewGitWeb extends GitRepositoryBrowser {
         if (path.getEditType() == EditType.EDIT) {
             URL url = getUrl();
             String spec = buildCommitDiffSpec(url, path);
-        	return new URL(url, url.getPath() + spec);
+            return new URL(url, url.getPath() + spec);
         }
         return null;
     }
@@ -52,14 +58,14 @@ public class ViewGitWeb extends GitRepositoryBrowser {
             String spec = buildCommitDiffSpec(url, path);
             return encodeURL(new URL(url, url.getPath() + spec));
         }
-        String spec = param(url).add("p=" + projectName).add("a=viewblob").add("h=" + path.getDst()).add("f=" +  path.getPath()).toString();
+        String spec = param(url).add("p=" + projectName).add("a=viewblob").add("h=" + path.getDst()).add("f=" + path.getPath()).toString();
         return encodeURL(new URL(url, url.getPath() + spec));
     }
 
-	private String buildCommitDiffSpec(URL url, Path path)
-			throws UnsupportedEncodingException {
-        return param(url).add("p=" + projectName).add("a=commitdiff").add("h=" + path.getChangeSet().getId()) + "#" +  URLEncoder.encode(path.getPath(),"UTF-8").toString();
-	}
+    private String buildCommitDiffSpec(URL url, Path path)
+            throws UnsupportedEncodingException {
+        return param(url).add("p=" + projectName).add("a=commitdiff").add("h=" + path.getChangeSet().getId()) + "#" + URLEncoder.encode(path.getPath(), "UTF-8").toString();
+    }
 
     @Override
     public URL getChangeSetLink(GitChangeSet changeSet) throws IOException {
@@ -89,29 +95,54 @@ public class ViewGitWeb extends GitRepositoryBrowser {
         }
 
         @RequirePOST
-        public FormValidation doCheckUrl(@QueryParameter(fixEmpty = true) final String url) throws IOException, ServletException {
-            if (url == null) // nothing entered yet
-                return FormValidation.ok();
-            // Connect to URL and check content only if we have admin permission
-            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
-                return FormValidation.ok();
-            return new URLCheck() {
-                protected FormValidation check() throws IOException, ServletException {
-                    String v = url;
-                    if (!v.endsWith("/"))
-                        v += '/';
+        public FormValidation doCheckRepoUrl(@AncestorInPath Item project, @QueryParameter(fixEmpty = true) final String repoUrl)
+                throws IOException, ServletException, URISyntaxException {
 
-                    try {
-                        if (findText(open(new URL(v)), "ViewGit")) {
-                            return FormValidation.ok();
-                        } else {
-                            return FormValidation.error("This is a valid URL but it doesn't look like ViewGit");
+            String cleanUrl = Util.fixEmptyAndTrim(repoUrl);
+
+            if (cleanUrl == null) {
+                return FormValidation.ok();
+            }
+
+            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
+                return FormValidation.ok();
+            }
+
+            if (cleanUrl.contains("$")) {
+                // set by variable, can't validate
+                return FormValidation.ok();
+            }
+            FormValidation response;
+            if (checkURIFormat(cleanUrl)) {
+                return new URLCheck() {
+                    protected FormValidation check() throws IOException, ServletException {
+                        String v = cleanUrl;
+                        if (!v.endsWith("/")) {
+                            v += '/';
                         }
-                    } catch (IOException e) {
-                        return handleIOException(v, e);
+
+                        try {
+                            if (findText(open(new URL(v)), "ViewGit")) {
+                                return FormValidation.ok();
+                            } else {
+                                return FormValidation.error("This is a valid URL but it doesn't look like ViewGit");
+                            }
+                        } catch (IOException e) {
+                            return handleIOException(v, e);
+                        }
                     }
-                }
-            }.check();
+                }.check();
+            } else {
+                response = FormValidation.error(Messages.invalidUrl());
+            }
+            return response;
+        }
+
+        private boolean checkURIFormat(String url) throws URISyntaxException {
+            URI uri = new URI(url);
+            String[] schemes = {"http", "https"};
+            UrlValidator urlValidator = new UrlValidator(schemes);
+            return urlValidator.isValid(uri.toString()) && uri.getHost().contains("viewgit");
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -44,7 +44,7 @@ public class ViewGitWeb extends GitRepositoryBrowser {
         if (path.getEditType() == EditType.EDIT) {
             URL url = getUrl();
             String spec = buildCommitDiffSpec(url, path);
-              return new URL(url, url.getPath() + spec);
+        	return new URL(url, url.getPath() + spec);
         }
         return null;
     }
@@ -60,10 +60,10 @@ public class ViewGitWeb extends GitRepositoryBrowser {
         return encodeURL(new URL(url, url.getPath() + spec));
     }
 
-      private String buildCommitDiffSpec(URL url, Path path)
-                      throws UnsupportedEncodingException {
-        return param(url).add("p=" + projectName).add("a=commitdiff").add("h=" + path.getChangeSet().getId()) + "#" +  URLEncoder.encode(path.getPath(), "UTF-8").toString();
-      }
+	private String buildCommitDiffSpec(URL url, Path path)
+			throws UnsupportedEncodingException {
+        return param(url).add("p=" + projectName).add("a=commitdiff").add("h=" + path.getChangeSet().getId()) + "#" +  URLEncoder.encode(path.getPath(),"UTF-8").toString();
+	}
 
     @Override
     public URL getChangeSetLink(GitChangeSet changeSet) throws IOException {
@@ -97,31 +97,29 @@ public class ViewGitWeb extends GitRepositoryBrowser {
                 throws IOException, ServletException, URISyntaxException {
 
             String cleanUrl = Util.fixEmptyAndTrim(repoUrl);
-            if(initialChecksAndReturnOk(project, cleanUrl)){
+            // Connect to URL and check content only if we have admin permission
+            if (initialChecksAndReturnOk(project, cleanUrl))
                 return FormValidation.ok();
-            }
-            if (checkURIFormat(cleanUrl)) {
-                return new URLCheck() {
-                    protected FormValidation check() throws IOException, ServletException {
-                        String v = cleanUrl;
-                        if (!v.endsWith("/")) {
-                            v += '/';
-                        }
-
-                        try {
-                            if (findText(open(new URL(v)), "ViewGit")) {
-                                return FormValidation.ok();
-                            } else {
-                                return FormValidation.error("This is a valid URL but it doesn't look like ViewGit");
-                            }
-                        } catch (IOException e) {
-                            return handleIOException(v, e);
-                        }
-                    }
-                }.check();
-            } else {
+            if (!checkURIFormat(cleanUrl)) {
                 return FormValidation.error(Messages.invalidUrl());
             }
+            return new URLCheck() {
+                protected FormValidation check() throws IOException, ServletException {
+                    String v = cleanUrl;
+                    if (!v.endsWith("/"))
+                        v += '/';
+
+                    try {
+                        if (findText(open(new URL(v)), "ViewGit")) {
+                            return FormValidation.ok();
+                        } else {
+                            return FormValidation.error("This is a valid URL but it doesn't look like ViewGit");
+                        }
+                    } catch (IOException e) {
+                        return handleIOException(v, e);
+                    }
+                }
+            }.check();
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -13,7 +13,6 @@ import hudson.scm.browsers.QueryBuilder;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.URLCheck;
 import net.sf.json.JSONObject;
-import org.apache.commons.validator.routines.UrlValidator;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -24,7 +23,6 @@ import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -99,21 +97,11 @@ public class ViewGitWeb extends GitRepositoryBrowser {
                 throws IOException, ServletException, URISyntaxException {
 
             String cleanUrl = Util.fixEmptyAndTrim(repoUrl);
-
-            if (cleanUrl == null) {
-                return FormValidation.ok();
-            }
-
-            if (project == null || !project.hasPermission(Item.CONFIGURE)) {
-                return FormValidation.ok();
-            }
-
-            if (cleanUrl.contains("$")) {
-                // set by variable, can't validate
+            if(initialChecksAndReturnOk(project, cleanUrl)){
                 return FormValidation.ok();
             }
             FormValidation response;
-            if (checkURIFormat(cleanUrl)) {
+            if (checkURIFormat(cleanUrl, "viewgit")) {
                 return new URLCheck() {
                     protected FormValidation check() throws IOException, ServletException {
                         String v = cleanUrl;
@@ -136,13 +124,6 @@ public class ViewGitWeb extends GitRepositoryBrowser {
                 response = FormValidation.error(Messages.invalidUrl());
             }
             return response;
-        }
-
-        private boolean checkURIFormat(String url) throws URISyntaxException {
-            URI uri = new URI(url);
-            String[] schemes = {"http", "https"};
-            UrlValidator urlValidator = new UrlValidator(schemes);
-            return urlValidator.isValid(uri.toString()) && uri.getHost().contains("viewgit");
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -14,7 +14,6 @@ import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.plugins.git.util.GitUtils;
 import hudson.slaves.NodeProperty;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.eclipse.jgit.transport.RefSpec;
@@ -149,12 +148,7 @@ public class CloneOption extends GitSCMExtension {
             // in a single job definition.
             RemoteConfig rc = scm.getRepositories().get(0);
             List<RefSpec> refspecs = rc.getFetchRefSpecs();
-            List<RefSpec> expandedRefSpecs = new ArrayList<>();
-            EnvVars env = build.getEnvironment(listener);
-            for (RefSpec ref : refspecs) {
-                expandedRefSpecs.add(new RefSpec(env.expand(ref.toString())));
-            }
-            cmd.refspecs(expandedRefSpecs);
+            cmd.refspecs(refspecs);
         }
         cmd.timeout(timeout);
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -149,20 +149,12 @@ public class CloneOption extends GitSCMExtension {
             // in a single job definition.
             RemoteConfig rc = scm.getRepositories().get(0);
             List<RefSpec> refspecs = rc.getFetchRefSpecs();
-            List<RefSpec> expandedrefSpecs = new ArrayList<>();
-            Boolean check = false;
+            List<RefSpec> expandedRefSpecs = new ArrayList<>();
+            EnvVars env = build.getEnvironment(listener);
             for (RefSpec ref:refspecs) {
-                if(ref.toString().contains("$")){
-                    EnvVars env = build.getEnvironment(listener);
-                    expandedrefSpecs.add(new RefSpec(env.expand(ref.toString())));
-                    check = true;
-                }
+                expandedRefSpecs.add(new RefSpec(env.expand(ref.toString())));
             }
-            if(!check) {
-                cmd.refspecs(refspecs);
-            } else{
-                cmd.refspecs(expandedrefSpecs);
-            }
+                cmd.refspecs(expandedRefSpecs);
         }
         cmd.timeout(timeout);
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -14,6 +14,7 @@ import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.plugins.git.util.GitUtils;
 import hudson.slaves.NodeProperty;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.eclipse.jgit.transport.RefSpec;
@@ -148,7 +149,20 @@ public class CloneOption extends GitSCMExtension {
             // in a single job definition.
             RemoteConfig rc = scm.getRepositories().get(0);
             List<RefSpec> refspecs = rc.getFetchRefSpecs();
-            cmd.refspecs(refspecs);
+            List<RefSpec> expandedrefSpecs = new ArrayList<>();
+            Boolean check = false;
+            for (RefSpec ref:refspecs) {
+                if(ref.toString().contains("$")){
+                    EnvVars env = build.getEnvironment(listener);
+                    expandedrefSpecs.add(new RefSpec(env.expand(ref.toString())));
+                    check = true;
+                }
+            }
+            if(!check) {
+                cmd.refspecs(refspecs);
+            } else{
+                cmd.refspecs(expandedrefSpecs);
+            }
         }
         cmd.timeout(timeout);
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -151,10 +151,10 @@ public class CloneOption extends GitSCMExtension {
             List<RefSpec> refspecs = rc.getFetchRefSpecs();
             List<RefSpec> expandedRefSpecs = new ArrayList<>();
             EnvVars env = build.getEnvironment(listener);
-            for (RefSpec ref:refspecs) {
+            for (RefSpec ref : refspecs) {
                 expandedRefSpecs.add(new RefSpec(env.expand(ref.toString())));
             }
-                cmd.refspecs(expandedRefSpecs);
+            cmd.refspecs(expandedRefSpecs);
         }
         cmd.timeout(timeout);
 

--- a/src/main/resources/hudson/plugins/git/Messages.properties
+++ b/src/main/resources/hudson/plugins/git/Messages.properties
@@ -6,6 +6,7 @@ BuildChooser_BuildingLastRevision=No new revisions were found; the most-recently
 UserRemoteConfig.FailedToConnect=Failed to connect to repository : {0}
 UserRemoteConfig.CheckUrl.UrlIsNull=Please enter Git repository.
 UserRemoteConfig.CheckRefSpec.InvalidRefSpec=Specification is invalid.
+invalidUrl=Invalid URL
 
 GitPublisher.Check.TagName=Tag Name
 GitPublisher.Check.BranchName=Branch Name

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -99,6 +99,6 @@ public class AssemblaWebDoCheckURLTest {
         };
         String url = urls[random.nextInt(urls.length)]; // Don't abuse a single web site with tests
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
-                is("This is a valid URL but it does not look like Assembla"));
+                is("Invalid URL"));
     }
 }

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -45,21 +45,21 @@ public class AssemblaWebDoCheckURLTest {
 
     @Test
     public void testDomainLevelChecksOnRepoUrl() throws Exception {
-        // illegal syntax - Earlier it would open connection for such mistakes but now check resolves it beforehand.
+        // Invalid URL, missing '/' character - Earlier it would open connection for such mistakes but now check resolves it beforehand.
         String url = "https:/assembla.com";
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is("Invalid URL"));
     }
 
     @Test
     public void testDomainLevelChecksOnRepoUrlInvalidURL() throws Exception {
-        // illegal syntax - Earlier it would open connection for such mistakes but now check resolves it beforehand.
+        // Invalid URL, missing ':' character - Earlier it would open connection for such mistakes but now check resolves it beforehand.
         String url = "http//assmebla";
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is("Invalid URL"));
     }
 
     @Test
     public void testPathLevelChecksOnRepoUrlInvalidPathSyntax() throws Exception {
-        // Invalid path syntax
+        // Invalid hostname in URL
         String url = "https://assembla.comspaces/git-plugin/git/source";
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is("Invalid URL"));
     }

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -87,7 +87,7 @@ public class AssemblaWebDoCheckURLTest {
 
     @Test
     public void testPathLevelChecksOnRepoUrlSupersetOfAssembla() throws Exception {
-        Random random = new Random();
+        java.util.Random random = new java.util.Random();
         String [] urls = {
           "http://assemblage.com/",
           "http://assemblage.net/",

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -87,7 +87,17 @@ public class AssemblaWebDoCheckURLTest {
 
     @Test
     public void testPathLevelChecksOnRepoUrlSupersetOfAssembla() throws Exception {
-        String url = "http://assemblagist.com/";
+        Random random = new Random();
+        String [] urls = {
+          "http://assemblage.com/",
+          "http://assemblage.net/",
+          "http://assemblage.org/",
+          "http://assemblages.com/",
+          "http://assemblages.net/",
+          "http://assemblages.org/",
+          "http://assemblagist.com/",
+        };
+        String url = urls[random.nextInt(urls.length)]; // Don't abuse a single web site with tests
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
                 is("This is a valid URL but it does not look like Assembla"));
     }

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -65,8 +65,7 @@ public class AssemblaWebDoCheckURLTest {
     }
 
     @Test
-    public void testPathLevelChecksOnRepoUrlValidURL() throws Exception {
-        // Syntax issue related specific to Assembla
+    public void testPathLevelChecksOnRepoUrlValidURLNullProject() throws Exception {
         String url = "https://app.assembla.com/space/git-plugin/git/source";
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(null, url), is(FormValidation.ok()));
     }

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -1,0 +1,63 @@
+package hudson.plugins.git.browser;
+
+import hudson.model.FreeStyleProject;
+import hudson.util.FormValidation;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+
+import static org.junit.Assert.assertEquals;
+
+public class AssemblaWebDoCheckURLTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    private FreeStyleProject project;
+    private AssemblaWeb.AssemblaWebDescriptor assemblaWebDescriptor;
+
+    @Before
+    public void setProject() throws Exception {
+        project = r.createFreeStyleProject("p1");
+        assemblaWebDescriptor = new AssemblaWeb.AssemblaWebDescriptor();
+    }
+
+    @Test
+    public void testInitialChecksOnRepoUrl() throws Exception {
+        String url = "https://app.assembla.com/spaces/git-plugin/git/source";
+        // Empty url
+        String url2 = "";
+        // URL with env variable
+        String url3 = "https://www.assembla.com/spaces/$";
+
+        assertEquals(FormValidation.ok(), assemblaWebDescriptor.doCheckRepoUrl(project, url));
+        assertEquals(FormValidation.ok(), assemblaWebDescriptor.doCheckRepoUrl(project, url2));
+        assertEquals(FormValidation.ok(), assemblaWebDescriptor.doCheckRepoUrl(project, url3));
+    }
+
+    @Test
+    public void testDomainLevelChecksOnRepoUrl() throws Exception {
+        // illegal syntax - Earlier it would open connection for such mistakes but now check resolves it beforehand.
+        String url = "https:/assembla.com";
+        String url2 = "http//assmebla";
+
+        assertEquals("Invalid URL", assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage());
+        assertEquals("Invalid URL", assemblaWebDescriptor.doCheckRepoUrl(project, url2).getLocalizedMessage());
+    }
+
+    @Test
+    public void testPathLevelChecksOnRepoUrl() throws Exception {
+        // Invalid path syntax
+        String url = "https://assembla.comspaces/git-plugin/git/source";
+        // Syntax issue related specific to Assembla
+        String url2 = "https://app.assembla.com/space/git-plugin/git/source";
+        // Any path related errors will not be caught except syntax issues
+        String url3 = "https://app.assembla.com/spaces";
+
+        assertEquals("Invalid URL", assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage());
+        assertEquals("Unable to connect https://app.assembla.com/space/git-plugin/git/source/", assemblaWebDescriptor.doCheckRepoUrl(project, url2).getLocalizedMessage());
+        assertEquals(FormValidation.ok(), assemblaWebDescriptor.doCheckRepoUrl(project, url3));
+    }
+}


### PR DESCRIPTION
## [JENKINS-48625](https://issues.jenkins-ci.org/browse/JENKINS-48625) 

The earlier **doCheckUrl** methods used to open a connection to validate a particular browser URL but that can be avoided (mostly) by adding some initial checks based on URL syntax validity and domain name match of the particular browser.

This change has been implemented for _AssemblaWeb_, _GitBlitRepositoryBrowser_, _Gitiles_ and _ViewGitWeb._ 

**Note**: A test file has been written for AssemblaWeb class, if it is considered okay then will do the same thing for the other 3 browser classes as well.

## Submitter Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Reviewer Checklist

* [x] Interactive test the assemblaweb doCheck method
* [ ] Interactive test the other doCheck methods
* [ ] Review the code in the other doCheck methods
* [ ] Look for changes that are purely white space and remove them