### PR TITLE
Exclude jsoup from git plugin jpi packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,12 @@
       <artifactId>test-harness</artifactId>
       <version>${configuration-as-code.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jsoup</groupId>
+          <artifactId>jsoup</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- Exclude JTH dependency commons-net - otherwise it is included in hpi file as a transient dependency -->
     <dependency>


### PR DESCRIPTION
## Exclude jsoup from git plugin jpi packaging

The jsoup jar file is added to the hpi file as a transitive dependency of the configuration as code test harness.  The git plugin does not deliver the configuration as code test harness and so it should not deliver the dependencies of that test harness either.

We've had issues in the past where other plugins mistakenly depended on a jar file that the git plugin bundled (like joda-time). Better to avoid others from depending on a transitive test dependency by not including the transitive test dependency.

The jsoup jar file was included in git plugin 4.1.0 and 4.1.1.  Earlier versions did not include it.

https://github.com/jenkinsci/git-plugin/pull/814/commits/f3c65cb72548d3ab8ed863d5817624119b199455 added the transitive dependency.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update