### PR TITLE
WIP: [JENKINS-48822] Better browser URL guessing

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/BrowserInference.java
+++ b/src/main/java/hudson/plugins/git/extensions/BrowserInference.java
@@ -1,0 +1,22 @@
+package hudson.plugins.git.extensions;
+
+import hudson.plugins.git.browser.GitRepositoryBrowser;
+import hudson.scm.RepositoryBrowsers;
+import org.apache.tools.ant.ExtensionPoint;
+
+public abstract class BrowserInference extends ExtensionPoint {
+
+    private GitRepositoryBrowser browser;
+
+    public BrowserInference(){
+        browser = null;
+    }
+
+    public BrowserInference(GitRepositoryBrowser browser){
+        this.browser = browser;
+    }
+
+    String inferRepositoryBrowser(){
+            return "no-browser";
+    }
+}


### PR DESCRIPTION
# [JENKINS-48822](https://issues.jenkins-ci.org/browse/JENKINS-48822) - Improve browser URL guessing

I have made the abstract BrowserInference Class which is the extension point and can be used by other GitRepository Browsers.

## This is a work in progress. Do not merge