### PR TITLE
Fix for Git plugin calls fetch twice per checkout

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -904,7 +904,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 for (GitSCMExtension extension : extensions) {
                     extension.decorateFetchCommand(this, run, git, listener, fetch);
                 }
-                fetch.execute();
             } catch (GitException ex) {
                 throw new GitException("Failed to fetch from "+url.toString(), ex);
             }


### PR DESCRIPTION
## [JENKINS-49757](https://issues.jenkins-ci.org/browse/JENKINS-49757) - Redundant Git fetch has resolved

After removing fetch.execute, testRedundantFetch passes successfully.

`Building in workspace /home/loghi/Documents/GSoC/git-plugin/work/workspace/fetch_twice_fixed
No credentials specified
Cloning the remote Git repository
Cloning repository https://github.com/Loghijiaha/ipython
 > git init /home/loghi/Documents/GSoC/git-plugin/work/workspace/fetch_twice_fixed # timeout=10
Fetching upstream changes from https://github.com/Loghijiaha/ipython
 > git --version # timeout=10
 > git fetch --tags --force --progress -- https://github.com/Loghijiaha/ipython +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/Loghijiaha/ipython # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/Loghijiaha/ipython # timeout=10
 > git rev-parse refs/remotes/origin/master^{commit} # timeout=10
 > git rev-parse refs/remotes/origin/origin/master^{commit} # timeout=10
Checking out Revision 1f372309c074c62d1e13aeebf33c60726a9baff4 (refs/remotes/origin/master)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 1f372309c074c62d1e13aeebf33c60726a9baff4 # timeout=10
Commit message: "Finally done with simple plugin for ipython"
First time build. Skipping changelog.
Finished: SUCCESS`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes


- [x] Dependency or infrastructure update
- [x] Bug fix (non-breaking change which fixes an issue)


## Further comments


