### PR TITLE
[JENKINS-40529] Prune tags on fetch

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/PruneStaleTag.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PruneStaleTag.java
@@ -1,0 +1,152 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020 Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+package hudson.plugins.git.extensions.impl;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
+import org.jenkinsci.plugins.gitclient.FetchCommand;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Prune stale local tags that do not exist on any remote.
+ *
+ * @author Nikolas Falco
+ * @since 4.3.0
+ */
+public class PruneStaleTag extends GitSCMExtension {
+
+    private static final String TAG_REF = "refs/tags/";
+    private boolean pruneTags;
+
+    /**
+     * Default constructor.
+     */
+    @DataBoundConstructor
+    public PruneStaleTag(boolean pruneTags) {
+        this.pruneTags = pruneTags;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void decorateFetchCommand(GitSCM scm,
+                                     @CheckForNull Run<?, ?> run,
+                                     GitClient git,
+                                     TaskListener listener,
+                                     FetchCommand cmd) throws IOException, InterruptedException, GitException {
+
+        if (!pruneTags) {
+            return;
+        }
+
+        listener.getLogger().println("Pruning obsolete local tags that do not exist on remotes");
+
+        // all local tag are marked for removal unless match a tag on any remote
+        Map<String, ObjectId> localTags = new HashMap<>();
+        git.getTags().forEach(t -> localTags.put(t.getName(), t.getSHA1()));
+
+        if (localTags.isEmpty()) {
+            return;
+        }
+
+        List<RemoteConfig> remoteRepos = run == null ? scm.getRepositories() : scm.getParamExpandedRepos(run, listener);
+        for (RemoteConfig remote : remoteRepos) {
+            for(URIish url : remote.getURIs()) {
+                Map<String, ObjectId> refs = git.getRemoteReferences(url.toASCIIString(), null, false, true);
+                for (Entry<String, ObjectId> ref : refs.entrySet()) {
+                    String remoteTagName = ref.getKey();
+                    if (remoteTagName.startsWith(TAG_REF)) {
+                        remoteTagName = remoteTagName.substring(TAG_REF.length());
+                    }
+                    ObjectId remoteTagId = ref.getValue();
+                    if (localTags.containsKey(remoteTagName) && localTags.get(remoteTagName).equals(remoteTagId)) {
+                        localTags.remove(remoteTagName);
+                    }
+                }
+            }
+        }
+
+        for (String localTag : localTags.keySet()) {
+            git.deleteTag(localTag);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return o instanceof PruneStaleTag;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return PruneStaleTag.class.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "PruneStaleTag {}";
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Prune stale tags";
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/git/traits/PruneStaleTagTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/PruneStaleTagTrait.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020 Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package jenkins.plugins.git.traits;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.impl.PruneStaleTag;
+import jenkins.scm.api.trait.SCMSourceTrait;
+
+/**
+ * Exposes {@link PruneStaleTag} as a {@link SCMSourceTrait}.
+ *
+ * @author Nikolas Falco
+ * @since 4.3.0
+ */
+public class PruneStaleTagTrait extends GitSCMExtensionTrait<PruneStaleTag> {
+    /**
+     * Stapler constructor.
+     */
+    @DataBoundConstructor
+    public PruneStaleTagTrait() {
+        super(new PruneStaleTag(true));
+    }
+
+    /**
+     * Our {@link hudson.model.Descriptor}
+     */
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionTraitDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Prune stale tags";
+        }
+    }
+}

--- a/src/test/java/hudson/plugins/git/extensions/impl/PruneStaleTagTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/PruneStaleTagTest.java
@@ -1,0 +1,233 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020 Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+package hudson.plugins.git.extensions.impl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.gitclient.TestCliGitAPIImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import hudson.EnvVars;
+import hudson.Functions;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitSCM;
+import hudson.util.LogTaskListener;
+
+public class PruneStaleTagTest {
+
+    @Rule
+    public TemporaryFolder fileRule = new TemporaryFolder();
+
+    private TaskListener listener;
+    private Run<?, ?> run;
+
+    @Before
+    public void setup() throws Exception {
+        listener = new LogTaskListener(Logger.getLogger("prune tags"), Level.FINEST);
+
+        run = mock(Run.class);
+        when(run.getEnvironment(listener)).thenReturn(new EnvVars());
+    }
+
+    /*
+     * Local tag       | Remote tag
+     * ---------------------------------
+     * exists - differ | exists - differ
+     */
+    @Test
+    public void verify_local_tag_is_pruned_if_different_than_on_remote() throws Exception {
+        File remoteRepo = fileRule.newFolder("remote");
+
+        // create a remote repository without one tag
+        GitClient remoteClient = initRepository(remoteRepo);
+        String tagName = "tag";
+        String tagComment = "tag comment";
+        remoteClient.tag(tagName, tagComment);
+
+        // clone remote repository to workspace
+        GitClient localClient =  cloneRepository(remoteRepo);
+
+        GitSCM scm = new GitSCM(localClient.getRemoteUrl("origin"));
+        PruneStaleTag extension = new PruneStaleTag(true);
+
+        // get remote SHA1 for the tag
+        String remoteTagHash = remoteClient.getTags().stream().filter(t -> tagName.equals(t.getName())).findFirst().get().getSHA1String();
+
+        FileUtils.touch(new File(localClient.getWorkTree().getRemote(), "localTest"));
+        localClient.add("localTest");
+        localClient.commit("more commits");
+        localClient.deleteTag(tagName);
+        localClient.tag(tagName, tagComment);
+        String localHashTag = localClient.getTags().stream().filter(t -> tagName.equals(t.getName())).findFirst().get().getSHA1String();
+        Assert.assertNotEquals("pre validation failed, local tag must not be the same than remote", remoteTagHash, localHashTag);
+
+        extension.decorateFetchCommand(scm, run, localClient, listener, null);
+        Assert.assertFalse("local tag differ from remote tag and is not pruned", localClient.tagExists(tagName));
+    }
+
+    /*
+     * Local tag       | Remote tag
+     * -------------------------------
+     * not exists      | exists
+     */
+    @Test
+    public void verify_do_nothing_when_remote_tag_do_not_exist_locally() throws Exception {
+        File remoteRepo = fileRule.newFolder("remote");
+
+        // create a remote repository without one tag
+        GitClient remoteClient = initRepository(remoteRepo);
+
+        // clone remote repository to workspace
+        GitClient localClient =  cloneRepository(remoteRepo);
+
+        GitSCM scm = new GitSCM(localClient.getRemoteUrl("origin"));
+        PruneStaleTag extension = new PruneStaleTag(true);
+
+        // new tags should not be fetched
+        String tagName = "tag";
+        String tagComment = "tag comment";
+        remoteClient.tag(tagName, tagComment);
+        extension.decorateFetchCommand(scm, run, localClient, listener, null);
+        Assert.assertFalse("new tags should not be fetched", localClient.tagExists(tagName));
+    }
+
+    /*
+     * Local tag       | Remote tag
+     * -------------------------------
+     * exists - same   | exists - same
+     */
+    @Test
+    public void verify_that_local_tag_is_not_pruned_when_exist_on_remote() throws Exception {
+        File remoteRepo = fileRule.newFolder("remote");
+
+        // create a remote repository without one tag
+        GitClient remoteClient = initRepository(remoteRepo);
+        String tagName = "tag";
+        String tagComment = "tag comment";
+        remoteClient.tag(tagName, tagComment);
+
+        // clone remote repository to workspace
+        GitClient localClient =  cloneRepository(remoteRepo);
+
+        GitSCM scm = new GitSCM(localClient.getRemoteUrl("origin"));
+        PruneStaleTag extension = new PruneStaleTag(true);
+
+        extension.decorateFetchCommand(scm, run, localClient, listener, null);
+        Assert.assertTrue("local tags must not be pruned when exists on remote", localClient.tagExists(tagName));
+    }
+
+    /*
+     * Local tag       | Remote tag
+     * -------------------------------
+     * exists          | not exists
+     */
+    @Test
+    public void verify_that_local_tag_is_pruned_when_not_exist_on_remote() throws Exception {
+        File remoteRepo = fileRule.newFolder("remote");
+
+        // create a remote repository without one tag
+        GitClient remoteClient = initRepository(remoteRepo);
+        String tagName = "tag";
+        String tagComment = "tag comment";
+        remoteClient.tag(tagName, tagComment);
+
+        // clone remote repository to workspace
+        GitClient localClient =  cloneRepository(remoteRepo);
+
+        GitSCM scm = new GitSCM(localClient.getRemoteUrl("origin"));
+        PruneStaleTag extension = new PruneStaleTag(true);
+
+        // remove tag on remote, tag remains on local cloned repository
+        remoteClient.deleteTag(tagName);
+        extension.decorateFetchCommand(scm, run, localClient, listener, null);
+        Assert.assertFalse("local tag has not been pruned", localClient.tagExists(tagName));
+    }
+
+    @Test
+    public void verify_fetch_do_not_prune_local_branches() throws Exception {
+        File remoteRepo = fileRule.newFolder("remote");
+
+        // create a remote repository without one tag
+        initRepository(remoteRepo);
+
+        // clone remote repository to workspace
+        GitClient localClient =  cloneRepository(remoteRepo);
+
+        // create a local branch that should not be pruned with tags
+        String branchName = "localBranch";
+        localClient.branch(branchName);
+
+        String gitURL = remoteRepo.toURI().toString();
+        GitSCM scm = new GitSCM(gitURL);
+        PruneStaleTag extension = new PruneStaleTag(true);
+        extension.decorateFetchCommand(scm, run, localClient, listener, null);
+
+        Assert.assertTrue("Local branches must not be pruned", localClient.getBranches().stream().anyMatch(b -> branchName.equals(b.getName())));
+    }
+
+    private GitClient newGitClient(File localRepo) {
+        String gitExe = Functions.isWindows() ? "git.exe" : "git";
+        GitClient localClient = new TestCliGitAPIImpl(gitExe, localRepo, listener, new EnvVars());
+        return localClient;
+    }
+
+    private GitClient cloneRepository(File remoteRepository) throws Exception {
+        File localRepo = fileRule.newFolder("local");
+        GitClient localClient = newGitClient(localRepo);
+        /*
+         * Workaround because File.toURI.toURL returns always one slash after
+         * file protocol. Git command on Unix always fails with 'ssh: Could not
+         * resolve hostname file: nodename nor servname provided, or not known'
+         */
+        String gitURL = "file://" + remoteRepository.toURI().getPath();
+        localClient.clone(gitURL, "origin", false, "+refs/heads/*:refs/remotes/origin/*");
+        localClient.checkoutBranch("master", "refs/remotes/origin/master");
+        return localClient;
+    }
+
+    private GitClient initRepository(File workspace) throws Exception {
+        GitClient remoteClient = newGitClient(workspace);
+        remoteClient.init();
+
+        FileUtils.touch(new File(workspace, "test"));
+        remoteClient.add("test");
+
+        remoteClient.commit("initial commit");
+        return remoteClient;
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/gitclient/TestCliGitAPIImpl.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/TestCliGitAPIImpl.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020 Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.EnvVars;
+import hudson.model.TaskListener;
+import java.io.File;
+
+/**
+ * This is just here to make the constructors public.
+ */
+public class TestCliGitAPIImpl extends CliGitAPIImpl {
+
+    public TestCliGitAPIImpl(String gitExe, File workspace, TaskListener listener, EnvVars environment) {
+        super(gitExe, workspace, listener, environment);
+    }
+
+}


### PR DESCRIPTION
## [JENKINS-40529](https://issues.jenkins-ci.org/browse/JENKINS-40529) - Trait to prune stale tags on fetch

I our infrastructure we use pipeline to perform releases. Releases are performed in Maven, Lerna (NodeJS) and fastlane (IOS). All tools requires that release tag does not in the current git repo. When a releases fails for some reason we fix and re-run the process that will fail again because the tag exists locally. This force the DevOps teams manually remove tags from workspaces in Jenkins slaves. The trait in this PR always prune tags that do not exists on remote.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [X] I have referenced the Jira issue related to my changes in one or more commit messages
- [X] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [X] I have added documentation as necessary
- [X] No Javadoc warnings were introduced with my changes
- [X] No spotbugs warnings were introduced with my changes
- [X] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [X] New feature (non-breaking change which adds functionality)