### PR TITLE
[GSoC] Add UserIdentityTest to improve code coverage in git-plugin 

### DIFF
--- a/src/test/java/hudson/plugins/git/extensions/impl/UserIdentityTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/UserIdentityTest.java
@@ -4,20 +4,14 @@ import hudson.EnvVars;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
-import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.TestGitRepo;
-import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/hudson/plugins/git/extensions/impl/UserIdentityTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/UserIdentityTest.java
@@ -4,7 +4,6 @@ import hudson.EnvVars;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
-import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.TestGitRepo;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionTest;
@@ -12,6 +11,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.junit.Test;
+import org.jvnet.hudson.test.WithoutJenkins;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -22,9 +22,8 @@ public class UserIdentityTest extends GitSCMExtensionTest  {
     GitClient git;
 
     @Override
-    public void before() throws Exception {
-        repo = new TestGitRepo("repo", tmp.newFolder(), listener);
-        git = Git.with(listener, new EnvVars()).in(repo.gitDir).getClient();
+    public void before() {
+        // do nothing
     }
 
     @Override
@@ -34,19 +33,20 @@ public class UserIdentityTest extends GitSCMExtensionTest  {
 
     @Test
     public void testUserIdentity() throws Exception {
+        repo = new TestGitRepo("repo", tmp.newFolder(), listener);
+        git = Git.with(listener, new EnvVars()).in(repo.gitDir).getClient();
+
         FreeStyleProject projectWithMaster = setupBasicProject(repo);
-        UserIdentity userIdentity = new UserIdentity("Jane Doe", "janeDoe@xyz.com");
-        ((GitSCM)projectWithMaster.getScm()).getExtensions().add(userIdentity);
-
         git.commit("First commit");
-
         FreeStyleBuild build = build(projectWithMaster, Result.SUCCESS);
         EnvVars envVars = build.getEnvironment(listener);
+
         assertThat("Jane Doe", is(envVars.get("GIT_AUTHOR_NAME")));
         assertThat("janeDoe@xyz.com", is(envVars.get("GIT_AUTHOR_EMAIL")));
     }
 
     @Test
+    @WithoutJenkins
     public void testGetNameAndEmail(){
         UserIdentity userIdentity = new UserIdentity("Jane Doe", "janeDoe@xyz.com");
 
@@ -55,6 +55,7 @@ public class UserIdentityTest extends GitSCMExtensionTest  {
     }
 
     @Test
+    @WithoutJenkins
     public void equalsContract() {
         EqualsVerifier.forClass(UserIdentity.class)
                 .usingGetClass()

--- a/src/test/java/hudson/plugins/git/extensions/impl/UserIdentityTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/UserIdentityTest.java
@@ -1,9 +1,64 @@
 package hudson.plugins.git.extensions.impl;
 
+import hudson.EnvVars;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.TestGitRepo;
+import hudson.plugins.git.UserRemoteConfig;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.jenkinsci.plugins.gitclient.Git;
+import org.jenkinsci.plugins.gitclient.GitClient;
 import org.junit.Test;
 
-public class UserIdentityTest {
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class UserIdentityTest extends GitSCMExtensionTest  {
+
+    TestGitRepo repo;
+    GitClient git;
+
+    @Override
+    public void before() throws Exception {
+        repo = new TestGitRepo("repo", tmp.newFolder(), listener);
+        git = Git.with(listener, new EnvVars()).in(repo.gitDir).getClient();
+    }
+
+    @Override
+    protected GitSCMExtension getExtension() {
+        return new UserIdentity("Jane Doe", "janeDoe@xyz.com");
+    }
+
+    @Test
+    public void testUserIdentity() throws Exception {
+        FreeStyleProject projectWithMaster = setupBasicProject(repo);
+        UserIdentity userIdentity = new UserIdentity("Jane Doe", "janeDoe@xyz.com");
+        ((GitSCM)projectWithMaster.getScm()).getExtensions().add(userIdentity);
+
+        git.commit("First commit");
+
+        FreeStyleBuild build = build(projectWithMaster, Result.SUCCESS);
+        EnvVars envVars = build.getEnvironment(listener);
+        assertThat("Jane Doe", is(envVars.get("GIT_AUTHOR_NAME")));
+        assertThat("janeDoe@xyz.com", is(envVars.get("GIT_AUTHOR_EMAIL")));
+    }
+
+    @Test
+    public void testGetNameAndEmail(){
+        UserIdentity userIdentity = new UserIdentity("Jane Doe", "janeDoe@xyz.com");
+
+        assertThat("Jane Doe", is(userIdentity.getName()));
+        assertThat("janeDoe@xyz.com", is(userIdentity.getEmail()));
+    }
 
     @Test
     public void equalsContract() {


### PR DESCRIPTION
The unit test was added in relevance to one the project goals of [Git-Plugin Performance Improvements](https://jenkins.io/projects/gsoc/2020/project-ideas/git-plugin-performance/) which is to improve the code coverage. 

<img width="373" alt="Screenshot 2020-03-06 at 3 16 47 AM" src="https://user-images.githubusercontent.com/31189405/76028581-ec091380-5f58-11ea-98c2-2958ea5fc885.png">
I ran the coverage report on IntelliJ and most of the report is not relevant to the test, I have just taken out the relevant part.


## Further comments

While writing tests for this class, UserIdentity, I came upon an issue with this extension, namely [JENKINS-46052](https://issues.jenkins-ci.org/browse/JENKINS-46052). 

While UserIdentity sets author _name_ and _email_ in the environment variable, wouldn't it be right to set  the new author name and email in the git.config for that particular repository as well? 

`git config user.name "GIT_AUTHOR_NAME"`
`git config user.email "GIT_AUTHOR_EMAIL"` 

Seems like a small fix, if needed.