### PR TITLE
[GSoC] Addition of unit test for WipeWorkspace extension behavior in GitSCM

### DIFF
--- a/src/test/java/hudson/plugins/git/extensions/impl/WipeWorkspaceTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/WipeWorkspaceTest.java
@@ -1,9 +1,52 @@
 package hudson.plugins.git.extensions.impl;
 
+import hudson.EnvVars;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.TestGitRepo;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.jenkinsci.plugins.gitclient.Git;
+import org.jenkinsci.plugins.gitclient.GitClient;
 import org.junit.Test;
 
-public class WipeWorkspaceTest {
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class WipeWorkspaceTest extends GitSCMExtensionTest {
+
+    TestGitRepo repo;
+    GitClient git;
+
+    @Override
+    public void before() throws Exception {
+        repo = new TestGitRepo("repo", tmp.newFolder(), listener);
+        git = Git.with(listener, new EnvVars()).in(repo.gitDir).getClient();
+    }
+
+    @Override
+    protected GitSCMExtension getExtension() {
+        return new WipeWorkspace();
+    }
+
+    /**
+     * Test to confirm the behavior of forcing re-clone before checkout by cleaning the workspace first.
+     **/
+    @Test
+    public void testWipeWorkspace() throws Exception {
+        FreeStyleProject projectWithMaster = setupBasicProject(repo);
+        WipeWorkspace wipeWorkspaceExtension = new WipeWorkspace();
+        ((GitSCM)projectWithMaster.getScm()).getExtensions().add(wipeWorkspaceExtension);
+
+        git.commit("First commit");
+        FreeStyleBuild build = build(projectWithMaster, Result.SUCCESS);
+
+        String buildLog = build.getLog();
+        assertThat("Workspace not cleaned before checkout",true, is(buildLog.contains("Wiping out workspace first.")));
+    }
 
     @Test
     public void equalsContract() {

--- a/src/test/java/hudson/plugins/git/extensions/impl/WipeWorkspaceTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/WipeWorkspaceTest.java
@@ -4,7 +4,6 @@ import hudson.EnvVars;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
-import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.TestGitRepo;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionTest;
@@ -12,6 +11,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.junit.Test;
+import org.jvnet.hudson.test.WithoutJenkins;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -38,9 +38,6 @@ public class WipeWorkspaceTest extends GitSCMExtensionTest {
     @Test
     public void testWipeWorkspace() throws Exception {
         FreeStyleProject projectWithMaster = setupBasicProject(repo);
-        WipeWorkspace wipeWorkspaceExtension = new WipeWorkspace();
-        ((GitSCM)projectWithMaster.getScm()).getExtensions().add(wipeWorkspaceExtension);
-
         git.commit("First commit");
         FreeStyleBuild build = build(projectWithMaster, Result.SUCCESS);
 
@@ -49,6 +46,7 @@ public class WipeWorkspaceTest extends GitSCMExtensionTest {
     }
 
     @Test
+    @WithoutJenkins
     public void equalsContract() {
         EqualsVerifier.forClass(WipeWorkspace.class)
                 .usingGetClass()

--- a/src/test/java/hudson/plugins/git/extensions/impl/WipeWorkspaceTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/WipeWorkspaceTest.java
@@ -23,8 +23,7 @@ public class WipeWorkspaceTest extends GitSCMExtensionTest {
 
     @Override
     public void before() throws Exception {
-        repo = new TestGitRepo("repo", tmp.newFolder(), listener);
-        git = Git.with(listener, new EnvVars()).in(repo.gitDir).getClient();
+        // do nothing
     }
 
     @Override
@@ -37,6 +36,9 @@ public class WipeWorkspaceTest extends GitSCMExtensionTest {
      **/
     @Test
     public void testWipeWorkspace() throws Exception {
+        repo = new TestGitRepo("repo", tmp.newFolder(), listener);
+        git = Git.with(listener, new EnvVars()).in(repo.gitDir).getClient();
+
         FreeStyleProject projectWithMaster = setupBasicProject(repo);
         git.commit("First commit");
         FreeStyleBuild build = build(projectWithMaster, Result.SUCCESS);


### PR DESCRIPTION
The unit test was added in relevance to one the project goals of [Git-Plugin Performance Improvements](https://jenkins.io/projects/gsoc/2020/project-ideas/git-plugin-performance/) which is to improve the code coverage.

<img width="361" alt="Screenshot 2020-03-06 at 1 25 22 PM" src="https://user-images.githubusercontent.com/31189405/76063544-f0abe700-5fad-11ea-9822-f1284efb17cb.png">

I ran the coverage report on IntelliJ and most of the report is not relevant to the test, I have just taken out the relevant part.