### PR TITLE
Use ACI agent for CI instead of default agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null         
                         [ jdk: '11', platform: 'linux',   jenkins: '2.164.1', javaLevel: '8' ]
                       ]
 
-buildPlugin(configurations: subsetConfiguration, failFast: false)
+buildPlugin(forceAci: true, configurations: subsetConfiguration, failFast: false)
 
 def branches = [:]
 


### PR DESCRIPTION
## Use ACI agent for CI instead of default agent

ACI agents previously did not have all the required tools for git plugin testing.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update