### PR TITLE
[JENKINS-47609] Add clone option "core.longpaths" to enable .git/config "core" property

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -31,19 +31,20 @@ import org.kohsuke.stapler.DataBoundSetter;
 public class CloneOption extends GitSCMExtension {
     private final boolean shallow;
     private final boolean noTags;
+    private final boolean longPath;
     private final String reference;
     private final Integer timeout;
     private Integer depth;
     private boolean honorRefspec;
 
-    public CloneOption(boolean shallow, String reference, Integer timeout) {
-        this(shallow, false, reference, timeout);
+    public CloneOption(boolean shallow, String reference, Integer timeout) { this(shallow, false, false, reference, timeout);
     }
 
     @DataBoundConstructor
-    public CloneOption(boolean shallow, boolean noTags, String reference, Integer timeout) {
+    public CloneOption(boolean shallow, boolean noTags, boolean longPath, String reference, Integer timeout) {
         this.shallow = shallow;
         this.noTags = noTags;
+        this.longPath = longPath;
         this.reference = reference;
         this.timeout = timeout;
         this.honorRefspec = false;
@@ -58,6 +59,9 @@ public class CloneOption extends GitSCMExtension {
     public boolean isNoTags() {
         return noTags;
     }
+
+    @Whitelisted
+    public boolean isLongPath() { return longPath; }
 
     /**
      * This setting allows the job definition to control whether the refspec
@@ -137,6 +141,10 @@ public class CloneOption extends GitSCMExtension {
             listener.getLogger().println("Avoid fetching tags");
             cmd.tags(false);
         }
+        if (longPath) {
+            listener.getLogger().println("Setting core.longpaths to true");
+            cmd.longPath(true);
+        }
         if (honorRefspec) {
             listener.getLogger().println("Honoring refspec on initial clone");
             // Read refspec configuration from the first configured repository.
@@ -209,6 +217,7 @@ public class CloneOption extends GitSCMExtension {
 
         return shallow == that.shallow
                 && noTags == that.noTags
+                && longPath == that.longPath
                 && Objects.equals(depth, that.depth)
                 && honorRefspec == that.honorRefspec
                 && Objects.equals(reference, that.reference)
@@ -220,7 +229,7 @@ public class CloneOption extends GitSCMExtension {
      */
     @Override
     public int hashCode() {
-        return Objects.hash(shallow, noTags, depth, honorRefspec, reference, timeout);
+        return Objects.hash(shallow, noTags, longPath, depth, honorRefspec, reference, timeout);
     }
 
     /**
@@ -231,6 +240,7 @@ public class CloneOption extends GitSCMExtension {
         return "CloneOption{" +
                 "shallow=" + shallow +
                 ", noTags=" + noTags +
+                ", longPath=" + longPath +
                 ", reference='" + reference + '\'' +
                 ", timeout=" + timeout +
                 ", depth=" + depth +

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/config.groovy
@@ -5,6 +5,9 @@ def f = namespace(lib.FormTagLib)
 f.entry(title:_("Fetch tags"), field:"noTags") {
     f.checkbox(negative:true, checked:(instance==null||!instance.noTags))
 }
+f.entry(title:_("Enable core.longpaths"), field:"longPath") {
+    f.checkbox()
+}
 f.entry(title:_("Honor refspec on initial clone"), field:"honorRefspec") {
     f.checkbox()
 }

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionDepthTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionDepthTest.java
@@ -69,7 +69,7 @@ public class CloneOptionDepthTest {
         PrintStream logger = mock(PrintStream.class);
         when(listener.getLogger()).thenReturn(logger);
 
-        CloneOption cloneOption = new CloneOption(true, false, null, null);
+        CloneOption cloneOption = new CloneOption(true, false, false,null, null);
         cloneOption.setDepth(configuredDepth);
 
         cloneOption.decorateCloneCommand(scm, build, git, listener, cloneCommand);
@@ -87,7 +87,7 @@ public class CloneOptionDepthTest {
         PrintStream logger = mock(PrintStream.class);
         when(listener.getLogger()).thenReturn(logger);
 
-        CloneOption cloneOption = new CloneOption(true, false, null, null);
+        CloneOption cloneOption = new CloneOption(true, false, false,null, null);
         cloneOption.setDepth(configuredDepth);
 
         cloneOption.decorateFetchCommand(scm, git, listener, fetchCommand);

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionLongPathTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionLongPathTest.java
@@ -1,0 +1,62 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.EnvVars;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.util.Build;
+import hudson.plugins.git.util.BuildData;
+import org.jenkinsci.plugins.gitclient.CloneCommand;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
+
+import java.io.PrintStream;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+
+public class CloneOptionLongPathTest {
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    private GitSCM scm;
+    private Run<?, ?> build;
+    private GitClient git;
+    private TaskListener listener;
+
+    @Before
+    public void mockDependencies() throws Exception {
+        scm = mock(GitSCM.class);
+        build = mock(Run.class);
+        git = mock(GitClient.class);
+        listener = mock(TaskListener.class);
+
+        BuildData buildData = mock(BuildData.class);
+        buildData.lastBuild = mock(Build.class);
+        when(build.getEnvironment(listener)).thenReturn(mock(EnvVars.class));
+        when(scm.getBuildData(build)).thenReturn(buildData);
+    }
+
+    @Issue("JENKINS-47609")
+    @Test
+    public void decorateCloneCommandShouldUseValidLongPath() throws Exception {
+        CloneCommand cloneCommand = mock(CloneCommand.class, Mockito.RETURNS_SELF);
+
+        PrintStream logger = mock(PrintStream.class);
+        when(listener.getLogger()).thenReturn(logger);
+
+        boolean enableLongPath = true;
+        CloneOption cloneOption = new CloneOption(true, false, enableLongPath,null, null);
+
+        cloneOption.decorateCloneCommand(scm, build, git, listener, cloneCommand);
+
+        verify(cloneCommand).longPath(true);
+        verify(logger).println("Setting core.longpaths to true");
+    }
+}

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionNoTagsTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionNoTagsTest.java
@@ -36,7 +36,7 @@ public class CloneOptionNoTagsTest extends GitSCMExtensionTest {
         final boolean dontFetchTags = true;
         final String noReference = null;
         final Integer noTimeout = null;
-        return new CloneOption(shallowClone, dontFetchTags, noReference, noTimeout);
+        return new CloneOption(shallowClone, dontFetchTags, false, noReference, noTimeout);
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/git/GitSCMBuilderTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMBuilderTest.java
@@ -291,7 +291,7 @@ public class GitSCMBuilderTest {
     @Test
     public void withRefSpecAndCloneOption() throws Exception {
         instance.withRefSpec("+refs/heads/master:refs/remotes/@{remote}/master");
-        instance.withExtension(new CloneOption(false, false, null, null));
+        instance.withExtension(new CloneOption(false, false, false, null, null));
         assertThat(instance.refSpecs(), contains("+refs/heads/master:refs/remotes/@{remote}/master"));
         GitSCM scm = instance.build();
         assertThat(scm.getBrowser(), is(nullValue()));


### PR DESCRIPTION
## [JENKINS-47609](https://issues.jenkins-ci.org/browse/JENKINS-47609)

<img width="1440" alt="Screenshot 2020-03-19 at 3 36 31 PM" src="https://user-images.githubusercontent.com/31189405/77055720-6b85f080-69f7-11ea-88d4-aa81ce3fdbdc.png">
**The figure shows addition of the new option.**

Some users face a 260 character limit for filenames in a Windows environment although Git has a limit of 4096 characters for a filename.

By setting core.longpaths to true in git config, we bypass this limit. This clone option provides this setting.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
