### PR TITLE
Adapt the test for recent core

### DIFF
--- a/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
@@ -44,7 +44,7 @@ public class GitStatusCrumbExclusionTest {
 
     @AfterClass
     public static void unsetProps() {
-        System.setProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO", systemPropertyPreviousValue);
+        System.setProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO", systemPropertyPreviousValue != null ? systemPropertyPreviousValue : "");
     }
 
     @Before

--- a/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
@@ -34,14 +34,17 @@ public class GitStatusCrumbExclusionTest {
     private HttpServletResponse resp;
     private FilterChain chain;
 
+    private static String systemPropertyPreviousValue;
+
     @BeforeClass
     public static void setProps() {
+        systemPropertyPreviousValue = System.getProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO");
         System.setProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO", "true");
     }
 
     @AfterClass
     public static void unsetProps() {
-        System.setProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO", "");
+        System.setProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO", systemPropertyPreviousValue);
     }
 
     @Before

--- a/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
@@ -44,7 +44,11 @@ public class GitStatusCrumbExclusionTest {
 
     @AfterClass
     public static void unsetProps() {
-        System.setProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO", systemPropertyPreviousValue != null ? systemPropertyPreviousValue : "");
+        if (systemPropertyPreviousValue == null) {
+            System.clearProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO");
+        } else {
+            System.setProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO", systemPropertyPreviousValue);
+        }
     }
 
     @Before

--- a/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
@@ -2,7 +2,9 @@ package hudson.plugins.git;
 
 import hudson.security.csrf.CrumbFilter;
 
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -31,6 +33,16 @@ public class GitStatusCrumbExclusionTest {
     private HttpServletRequest req;
     private HttpServletResponse resp;
     private FilterChain chain;
+
+    @BeforeClass
+    public static void setProps() {
+        System.setProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO", "true");
+    }
+
+    @AfterClass
+    public static void unsetProps() {
+        System.setProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO", "");
+    }
 
     @Before
     public void before() {


### PR DESCRIPTION
With the security release of yesterday, some tests are no longer passing for the git plugin. As it uses a mock for the crumb filter and we added some logic there, it results in NPE.

By disabling the new security correction for tests only, we prevent the test to fail on recent core version. It does not modify the behavior of the plugin that is safe, it's just the way the test is written that make it fail.

The new system property support was added in 2.204.6 but due to its nature, we can inject it in previous version without issue.