### PR TITLE
Fix javadoc and spotbugs warnings

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -209,7 +209,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         this.userRemoteConfigs = userRemoteConfigs;
         updateFromUserData();
 
-        // TODO: getBrowserFromRequest
         this.browser = browser;
 
         // emulate bindJSON behavior here
@@ -1584,20 +1583,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
          */
         public String getOldGitExe() {
             return gitExe;
-        }
-
-        /**
-         * Determine the browser from the scmData contained in the {@link StaplerRequest}.
-         *
-         * @param scmData data read for SCM browser
-         * @return browser based on request scmData
-         */
-        private GitRepositoryBrowser getBrowserFromRequest(final StaplerRequest req, final JSONObject scmData) {
-            if (scmData.containsKey("browser")) {
-                return req.bindJSON(GitRepositoryBrowser.class, scmData.getJSONObject("browser"));
-            } else {
-                return null;
-            }
         }
 
         public static List<RemoteConfig> createRepositoryConfigurations(String[] urls,

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -984,11 +984,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         private Object writeReplace() {
             return Channel.current().export(BuildChooserContext.class,new BuildChooserContext() {
-                public <T> T actOnBuild(ContextCallable<Run<?,?>, T> callable) throws IOException, InterruptedException {
+                public <T> T actOnBuild(@NonNull ContextCallable<Run<?,?>, T> callable) throws IOException, InterruptedException {
                     return callable.invoke(build,Channel.current());
                 }
 
-                public <T> T actOnProject(ContextCallable<Job<?,?>, T> callable) throws IOException, InterruptedException {
+                public <T> T actOnProject(@NonNull ContextCallable<Job<?,?>, T> callable) throws IOException, InterruptedException {
                     return callable.invoke(project,Channel.current());
                 }
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -966,11 +966,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             this.environment = environment;
         }
 
-        public <T> T actOnBuild(ContextCallable<Run<?,?>, T> callable) throws IOException, InterruptedException {
+        public <T> T actOnBuild(@NonNull ContextCallable<Run<?,?>, T> callable) throws IOException, InterruptedException {
             return callable.invoke(build, FilePath.localChannel);
         }
 
-        public <T> T actOnProject(ContextCallable<Job<?,?>, T> callable) throws IOException, InterruptedException {
+        public <T> T actOnProject(@NonNull ContextCallable<Job<?,?>, T> callable) throws IOException, InterruptedException {
             return callable.invoke(project, FilePath.localChannel);
         }
 

--- a/src/main/java/hudson/plugins/git/GitTagAction.java
+++ b/src/main/java/hudson/plugins/git/GitTagAction.java
@@ -185,15 +185,10 @@ public class GitTagAction extends AbstractScmTagAction implements Describable<Gi
      */
     public final class TagWorkerThread extends TaskThread {
         private final Map<String, String> tagSet;
-        /**
-         * If the user provided a separate credential, this object represents that.
-         */
-        private final String comment;
 
-        public TagWorkerThread(Map<String, String> tagSet,String comment) {
+        public TagWorkerThread(Map<String, String> tagSet,String ignoredComment) {
             super(GitTagAction.this, ListenerAndText.forMemory(null));
             this.tagSet = tagSet;
-            this.comment = comment;
         }
 
         @Override

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -62,7 +62,7 @@ public class ViewGitWeb extends GitRepositoryBrowser {
 
 	private String buildCommitDiffSpec(URL url, Path path)
 			throws UnsupportedEncodingException {
-        return param(url).add("p=" + projectName).add("a=commitdiff").add("h=" + path.getChangeSet().getId()) + "#" +  URLEncoder.encode(path.getPath(),"UTF-8").toString();
+        return param(url).add("p=" + projectName).add("a=commitdiff").add("h=" + path.getChangeSet().getId()) + "#" +  URLEncoder.encode(path.getPath(),"UTF-8");
 	}
 
     @Override

--- a/src/main/java/hudson/plugins/git/extensions/impl/PruneStaleTag.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PruneStaleTag.java
@@ -56,7 +56,12 @@ public class PruneStaleTag extends GitSCMExtension {
     private boolean pruneTags;
 
     /**
-     * Default constructor.
+     * Control pruning of tags that exist in the local repository but
+     * not in any remote repository.  If pruneTags is true, then local
+     * tags will be deleted if no corresponding tag exists in at least
+     * one of the remote repositories.
+     *
+     * @param pruneTags if true, tags not found in any remote are deleted from local repository
      */
     @DataBoundConstructor
     public PruneStaleTag(boolean pruneTags) {

--- a/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPath.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPath.java
@@ -1,6 +1,7 @@
 package hudson.plugins.git.extensions.impl;
 
 import com.google.common.base.Function;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -15,6 +16,7 @@ public class SparseCheckoutPath extends AbstractDescribableImpl<SparseCheckoutPa
 
     private static final long serialVersionUID = -6177158367915899356L;
 
+    @SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification="Default value is OK in deserialization")
     public static final transient SparseCheckoutPathToPath SPARSE_CHECKOUT_PATH_TO_PATH = new SparseCheckoutPathToPath();
 
     private final String path;

--- a/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPath.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPath.java
@@ -1,6 +1,7 @@
 package hudson.plugins.git.extensions.impl;
 
 import com.google.common.base.Function;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
@@ -56,7 +57,7 @@ public class SparseCheckoutPath extends AbstractDescribableImpl<SparseCheckoutPa
     }
 
     private static class SparseCheckoutPathToPath implements Function<SparseCheckoutPath, String>, Serializable {
-        public String apply(SparseCheckoutPath sparseCheckoutPath) {
+        public String apply(@NonNull SparseCheckoutPath sparseCheckoutPath) {
             return sparseCheckoutPath.getPath();
         }
     }

--- a/src/main/java/hudson/plugins/git/util/AncestryBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/AncestryBuildChooser.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
@@ -112,7 +113,7 @@ public class AncestryBuildChooser extends DefaultBuildChooser {
         }
         
         @Override
-        public boolean apply(RevCommit rev) {
+        public boolean apply(@NonNull RevCommit rev) {
             return LocalDateTime.ofInstant(rev.getCommitterIdent().getWhen().toInstant(), ZoneId.systemDefault()).isAfter(this.oldestAllowableCommitDate);
         }
         

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -166,17 +166,21 @@ public class BuildData implements Action, Serializable, Cloneable {
     public Build getLastBuild(ObjectId sha1) {
         // fast check by first checking most recent build
         if (lastBuild != null && (lastBuild.revision.getSha1().equals(sha1) || lastBuild.marked.getSha1().equals(sha1))) return lastBuild;
-        try {
-            for(Build b : buildsByBranchName.values()) {
-                if(b.revision.getSha1().equals(sha1) || b.marked.getSha1().equals(sha1))
-                    return b;
+        for (Build b : buildsByBranchName.values()) {
+            if (b == null || b.revision == null || b.revision.getSha1() == null) {
+                continue;
             }
-
-            return null;
+            if (b.revision.getSha1().equals(sha1)) {
+                return b;
+            }
+            if (b.marked == null || b.marked.getSha1() == null) {
+                continue;
+            }
+            if (b.marked.getSha1().equals(sha1)) {
+                return b;
+            }
         }
-        catch(Exception ex) {
-            return null;
-        }
+        return null;
     }
 
     public void saveBuild(Build build) {

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -140,42 +140,11 @@ public class DefaultBuildChooser extends BuildChooser {
             Revision revision = new Revision(sha1);
             revision.getBranches().add(new Branch(singleBranch, sha1));
             return Collections.singletonList(revision);
-            /*
-            // calculate the revisions that are new compared to the last build
-            List<Revision> candidateRevs = new ArrayList<Revision>();
-            List<ObjectId> allRevs = git.revListAll(); // index 0 contains the newest revision
-            if (data != null && allRevs != null) {
-                Revision lastBuiltRev = data.getLastBuiltRevision();
-                if (lastBuiltRev == null) {
-                    return Collections.singletonList(objectId2Revision(singleBranch, sha1));
-                }
-                int indexOfLastBuildRev = allRevs.indexOf(lastBuiltRev.getSha1());
-                if (indexOfLastBuildRev == -1) {
-                    // mhmmm ... can happen when branches are switched.
-                    return Collections.singletonList(objectId2Revision(singleBranch, sha1));
-                }
-                List<ObjectId> newRevisionsSinceLastBuild = allRevs.subList(0, indexOfLastBuildRev);
-                // translate list of ObjectIds into list of Revisions
-                for (ObjectId objectId : newRevisionsSinceLastBuild) {
-                    candidateRevs.add(objectId2Revision(singleBranch, objectId));
-                }
-            }
-            if (candidateRevs.isEmpty()) {
-                return Collections.singletonList(objectId2Revision(singleBranch, sha1));
-            }
-            return candidateRevs;
-            */
         } catch (GitException e) {
             // branch does not exist, there is nothing to build
             verbose(listener, "Failed to rev-parse: {0}", singleBranch);
             return emptyList();
         }
-    }
-
-    private Revision objectId2Revision(String singleBranch, ObjectId sha1) {
-        Revision revision = new Revision(sha1);
-        revision.getBranches().add(new Branch(singleBranch, sha1));
-        return revision;
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -363,16 +363,14 @@ public class GitUtils implements Serializable {
 
     private static void addEnvironmentContributingActionsValues(EnvVars env, AbstractBuild b) {
         List<? extends Action> buildActions = b.getAllActions();
-        if (buildActions != null) {
-            for (Action action : buildActions) {
-                // most importantly, ParametersAction will be processed here (for parameterized builds)
-                if (action instanceof ParametersAction) {
-                    ParametersAction envAction = (ParametersAction) action;
-                    envAction.buildEnvVars(b, env);
-                }
+        for (Action action : buildActions) {
+            // most importantly, ParametersAction will be processed here (for parameterized builds)
+            if (action instanceof ParametersAction) {
+                ParametersAction envAction = (ParametersAction) action;
+                envAction.buildEnvVars(b, env);
             }
         }
-        
+
         // Use the default parameter values (if any) instead of the ones from the last build
         ParametersDefinitionProperty paramDefProp = (ParametersDefinitionProperty) b.getProject().getProperty(ParametersDefinitionProperty.class);
         if (paramDefProp != null) {

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -287,6 +287,9 @@ public class GitSCMFileSystem extends SCMFileSystem {
             if (rev != null && !(rev instanceof AbstractGitSCMSource.SCMRevisionImpl)) {
                 return null;
             }
+            if (!(scm instanceof GitSCM)) {
+                return null; // Spotbugs warns about unchecked cast without this check
+            }
             GitSCM gitSCM = (GitSCM) scm;
             UserRemoteConfig config = gitSCM.getUserRemoteConfigs().get(0);
             BranchSpec branchSpec = gitSCM.getBranches().get(0);

--- a/src/main/java/jenkins/plugins/git/GitSCMSourceRequest.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSourceRequest.java
@@ -42,14 +42,6 @@ import org.eclipse.jgit.transport.RefSpec;
  */
 public class GitSCMSourceRequest extends SCMSourceRequest {
     /**
-     * {@code true} if branch details need to be fetched.
-     */
-    private final boolean fetchBranches;
-    /**
-     * {@code true} if tag details need to be fetched.
-     */
-    private final boolean fetchTags;
-    /**
      * The {@link RefSpec} instances.
      */
     private final List<RefSpec> refSpecs;
@@ -71,8 +63,6 @@ public class GitSCMSourceRequest extends SCMSourceRequest {
      */
     public GitSCMSourceRequest(@NonNull SCMSource source, @NonNull GitSCMSourceContext<?, ?> context, TaskListener listener) {
         super(source, context, listener);
-        fetchBranches = context.wantBranches();
-        fetchTags = context.wantTags();
         remoteName = context.remoteName();
         gitTool = context.gitTool();
         refSpecs = Collections.unmodifiableList(context.asRefSpecs());

--- a/src/main/java/jenkins/plugins/git/traits/LocalBranchTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/LocalBranchTrait.java
@@ -67,6 +67,9 @@ public class LocalBranchTrait extends GitSCMExtensionTrait<LocalBranch> {
          */
         @Override
         public SCMSourceTrait convertToTrait(@NonNull GitSCMExtension extension) {
+            if (!(extension instanceof LocalBranch)) {
+                return null; // spotbugs warns of unchecked cast without this check
+            }
             LocalBranch ext = (LocalBranch) extension;
             if ("**".equals(StringUtils.defaultIfBlank(ext.getLocalBranch(), "**"))) {
                 return new LocalBranchTrait();


### PR DESCRIPTION
## Fix PruneStaleTag javadoc warning and spotbugs warnings

Recent change introduced a javadoc warning about an undocumented parameter.  This documents the parameter.

Recent change introduced a deeper check from spotbugs.  This resolves many of the spotbugs reports from that deeper check.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Documentation