### PR TITLE
Replace javax annotations with spotbugs annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,23 +51,9 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>4.0.0</version>
-        <executions>
-          <execution>
-            <id>spotbugs</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <configuration>
-              <xmlOutput>true</xmlOutput>
-              <spotbugsXmlOutput>false</spotbugsXmlOutput>
-              <effort>default</effort>
-              <threshold>Medium</threshold>
-              <failOnError>true</failOnError>
-            </configuration>
-          </execution>
-        </executions>
         <configuration>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
           <failOnError>true</failOnError>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,13 @@
           <threshold>Low</threshold>
           <failOnError>true</failOnError>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>4.0.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,18 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+      <optional>true</optional>
+      <version>4.0.1</version>
+    </dependency>
     <!-- JCasC compatibility -->
     <dependency>
       <groupId>io.jenkins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,30 @@
           <failOnViolation>true</failOnViolation>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.0.0</version>
+        <executions>
+          <execution>
+            <id>spotbugs</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <xmlOutput>true</xmlOutput>
+              <spotbugsXmlOutput>false</spotbugsXmlOutput>
+              <effort>default</effort>
+              <threshold>Medium</threshold>
+              <failOnError>true</failOnError>
+            </configuration>
+          </execution>
+        </executions>
+        <configuration>
+          <failOnError>true</failOnError>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/hudson/plugins/git/GitChangeLogParser.java
+++ b/src/main/java/hudson/plugins/git/GitChangeLogParser.java
@@ -11,7 +11,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.xml.sax.SAXException;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.io.File;
 import java.io.InputStream;
@@ -68,11 +68,11 @@ public class GitChangeLogParser extends ChangeLogParser {
         this.showEntireCommitSummaryInChanges = GitChangeSet.isShowEntireCommitSummaryInChanges() || !(git instanceof CliGitAPIImpl);
     }
     
-    public List<GitChangeSet> parse(@Nonnull InputStream changelog) throws IOException {
+    public List<GitChangeSet> parse(@NonNull InputStream changelog) throws IOException {
         return parse(IOUtils.readLines(changelog, "UTF-8"));
     }
 
-    public List<GitChangeSet> parse(@Nonnull List<String> changelog) {
+    public List<GitChangeSet> parse(@NonNull List<String> changelog) {
         return parse(changelog.iterator());
     }
 

--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -13,7 +13,7 @@ import org.apache.commons.lang.math.NumberUtils;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.ParseException;

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -19,7 +19,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.URI;
@@ -88,13 +88,13 @@ public class AssemblaWeb extends GitRepositoryBrowser {
 
     @Extension
     public static class AssemblaWebDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "AssemblaWeb";
         }
 
         @Override
-        public AssemblaWeb newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public AssemblaWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(AssemblaWeb.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/BitbucketWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/BitbucketWeb.java
@@ -9,7 +9,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URL;
 
@@ -71,13 +71,13 @@ public class BitbucketWeb extends GitRepositoryBrowser {
 
     @Extension
     public static class BitbucketWebDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "bitbucketweb";
         }
 
         @Override
-        public BitbucketWeb newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public BitbucketWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(BitbucketWeb.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/CGit.java
+++ b/src/main/java/hudson/plugins/git/browser/CGit.java
@@ -11,7 +11,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URL;
 
@@ -81,13 +81,13 @@ public class CGit extends GitRepositoryBrowser {
 
     @Extension
     public static class CGITDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "cgit";
         }
 
         @Override
-        public CGit newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public CGit newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(CGit.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
@@ -15,7 +15,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.URL;
@@ -68,13 +68,13 @@ public class FisheyeGitRepositoryBrowser extends GitRepositoryBrowser {
 	@Extension
 	public static class FisheyeGitRepositoryBrowserDescriptor extends Descriptor<RepositoryBrowser<?>> {
 
-		@Nonnull
+		@NonNull
 		public String getDisplayName() {
 			return "FishEye";
 		}
 
 		@Override
-		public FisheyeGitRepositoryBrowser newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+		public FisheyeGitRepositoryBrowser newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
 			assert req != null; //see inherited javadoc
 			return req.bindJSON(FisheyeGitRepositoryBrowser.class, jsonObject);
 		}

--- a/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
@@ -18,7 +18,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -73,13 +73,13 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
 
     @Extension
     public static class ViewGitWebDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "gitblit";
         }
 
         @Override
-        public GitBlitRepositoryBrowser newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public GitBlitRepositoryBrowser newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(GitBlitRepositoryBrowser.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/GitLab.java
+++ b/src/main/java/hudson/plugins/git/browser/GitLab.java
@@ -16,7 +16,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import java.io.IOException;
 import java.net.URL;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 
 import org.kohsuke.stapler.QueryParameter;
@@ -135,13 +135,13 @@ public class GitLab extends GitRepositoryBrowser {
 
     @Extension
     public static class GitLabDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "gitlab";
         }
 
         @Override
-        public GitLab newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public GitLab newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(GitLab.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/GitList.java
+++ b/src/main/java/hudson/plugins/git/browser/GitList.java
@@ -11,7 +11,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URL;
 
@@ -83,13 +83,13 @@ public class GitList extends GitRepositoryBrowser {
 
     @Extension
     public static class GitListDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "gitlist";
         }
 
         @Override
-        public GitList newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public GitList newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(GitList.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/GitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GitWeb.java
@@ -11,7 +11,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URL;
 
@@ -83,13 +83,13 @@ public class GitWeb extends GitRepositoryBrowser {
 
     @Extension
     public static class GitWebDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "gitweb";
         }
 
         @Override
-        public GitWeb newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public GitWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(GitWeb.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/GithubWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GithubWeb.java
@@ -11,7 +11,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URL;
 
@@ -89,13 +89,13 @@ public class GithubWeb extends GitRepositoryBrowser {
 
     @Extension
     public static class GithubWebDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "githubweb";
         }
 
         @Override
-		public GithubWeb newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+		public GithubWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
 			return req.bindJSON(GithubWeb.class, jsonObject);
 		}

--- a/src/main/java/hudson/plugins/git/browser/Gitiles.java
+++ b/src/main/java/hudson/plugins/git/browser/Gitiles.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 
 import net.sf.json.JSONObject;
@@ -61,13 +61,13 @@ public class Gitiles extends GitRepositoryBrowser {
 
     @Extension
     public static class ViewGitWebDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "gitiles";
         }
 
         @Override
-        public Gitiles newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public Gitiles newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(Gitiles.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/GitoriousWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GitoriousWeb.java
@@ -10,7 +10,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URL;
 
@@ -67,13 +67,13 @@ public class GitoriousWeb extends GitRepositoryBrowser {
 
     @Extension
     public static class GitoriousWebDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "gitoriousweb";
         }
 
         @Override
-        public GitoriousWeb newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public GitoriousWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(GitoriousWeb.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/GogsGit.java
+++ b/src/main/java/hudson/plugins/git/browser/GogsGit.java
@@ -11,7 +11,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URL;
 
@@ -91,13 +91,13 @@ public class GogsGit extends GitRepositoryBrowser {
 
     @Extension
     public static class GogsGitDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "gogs";
         }
 
         @Override
-        public GogsGit newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public GogsGit newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(GogsGit.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/KilnGit.java
+++ b/src/main/java/hudson/plugins/git/browser/KilnGit.java
@@ -12,7 +12,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URL;
 
@@ -102,13 +102,13 @@ public class KilnGit extends GitRepositoryBrowser {
 
     @Extension
     public static class KilnGitDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "Kiln";
         }
 
         @Override
-        public KilnGit newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public KilnGit newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(KilnGit.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/Phabricator.java
+++ b/src/main/java/hudson/plugins/git/browser/Phabricator.java
@@ -9,7 +9,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URL;
 
@@ -81,13 +81,13 @@ public class Phabricator extends GitRepositoryBrowser {
 
     @Extension
     public static class PhabricatorDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "phabricator";
         }
 
         @Override
-        public Phabricator newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public Phabricator newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(Phabricator.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/RedmineWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/RedmineWeb.java
@@ -10,7 +10,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URL;
 
@@ -84,13 +84,13 @@ public class RedmineWeb extends GitRepositoryBrowser {
 
     @Extension
     public static class RedmineWebDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "redmineweb";
         }
 
         @Override
-        public RedmineWeb newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public RedmineWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(RedmineWeb.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/RhodeCode.java
+++ b/src/main/java/hudson/plugins/git/browser/RhodeCode.java
@@ -11,7 +11,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URL;
 
@@ -86,13 +86,13 @@ public class RhodeCode extends GitRepositoryBrowser {
 
     @Extension
     public static class RhodeCodeDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "rhodecode";
         }
 
         @Override
-        public RhodeCode newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public RhodeCode newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(RhodeCode.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/Stash.java
+++ b/src/main/java/hudson/plugins/git/browser/Stash.java
@@ -11,7 +11,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URL;
 
@@ -87,13 +87,13 @@ public class Stash extends GitRepositoryBrowser {
 
     @Extension
     public static class StashDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "stash";
         }
 
         @Override
-        public Stash newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public Stash newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(Stash.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
@@ -18,7 +18,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -85,13 +85,13 @@ public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
     public static class TFS2013GitRepositoryBrowserDescriptor extends Descriptor<RepositoryBrowser<?>> {
 
         private static final String REPOSITORY_BROWSER_LABEL = "Microsoft Team Foundation Server/Visual Studio Team Services";
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return REPOSITORY_BROWSER_LABEL;
         }
 
         @Override
-        public TFS2013GitRepositoryBrowser newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public TFS2013GitRepositoryBrowser newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             try {
                 req.getSubmittedForm();

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -19,7 +19,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -81,13 +81,13 @@ public class ViewGitWeb extends GitRepositoryBrowser {
 
     @Extension
     public static class ViewGitWebDescriptor extends Descriptor<RepositoryBrowser<?>> {
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "viewgit";
         }
 
         @Override
-        public ViewGitWeb newInstance(StaplerRequest req, @Nonnull JSONObject jsonObject) throws FormException {
+        public ViewGitWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             assert req != null; //see inherited javadoc
             return req.bindJSON(ViewGitWeb.class, jsonObject);
         }

--- a/src/main/java/hudson/plugins/git/util/BuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooser.java
@@ -16,7 +16,6 @@ import hudson.plugins.git.IGitAPI;
 import hudson.plugins.git.Revision;
 import org.jenkinsci.plugins.gitclient.GitClient;
 
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -270,7 +269,6 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
      * @throws IOException on input or output error
      * @throws InterruptedException when interrupted
      */
-    @ParametersAreNonnullByDefault
     public void prepareWorkingTree(GitClient git, TaskListener listener, BuildChooserContext context) throws IOException,InterruptedException {
         // Nop
     }

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -29,7 +29,7 @@ import java.text.MessageFormat;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class GitUtils implements Serializable {

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -30,17 +30,17 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class GitUtils implements Serializable {
     
     @SuppressFBWarnings(value="SE_BAD_FIELD", justification="known non-serializable field")
-    @Nonnull
+    @NonNull
     GitClient git;
-    @Nonnull
+    @NonNull
     TaskListener listener;
 
-    public GitUtils(@Nonnull TaskListener listener, @Nonnull GitClient git) {
+    public GitUtils(@NonNull TaskListener listener, @NonNull GitClient git) {
         this.git = git;
         this.listener = listener;
     }
@@ -59,7 +59,7 @@ public class GitUtils implements Serializable {
     public static GitTool resolveGitTool(@CheckForNull String gitTool,
                                          @CheckForNull Node builtOn,
                                          @CheckForNull EnvVars env,
-                                         @Nonnull TaskListener listener) {
+                                         @NonNull TaskListener listener) {
         GitTool git = gitTool == null
                 ? GitTool.getDefaultInstallation()
                 : Jenkins.get().getDescriptorByType(GitTool.DescriptorImpl.class).getInstallation(gitTool);
@@ -91,7 +91,7 @@ public class GitUtils implements Serializable {
      * @since TODO
      */
     @CheckForNull
-    public static GitTool resolveGitTool(@CheckForNull String gitTool, @Nonnull TaskListener listener) {
+    public static GitTool resolveGitTool(@CheckForNull String gitTool, @NonNull TaskListener listener) {
         return resolveGitTool(gitTool, null, null, listener);
     }
 

--- a/src/main/java/jenkins/plugins/git/traits/CleanAfterCheckoutTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/CleanAfterCheckoutTrait.java
@@ -31,7 +31,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Exposes {@link CleanCheckout} as a {@link SCMSourceTrait}.

--- a/src/main/java/jenkins/plugins/git/traits/CleanAfterCheckoutTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/CleanAfterCheckoutTrait.java
@@ -30,7 +30,7 @@ import hudson.plugins.git.extensions.impl.CleanCheckout;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**

--- a/src/main/java/jenkins/plugins/git/traits/CleanBeforeCheckoutTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/CleanBeforeCheckoutTrait.java
@@ -31,7 +31,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Exposes {@link CleanBeforeCheckout} as a {@link SCMSourceTrait}.

--- a/src/main/java/jenkins/plugins/git/traits/CleanBeforeCheckoutTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/CleanBeforeCheckoutTrait.java
@@ -30,7 +30,7 @@ import hudson.plugins.git.extensions.impl.CleanBeforeCheckout;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**

--- a/src/main/java/jenkins/plugins/git/traits/GitSCMExtensionTraitDescriptor.java
+++ b/src/main/java/jenkins/plugins/git/traits/GitSCMExtensionTraitDescriptor.java
@@ -37,7 +37,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMBuilder;
 import jenkins.scm.api.trait.SCMBuilder;

--- a/src/test/java/hudson/plugins/git/UserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/UserRemoteConfigTest.java
@@ -12,7 +12,7 @@ import hudson.util.ListBoxModel;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.TreeSet;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.model.Jenkins;
 import org.junit.Test;

--- a/src/test/java/hudson/plugins/git/UserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/UserRemoteConfigTest.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.TreeSet;
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.model.Jenkins;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -49,7 +49,7 @@ public class UserRemoteConfigTest {
         assertCredentials(null, "othercreds", "admin", "", "mycreds", "othercreds");
     }
     
-    private void assertCredentials(@CheckForNull final Item project, @CheckForNull final String currentCredentialsId, @Nonnull String user, @Nonnull String... expectedCredentialsIds) {
+    private void assertCredentials(@CheckForNull final Item project, @CheckForNull final String currentCredentialsId, @NonNull String user, @NonNull String... expectedCredentialsIds) {
         final Set<String> actual = new TreeSet<>(); // for purposes of this test we do not care about order (though StandardListBoxModel does define some)
         ACL.impersonate(User.get(user).impersonate(), () -> {
             for (ListBoxModel.Option option : r.jenkins.getDescriptorByType(UserRemoteConfig.DescriptorImpl.class).


### PR DESCRIPTION
## Replace javax annotations with spotbugs annotations

The javax annotations from JSR-305 were never finalized and never will be finalized. The spotbugs team has provided replacements that match with spotbugs usage.

Also updates to spotbugs 4.0.1.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency or infrastructure update

In the spirit of https://github.com/jenkinsci/jenkins/pull/4604