### PR TITLE
Require Jenkins 2.204.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,14 @@
 #!groovy
 
+Random random = new Random() // Randomize which Jenkins version is selected for more testing
+def use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but slightly older on other
+
 // Test plugin compatibility to recommended configurations
-// Allow failing tests to retry execution
 subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                      ],
-                        [ jdk: '8',  platform: 'linux',   jenkins: '2.164.1', javaLevel: '8' ],
-                        [ jdk: '11', platform: 'linux',   jenkins: '2.164.1', javaLevel: '8' ]
+                        // Compile with Java 8, test 2.204.6 or 2.222.1 depending on random use_newer_jenkins
+                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.204.6' : '2.222.1', javaLevel: '8' ],
+                        // Compile with Java 11, test the Jenkins version that Java 8 did *not* test
+                        [ jdk: '11', platform: 'linux',   jenkins:  use_newer_jenkins ? '2.204.6' : '2.222.1', javaLevel: '8' ]
                       ]
 
 buildPlugin(configurations: subsetConfiguration, failFast: false)

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
-    <forkCount>3</forkCount>
     <linkXRef>false</linkXRef>
     <configuration-as-code.version>1.36</configuration-as-code.version>
     <slf4jVersion>1.7.26</slf4jVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.57</version>
+    <version>4.0-beta-6</version>
     <relativePath />
   </parent>
 
@@ -27,13 +27,16 @@
   <properties>
     <revision>4.3.0</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.138.4</jenkins.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+    <jenkins.version>2.204.1</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
     <forkCount>3</forkCount>
     <linkXRef>false</linkXRef>
-    <configuration-as-code.version>1.35</configuration-as-code.version>
+    <configuration-as-code.version>1.36</configuration-as-code.version>
+    <slf4jVersion>1.7.26</slf4jVersion>
   </properties>
 
   <build>
@@ -298,6 +301,10 @@
           <groupId>commons-digester</groupId>
           <artifactId>commons-digester</artifactId>
         </exclusion>
+        <exclusion> <!-- Jenkins 2.204.1 provides a newer version than commons-validator mandates -->
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>
@@ -306,7 +313,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.138.x</artifactId>
+        <artifactId>bom-2.176.x</artifactId>
         <version>4</version>
         <scope>import</scope>
         <type>pom</type>

--- a/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
@@ -1,79 +1,297 @@
 package hudson.plugins.git;
 
-import hudson.security.csrf.CrumbFilter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
-
-import javax.servlet.FilterChain;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import java.util.Collections;
-
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import org.jvnet.hudson.test.JenkinsRule;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Check that no crumb is required for successful calls to notifyCommit.
+ */
 public class GitStatusCrumbExclusionTest {
 
-    @Rule
-    public JenkinsRule r = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule r = new JenkinsRule();
 
-    private CrumbFilter filter;
-    private HttpServletRequest req;
-    private HttpServletResponse resp;
-    private FilterChain chain;
+    private static final String GIT_REPO_URL = "https://github.com/jenkinsci/git-client-plugin";
 
-    private static String systemPropertyPreviousValue;
+    private final URL notifyCommitURL;
+    private final URL manageURL; // Valid URL that is not notifyCommit
+    private final URL invalidURL; // Jenkins internal URL that reports page not found
 
-    @BeforeClass
-    public static void setProps() {
-        systemPropertyPreviousValue = System.getProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO");
-        System.setProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO", "true");
-    }
+    private final String urlArgument;
+    private final byte[] urlArgumentBytes;
 
-    @AfterClass
-    public static void unsetProps() {
-        if (systemPropertyPreviousValue == null) {
-            System.clearProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO");
-        } else {
-            System.setProperty("hudson.security.csrf.CrumbFilter.UNPROCESSED_PATHINFO", systemPropertyPreviousValue);
+    private final String separator;
+    private final byte[] separatorBytes;
+
+    private final String branchArgument;
+    private final byte[] branchArgumentBytes;
+
+    public GitStatusCrumbExclusionTest() throws IOException {
+        String jenkinsUrl = r.getURL().toExternalForm();
+        if (!jenkinsUrl.endsWith("/")) {
+            jenkinsUrl = jenkinsUrl + "/";
         }
+        notifyCommitURL = new URL(jenkinsUrl + "git/notifyCommit");
+        manageURL = new URL(jenkinsUrl + "manage");
+        invalidURL = new URL(jenkinsUrl + "jobs/no-such-job");
+
+        urlArgument = "url=" + GIT_REPO_URL;
+        urlArgumentBytes = urlArgument.getBytes(StandardCharsets.UTF_8);
+
+        separator = "&";
+        separatorBytes = separator.getBytes(StandardCharsets.UTF_8);
+
+        branchArgument = "branches=origin/some-branch-name";
+        branchArgumentBytes = branchArgument.getBytes(StandardCharsets.UTF_8);
     }
+
+    private HttpURLConnection connectionPOST;
 
     @Before
-    public void before() {
-        filter = new CrumbFilter();
-        req = mock(HttpServletRequest.class);
-        resp = mock(HttpServletResponse.class);
-        chain = mock(FilterChain.class);
+    public void connectWithPOST() throws IOException {
+        URL postURL = notifyCommitURL;
+        connectionPOST = (HttpURLConnection) postURL.openConnection();
+        connectionPOST.setRequestMethod("POST");
+        connectionPOST.setDoOutput(true);
+    }
+
+    @After
+    public void disconnectFromPOST() {
+        connectionPOST.disconnect();
+    }
+
+    /*
+     * POST tests.
+     */
+    @Test
+    public void testPOSTValidPathNoArgument() throws Exception {
+        assertThat(connectionPOST.getResponseCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
+        assertThat(connectionPOST.getResponseMessage(), is("Server Error"));
     }
 
     @Test
-    public void testNotifyCommit() throws Exception {
-        when(req.getPathInfo()).thenReturn("/git/notifyCommit");
-        when(req.getMethod()).thenReturn("POST");
-        when(req.getParameterNames()).thenReturn(Collections.<String>emptyEnumeration());
-        filter.doFilter(req, resp, chain);
-        verify(resp, never()).sendError(anyInt(), anyString());
+    public void testPOSTValidPathMandatoryArgument() throws Exception {
+        try (OutputStream os = connectionPOST.getOutputStream()) {
+            os.write(urlArgumentBytes);
+        }
+        assertThat(connectionPOST.getResponseCode(), is(HttpURLConnection.HTTP_OK));
+        assertThat(connectionPOST.getResponseMessage(), is("OK"));
     }
 
     @Test
-    public void testInvalidPath() throws Exception {
-        when(req.getPathInfo()).thenReturn("/git/somethingElse");
-        when(req.getMethod()).thenReturn("POST");
-        when(req.getParameterNames()).thenReturn(Collections.<String>emptyEnumeration());
-        filter.doFilter(req, resp, chain);
-        verify(resp, times(1)).sendError(anyInt(), anyString());
+    public void testPOSTValidPathEmptyMandatoryArgument() throws Exception {
+        try (OutputStream os = connectionPOST.getOutputStream()) {
+            String urlEmptyArgument = "url="; // Empty argument is not a valid URL
+            byte[] urlEmptyArgumentBytes = urlEmptyArgument.getBytes(StandardCharsets.UTF_8);
+            os.write(urlEmptyArgumentBytes);
+        }
+        assertThat(connectionPOST.getResponseCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
+        assertThat(connectionPOST.getResponseMessage(), is("Bad Request"));
+    }
+
+    @Test
+    public void testPOSTValidPathBadURLInMandatoryArgument() throws Exception {
+        try (OutputStream os = connectionPOST.getOutputStream()) {
+            String urlBadArgument = "url=" + "http://256.256.256.256/"; // Not a valid URI per Java 8 javadoc
+            byte[] urlBadArgumentBytes = urlBadArgument.getBytes(StandardCharsets.UTF_8);
+            os.write(urlBadArgumentBytes);
+        }
+        assertThat(connectionPOST.getResponseCode(), is(HttpURLConnection.HTTP_OK));
+        assertThat(connectionPOST.getResponseMessage(), is("OK"));
+    }
+
+    @Test
+    public void testPOSTValidPathMandatoryAndOptionalArgument() throws Exception {
+        try (OutputStream os = connectionPOST.getOutputStream()) {
+            os.write(urlArgumentBytes);
+            os.write(separatorBytes);
+            os.write(branchArgumentBytes);
+        }
+        assertThat(connectionPOST.getResponseCode(), is(HttpURLConnection.HTTP_OK));
+        assertThat(connectionPOST.getResponseMessage(), is("OK"));
+    }
+
+    @Test
+    public void testPOSTValidPathOnlyOptionalArgument() throws Exception {
+        try (OutputStream os = connectionPOST.getOutputStream()) {
+            os.write(branchArgumentBytes);
+        }
+        assertThat(connectionPOST.getResponseCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
+        assertThat(connectionPOST.getResponseMessage(), is("Server Error"));
+    }
+
+    @Test
+    public void testPOSTInvalidPathNoArgument() throws Exception {
+        URL invalidPathURL = invalidURL;
+        HttpURLConnection invalidPathConnection = (HttpURLConnection) invalidPathURL.openConnection();
+        invalidPathConnection.setRequestMethod("POST");
+        invalidPathConnection.setDoOutput(true);
+        assertThat(invalidPathConnection.getResponseCode(), is(HttpURLConnection.HTTP_FORBIDDEN));
+        assertThat(invalidPathConnection.getResponseMessage(), is("Forbidden"));
+        invalidPathConnection.disconnect();
+    }
+
+    @Test
+    public void testPOSTInvalidPathMandatoryArgument() throws Exception {
+        URL invalidPathURL = invalidURL;
+        HttpURLConnection invalidPathConnection = (HttpURLConnection) invalidPathURL.openConnection();
+        invalidPathConnection.setRequestMethod("POST");
+        invalidPathConnection.setDoOutput(true);
+        try (OutputStream os = invalidPathConnection.getOutputStream()) {
+            os.write(urlArgumentBytes);
+        }
+        assertThat(invalidPathConnection.getResponseCode(), is(HttpURLConnection.HTTP_FORBIDDEN));
+        assertThat(invalidPathConnection.getResponseMessage(), is("Forbidden"));
+        invalidPathConnection.disconnect();
+    }
+
+    @Test
+    public void testPOSTInvalidPathMandatoryAndOptionalArgument() throws Exception {
+        URL invalidPathURL = invalidURL;
+        HttpURLConnection invalidPathConnection = (HttpURLConnection) invalidPathURL.openConnection();
+        invalidPathConnection.setRequestMethod("POST");
+        invalidPathConnection.setDoOutput(true);
+        try (OutputStream os = invalidPathConnection.getOutputStream()) {
+            os.write(urlArgumentBytes);
+            os.write(separatorBytes);
+            os.write(branchArgumentBytes);
+        }
+        assertThat(invalidPathConnection.getResponseCode(), is(HttpURLConnection.HTTP_FORBIDDEN));
+        assertThat(invalidPathConnection.getResponseMessage(), is("Forbidden"));
+        invalidPathConnection.disconnect();
+    }
+
+    @Test
+    public void testPOSTManageNoArgument() throws Exception {
+        URL postURL = manageURL;
+        HttpURLConnection manageConnection = (HttpURLConnection) postURL.openConnection();
+        manageConnection.setRequestMethod("POST");
+        manageConnection.setDoOutput(true);
+        assertThat(manageConnection.getResponseCode(), is(HttpURLConnection.HTTP_FORBIDDEN));
+        assertThat(manageConnection.getResponseMessage(), is("Forbidden"));
+        manageConnection.disconnect();
+    }
+
+    @Test
+    public void testPOSTManageMandatoryArgument() throws Exception {
+        URL postURL = manageURL;
+        HttpURLConnection manageConnection = (HttpURLConnection) postURL.openConnection();
+        manageConnection.setRequestMethod("POST");
+        manageConnection.setDoOutput(true);
+        try (OutputStream os = manageConnection.getOutputStream()) {
+            os.write(urlArgumentBytes);
+        }
+        assertThat(manageConnection.getResponseCode(), is(HttpURLConnection.HTTP_FORBIDDEN));
+        assertThat(manageConnection.getResponseMessage(), is("Forbidden"));
+        manageConnection.disconnect();
+    }
+
+    @Test
+    public void testPOSTManageMandatoryAndOptionalArgument() throws Exception {
+        URL postURL = manageURL;
+        HttpURLConnection manageConnection = (HttpURLConnection) postURL.openConnection();
+        manageConnection.setRequestMethod("POST");
+        manageConnection.setDoOutput(true);
+        try (OutputStream os = manageConnection.getOutputStream()) {
+            os.write(urlArgumentBytes);
+            os.write(separatorBytes);
+            os.write(branchArgumentBytes);
+        }
+        assertThat(manageConnection.getResponseCode(), is(HttpURLConnection.HTTP_FORBIDDEN));
+        assertThat(manageConnection.getResponseMessage(), is("Forbidden"));
+        manageConnection.disconnect();
+    }
+
+    /*
+     * GET tests.
+     */
+    @Test
+    public void testGETValidPathNoArgument() throws Exception {
+        URL getURL = notifyCommitURL;
+        HttpURLConnection connectionGET = (HttpURLConnection) getURL.openConnection();
+        connectionGET.setRequestMethod("GET");
+        connectionGET.connect();
+        assertThat(connectionGET.getResponseCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
+        assertThat(connectionGET.getResponseMessage(), is("Server Error"));
+        connectionGET.disconnect();
+    }
+
+    @Test
+    public void testGETValidPathMandatoryArgument() throws Exception {
+        URL getURL = new URL(notifyCommitURL + "?" + urlArgument);
+        HttpURLConnection connectionGET = (HttpURLConnection) getURL.openConnection();
+        connectionGET.setRequestMethod("GET");
+        connectionGET.connect();
+        assertThat(connectionGET.getResponseCode(), is(HttpURLConnection.HTTP_OK));
+        assertThat(connectionGET.getResponseMessage(), is("OK"));
+        connectionGET.disconnect();
+    }
+
+    @Test
+    public void testGETValidPathMandatoryAndOptionalArgument() throws Exception {
+        URL getURL = new URL(notifyCommitURL + "?" + urlArgument + separator + branchArgument);
+        HttpURLConnection connectionGET = (HttpURLConnection) getURL.openConnection();
+        connectionGET.setRequestMethod("GET");
+        connectionGET.connect();
+        assertThat(connectionGET.getResponseCode(), is(HttpURLConnection.HTTP_OK));
+        assertThat(connectionGET.getResponseMessage(), is("OK"));
+        connectionGET.disconnect();
+    }
+
+    @Test
+    public void testGETInvalidPath() throws Exception {
+        URL getURL = invalidURL;
+        HttpURLConnection connectionGET = (HttpURLConnection) getURL.openConnection();
+        connectionGET.setRequestMethod("GET");
+        connectionGET.connect();
+        assertThat(connectionGET.getResponseCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
+        assertThat(connectionGET.getResponseMessage(), is("Not Found"));
+        connectionGET.disconnect();
+    }
+
+    @Test
+    public void testGETInvalidPathWithArgument() throws Exception {
+        URL getURL = new URL(invalidURL + "?" + urlArgument);
+        HttpURLConnection connectionGET = (HttpURLConnection) getURL.openConnection();
+        connectionGET.setRequestMethod("GET");
+        connectionGET.connect();
+        assertThat(connectionGET.getResponseCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
+        assertThat(connectionGET.getResponseMessage(), is("Not Found"));
+        connectionGET.disconnect();
+    }
+
+    @Test
+    public void testGETManagePath() throws Exception {
+        URL getURL = manageURL;
+        HttpURLConnection connectionGET = (HttpURLConnection) getURL.openConnection();
+        connectionGET.setRequestMethod("GET");
+        connectionGET.connect();
+        assertThat(connectionGET.getResponseCode(), is(HttpURLConnection.HTTP_OK));
+        assertThat(connectionGET.getResponseMessage(), is("OK"));
+        connectionGET.disconnect();
+    }
+
+    @Test
+    public void testGETManagePathWithArgument() throws Exception {
+        URL getURL = new URL(manageURL + "?" + urlArgument);
+        HttpURLConnection connection = (HttpURLConnection) getURL.openConnection();
+        connection.setRequestMethod("GET");
+        connection.connect();
+        assertThat(connection.getResponseCode(), is(HttpURLConnection.HTTP_OK));
+        assertThat(connection.getResponseMessage(), is("OK"));
+        connection.disconnect();
     }
 }

--- a/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
@@ -3,17 +3,53 @@ package hudson.plugins.git.extensions.impl;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.View;
 import hudson.plugins.git.AbstractGitTestCase;
 import hudson.plugins.git.BranchSpec;
 
 import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.GitStatusTest;
+import hudson.util.RunList;
+import java.io.File;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
 
 public class BuildSingleRevisionOnlyTest extends AbstractGitTestCase {
+
+    @After
+    public void waitForAllJobsToComplete() {
+        /* Windows job cleanup fails to delete build logs in some of these tests.
+         * Wait for the jobs to complete before exiting the test so that the
+         * build logs will not be active when the cleanup process tries to
+         * delete them.
+         */
+        if (!isWindows() || rule == null || rule.jenkins == null) {
+            return;
+        }
+        View allView = rule.jenkins.getView("All");
+        if (allView == null) {
+            return;
+        }
+        RunList<Run> runList = allView.getBuilds();
+        if (runList == null) {
+            return;
+        }
+        runList.forEach((Run run) -> {
+            try {
+                Logger.getLogger(GitStatusTest.class.getName()).log(Level.INFO, "Waiting for {0}", run);
+                rule.waitForCompletion(run);
+            } catch (InterruptedException ex) {
+                Logger.getLogger(GitStatusTest.class.getName()).log(Level.SEVERE, "Interrupted waiting for GitStatusTest job", ex);
+            }
+        });
+    }
 
     @Test
     public void testSingleRevision() throws Exception {
@@ -73,8 +109,14 @@ public class BuildSingleRevisionOnlyTest extends AbstractGitTestCase {
         final FreeStyleBuild build = build(project, Result.SUCCESS, commitFile);
 
         rule.assertBuildStatusSuccess(build);
-        boolean result = build.getLog(100).contains(
-                String.format("Scheduling another build to catch up with %s", project.getName()));
-        Assert.assertTrue(result);
+        rule.waitForMessage(String.format("Scheduling another build to catch up with %s", project.getName()), build);
+    }
+
+    /**
+     * inline ${@link hudson.Functions#isWindows()} to prevent a transient
+     * remote class loader issue
+     */
+    private boolean isWindows() {
+        return File.pathSeparatorChar == ';';
     }
 }

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
@@ -114,7 +114,22 @@ public class GitSCMSourceTest {
         return owner;
     }
 
-    private interface GitSCMSourceOwner extends TopLevelItem, SCMSourceOwner {
+    /* Intentionally made public to prevent Java 11 mocking failure
+     * due to class loading of a non-public interface in a different
+     * class loader than the mocking framework. Since this is a test,
+     * it seems quite safe to make the interface slightly more visible
+     * than private.
+     *
+     * The message from mockito is:
+     *
+     * The type is not public and its mock class is loaded by a different class loader.
+     * This can have multiple reasons:
+     *  - You are mocking a class with additional interfaces of another class loader
+     *  - Mockito is loaded by a different class loader than the mocked type (e.g. with OSGi)
+     *  - The thread's context class loader is different than the mock's class loader
+     *
+     */
+    public interface GitSCMSourceOwner extends TopLevelItem, SCMSourceOwner {
     }
 
     @TestExtension


### PR DESCRIPTION
## Require Jenkins 2.204.1

This pull request switches from requiring Jenkins 2.138.4 as minimum version to require Jenkins 2.204.1 as minimum version.  Using a modern version like 2.204.1 includes the trilead-api separation from the Jenkins core and simplifies testing.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update

## Further comments

User based justification for choosing 2.204.1 as the new minimum version:

* Over 48% of the 240 000 installations of git plugin are running git plugin 4.0.0 or newer.  Over 40 000 git plugin installations are using Jenkins 2.204.2
* Almost 10x more installations of git plugin are on Jenkins 2.204.2 than any other single release

Users that are choosing to stay current with the git plugin are also choosing to stay current with Jenkins releases.  That's a very good thing.  Special thanks to the users for choosing to update to recent releases!

The Jenkinsfile is now configured to test Jenkins 2.204.6 on Windows with Java 8 and Jenkins 2.222.1 or 2.204.6 on Linux with both Java 8 and Java 11.  It intentionally tests the most recent release of Jenkins 2.204.x while only requiring 2.204.1 so that users of 2.204.2 are not forced to update to use the git client plugin.

There are still some spotbugs warnings that will either need to be suppressed, resolved, or hidden by restoring the spotbugs settings that were used until the recent update to spotbugs 4.0.1.  Specifically, the spotbugs threshold was previously set to 'High' with the effort set to 'Low'.  The new settings invert that and set the threshold to 'Low' and the effort to 'Max'.

This change intentionally uses plugin pom 4.0-beta with the assumption that plugin pom 4.0 will be released within the next month or so.  If it is not released in that time, then the most recent released parent will be used instead.

Matching pull request for git client plugin at https://github.com/jenkinsci/git-client-plugin/pull/532