### PR TITLE
Use waitForMessage instead of assertLogContains

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -812,6 +812,14 @@ Excluded Messages::
 Removes remote tracking branches from the local workspace if they no longer exist on the remote.
 See `link:https://git-scm.com/docs/git-remote#Documentation/git-remote.txt-empruneem[git remote prune]` and `link:https://git-scm.com/docs/git-fetch#_pruning[git fetch --prune]` for more details.
 
+[#prune-stale-tags]
+==== Prune stale tags
+
+Removes tags from the local workspace before fetch if they no longer exist on the remote.
+If stale tags are not pruned, deletion of a remote tag will not remove the local tag in the workspace.
+If the local tag already exists in the workspace, git correctly refuses to create the tag again.
+Pruning stale tags allows the local workspace to create a tag with the same name as a tag which was removed from the remote.
+
 [#sparse-checkout-paths]
 ==== Sparse Checkout paths
 

--- a/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
@@ -59,7 +59,7 @@ public class CredentialsUserRemoteConfigTest {
                         + "  )"
                         + "}", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        r.assertLogContains("using credential github", b);
+        r.waitForMessage("using credential github", b);
     }
 
     @Issue("JENKINS-30515")
@@ -78,7 +78,7 @@ public class CredentialsUserRemoteConfigTest {
                         + "  )"
                         + "}", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        r.assertLogContains("Warning: CredentialId \"github\" could not be found", b);
+        r.waitForMessage("Warning: CredentialId \"github\" could not be found", b);
     }
 
     @Issue("JENKINS-30515")
@@ -97,7 +97,7 @@ public class CredentialsUserRemoteConfigTest {
                         + "  )"
                         + "}", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        r.assertLogContains("Warning: CredentialId \"github\" could not be found", b);
+        r.waitForMessage("Warning: CredentialId \"github\" could not be found", b);
     }
 
     @Issue("JENKINS-30515")
@@ -114,7 +114,7 @@ public class CredentialsUserRemoteConfigTest {
                         + "  )"
                         + "}", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        r.assertLogContains("Warning: CredentialId \"github\" could not be found", b);
+        r.waitForMessage("Warning: CredentialId \"github\" could not be found", b);
     }
 
     @Issue("JENKINS-30515")
@@ -131,7 +131,7 @@ public class CredentialsUserRemoteConfigTest {
                         + "  )"
                         + "}", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        r.assertLogContains("No credentials specified", b);
+        r.waitForMessage("No credentials specified", b);
     }
 
 

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1119,19 +1119,19 @@ public class GitSCMTest extends AbstractGitTestCase {
         FreeStyleBuild build1 = build(project, Result.SUCCESS, commitFile1);
 
         assertEquals("origin/master", getEnvVars(project).get(GitSCM.GIT_BRANCH));
-        rule.assertLogContains(getEnvVars(project).get(GitSCM.GIT_BRANCH), build1);
+        rule.waitForMessage(getEnvVars(project).get(GitSCM.GIT_BRANCH), build1);
 
-        rule.assertLogContains(checkoutString(project, GitSCM.GIT_COMMIT), build1);
+        rule.waitForMessage(checkoutString(project, GitSCM.GIT_COMMIT), build1);
 
         final String commitFile2 = "commitFile2";
         commit(commitFile2, johnDoe, "Commit number 2");
         FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile2);
 
         rule.assertLogNotContains(checkoutString(project, GitSCM.GIT_PREVIOUS_COMMIT), build2);
-        rule.assertLogContains(checkoutString(project, GitSCM.GIT_PREVIOUS_COMMIT), build1);
+        rule.waitForMessage(checkoutString(project, GitSCM.GIT_PREVIOUS_COMMIT), build1);
 
         rule.assertLogNotContains(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build2);
-        rule.assertLogContains(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build1);
+        rule.waitForMessage(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build1);
     }
 
     @Issue("HUDSON-7411")
@@ -2140,7 +2140,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         try {
             FileUtils.touch(lock);
             final FreeStyleBuild build2 = build(project, Result.FAILURE);
-            rule.assertLogContains("java.io.IOException: Could not checkout", build2);
+            rule.waitForMessage("java.io.IOException: Could not checkout", build2);
         } finally {
             lock.delete();
         }

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -595,7 +595,7 @@ public class GitStatusTest extends AbstractGitProject {
 
         FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserCause()).get();
 
-        jenkins.assertLogContains("aaa aaaccc ccc", build);
+        jenkins.waitForMessage("aaa aaaccc ccc", build);
 
         String extraValue = "An-extra-value";
         when(requestWithParameter.getParameterMap()).thenReturn(setupParameterMap(extraValue));

--- a/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
@@ -112,15 +112,13 @@ public class BuildSingleRevisionOnlyTest extends AbstractGitTestCase {
         rule.assertBuildStatusSuccess(build);
         rule.waitForMessage(String.format("Scheduling another build to catch up with %s", project.getName()), build);
 
-        Thread.sleep(750L); // Wait briefly for scheduled job to start
-        RunList<FreeStyleBuild> builds = project.getBuilds();
-        for (FreeStyleBuild aBuild : builds) {
-            if (!aBuild.equals(build)) {
-                /* Don't wait for the build that already finished */
-                rule.assertBuildStatusSuccess(aBuild);
-                rule.waitForMessage("Finished: SUCCESS", aBuild);
-            }
-        }
+        // Wait briefly for newly scheduled job to start.
+        // Once job has started, waitForAllJobsToComplete will hold the test until job completes.
+        // Windows can remove log files once job completes.
+        // Wait on non-Windows reduces log file InterruptedException from rule teardown before job completion.
+        // Wait on non-Windows not strictly required but gives one less exception in the test log.
+        java.util.Random random = new java.util.Random();
+        Thread.sleep(500L + random.nextInt(300));
     }
 
     /**

--- a/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
@@ -15,6 +15,7 @@ import java.io.File;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.Thread;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -110,6 +111,13 @@ public class BuildSingleRevisionOnlyTest extends AbstractGitTestCase {
 
         rule.assertBuildStatusSuccess(build);
         rule.waitForMessage(String.format("Scheduling another build to catch up with %s", project.getName()), build);
+
+        Thread.sleep(750L); // Wait briefly for scheduled job to start
+        RunList<FreeStyleBuild> builds = project.getBuilds();
+        for (FreeStyleBuild aBuild : builds) {
+            rule.assertBuildStatusSuccess(aBuild);
+            rule.waitForMessage("Finished: SUCCESS", aBuild);
+        }
     }
 
     /**

--- a/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
@@ -115,8 +115,11 @@ public class BuildSingleRevisionOnlyTest extends AbstractGitTestCase {
         Thread.sleep(750L); // Wait briefly for scheduled job to start
         RunList<FreeStyleBuild> builds = project.getBuilds();
         for (FreeStyleBuild aBuild : builds) {
-            rule.assertBuildStatusSuccess(aBuild);
-            rule.waitForMessage("Finished: SUCCESS", aBuild);
+            if (!aBuild.equals(build)) {
+                /* Don't wait for the build that already finished */
+                rule.assertBuildStatusSuccess(aBuild);
+                rule.waitForMessage("Finished: SUCCESS", aBuild);
+            }
         }
     }
 

--- a/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
@@ -81,7 +81,7 @@ public class BuildSingleRevisionOnlyTest extends AbstractGitTestCase {
         rule.assertBuildStatusSuccess(build);
         boolean result = build.getLog(100).contains(
                 String.format("Scheduling another build to catch up with %s", project.getName()));
-        Assert.assertFalse(result);
+        Assert.assertFalse("Single revision scheduling did not prevent a build of a different revision", result);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/git/extensions/impl/CheckoutOptionWorkflowTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CheckoutOptionWorkflowTest.java
@@ -27,6 +27,6 @@ public class CheckoutOptionWorkflowTest {
                 + "  )"
                 + "}", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        r.assertLogContains("# timeout=1234", b);
+        r.waitForMessage("# timeout=1234", b);
     }
 }

--- a/src/test/java/jenkins/plugins/git/GitStepTest.java
+++ b/src/test/java/jenkins/plugins/git/GitStepTest.java
@@ -100,13 +100,13 @@ public class GitStepTest {
             "    }\n" +
             "}", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        r.assertLogContains("Cloning the remote Git repository", b); // GitSCM.retrieveChanges
+        r.waitForMessage("Cloning the remote Git repository", b); // GitSCM.retrieveChanges
         assertTrue(b.getArtifactManager().root().child("file").isFile());
         sampleRepo.write("nextfile", "");
         sampleRepo.git("add", "nextfile");
         sampleRepo.git("commit", "--message=next");
         b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        r.assertLogContains("Fetching changes from the remote Git repository", b); // GitSCM.retrieveChanges
+        r.waitForMessage("Fetching changes from the remote Git repository", b); // GitSCM.retrieveChanges
         assertTrue(b.getArtifactManager().root().child("nextfile").isFile());
     }
 
@@ -123,14 +123,14 @@ public class GitStepTest {
             "    }\n" +
             "}", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        r.assertLogContains("Cloning the remote Git repository", b);
+        r.waitForMessage("Cloning the remote Git repository", b);
         sampleRepo.write("nextfile", "");
         sampleRepo.git("add", "nextfile");
         sampleRepo.git("commit", "--message=next");
         sampleRepo.notifyCommit(r);
         b = p.getLastBuild();
         assertEquals(2, b.number);
-        r.assertLogContains("Fetching changes from the remote Git repository", b);
+        r.waitForMessage("Fetching changes from the remote Git repository", b);
         List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = b.getChangeSets();
         assertEquals(1, changeSets.size());
         ChangeLogSet<? extends ChangeLogSet.Entry> changeSet = changeSets.get(0);
@@ -254,7 +254,7 @@ public class GitStepTest {
             "  rungit 'show master'\n" +
             "}", true));
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        r.assertLogContains("+edited by build", b);
+        r.waitForMessage("+edited by build", b);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/gittagmessage/GitTagMessageExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gittagmessage/GitTagMessageExtensionTest.java
@@ -48,8 +48,8 @@ public class GitTagMessageExtensionTest extends AbstractGitTagMessageExtensionTe
     protected void assertBuildEnvironment(FreeStyleBuild build, String expectedName, String expectedMessage)
             throws Exception {
         // In the freestyle shell step, unknown environment variables are returned as empty strings
-        jenkins.assertLogContains(String.format("tag='%s'", Util.fixNull(expectedName)), build);
-        jenkins.assertLogContains(String.format("msg='%s'", Util.fixNull(expectedMessage)), build);
+        jenkins.waitForMessage(String.format("tag='%s'", Util.fixNull(expectedName)), build);
+        jenkins.waitForMessage(String.format("msg='%s'", Util.fixNull(expectedMessage)), build);
     }
 
     private static Builder createEnvEchoBuilder(String key, String envVarName) {


### PR DESCRIPTION
## Use waitForMessage instead of assertLogContains

Jesse Glick noted in a [comment](https://github.com/jenkinsci/bom/pull/110#issuecomment-594782396) that some flaky pipeline tests in other plugins could be resolved by switching from assertLogContains to waitForMessage. Since the git plugin has shown a tendency to flaky tests on Windows, let's use Jesse's recommendation as well.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Test