### PR TITLE
[JENKINS-61869] Prune tags during fetch shown incorrectly in syntax generator

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/PruneStaleTag.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PruneStaleTag.java
@@ -36,10 +36,12 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Map.Entry;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -69,6 +71,15 @@ public class PruneStaleTag extends GitSCMExtension {
     }
 
     /**
+     * Needed for pipeline syntax generator.
+     *
+     * @return {@code true} if this extension is enable, {@code false} otherwise.
+     */
+    public boolean getPruneTags() {
+        return pruneTags;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -94,7 +105,7 @@ public class PruneStaleTag extends GitSCMExtension {
 
         List<RemoteConfig> remoteRepos = run == null ? scm.getRepositories() : scm.getParamExpandedRepos(run, listener);
         for (RemoteConfig remote : remoteRepos) {
-            for(URIish url : remote.getURIs()) {
+            for (URIish url : remote.getURIs()) {
                 Map<String, ObjectId> refs = git.getRemoteReferences(url.toASCIIString(), null, false, true);
                 for (Entry<String, ObjectId> ref : refs.entrySet()) {
                     String remoteTagName = ref.getKey();
@@ -125,7 +136,10 @@ public class PruneStaleTag extends GitSCMExtension {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        return o instanceof PruneStaleTag;
+
+        PruneStaleTag that = (PruneStaleTag) o;
+
+        return pruneTags == that.pruneTags;
     }
 
     /**
@@ -133,7 +147,7 @@ public class PruneStaleTag extends GitSCMExtension {
      */
     @Override
     public int hashCode() {
-        return PruneStaleTag.class.hashCode();
+        return Objects.hashCode(pruneTags);
     }
 
     /**
@@ -144,6 +158,7 @@ public class PruneStaleTag extends GitSCMExtension {
         return "PruneStaleTag {}";
     }
 
+    @Symbol("pruneTags")
     @Extension
     public static class DescriptorImpl extends GitSCMExtensionDescriptor {
         /**

--- a/src/main/java/hudson/plugins/git/extensions/impl/PruneStaleTag.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PruneStaleTag.java
@@ -32,6 +32,8 @@ import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import net.sf.json.JSONObject;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +47,7 @@ import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Prune stale local tags that do not exist on any remote.
@@ -161,6 +164,12 @@ public class PruneStaleTag extends GitSCMExtension {
     @Symbol("pruneTags")
     @Extension
     public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+
+        @Override
+        public GitSCMExtension newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            return new PruneStaleTag(true);
+        }
+
         /**
          * {@inheritDoc}
          */

--- a/src/test/java/hudson/plugins/git/extensions/impl/PruneStaleTagPipelineTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/PruneStaleTagPipelineTest.java
@@ -1,0 +1,125 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020 Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+package hudson.plugins.git.extensions.impl;
+
+import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.gitclient.TestCliGitAPIImpl;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Functions;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
+
+public class PruneStaleTagPipelineTest {
+
+    @Rule
+    public TemporaryFolder fileRule = new TemporaryFolder();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private TaskListener listener;
+
+    @Before
+    public void setup() throws Exception {
+        listener = new LogTaskListener(Logger.getLogger("prune tags"), Level.FINEST);
+    }
+
+    @Issue("JENKINS-61869")
+    @Test
+    public void verify_that_local_tag_is_pruned_when_not_exist_on_remote_using_pipeline() throws Exception {
+        File remoteRepo = fileRule.newFolder("remote");
+
+        // create a remote repository without one tag
+        GitClient remoteClient = initRepository(remoteRepo);
+        String tagName = "tag";
+        String tagComment = "tag comment";
+        remoteClient.tag(tagName, tagComment);
+
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "pruneTags");
+
+        FilePath workspace = j.jenkins.getWorkspaceFor(job);
+        String remoteURL = "file://" + remoteRepo.toURI().getPath();
+
+        job.setDefinition(new CpsFlowDefinition(""
+                + "  node {\n"
+                + "    checkout([$class: 'GitSCM',"
+                + "             branches: [[name: '*/master']],"
+                + "             doGenerateSubmoduleConfigurations: false,"
+                + "             extensions: [pruneTags(true)],"
+                + "             submoduleCfg: [],"
+                + "             userRemoteConfigs: [[url: '" + remoteURL + "']]"
+                + "    ])"
+                + "  }\n", true));
+
+        // first run clone the repository
+        WorkflowRun r = job.scheduleBuild2(0).waitForStart();
+        j.assertBuildStatus(Result.SUCCESS, j.waitForCompletion(r));
+
+        // remove tag on remote, tag remains on local cloned repository
+        remoteClient.deleteTag(tagName);
+
+        // second run it should remove stale tags
+        r = job.scheduleBuild2(0).waitForStart();
+        j.assertBuildStatus(Result.SUCCESS, j.waitForCompletion(r));
+
+        GitClient localClient = newGitClient(new File(workspace.getRemote()));
+        Assert.assertFalse("local tag has not been pruned", localClient.tagExists(tagName));
+    }
+
+    private GitClient newGitClient(File localRepo) {
+        String gitExe = Functions.isWindows() ? "git.exe" : "git";
+        GitClient localClient = new TestCliGitAPIImpl(gitExe, localRepo, listener, new EnvVars());
+        return localClient;
+    }
+
+    private GitClient initRepository(File workspace) throws Exception {
+        GitClient remoteClient = newGitClient(workspace);
+        remoteClient.init();
+
+        FileUtils.touch(new File(workspace, "test"));
+        remoteClient.add("test");
+
+        remoteClient.commit("initial commit");
+        return remoteClient;
+    }
+
+}


### PR DESCRIPTION
## [JENKINS-61869](https://issues.jenkins-ci.org/browse/JENKINS-61869) - Prune tags during fetch shown incorrectly in syntax generator
## [JENKINS-61871](https://issues.jenkins-ci.org/browse/JENKINS-61871) - Prune stale tags does not prune stale tags in my docker test

Add missing getter method required by the pipeline syntax generator.
Add symbol on this extension to render it more readable.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

@MarkEWaite I have a doubt in PruneStaleTag.DescriptorImpl.newInstance. For latest code review you suggest to add a boolean to enable/disable this extesion. To do that I added in a previous request a boolean field in the constructor but I realize that to make it true by default I adopt a method that I do not like so much.
Maybe there are 3 way to perform the goal
- Actual way edit the JSON formData of request putting pruneTags as true if not present in the original request (this make true as default unless specified and cover future additional settings for this trait)
- other way is instantiate the extension class like `return new PruneStaleTag(true)`
- add a jelly file (I do not know how) with hidden pruneTags input data true by default

What do you suggest?