### PR TITLE
Use MarkEWaite pipeline library fork

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,7 @@
 #!groovy
 
 // Temporary library until https://github.com/jenkins-infra/pipeline-library/pull/141 is merged
-library retriever:  modernSCM([$class: 'GitSCMSource', remote: 'https://github.com/MarkEWaite/pipeline-library']),
-        identifier: 'infra@clean-workspace-if-incrementals'
+library retriever:  modernSCM([$class: 'GitSCMSource', remote: 'https://github.com/MarkEWaite/pipeline-library']), identifier: 'infra@clean-workspace-if-incrementals'
 
 Random random = new Random() // Randomize which Jenkins version is selected for more testing
 def use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but slightly older on other
@@ -16,56 +15,3 @@ subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null         
                       ]
 
 buildPlugin(configurations: subsetConfiguration, failFast: false)
-
-def branches = [:]
-
-branches["ATH"] = {
-    node("docker && highmem") {
-        def checkoutGit
-        stage("ATH: Checkout") {
-            checkoutGit = pwd(tmp:true) + "/athgit"
-            dir(checkoutGit) {
-                checkout scm
-                infra.runMaven(["clean", "package", "-DskipTests"])
-                // Include experimental git-client in target dir for ATH
-                // This Git plugin requires experimental git-client
-                infra.runMaven(["dependency:copy", "-Dartifact=org.jenkins-ci.plugins:git-client:3.0.0-beta3:hpi", "-DoutputDirectory=target", "-Dmdep.stripVersion=true"])
-                dir("target") {
-                    stash name: "localPlugins", includes: "*.hpi"
-                }
-            }
-        }
-        def metadataPath = checkoutGit + "/essentials.yml"
-        stage("Run ATH") {
-            def athFolder=pwd(tmp:true) + "/ath"
-            dir(athFolder) {
-                runATH metadataFile: metadataPath
-            }
-        }
-    }
-}
-branches["PCT"] = {
-    node("docker && highmem") {
-        def metadataPath
-        env.RUN_PCT_LOCAL_PLUGIN_SOURCES_STASH_NAME = "localPluginsPCT"
-        stage("PCT: Checkout") {
-            def checkoutGit = pwd(tmp:true) + "/pctgit"
-            dir(checkoutGit) {
-                dir("git") {
-                    checkout scm
-                }
-                stash name: "localPluginsPCT", useDefaultExcludes: false
-            }
-            metadataPath = checkoutGit + "/git/essentials.yml"
-        }
-        stage("Run PCT") {
-            def pctFolder = pwd(tmp:true) + "/pct"
-            dir(pctFolder) {
-                runPCT metadataFile: metadataPath
-            }
-        }
-    }
-}
-
-// Intentionally disabled until tests are more reliable
-// parallel branches

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,8 @@
 #!groovy
 
-library identifier: 'MarkEWaite-fork-of-ci-jenkins-io-pipeline-library', retriever: modernSCM([$class: 'GitSCMSource', remote: 'https://github.com/MarkEWaite/pipeline-library'])
+library identifier: 'MarkEWaite@clean-workspace-if-incrementals',
+        retriever:  modernSCM([$class: 'GitSCMSource', remote: 'https://github.com/MarkEWaite/pipeline-library']),
+        changelog:  false
 
 Random random = new Random() // Randomize which Jenkins version is selected for more testing
 def use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but slightly older on other

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,7 @@
 #!groovy
 
+library identifier: 'MarkEWaite-fork-of-ci-jenkins-io-pipeline-library', retriever: modernSCM([$class: 'GitSCMSource', remote: 'https://github.com/MarkEWaite/pipeline-library'])
+
 Random random = new Random() // Randomize which Jenkins version is selected for more testing
 def use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but slightly older on other
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!groovy
 
 // Temporary library until https://github.com/jenkins-infra/pipeline-library/pull/141 is merged
-library retriever:  modernSCM([$class: 'GitSCMSource', remote: 'https://github.com/MarkEWaite/pipeline-library']), identifier: 'infra@clean-workspace-if-incrementals'
+library retriever:  modernSCM([$class: 'GitSCMSource', remote: 'https://github.com/MarkEWaite/pipeline-library']), identifier: 'MarkEWaiteFork@clean-workspace-if-incrementals'
 
 Random random = new Random() // Randomize which Jenkins version is selected for more testing
 def use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but slightly older on other

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 #!groovy
 
+// Temporary library until https://github.com/jenkins-infra/pipeline-library/pull/141 is merged
 library identifier: 'MarkEWaite@clean-workspace-if-incrementals',
         retriever:  modernSCM([$class: 'GitSCMSource', remote: 'https://github.com/MarkEWaite/pipeline-library']),
         changelog:  false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,8 @@
 #!groovy
 
 // Temporary library until https://github.com/jenkins-infra/pipeline-library/pull/141 is merged
-library identifier: 'MarkEWaite@clean-workspace-if-incrementals',
-        retriever:  modernSCM([$class: 'GitSCMSource', remote: 'https://github.com/MarkEWaite/pipeline-library']),
-        changelog:  false
+library retriever:  modernSCM([$class: 'GitSCMSource', remote: 'https://github.com/MarkEWaite/pipeline-library']),
+        identifier: 'infra@clean-workspace-if-incrementals'
 
 Random random = new Random() // Randomize which Jenkins version is selected for more testing
 def use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but slightly older on other


### PR DESCRIPTION
## Use MarkEWaite pipeline library fork

Use my pipeline library fork so that it cleans the workspace before running maven.  Prevents `git status -s` failures from maven incrementals.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update