### PR TITLE
Reduce spotbugs warnings

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -983,7 +983,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         private Object writeReplace() {
-            return Channel.current().export(BuildChooserContext.class,new BuildChooserContext() {
+            Channel currentChannel = Channel.current();
+            if (currentChannel == null) {
+                return null;
+            }
+            return currentChannel.export(BuildChooserContext.class,new BuildChooserContext() {
                 public <T> T actOnBuild(@NonNull ContextCallable<Run<?,?>, T> callable) throws IOException, InterruptedException {
                     return callable.invoke(build,Channel.current());
                 }

--- a/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
+++ b/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.RelativePath;
 import hudson.plugins.git.GitSCM.DescriptorImpl;
 import hudson.plugins.git.extensions.GitSCMExtension;
@@ -272,12 +273,14 @@ public abstract class GitSCMBackwardCompatibility extends SCM implements Seriali
     }
 
     @Deprecated
+    @SuppressFBWarnings(value="PZLA_PREFER_ZERO_LENGTH_ARRAYS", justification="Not willing to change behavior of deprecated methods")
     public String[] getExcludedRegionsNormalized() {
         PathRestriction pr = getExtensions().get(PathRestriction.class);
         return pr!=null ? pr.getExcludedRegionsNormalized() : null;
     }
 
     @Deprecated
+    @SuppressFBWarnings(value="PZLA_PREFER_ZERO_LENGTH_ARRAYS", justification="Not willing to change behavior of deprecated methods")
     public String[] getIncludedRegionsNormalized() {
         PathRestriction pr = getExtensions().get(PathRestriction.class);
         return pr!=null ? pr.getIncludedRegionsNormalized() : null;

--- a/src/main/java/hudson/plugins/git/util/CommitTimeComparator.java
+++ b/src/main/java/hudson/plugins/git/util/CommitTimeComparator.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.git.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.plugins.git.Revision;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevWalk;
@@ -35,6 +36,7 @@ import java.util.Comparator;
  * 
  * @author Kohsuke Kawaguchi
  */
+@SuppressFBWarnings(value="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE", justification="Known non-serializable field critical part of class")
 public class CommitTimeComparator implements Comparator<Revision> {
     private final RevWalk walk;
 

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -1609,18 +1609,18 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         @Override
         public SCMProbeStat stat(@NonNull String path) throws IOException {
             try {
-                SCMFileSystem fileSystem;
+                SCMFileSystem fileSystemForStat;
                 synchronized (this) {
                     if (this.fileSystem == null) {
                         this.fileSystem = telescope.build(remote, credentials, revision.getHead(), revision);
                     }
-                    fileSystem = this.fileSystem;
+                    fileSystemForStat = this.fileSystem;
                 }
-                if (fileSystem == null) {
+                if (fileSystemForStat == null) {
                     throw new IOException("Cannot connect to " + remote + " as "
                             + (credentials == null ? "anonymous" : CredentialsNameProvider.name(credentials)));
                 }
-                return SCMProbeStat.fromType(fileSystem.child(path).getType());
+                return SCMProbeStat.fromType(fileSystemForStat.child(path).getType());
             } catch (InterruptedException e) {
                 throw new IOException(e);
             }
@@ -1655,16 +1655,16 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                     return lastModified;
                 }
             }
-            long lastModified;
+            long lastModifiedTimeStamp;
             try {
-                lastModified = telescope.getTimestamp(remote, credentials, revision.getHead());
+                lastModifiedTimeStamp = telescope.getTimestamp(remote, credentials, revision.getHead());
             } catch (IOException | InterruptedException e) {
                 return -1L;
             }
             synchronized (this) {
-                this.lastModified = lastModified;
+                this.lastModified = lastModifiedTimeStamp;
             }
-            return lastModified;
+            return lastModifiedTimeStamp;
         }
     }
 }

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -517,7 +517,12 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                 continue;
                             }
                             count++;
-                            if (request.process((GitTagSCMHead) revision.getHead(),
+                            SCMHead scmHead = revision.getHead();
+                            if (!(scmHead instanceof GitTagSCMHead)) {
+                                continue;
+                            }
+                            GitTagSCMHead gitTagHead = (GitTagSCMHead) scmHead;
+                            if (request.process(gitTagHead,
                                     new SCMSourceRequest.RevisionLambda<GitTagSCMHead, GitTagSCMRevision>() {
                                         @NonNull
                                         @Override

--- a/src/main/java/jenkins/plugins/git/GitSCMBuilder.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMBuilder.java
@@ -514,8 +514,10 @@ public class GitSCMBuilder<B extends GitSCMBuilder<B>> extends SCMBuilder<B, Git
             extensions.add(new BuildChooserSetting(new AbstractGitSCMSource.SpecificRevisionBuildChooser(
                     (AbstractGitSCMSource.SCMRevisionImpl) revision)));
         }
-        if (head() instanceof GitRefSCMHead) {
-            withRefSpec(((GitRefSCMHead) head()).getRef());
+        SCMHead scmHead = head();
+        if (scmHead instanceof GitRefSCMHead) {
+            GitRefSCMHead gitHead = (GitRefSCMHead) scmHead;
+            withRefSpec(gitHead.getRef());
         }
         return new GitSCM(
                 asRemoteConfigs(),


### PR DESCRIPTION
## Reduce spotbugs warnings

A recent settings change increased the number of spotbugs warnings by allowing higher effort and a lower threshold.  Resolve several spotbugs warnings that are easy to resolve.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Refactoring to remove warnings