### PR TITLE
Use BOM 2.190.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,13 +296,17 @@
       <artifactId>commons-validator</artifactId>
       <version>1.6</version>
       <exclusions>
-        <exclusion>
+        <exclusion> <!-- Jenkins 2.204.1 provides a newer version than commons-digester mandates -->
           <groupId>commons-digester</groupId>
           <artifactId>commons-digester</artifactId>
         </exclusion>
         <exclusion> <!-- Jenkins 2.204.1 provides a newer version than commons-validator mandates -->
           <groupId>commons-beanutils</groupId>
           <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+        <exclusion> <!-- Jenkins 2.204.1 provides commons-collections, no need to bundle it -->
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -146,9 +146,20 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
+      <artifactId>hamcrest</artifactId>
       <version>2.2</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion> <!-- Hamcrest 2.x bundles all hamcrest-core functionality in the hamcrest artifact -->
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -235,6 +246,12 @@
       <artifactId>xmlunit-matchers</artifactId>
       <version>2.6.4</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion> <!-- Hamcrest 2.x bundles all hamcrest-core functionality in the hamcrest artifact -->
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.176.x</artifactId>
+        <artifactId>bom-2.190.x</artifactId>
         <version>7</version>
         <scope>import</scope>
         <type>pom</type>

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -74,7 +74,17 @@ public class GitStatusTest extends AbstractGitProject {
     }
 
     @After
-    public void waitForAllJobsToComplete() {
+    public void waitForAllJobsToComplete() throws Exception {
+        // Put JenkinsRule into shutdown state, trying to reduce Windows cleanup exceptions
+        if (jenkins != null && jenkins.jenkins != null) {
+            jenkins.jenkins.doQuietDown();
+        }
+        // JenkinsRule cleanup throws exceptions during tearDown.
+        // Reduce exceptions by a random delay from 0.5 to 0.9 seconds.
+        // Adding roughly 0.7 seconds to these JenkinsRule tests is a small price
+        // for fewer exceptions and for better Windows job cleanup.
+        java.util.Random random = new java.util.Random();
+        Thread.sleep(500L + random.nextInt(400));
         /* Windows job cleanup fails to delete build logs in some of these tests.
          * Wait for the jobs to complete before exiting the test so that the
          * build logs will not be active when the cleanup process tries to


### PR DESCRIPTION
## use BOM 2.190.x

Use plugin BOM 2.190.x 7 with version numbers preferred from it rather than being maintained inside the pom file.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update

## Further comments

Aligns with git client plugin.