### PR TITLE
Use pom 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.0-beta-6</version>
+    <version>4.0</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>4.0.1</version>
+            <version>4.0.2</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -274,7 +274,7 @@
         </exclusion>
       </exclusions>
       <optional>true</optional>
-      <version>4.0.1</version>
+      <version>4.0.2</version>
     </dependency>
     <!-- JCasC compatibility -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -330,8 +330,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.190.x</artifactId>
-        <version>7</version>
+        <artifactId>bom-2.204.x</artifactId>
+        <version>9</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
     <linkXRef>false</linkXRef>
     <configuration-as-code.version>1.36</configuration-as-code.version>
     <slf4jVersion>1.7.26</slf4jVersion>
+    <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.failOnError>true</spotbugs.failOnError>
+    <spotbugs.threshold>Medium</spotbugs.threshold>
   </properties>
 
   <build>
@@ -53,11 +56,6 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>4.0.0</version>
-        <configuration>
-          <effort>Max</effort>
-          <threshold>Low</threshold>
-          <failOnError>true</failOnError>
-        </configuration>
         <dependencies>
           <dependency>
             <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
## Use pom 4.0

Use parent pom 4.0 for easier maintenance and better spotbugs integration.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency or infrastructure update