### PR TITLE
Fix typo on Japanese translation

### DIFF
--- a/src/main/resources/hudson/plugins/git/BranchSpec/help-name_ja.html
+++ b/src/main/resources/hudson/plugins/git/BranchSpec/help-name_ja.html
@@ -54,7 +54,7 @@
       <li> <strong><code>&lt;ワイルドカード&gt;</code></strong><br/>
            文法は、<code>リポジトリ名/ブランチ名</code>の形式です。
            加えて、<code>ブランチ名</code>は、<code>*/ブランチ名</code>の省略と扱われます。ここで、'*'はワイルドカードとして扱われ、
-           '**'はセパレータ'/'を含むワルドカードとして扱われます。それゆえ、<code>origin/branches*</code>は、<code>origin/branches-foo</code>に合致しますが、
+           '**'はセパレータ'/'を含むワイルドカードとして扱われます。それゆえ、<code>origin/branches*</code>は、<code>origin/branches-foo</code>に合致しますが、
            <code>origin/branches/foo</code>には合致しません。
            一方、<code>origin/branches**</code>は、<code>origin/branches-foo</code>と<code>origin/branches/foo</code>の両方に一致します。
       </li>


### PR DESCRIPTION
## Fix typo on Japanese translation

I applied `s/ワルドカード/ワイルドカード/g`.

* `ワルドカード` is incorrect Japanese phrase.
* `ワイルドカード` is correct. (like [help-name_ja.html#L10](https://github.com/jenkinsci/git-plugin/blob/git-4.2.2/src/main/resources/hudson/plugins/git/BranchSpec/help-name_ja.html#L10) , [#L54](https://github.com/jenkinsci/git-plugin/blob/git-4.2.2/src/main/resources/hudson/plugins/git/BranchSpec/help-name_ja.html#L54) and [#L56](https://github.com/jenkinsci/git-plugin/blob/git-4.2.2/src/main/resources/hudson/plugins/git/BranchSpec/help-name_ja.html#L56) )

I have checked no `ワルドカード` under fixed commit. below:

```
$ git rev-parse HEAD
e533614dd10592695da8c0861ef203900fcdf344
$ git grep -n ワルドカード | wc -l
0
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

Only fix typo

- [x] Bug fix (non-breaking change which fixes an issue)
