### PR TITLE
Use Hamcrest instead of deprecated JUnit methods

### DIFF
--- a/src/test/java/hudson/plugins/git/ChangelogToBranchOptionsTest.java
+++ b/src/test/java/hudson/plugins/git/ChangelogToBranchOptionsTest.java
@@ -24,7 +24,7 @@
 package hudson.plugins.git;
 
 import org.junit.Test;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 public class ChangelogToBranchOptionsTest {

--- a/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
@@ -18,7 +18,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CredentialsUserRemoteConfigTest {
 

--- a/src/test/java/hudson/plugins/git/GitBranchSpecifierColumnTest.java
+++ b/src/test/java/hudson/plugins/git/GitBranchSpecifierColumnTest.java
@@ -26,9 +26,10 @@ package hudson.plugins.git;
 import hudson.model.Item;
 import java.util.ArrayList;
 import java.util.List;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Mark Waite

--- a/src/test/java/hudson/plugins/git/GitChangeLogParserTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeLogParserTest.java
@@ -9,8 +9,11 @@ import org.jenkinsci.plugins.gitclient.JGitAPIImpl;
 
 import java.io.File;
 import java.io.FileWriter;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;

--- a/src/test/java/hudson/plugins/git/GitChangeSetBasicTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetBasicTest.java
@@ -3,8 +3,10 @@ package hudson.plugins.git;
 import java.util.ArrayList;
 import java.util.Arrays;
 import static hudson.plugins.git.GitChangeSet.TRUNCATE_LIMIT;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 public class GitChangeSetBasicTest {

--- a/src/test/java/hudson/plugins/git/GitChangeSetListTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetListTest.java
@@ -30,8 +30,10 @@ import java.util.List;
 import java.util.ArrayList;
 
 import org.junit.Test;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 
 public class GitChangeSetListTest {

--- a/src/test/java/hudson/plugins/git/GitChangeSetPluginHistoryTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetPluginHistoryTest.java
@@ -23,8 +23,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/hudson/plugins/git/GitChangeSetSimpleTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetSimpleTest.java
@@ -7,17 +7,20 @@ import java.util.HashSet;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
 public class GitChangeSetSimpleTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private GitChangeSet changeSet = null;
     private final boolean useAuthorName;
@@ -174,8 +177,10 @@ public class GitChangeSetSimpleTest {
         final String expectedLineContent = "commit ";
         ArrayList<String> lines = new ArrayList<>();
         lines.add(expectedLineContent);
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Commit has no ID[" + expectedLineContent + "]");
-        GitChangeSet badChangeSet = new GitChangeSet(lines, true);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                                                  () -> {
+                                                      new GitChangeSet(lines, true);
+                                                  });
+        assertThat(e.getMessage(), containsString("Commit has no ID[" + expectedLineContent + "]"));
     }
 }

--- a/src/test/java/hudson/plugins/git/GitChangeSetTimestampTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTimestampTest.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/hudson/plugins/git/GitChangeSetTruncateTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTruncateTest.java
@@ -23,8 +23,8 @@ import jenkins.plugins.git.GitSampleRepoRule;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;

--- a/src/test/java/hudson/plugins/git/GitRevisionTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/git/GitRevisionTokenMacroTest.java
@@ -30,8 +30,10 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.junit.Test;
 import org.junit.Before;
 import org.mockito.Mockito;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class GitRevisionTokenMacroTest {
 

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -77,12 +77,17 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.jgit.transport.RemoteConfig;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/hudson/plugins/git/GitSCMUnitTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMUnitTest.java
@@ -41,7 +41,9 @@ import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
 public class GitSCMUnitTest {

--- a/src/test/java/hudson/plugins/git/GitStatusMultipleSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusMultipleSCMTest.java
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 

--- a/src/test/java/hudson/plugins/git/GitTagActionTest.java
+++ b/src/test/java/hudson/plugins/git/GitTagActionTest.java
@@ -30,8 +30,10 @@ import org.jenkinsci.plugins.gitclient.GitClient;
 
 import jenkins.plugins.git.GitSampleRepoRule;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.*;
 
 import com.gargoylesoftware.htmlunit.html.HtmlForm;

--- a/src/test/java/hudson/plugins/git/SubmoduleConfigTest.java
+++ b/src/test/java/hudson/plugins/git/SubmoduleConfigTest.java
@@ -29,8 +29,10 @@ import java.util.List;
 import org.eclipse.jgit.lib.ObjectId;
 import org.junit.Before;
 import org.junit.Test;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class SubmoduleConfigTest {
 

--- a/src/test/java/hudson/plugins/git/browser/GitRepositoryBrowserTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitRepositoryBrowserTest.java
@@ -16,8 +16,7 @@ import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowserTest.java
+++ b/src/test/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowserTest.java
@@ -14,7 +14,7 @@ import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/hudson/plugins/git/browser/casc/GitLabConfiguratorTest.java
+++ b/src/test/java/hudson/plugins/git/browser/casc/GitLabConfiguratorTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class GitLabConfiguratorTest {

--- a/src/test/java/hudson/plugins/git/browser/casc/GitLabConfiguratorTest.java
+++ b/src/test/java/hudson/plugins/git/browser/casc/GitLabConfiguratorTest.java
@@ -5,7 +5,6 @@ import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.model.Mapping;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
@@ -18,9 +17,6 @@ public class GitLabConfiguratorTest {
 
     private final GitLabConfigurator configurator = new GitLabConfigurator();
     private static final ConfigurationContext NULL_CONFIGURATION_CONTEXT = null;
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testGetName() {

--- a/src/test/java/hudson/plugins/git/extensions/impl/SubmoduleOptionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/SubmoduleOptionTest.java
@@ -8,10 +8,10 @@ import org.jenkinsci.plugins.gitclient.*;
 import org.junit.Test;
 
 import java.io.IOException;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.fail;
 import org.jvnet.hudson.test.Issue;
-
-import static org.junit.Assert.*;
 
 import hudson.model.Run;
 import hudson.plugins.git.GitException;

--- a/src/test/java/hudson/plugins/git/util/BuildDataLoggingTest.java
+++ b/src/test/java/hudson/plugins/git/util/BuildDataLoggingTest.java
@@ -4,8 +4,9 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/hudson/plugins/git/util/BuildDataTest.java
+++ b/src/test/java/hudson/plugins/git/util/BuildDataTest.java
@@ -14,8 +14,12 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.eclipse.jgit.lib.ObjectId;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;

--- a/src/test/java/hudson/plugins/git/util/GitUtilsJenkinsRuleTest.java
+++ b/src/test/java/hudson/plugins/git/util/GitUtilsJenkinsRuleTest.java
@@ -34,8 +34,8 @@ import hudson.slaves.DumbSlave;
 import hudson.util.StreamTaskListener;
 import java.util.UUID;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;

--- a/src/test/java/hudson/plugins/git/util/GitUtilsTest.java
+++ b/src/test/java/hudson/plugins/git/util/GitUtilsTest.java
@@ -44,7 +44,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -61,19 +61,13 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Mockito;
 
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.hamcrest.collection.IsMapContaining.hasKey;
-import static org.hamcrest.core.AllOf.allOf;
-import static org.hamcrest.core.CombinableMatcher.both;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItems;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
-import static org.hamcrest.number.OrderingComparison.lessThanOrEqualTo;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/jenkins/plugins/git/BrowsersJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/BrowsersJCasCCompatibilityTest.java
@@ -39,7 +39,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BrowsersJCasCCompatibilityTest extends RoundTripAbstractTest {
     @Override

--- a/src/test/java/jenkins/plugins/git/CliGitCommand.java
+++ b/src/test/java/jenkins/plugins/git/CliGitCommand.java
@@ -42,7 +42,7 @@ import org.eclipse.jgit.lib.Repository;
 import static org.hamcrest.Matchers.hasItems;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.junit.Assert;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Run a command line git command, return output as array of String, optionally

--- a/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java
@@ -13,7 +13,7 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
 import java.util.Collection;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class GitJCasCCompatibilityTest extends RoundTripAbstractTest {

--- a/src/test/java/jenkins/plugins/git/GitSCMBuilderTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMBuilderTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeThat;
 
 public class GitSCMBuilderTest {

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -65,7 +65,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
@@ -66,7 +66,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
@@ -54,7 +54,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GitSCMSourceTraitsTest {
     /**

--- a/src/test/java/jenkins/plugins/git/GitSCMTelescopeTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMTelescopeTest.java
@@ -69,7 +69,9 @@ import org.acegisecurity.AccessDeniedException;
 import org.junit.Test;
 import static org.hamcrest.Matchers.*;
 import org.jenkinsci.plugins.gitclient.GitClient;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.ClassRule;
 

--- a/src/test/java/jenkins/plugins/git/GitToolJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolJCasCCompatibilityTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GitToolJCasCCompatibilityTest extends RoundTripAbstractTest {
     @Override

--- a/src/test/java/jenkins/plugins/git/GlobalLibraryWithLegacyJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/GlobalLibraryWithLegacyJCasCCompatibilityTest.java
@@ -48,7 +48,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class GlobalLibraryWithLegacyJCasCCompatibilityTest extends RoundTripAbstractTest {

--- a/src/test/java/jenkins/plugins/git/GlobalLibraryWithModernJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/GlobalLibraryWithModernJCasCCompatibilityTest.java
@@ -40,7 +40,7 @@ import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class GlobalLibraryWithModernJCasCCompatibilityTest extends RoundTripAbstractTest {

--- a/src/test/java/jenkins/plugins/git/ModernScmTest.java
+++ b/src/test/java/jenkins/plugins/git/ModernScmTest.java
@@ -33,7 +33,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ModernScmTest {
 

--- a/src/test/java/jenkins/plugins/git/traits/GitSCMExtensionTraitTest.java
+++ b/src/test/java/jenkins/plugins/git/traits/GitSCMExtensionTraitTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GitSCMExtensionTraitTest {
     @ClassRule

--- a/src/test/java/jenkins/plugins/git/traits/PruneStaleBranchTraitTest.java
+++ b/src/test/java/jenkins/plugins/git/traits/PruneStaleBranchTraitTest.java
@@ -8,7 +8,7 @@ import jenkins.scm.api.SCMSourceCriteria;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceRequest;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;


### PR DESCRIPTION
## Use Hamcrest instead of deprecated JUnit methods

JUnit 4.13 deprecated the Assert.assertThat method.  The Hamcrest assertThat is the replacement for Assert.assertThat.  Use the replacement.

JUnit 4.13 deprecated the ExpectedException class.  The Assert.assertThrows method is the replacement.  Use the replacement.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency or infrastructure update