### PR TITLE
[JENKINS-62261] RepositoryBrowser: Use UrlValidator.ALLOW_LOCAL_URLS

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -128,7 +128,7 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                             return FormValidation.error("This is a valid URL but it does not look like Assembla");
                         }
                     } catch (IOException e) {
-                        return handleIOException(v, e);
+                        return FormValidation.error("Exception reading from Assembla URL " + cleanUrl + " : " + handleIOException(v, e));
                     }
                 }
             }.check();
@@ -153,6 +153,11 @@ public class AssemblaWeb extends GitRepositoryBrowser {
             }
             if (!hostname.contains(hostNameFragment + ".")) {
                 return FormValidation.error("Invalid URL: " + url + " hostname does not include " + hostNameFragment + ".");
+            }
+            if (hostname.endsWith(".corp") || hostname.endsWith(".home") || hostname.endsWith(".local") || hostname.endsWith(".localnet")) {
+                /* UrlValidator does not handle those common local host suffixes */
+                /* Rely on later checks to confirm connectivity to the server */
+                return FormValidation.ok();
             }
             String[] schemes = {"http", "https"};
             UrlValidator urlValidator = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS);

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -22,7 +22,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.net.URI;
+import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 
@@ -134,11 +134,31 @@ public class AssemblaWeb extends GitRepositoryBrowser {
         }
 
         private boolean checkURIFormatAndHostName(String url, String hostNameFragment) throws URISyntaxException {
-            URI uri = new URI(url);
+            URL checkURL;
+            try {
+                checkURL = new URL(url);
+            } catch (MalformedURLException e) {
+                return false;
+            }
+            if (!checkURL.getHost().contains(hostNameFragment + ".")) {
+                return false;
+            }
             String[] schemes = {"http", "https"};
             UrlValidator urlValidator = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS);
-            hostNameFragment = hostNameFragment + ".";
-            return urlValidator.isValid(uri.toString()) && uri.getHost().contains(hostNameFragment);
+            return urlValidator.isValid(url) || simpleCheck(checkURL);
+        }
+
+        private boolean simpleCheck(URL url) {
+            if (!url.getProtocol().equals("https") && !url.getProtocol().equals("http")) {
+                return false;
+            }
+            if (url.getHost().isEmpty()) {
+                return false;
+            }
+            if (url.getPath().isEmpty()) {
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -89,6 +89,7 @@ public class AssemblaWeb extends GitRepositoryBrowser {
     @Extension
     public static class AssemblaWebDescriptor extends Descriptor<RepositoryBrowser<?>> {
         @NonNull
+        @Override
         public String getDisplayName() {
             return "AssemblaWeb";
         }

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -135,7 +135,7 @@ public class AssemblaWeb extends GitRepositoryBrowser {
         private boolean checkURIFormatAndHostName(String url, String hostNameFragment) throws URISyntaxException {
             URI uri = new URI(url);
             String[] schemes = {"http", "https"};
-            UrlValidator urlValidator = new UrlValidator(schemes);
+            UrlValidator urlValidator = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS);
             hostNameFragment = hostNameFragment + ".";
             return urlValidator.isValid(uri.toString()) && uri.getHost().contains(hostNameFragment);
         }

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -135,7 +135,7 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
 
     protected static boolean checkURIFormat(String url) throws URISyntaxException {
         String[] schemes = {"http", "https"};
-        UrlValidator urlValidator = new UrlValidator(schemes);
+        UrlValidator urlValidator = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS);
         return urlValidator.isValid(url);
     }
 

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -44,15 +44,30 @@ public class AssemblaWebDoCheckURLTest {
     }
 
     @Test
-    public void testDomainLevelChecksOnRepoUrlAllowLocalHostnames() throws Exception {
-        String url = "https://localhost/space/git-plugin/git/source";
-        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url), is(FormValidation.ok()));
+    public void testDomainLevelChecksOnRepoUrlAllowDNSLocalHostnamesLocalNet() throws Exception {
+        String hostname = "assembla.example.localnet";
+        String url = "https://" + hostname + "/space/git-plugin/git/source";
+        FormValidation validation = assemblaWebDescriptor.doCheckRepoUrl(project, url);
+        assertThat(validation.kind, is(FormValidation.Kind.ERROR));
+        assertThat(validation.getLocalizedMessage(), is(hostname));
+    }
+
+    @Test
+    public void testDomainLevelChecksOnRepoUrlAllowDNSLocalHostnamesHome() throws Exception {
+        String hostname = "assembla.example.home";
+        String url = "https://" + hostname + "/space/git-plugin/git/source";
+        FormValidation validation = assemblaWebDescriptor.doCheckRepoUrl(project, url);
+        assertThat(validation.kind, is(FormValidation.Kind.ERROR));
+        assertThat(validation.getLocalizedMessage(), is(hostname));
     }
 
     @Test
     public void testDomainLevelChecksOnRepoUrlCorpDomainMustBeValid() throws Exception {
-        String url = "https://assembla.myorg.corp/space/git-plugin/git/source";
-        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url), is(FormValidation.ok()));
+        String hostname = "assembla.myorg.corp";
+        String url = "https://" + hostname + "/space/git-plugin/git/source";
+        FormValidation validation = assemblaWebDescriptor.doCheckRepoUrl(project, url);
+        assertThat(validation.kind, is(FormValidation.Kind.ERROR));
+        assertThat(validation.getLocalizedMessage(), is(hostname));
     }
 
     @Test
@@ -67,6 +82,14 @@ public class AssemblaWebDoCheckURLTest {
         // Invalid URL, missing ':' character - Earlier it would open connection for such mistakes but now check resolves it beforehand.
         String url = "http//assmebla";
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is("Invalid URL"));
+    }
+
+    @Test
+    public void testPathLevelChecksOnRepoUrlInvalidPathSyntax() throws Exception {
+        // Invalid hostname in URL
+        String hostname = "assembla.comspaces";
+        String url = "https://" + hostname + "/git-plugin/git/source";
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is(hostname));
     }
 
     @Test

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -44,6 +44,18 @@ public class AssemblaWebDoCheckURLTest {
     }
 
     @Test
+    public void testDomainLevelChecksOnRepoUrlAllowLocalHostnames() throws Exception {
+        String url = "https://localhost/space/git-plugin/git/source";
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url), is(FormValidation.ok()));
+    }
+
+    @Test
+    public void testDomainLevelChecksOnRepoUrlCorpDomainMustBeValid() throws Exception {
+        String url = "https://assembla.myorg.corp/space/git-plugin/git/source";
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url), is(FormValidation.ok()));
+    }
+
+    @Test
     public void testDomainLevelChecksOnRepoUrl() throws Exception {
         // Invalid URL, missing '/' character - Earlier it would open connection for such mistakes but now check resolves it beforehand.
         String url = "https:/assembla.com";
@@ -54,13 +66,6 @@ public class AssemblaWebDoCheckURLTest {
     public void testDomainLevelChecksOnRepoUrlInvalidURL() throws Exception {
         // Invalid URL, missing ':' character - Earlier it would open connection for such mistakes but now check resolves it beforehand.
         String url = "http//assmebla";
-        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is("Invalid URL"));
-    }
-
-    @Test
-    public void testPathLevelChecksOnRepoUrlInvalidPathSyntax() throws Exception {
-        // Invalid hostname in URL
-        String url = "https://assembla.comspaces/git-plugin/git/source";
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is("Invalid URL"));
     }
 

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -44,12 +44,18 @@ public class AssemblaWebDoCheckURLTest {
     }
 
     @Test
+    public void testInitialChecksOnRepoUrlWithEmptyPath() throws Exception {
+        String url = "https://www.assembla.com";
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url), is(FormValidation.ok()));
+    }
+
+    @Test
     public void testDomainLevelChecksOnRepoUrlAllowDNSLocalHostnamesLocalNet() throws Exception {
         String hostname = "assembla.example.localnet";
         String url = "https://" + hostname + "/space/git-plugin/git/source";
         FormValidation validation = assemblaWebDescriptor.doCheckRepoUrl(project, url);
         assertThat(validation.kind, is(FormValidation.Kind.ERROR));
-        assertThat(validation.getLocalizedMessage(), is(hostname));
+        assertThat(validation.getLocalizedMessage(), is("Invalid URL: " + url));
     }
 
     @Test
@@ -58,7 +64,7 @@ public class AssemblaWebDoCheckURLTest {
         String url = "https://" + hostname + "/space/git-plugin/git/source";
         FormValidation validation = assemblaWebDescriptor.doCheckRepoUrl(project, url);
         assertThat(validation.kind, is(FormValidation.Kind.ERROR));
-        assertThat(validation.getLocalizedMessage(), is(hostname));
+        assertThat(validation.getLocalizedMessage(), is("Invalid URL: " + url));
     }
 
     @Test
@@ -67,21 +73,22 @@ public class AssemblaWebDoCheckURLTest {
         String url = "https://" + hostname + "/space/git-plugin/git/source";
         FormValidation validation = assemblaWebDescriptor.doCheckRepoUrl(project, url);
         assertThat(validation.kind, is(FormValidation.Kind.ERROR));
-        assertThat(validation.getLocalizedMessage(), is(hostname));
+        assertThat(validation.getLocalizedMessage(), is("Invalid URL: " + url));
     }
 
     @Test
     public void testDomainLevelChecksOnRepoUrl() throws Exception {
         // Invalid URL, missing '/' character - Earlier it would open connection for such mistakes but now check resolves it beforehand.
         String url = "https:/assembla.com";
-        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is("Invalid URL"));
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
+                is("Invalid URL: " + url + " could not parse hostname in URL"));
     }
 
     @Test
     public void testDomainLevelChecksOnRepoUrlInvalidURL() throws Exception {
         // Invalid URL, missing ':' character - Earlier it would open connection for such mistakes but now check resolves it beforehand.
         String url = "http//assmebla";
-        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is("Invalid URL"));
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is("no protocol: " + url));
     }
 
     @Test
@@ -89,7 +96,7 @@ public class AssemblaWebDoCheckURLTest {
         // Invalid hostname in URL
         String hostname = "assembla.comspaces";
         String url = "https://" + hostname + "/git-plugin/git/source";
-        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is(hostname));
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is("Invalid URL: " + url));
     }
 
     @Test
@@ -101,9 +108,9 @@ public class AssemblaWebDoCheckURLTest {
     @Test
     public void testPathLevelChecksOnRepoUrlUnableToConnect() throws Exception {
         // Syntax issue related specific to Assembla
-        String url = "https://app.assembla.com/space/git-plugin/git/source";
+        String url = "https://app.assembla.com/space/git-plugin/git/source/";
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
-                is("Unable to connect https://app.assembla.com/space/git-plugin/git/source/"));
+                is("Unable to connect " + url));
     }
 
     @Test
@@ -127,6 +134,6 @@ public class AssemblaWebDoCheckURLTest {
         };
         String url = urls[random.nextInt(urls.length)]; // Don't abuse a single web site with tests
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
-                is("Invalid URL"));
+                is("Invalid URL: " + url + " hostname does not include assembla."));
     }
 }

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -54,8 +54,8 @@ public class AssemblaWebDoCheckURLTest {
         String hostname = "assembla.example.localnet";
         String url = "https://" + hostname + "/space/git-plugin/git/source";
         FormValidation validation = assemblaWebDescriptor.doCheckRepoUrl(project, url);
-        assertThat(validation.kind, is(FormValidation.Kind.ERROR));
-        assertThat(validation.getLocalizedMessage(), is("Invalid URL: " + url));
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
+                   is("Exception reading from Assembla URL " + url + " : ERROR: " + hostname));
     }
 
     @Test
@@ -63,8 +63,8 @@ public class AssemblaWebDoCheckURLTest {
         String hostname = "assembla.example.home";
         String url = "https://" + hostname + "/space/git-plugin/git/source";
         FormValidation validation = assemblaWebDescriptor.doCheckRepoUrl(project, url);
-        assertThat(validation.kind, is(FormValidation.Kind.ERROR));
-        assertThat(validation.getLocalizedMessage(), is("Invalid URL: " + url));
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
+                   is("Exception reading from Assembla URL " + url + " : ERROR: " + hostname));
     }
 
     @Test
@@ -72,8 +72,8 @@ public class AssemblaWebDoCheckURLTest {
         String hostname = "assembla.myorg.corp";
         String url = "https://" + hostname + "/space/git-plugin/git/source";
         FormValidation validation = assemblaWebDescriptor.doCheckRepoUrl(project, url);
-        assertThat(validation.kind, is(FormValidation.Kind.ERROR));
-        assertThat(validation.getLocalizedMessage(), is("Invalid URL: " + url));
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
+                   is("Exception reading from Assembla URL " + url + " : ERROR: " + hostname));
     }
 
     @Test
@@ -81,7 +81,7 @@ public class AssemblaWebDoCheckURLTest {
         // Invalid URL, missing '/' character - Earlier it would open connection for such mistakes but now check resolves it beforehand.
         String url = "https:/assembla.com";
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
-                is("Invalid URL: " + url + " could not parse hostname in URL"));
+                   is("Invalid URL: " + url + " could not parse hostname in URL"));
     }
 
     @Test
@@ -110,7 +110,7 @@ public class AssemblaWebDoCheckURLTest {
         // Syntax issue related specific to Assembla
         String url = "https://app.assembla.com/space/git-plugin/git/source/";
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
-                is("Unable to connect " + url));
+                   is("Exception reading from Assembla URL " + url + " : ERROR: Unable to connect " + url));
     }
 
     @Test
@@ -134,6 +134,6 @@ public class AssemblaWebDoCheckURLTest {
         };
         String url = urls[random.nextInt(urls.length)]; // Don't abuse a single web site with tests
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
-                is("Invalid URL: " + url + " hostname does not include assembla."));
+                   is("Invalid URL: " + url + " hostname does not include assembla."));
     }
 }


### PR DESCRIPTION
## [JENKINS-62261](https://issues.jenkins-ci.org/browse/JENKINS-62261) - Allow local URLs in repo browsers

Relax URL validation in repository browser such that *.corp domains and local hostnames are not dismissed as invalid.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)