### PR TITLE
Added help page for 'Show the entire commit summary in changes'

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitSCM/help-showEntireCommitSummaryInChanges.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-showEntireCommitSummaryInChanges.html
@@ -1,0 +1,5 @@
+<p>
+    The `changes` page for each job would truncate the change summary prior to git plugin 4.0.
+    With the release of git plugin 4.0, the default was changed to show the complete change summary.
+    Administrators that want to restore the old behavior may disable this setting.
+</p>


### PR DESCRIPTION
## [JENKINS-62588](https://issues.jenkins-ci.org/browse/JENKINS-62588) - Providing online help for a new global configuration option in v4.0.0

Git plugin 4.0.0 intentionally shows the entire first line of the commit message in the "changes" page, even if that first line is very long. A global compatibility option was included to allow users to revert to the git plugin 3 behavior of truncating the first line message in the "changes" page. Unfortunately, no online help was provided for that new global configuration option.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
