### PR TITLE
[JENKINS-62377] Place BuildData wiki docs inside git plugin documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1128,3 +1128,89 @@ https://issues.jenkins-ci.org[Jenkins issue tracker].
 
 Refer to link:CONTRIBUTING.adoc#contributing-to-the-git-plugin[contributing to the plugin] for contribution guidelines.
 Refer to link:Priorities.adoc#git-plugin-development-priorities[plugin development priorities] for the prioritized list of development topics.
+
+[#Remove Git Plugin BuildsByBranch BuildData Script]
+== Remove Git Plugin BuildsByBranch BuildData Script
+
+This script is used to remove the static list of BuildsByBranch that is
+uselessly stored for each build by the Git Plugin.
+
+* This is a workaround for the problem described here:
+https://issues.jenkins-ci.org/browse/JENKINS-19022
+* Updated to handle Matrix Project types.
+* Updated to better support SCM Polling
+* Updated to handle Projects inside Folders.
+* Updated to handle Pipeline job types (just call getJobNames() to find
+everything)
+
+[source,syntaxhighlighter-pre]
+----
+import hudson.matrix.*
+import hudson.model.*
+
+hudsonInstance = hudson.model.Hudson.instance
+jobNames = hudsonInstance.getJobNames()
+allItems = []
+for (name in jobNames) {
+  allItems += hudsonInstance.getItemByFullName(name)
+}
+ 
+// Iterate over all jobs and find the ones that have a hudson.plugins.git.util.BuildData
+// as an action.
+//
+// We then clean it by removing the useless array action.buildsByBranchName
+//
+
+for (job in allItems) {
+  println("job: " + job.name);
+  def counter = 0;
+  for (build in job.getBuilds()) {
+    // It is possible for a build to have multiple BuildData actions
+    // since we can use the Mulitple SCM plugin.
+    def gitActions = build.getActions(hudson.plugins.git.util.BuildData.class)
+    if (gitActions != null) {
+      for (action in gitActions) {
+        action.buildsByBranchName = new HashMap<String, Build>();
+        hudson.plugins.git.Revision r = action.getLastBuiltRevision();
+        if (r != null) {
+          for (branch in r.getBranches()) {
+            action.buildsByBranchName.put(branch.getName(), action.lastBuild)
+          }
+        }
+        build.actions.remove(action)
+        build.actions.add(action)
+        build.save();
+        counter++;
+      }
+    }
+    if (job instanceof MatrixProject) {
+      def runcounter = 0;
+      for (run in build.getRuns()) {
+        gitActions = run.getActions(hudson.plugins.git.util.BuildData.class)
+        if (gitActions != null) {
+          for (action in gitActions) {
+            action.buildsByBranchName = new HashMap<String, Build>();
+            hudson.plugins.git.Revision r = action.getLastBuiltRevision();
+            if (r != null) {
+              for (branch in r.getBranches()) {
+                action.buildsByBranchName.put(branch.getName(), action.lastBuild)
+              }
+            }
+            run.actions.remove(action)
+            run.actions.add(action)
+            run.save();
+            runcounter++;
+          }
+        }
+      }
+      if (runcounter > 0) {
+        println(" -->> cleaned: " + runcounter + " runs");
+      }
+    }
+  }
+  if (counter > 0) {
+    println("-- cleaned: " + counter + " builds");
+  }
+}
+----
+


### PR DESCRIPTION
[JENKINS-62377](https://issues.jenkins-ci.org/browse/JENKINS-62377) - Place BuildData wiki docs inside git plugin documentation

The Jenkins project is moving documentation pages from the Jenkins Wiki to www.jenkins.io. 

- [x ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x ] I have referenced the Jira issue related to my changes in one or more commit messages
