### PR TITLE
[JENKINS-62710] Ignore arithmetic exception in helper message

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1233,7 +1233,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         // Needs to be after the checkout so that revToBuild is in the workspace
         try {
             printCommitMessageToLog(listener, git, revToBuild);
-        } catch (GitException ge) {
+        } catch (ArithmeticException | GitException ge) {
+            // JENKINS-45729 reports a git exception when revToBuild cannot be found in the workspace.
+            // JENKINS-46628 reports a git exception when revToBuild cannot be found in the workspace.
+            // JENKINS-62710 reports a JGit arithmetic exception on an older Java 8 system.
+            // Don't let those exceptions block the build, this is an informational message only
             listener.getLogger().println("Exception logging commit message for " + revToBuild + ": " + ge.getMessage());
         }
 


### PR DESCRIPTION
## [JENKINS-62710](https://issues.jenkins-ci.org/browse/JENKINS-62710) - Ignore arithmetic exception in helper message

A user with an older Java version reported that the Java Duration object throws an arthimetic exception because a JGit computed duration in nanoseconds related to file system time stamps is larger than a Java long. I can't explain why the file system on that computer would have a time stamp that causes a Java duration greater than 290 years (2^64 nanoseconds).

Since the printCommitMessageToLog method is a convenience for readers of the build log, failures in printCommitMessageToLog should not fail the build.  Ignore ArithmeticException in addition to ignoring GitException.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes (not feasible, believed related to old Java version, either library bug in Duration or file system timestamp bug)
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)