### PR TITLE
Allow wider range of file system times

### DIFF
--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -188,6 +188,7 @@ public class AbstractGitSCMSourceTest {
                 // FAT file system time stamps only resolve to 2 second boundary
                 // EXT3 file system time stamps only resolve to 1 second boundary
                 long fileTimeStampFuzz = isWindows() ? 2000L : 1000L;
+                fileTimeStampFuzz = 12 * fileTimeStampFuzz / 10; // 20% grace for file system noise
                 switch (scmHead.getName()) {
                     case "lightweight":
                         {

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -207,7 +207,10 @@ public class GitSCMFileSystemTest {
         SCMRevision revision = source.fetch(new GitBranchSCMHead("dev"), null);
         sampleRepo.write("file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
-        final long fileSystemAllowedOffset = 1500;
+        long fileSystemAllowedOffset = 1500;
+        if ("OpenBSD".equals(System.getProperty("os.name"))) {
+            fileSystemAllowedOffset = 2 * fileSystemAllowedOffset;
+        }
         SCMFileSystem fs = SCMFileSystem.of(source, new SCMHead("dev"), revision);
         long currentTime = System.currentTimeMillis();
         long lastModified = fs.lastModified();


### PR DESCRIPTION
## Allow wider range of file system times in tests

File system times need a wider range of allowed values on two tests.  One of the tests fails consistently on OpenBSD, likely due to the precise one second data reporting of OpenBSD file system times and the slow hardware where I'm running it.  One of the tests fails less frequently with a small range error.  The second test now allows an additional 20% on its range for slow file systems.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)