### PR TITLE
[JENKINS-57587] Prevent GitSCMFileSystem NPE on '*' branch name

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -255,6 +255,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
             return source instanceof GitSCM
                     && ((GitSCM) source).getUserRemoteConfigs().size() == 1
                     && ((GitSCM) source).getBranches().size() == 1
+                    && !((GitSCM) source).getBranches().get(0).getName().equals("*") // JENKINS-57587
                     && (
                         ((GitSCM) source).getBranches().get(0).getName().matches(
                             "^((\\Q" + Constants.R_HEADS + "\\E.*)|([^/]+)|(\\*/[^/*]+(/[^/*]+)*))$"
@@ -263,7 +264,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                             "^((\\Q" + Constants.R_TAGS + "\\E.*)|([^/]+)|(\\*/[^/*]+(/[^/*]+)*))$"
                         )
                     );
-            // we only support where the branch spec is obvious
+            // we only support where the branch spec is obvious and not a wildcard
         }
 
         @Override

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -63,6 +63,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -195,6 +196,29 @@ public class GitSCMFileSystemTest {
         assertThat(iterator.hasNext(), is(false));
         assertThat(file.getName(), is("file"));
         assertThat(file.contentAsString(), is("modified"));
+    }
+
+    @Issue("JENKINS-57587")
+    @Test
+    public void wildcardBranchNameCausesNPE() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("file", "contents-for-npe-when-branch-name-is-asterisk");
+        sampleRepo.git("commit", "--all", "--message=npe-when-branch-name-is-asterisk");
+        /* Non-existent branch names like 'not-a-branch', will fail
+         * the build early with a message that the remote ref cannot
+         * be found.  Branch names that are valid portions of a
+         * refspec like '*' do not fail the build early but generate a
+         * null pointer exception when trying to resolve the branch
+         * name in the GitSCMFileSystem constructor.
+         */
+        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(),
+                                            new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null),
+                                                       Collections.singletonList(new BranchSpec("*")), // JENKINS-57587 issue here
+                                                       false,
+                                                       Collections.<SubmoduleConfig>emptyList(),
+                                                       null, null,
+                                                       Collections.<GitSCMExtension>emptyList()));
+        assertThat("Wildcard branch name '*' resolved to a specific checkout unexpectedly", fs, is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
## [JENKINS-57587](https://issues.jenkins-ci.org/browse/JENKINS-57587) - Prevent GitSCMFileSystem NPE on '*' branch

When a Pipeline job that is not a multibranch Pipeline job is defined to use '`*`' as its branch name and is configured with lightweight checkout, it reports a null pointer exception and fails the job.  A branch name '`*`' should be disallowed for Pipeline jobs that are not multibranch Pipeline jobs because a wildcard branch name would cause the job to switch between different branches each time it detects a change on one of the branches in the repository.  Switching branches within a job makes the change history and general user experience confusing for the user.

This has the questionable result that by avoiding the null pointer exception it now allows a Pipeline job that is not a multibranch Pipeline to switch from one branch to another inside the same job.

The technique of using a single job to validate multiple branches was commonly used with Freestyle jobs because they did not have the concept of multibranch.  It is generally much better to allow Jenkins to manage the Pipeline jobs with multibranch rather than having a single job that switches between branches.  However, a null pointer exception is not a friendly way to tell users that they should not use a specific technique.

Special thanks to Sven Hickstein for his suggestion to use the `supports` method to detect this case.  It is a much simpler change thanks to his suggestion.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)