### PR TITLE
Depend on parameterized trigger plugin 2.35.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <dependency><!-- we contribute AbstractBuildParameters for Git if it's available -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>parameterized-trigger</artifactId>
-      <version>2.33</version>
+      <version>2.35.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -187,11 +187,10 @@
       <version>0.6</version>
       <scope>test</scope>
     </dependency>
-    <!-- intentionally staying with promoted-builds 3.2 on advice of Oleg Nenashev -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>promoted-builds</artifactId>
-      <version>3.2</version>
+      <version>3.5</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Depend on parameterized trigger plugin 2.35.1

Do not force parameterized trigger plugin users to update to a newer version than required.  Majority of users are running 2.35.2 or later.  Even more likely to be running 2.35.2 or newer if they are running Jenkins 2.204.1 or later as required by git plugin 4.3.0.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [x] Dependency or infrastructure update

## Further comments

Do not force parameterized trigger plugin users to update to a newer version than required.  Majority of users are running 2.35.2 or later.  Even more likely to be running 2.35.2 or newer if they are running Jenkins 2.204.1 or later as required by git plugin 4.3.0.

If the user installs git plugin 4.3.0, they must be running Jenkins 2.204.1 or newer.  Requiring parameterized trigger plugin 2.35.1 or newer does not change the parameterized trigger plugin version installed on all but a very few installations.

91% of all parameterized trigger plugin installations are running 2.35.1 or newer.  That's enough to justify this increase in the minimum required parameterized trigger plugin version in the git plugin.