### PR TITLE
[JENKINS-62820] Ability to hide credential usage in job output

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -169,7 +169,7 @@ Show the entire commit summary in changes::
 [[hide-credentials]]
 Hide credential usage in job output::
 
-  If checked the output will not show the credential being used to clone a repository
+  If checked the output will not show the credential identifier used to clone a repository.
 
 [#repository-browser]
 === Repository Browser

--- a/README.adoc
+++ b/README.adoc
@@ -166,6 +166,11 @@ Show the entire commit summary in changes::
   With the release of git plugin 4.0, the default was changed to show the complete change summary.
   Administrators that want to restore the old behavior may disable this setting.
 
+[[hide-credentials]]
+Hide credential usage in job output::
+
+  If checked the output will not show the credential being used to clone a repository
+
 [#repository-browser]
 === Repository Browser
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -837,8 +837,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
     @NonNull
     /*package*/ GitClient createClient(TaskListener listener, EnvVars environment, Job project, Node n, FilePath ws) throws IOException, InterruptedException {
-
-        new DescriptorImpl().isHideCredentials()
         String gitExe = getGitExe(n, listener);
         Git git = Git.with(listener, environment).in(ws).using(gitExe);
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -837,6 +837,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
     @NonNull
     /*package*/ GitClient createClient(TaskListener listener, EnvVars environment, Job project, Node n, FilePath ws) throws IOException, InterruptedException {
+
         String gitExe = getGitExe(n, listener);
         Git git = Git.with(listener, environment).in(ws).using(gitExe);
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -438,6 +438,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return (gitDescriptor != null && gitDescriptor.isUseExistingAccountWithSameEmail());
     }
 
+    public boolean isHideCredentials() {
+        DescriptorImpl gitDescriptor = getDescriptor();
+        return gitDescriptor != null && gitDescriptor.isHideCredentials();
+    }
+
     @Whitelisted
     public BuildChooser getBuildChooser() {
         BuildChooser bc;
@@ -833,6 +838,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     @NonNull
     /*package*/ GitClient createClient(TaskListener listener, EnvVars environment, Job project, Node n, FilePath ws) throws IOException, InterruptedException {
 
+        new DescriptorImpl().isHideCredentials()
         String gitExe = getGitExe(n, listener);
         Git git = Git.with(listener, environment).in(ws).using(gitExe);
 
@@ -860,12 +866,16 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 StandardUsernameCredentials credentials = CredentialsMatchers.firstOrNull(urlCredentials, idMatcher);
                 if (credentials != null) {
                     c.addCredentials(url, credentials);
-                    listener.getLogger().println(format("using credential %s", credentials.getId()));
+                    if(!isHideCredentials()) {
+                        listener.getLogger().println(format("using credential %s", credentials.getId()));
+                    }
                     if (project != null && project.getLastBuild() != null) {
                         CredentialsProvider.track(project.getLastBuild(), credentials);
                     }
                 } else {
-                    listener.getLogger().println(format("Warning: CredentialId \"%s\" could not be found.", ucCredentialsId));
+                    if(!isHideCredentials()) {
+                        listener.getLogger().println(format("Warning: CredentialId \"%s\" could not be found.", ucCredentialsId));
+                    }
                 }
             }
         }
@@ -1487,6 +1497,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         private boolean useExistingAccountWithSameEmail;
 //        private GitClientType defaultClientType = GitClientType.GITCLI;
         private boolean showEntireCommitSummaryInChanges;
+        private boolean hideCredentials;
 
         public DescriptorImpl() {
             super(GitSCM.class, GitRepositoryBrowser.class);
@@ -1512,6 +1523,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         public boolean isShowEntireCommitSummaryInChanges() {
             return showEntireCommitSummaryInChanges;
+        }
+
+        public boolean isHideCredentials() { return hideCredentials; }
+
+        public void setHideCredentials(boolean hideCredentials) {
+            this.hideCredentials = hideCredentials;
         }
 
         public void setShowEntireCommitSummaryInChanges(boolean showEntireCommitSummaryInChanges) {

--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -16,6 +16,9 @@
     <f:entry field="showEntireCommitSummaryInChanges">
       <f:checkbox title="${%Show the entire commit summary in changes}" name="showEntireCommitSummaryInChanges" checked="${descriptor.showEntireCommitSummaryInChanges}"/>
     </f:entry>
+    <f:entry field="hideCredentials">
+          <f:checkbox title="${%Hide credential usage in job output}" name="hideCredentials" checked="${descriptor.hideCredentials}"/>
+        </f:entry>
     <!--
     <f:entry title="${%Default git client implementation}" field="defaultClientType">
         <select>

--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -17,8 +17,8 @@
       <f:checkbox title="${%Show the entire commit summary in changes}" name="showEntireCommitSummaryInChanges" checked="${descriptor.showEntireCommitSummaryInChanges}"/>
     </f:entry>
     <f:entry field="hideCredentials">
-          <f:checkbox title="${%Hide credential usage in job output}" name="hideCredentials" checked="${descriptor.hideCredentials}"/>
-        </f:entry>
+      <f:checkbox title="${%Hide credential usage in job output}" name="hideCredentials" checked="${descriptor.hideCredentials}"/>
+    </f:entry>
     <!--
     <f:entry title="${%Default git client implementation}" field="defaultClientType">
         <select>
@@ -29,4 +29,3 @@
     -->
   </f:section>
 </j:jelly>
-

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1476,12 +1476,12 @@ public class GitSCMTest extends AbstractGitTestCase {
         commit(commitFile1, johnDoe, "Commit number 1");
         build(project, Result.SUCCESS);
         List<String> logLines = project.getLastBuild().getLog(100);
-        assertTrue(logLines.get(3).contains("using credential"));
+        assertThat(logLines, hasItem("using credential github"));
 
         descriptor.setHideCredentials(true);
         build(project, Result.SUCCESS);
         logLines = project.getLastBuild().getLog(100);
-        assertFalse(logLines.get(3).contains("using credential"));
+        assertThat(logLines, not(hasItem("using credential github")));
 
     }
 


### PR DESCRIPTION
## [JENKINS-62820](https://issues.jenkins-ci.org/browse/JENKINS-62820) - add ability to hide credenital use in job output

In our company we are using git plugin to checkout git repositories with centrally managed credentials.  Pipeline users should not know which credentials are being used to not give them the opportunity to use this credentials in a withCredentials block and bypass certain 4-eyes principles that are in place.  Therefore we would like to introduce the possibility to add a global option to hide the output of credential usage in the job log.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Further comments

Not applicable
