### PR TITLE
Clarify the consequences of setting user.name and user.email

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -934,12 +934,12 @@ image:/images/git-custom-user-name-e-mail-address.png[Custom user name/e-mail ad
 user.name::
 
   Defines the user name value which git will assign to new commits made in the workspace.
-  If given, `git config user.name` is called before builds and overrides values from the global settings.
+  If given, the environment variables `GIT_COMMITTER_NAME` and `GIT_AUTHOR_NAME` are set for builds and override values from the global settings.
 
 user.email::
 
   Defines the user email value which git will assign to new commits made in the workspace.
-  If given, `git config user.email` is called before builds and overrides values from the global settings.
+  If given, the environment variables `GIT_COMMITTER_EMAIL` and `GIT_AUTHOR_EMAIL` are set for builds and override values from the global settings.
 
 [#deprecated-extensions]
 === Deprecated Extensions

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1563,7 +1563,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         /**
-         * Global setting to be used in call to "git config user.name".
+         * Global setting to be used to set GIT_COMMITTER_NAME and GIT_AUTHOR_NAME.
          * @return user.name value
          */
         public String getGlobalConfigName() {
@@ -1571,7 +1571,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         /**
-         * Global setting to be used in call to "git config user.name".
+         * Global setting to be used to set GIT_COMMITTER_NAME and GIT_AUTHOR_NAME.
          * @param globalConfigName user.name value to be assigned
          */
         public void setGlobalConfigName(String globalConfigName) {
@@ -1579,7 +1579,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         /**
-         * Global setting to be used in call to "git config user.email".
+         * Global setting to be used to set GIT_COMMITTER_EMAIL and GIT_AUTHOR_EMAIL.
          * @return user.email value
          */
         public String getGlobalConfigEmail() {
@@ -1587,7 +1587,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         /**
-         * Global setting to be used in call to "git config user.email".
+         * Global setting to be used to set GIT_COMMITTER_EMAIL and GIT_AUTHOR_EMAIL.
          * @param globalConfigEmail user.email value to be assigned
          */
         public void setGlobalConfigEmail(String globalConfigEmail) {

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-globalConfigEmail.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-globalConfigEmail.html
@@ -1,3 +1,3 @@
 <div>
-  <p>If given, "git config user.email [this]" is called before builds. This can be overridden by individual projects.</p>
+  <p>If given, "GIT_COMMITTER_EMAIL=[this]" and "GIT_AUTHOR_EMAIL=[this]" are set for builds. This can be overridden by individual projects.</p>
 </div>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-globalConfigName.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-globalConfigName.html
@@ -1,3 +1,3 @@
 <div>
-  <p>If given, "git config user.name [this]" is called before builds. This can be overridden by individual projects.</p>
+  <p>If given, "GIT_COMMITTER_NAME=[this]" and "GIT_AUTHOR_NAME=[this]" are set for builds. This can be overridden by individual projects.</p>
 </div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/UserIdentity/help-email.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/UserIdentity/help-email.html
@@ -1,3 +1,3 @@
 <div>
-  <p>If given, "git config user.email [this]" is called before builds. This overrides whatever is in the global settings.</p>
+  <p>If given, "GIT_COMMITTER_EMAIL=[this]" and "GIT_AUTHOR_EMAIL=[this]" are set for builds. This overrides whatever is in the global settings.</p>
 </div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/UserIdentity/help-name.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/UserIdentity/help-name.html
@@ -1,3 +1,3 @@
 <div>
-  <p>If given, "git config user.name [this]" is called before builds. This overrides whatever is in the global settings.</p>
+  <p>If given, "GIT_COMMITTER_NAME=[this]" and "GIT_AUTHOR_NAME=[this]" are set for builds. This overrides whatever is in the global settings.</p>
 </div>


### PR DESCRIPTION
It took me a while to realize that this plugin, in constrast to its documentation, does *not* alter `user.name` and `user.email`. So I took the additional time to adjust the documentation accordingly.

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
