### PR TITLE
Fix testAvoidRedundantFetchWithHonorRefSpec assertions

### DIFF
--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -568,8 +568,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         final String commitFile1 = "commitFile1";
         commit(commitFile1, johnDoe, "Commit in master");
         // create branch and make initial commit
-        git.branch("foo");
-        git.checkout().branch("foo");
+        git.checkout().ref("master").branch("foo").execute();
         commit(commitFile1, johnDoe, "Commit in foo");
 
         build(projectWithMaster, Result.SUCCESS); /* If clone refspec had been honored, this would fail */

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -391,8 +391,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         final String commitFile1 = "commitFile1";
         commit(commitFile1, johnDoe, "Commit in master");
         // Add another branch 'foo'
-        git.branch("foo");
-        git.checkout().branch("foo");
+        git.checkout().ref("master").branch("foo").execute();
         commit(commitFile1, johnDoe, "Commit in foo");
 
         // Build will be success because the initial clone disregards refspec and fetches all branches

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -332,8 +332,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         final String commitFile1 = "commitFile1";
         commit(commitFile1, johnDoe, "Commit in master");
         // create branch and make initial commit
-        git.branch("foo");
-        git.checkout().branch("foo");
+        git.checkout().ref("master").branch("foo").execute();
         commit(commitFile1, johnDoe, "Commit in foo");
 
         build(projectWithMaster, Result.FAILURE);


### PR DESCRIPTION
## Fix testAvoidRedundantFetchWithHonorRefSpec assertions

The previous implementation of the test failed when the branch name 'master' is used because the Jenkins job directory name includes the branch name.  This now asserts more precisely on the content of the FETCH_HEAD
file.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have tested my changes on multiple operating systems and CLI git versions
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update

## Further comments

As part of the exploration to find the problem, additional assertions have been added to confirm that the correct SHA1 is mentioned in the FETCH_HEAD file.

The previous test implementations would create a new CheckoutCommand with git.checkout() but then did nothing with it.  It created the "foo" branch but did not checkout the "foo" branch.  The commit that was described as "Commit in foo" was a commit to the master branch, not a commit to the foo branch.

The new code creates the branch and then uses the branch for new commits.