### PR TITLE
[JENKINS-62223] Add online help for several fields

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,8 @@ _Put an `x` in the boxes that apply. You can also fill these out after creating 
 - [ ] I have added documentation as necessary
 - [ ] No Javadoc warnings were introduced with my changes
 - [ ] No spotbugs warnings were introduced with my changes
+- [ ] Documentation in README has been updated as necessary
+- [ ] Online help has been added and reviewed for any new or modified fields
 - [ ] I have interactively tested my changes
 - [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 import java.util.Collections
 
 // Valid Jenkins versions for test
-def testJenkinsVersions = [ '2.204.1', '2.204.6', '2.222.1', '2.222.4', '2.235', '2.240' ]
+def testJenkinsVersions = [ '2.204.1', '2.204.6', '2.222.4', '2.235.1', '2.243' ]
 Collections.shuffle(testJenkinsVersions)
 
 // Test plugin compatibility to subset of Jenkins versions

--- a/README.adoc
+++ b/README.adoc
@@ -167,17 +167,17 @@ Show the entire commit summary in changes::
   Administrators that want to restore the old behavior may disable this setting.
 
 [[hide-credentials]]
-Hide credential usage in job output::
+Hide credential identifier in job output::
 
-  If checked the output will not show the credential identifier used to clone a repository.
+  If checked, the console log will not show the credential identifier used to clone a repository.
 
 [[preserve-second-fetch-during-checkout]]
-Preserve second fetch during checkout::
+Preserve second fetch during initial checkout::
 
-  If checked the checkout step will not avoid the second fetch.
-  Git plugin versions prior to git plugin 4.4 would perform two fetch operations for each repository checkout.
-  Git plugin 4.4 removes the redundant fetch operation.
-  Enabling this option will restore the redundant fetch operation.
+  If checked, the initial checkout step will not avoid the second fetch.
+  Git plugin versions prior to git plugin 4.4 would perform two fetch operations during the initial repository checkout.
+  Git plugin 4.4 removes the second fetch operation in most cases.
+  Enabling this option will restore the second fetch operation.
   This setting is only needed if there is a bug in the redundant fetch removal logic.
   If you enable this setting, please report a git plugin issue that describes why you needed to enable it.
 

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-allowSecondFetch.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-allowSecondFetch.html
@@ -1,0 +1,10 @@
+<p>
+  If checked, the initial checkout step will not avoid the second fetch.
+  Git plugin versions prior to git plugin 4.4 would perform two fetch operations during the initial repository checkout.
+  Git plugin 4.4 removes the second fetch operation in most cases.
+  Enabling this option will restore the second fetch operation.
+</p>
+<p>
+  This setting is only needed if there is a bug in the redundant fetch removal logic.
+  If you enable this setting, please report a git plugin issue that describes why you needed to enable it.
+</p>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-gitTool.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-gitTool.html
@@ -1,0 +1,8 @@
+<p>
+  Absolute path to the git executable.
+</p>
+<p>
+  This is <strong>different</strong> from other Jenkins tool definitions.
+  Rather than providing the directory that contains the executable, you <strong>must provide the complete path to the executable</strong>.
+  Setting '<code>/usr/bin/git</code>' would be correct, while setting '<code>/usr/bin/</code>' is not correct.
+</p>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-hideCredentials.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-hideCredentials.html
@@ -1,0 +1,3 @@
+<p>
+  The credential identifier used to clone a repository will not be reported in the console log if this is enabled.
+</p>

--- a/src/main/resources/hudson/plugins/git/UserRemoteConfig/help-credentialsId.html
+++ b/src/main/resources/hudson/plugins/git/UserRemoteConfig/help-credentialsId.html
@@ -1,0 +1,3 @@
+<div>
+    Credential used to <strong>check out</strong> sources.
+</div>

--- a/src/main/resources/hudson/plugins/git/browser/CGit/help-repoUrl.html
+++ b/src/main/resources/hudson/plugins/git/browser/CGit/help-repoUrl.html
@@ -1,0 +1,3 @@
+<div>
+  Specify the root URL serving this repository (such as <em>http://cgit.example.com:port/group/REPO/</em>).
+</div>

--- a/src/main/resources/hudson/plugins/git/browser/GogsGit/help-repoUrl.html
+++ b/src/main/resources/hudson/plugins/git/browser/GogsGit/help-repoUrl.html
@@ -1,0 +1,3 @@
+<div>
+  Specify the root URL serving this repository (such as <em>http://gogs.example.com:port/username/some-repo-url.git</em>).
+</div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/GitLFSPull/help.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/GitLFSPull/help.html
@@ -1,0 +1,4 @@
+<div>
+	Enable <a href="https://git-lfs.github.com/">git large file support</a> for the workspace by pulling large files after the checkout completes.
+	Requires that the master and each agent performing an LFS checkout have installed `git lfs`.
+</div>

--- a/src/test/java/jenkins/plugins/git/GitSCMJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMJCasCCompatibilityTest.java
@@ -5,6 +5,7 @@ import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class GitSCMJCasCCompatibilityTest extends RoundTripAbstractTest {
@@ -13,7 +14,11 @@ public class GitSCMJCasCCompatibilityTest extends RoundTripAbstractTest {
         GitSCM.DescriptorImpl gitSCM = (GitSCM.DescriptorImpl) restartableJenkinsRule.j.jenkins.getScm(GitSCM.class.getSimpleName());
         assertEquals("user_name", gitSCM.getGlobalConfigName());
         assertEquals("me@mail.com", gitSCM.getGlobalConfigEmail());
-        assertTrue(gitSCM.isCreateAccountBasedOnEmail());
+        assertTrue("Allow second fetch setting not honored", gitSCM.isAllowSecondFetch());
+        assertTrue("Show entire commit summary setting not honored", gitSCM.isShowEntireCommitSummaryInChanges());
+        assertTrue("Hide credentials setting not honored", gitSCM.isHideCredentials());
+        assertFalse("Use existing account setting not honored", gitSCM.isUseExistingAccountWithSameEmail());
+        assertTrue("Create account based on email setting not honored", gitSCM.isCreateAccountBasedOnEmail());
     }
 
     @Override

--- a/src/test/resources/jenkins/plugins/git/gitscm-casc.yaml
+++ b/src/test/resources/jenkins/plugins/git/gitscm-casc.yaml
@@ -1,5 +1,9 @@
 unclassified:
   gitSCM:
+    allowSecondFetch: true
     createAccountBasedOnEmail: true
     globalConfigEmail: "me@mail.com"
     globalConfigName: "user_name"
+    hideCredentials: true
+    showEntireCommitSummaryInChanges: true
+    useExistingAccountWithSameEmail: false


### PR DESCRIPTION
## [JENKINS-62223](https://issues.jenkins-ci.org/browse/JENKINS-62223) - Add online help for several fields

Online help is missing for several fields.  The online help is extracted into the jenkins.io pipeline help and is shown to users from inside the Jenkins web pages.

Also updates the pull request template to remind submitters to update documentaiton and online help.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)