### PR TITLE
[JENKINS-9346] - Fix token macro help formatting

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitBranchTokenMacro/help.jelly
+++ b/src/main/resources/hudson/plugins/git/GitBranchTokenMacro/help.jelly
@@ -3,19 +3,19 @@
   <dt>$${GIT_BRANCH}</dt>
   <dd>
     Expands to the name of the branch that was built.
-  </dd>
 
-  <h3>Parameters</h3>
-  <dl>
-    <dt>all</dt>
-    <dd>
-      If specified, all the branches that point to the given commit is listed.
-      By default, the token expands to just one of them.
-    </dd>
-    <dt>fullName</dt>
-    <dd>
-      If specified, this token expands to the full branch name, such as 'origin/master'.
-      Otherwise, it only expands to  the short name, such as 'master'.
-    </dd>
-  </dl>
+    <dl>
+      <dt>all</dt>
+      <dd>
+        If specified, all the branches that point to the given commit are listed.
+        By default, the token expands to just one of them.
+      </dd>
+      <dt>fullName</dt>
+      <dd>
+        If specified, this token expands to the full branch name, such as 'origin/master'.
+        Otherwise, it only expands to  the short name, such as 'master'.
+      </dd>
+    </dl>
+
+  </dd>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/git/GitRevisionTokenMacro/help.jelly
+++ b/src/main/resources/hudson/plugins/git/GitRevisionTokenMacro/help.jelly
@@ -3,14 +3,14 @@
   <dt>$${GIT_REVISION}</dt>
   <dd>
     Expands to the Git SHA1 commit ID that points to the commit that was built.
-  </dd>
 
-  <h3>Parameters</h3>
-  <dl>
-    <dt>length=N (optional, default to 40)</dt>
-    <dd>
-      Specify the commit ID length. Full SHA1 commit ID is 40 character long, but it is common
-      to cut it off at 8 or 12 as that often provide enough uniqueness and is a lot more legible.
-    </dd>
-  </dl>
+    <dl>
+      <dt>length=N (optional, default to 40)</dt>
+      <dd>
+        Specify the commit ID length. Full SHA1 commit ID is 40 characters long, but it is common
+        to truncate it at 8 or 12 as that usually provide enough uniqueness and is more legible.
+      </dd>
+    </dl>
+
+  </dd>
 </j:jelly>


### PR DESCRIPTION
## [JENKINS-9346](https://issues.jenkins-ci.org/browse/JENKINS-9346) - Fix token macro help formatting

Git plugin token macro help formatting was using an unnecessary heading to prefix the description of token macro parameters.  Other plugins use a definition list to describe the token macro parameters without the unnecessary heading.  Do the same for the git plugin.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Before the Fix

![Annotation 2020-07-11 164319](https://user-images.githubusercontent.com/156685/87235128-bb693880-c395-11ea-85d7-9252dd5a9ceb.png)

## After the Fix

![screencapture-localhost-9090-jenkins-job-git-help-job-configure-2020-07-11-16_47_02-edit](https://user-images.githubusercontent.com/156685/87235196-e2743a00-c396-11ea-943a-2a7f98543490.png)

