### PR TITLE
Remove subsetConfiguration parameter to enable incremental build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,3 @@
 #!/usr/bin/env groovy
 
-import java.util.Collections
-
-// Valid Jenkins versions for test
-def testJenkinsVersions = [ '2.204.1', '2.204.6', '2.222.4', '2.235.1', '2.243' ]
-Collections.shuffle(testJenkinsVersions)
-
-// Test plugin compatibility to subset of Jenkins versions
-subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: testJenkinsVersions[0], javaLevel: '8' ],
-                        [ jdk: '8',  platform: 'linux',   jenkins: testJenkinsVersions[1], javaLevel: '8' ],
-                        [ jdk: '11', platform: 'linux',   jenkins: testJenkinsVersions[2], javaLevel: '8' ]
-                      ]
-
-buildPlugin(configurations: subsetConfiguration, failFast: false)
+buildPlugin(failFast: false)


### PR DESCRIPTION
Currently there is an unidentifiable issue with using subsetConfiguration as a configurations parameter for the buildPlugin step. 
Simply removing it would ensure incremental builds for the git plugin.

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update


## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
