### PR TITLE
[JENKINS-37263] Prefer remote references for checkout

### DIFF
--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -69,7 +69,7 @@ public class DefaultBuildChooser extends BuildChooser {
             }
         }
 
-        Collection<Revision> revisions = new HashSet<>();
+        Collection<Revision> revisions = new LinkedHashSet<>();
 
         // if it doesn't contain '/' then it could be an unqualified branch
         if (!branchSpec.contains("/")) {
@@ -96,14 +96,14 @@ public class DefaultBuildChooser extends BuildChooser {
                 } else if(branchSpec.startsWith("refs/heads/")) {
                     fqbn = "refs/remotes/" + repository + "/" + branchSpec.substring("refs/heads/".length());
                 } else {
+                    //Check if exact branch name <branchSpec> exists
+                    fqbn = "refs/remotes/" + repository + "/" + branchSpec;
+                    verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
+                    possibleQualifiedBranches.add(fqbn);
+                    
                     //Try branchSpec as it is - e.g. "refs/tags/mytag"
                     fqbn = branchSpec;
                 }
-                verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
-                possibleQualifiedBranches.add(fqbn);
-
-                //Check if exact branch name <branchSpec> exists
-                fqbn = "refs/remotes/" + repository + "/" + branchSpec;
                 verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
                 possibleQualifiedBranches.add(fqbn);
             }

--- a/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
@@ -1,12 +1,16 @@
 package hudson.plugins.git.util;
 
 import hudson.plugins.git.AbstractGitRepository;
+import hudson.plugins.git.Branch;
 import java.util.Collection;
+import java.util.HashSet;
 
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
+import org.eclipse.jgit.lib.ObjectId;
 import static org.junit.Assert.*;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 /**
  * @author Arnout Engelen
@@ -43,4 +47,80 @@ public class DefaultBuildChooserTest extends AbstractGitRepository {
         assertTrue(buildChooser.isAdvancedSpec(":origin/master"));
         assertTrue(buildChooser.isAdvancedSpec(":origin/master-\\d{*}"));
     }
+
+	/* always failed before fix */
+    @Issue("JENKINS-37263")
+	@Test
+	public void testPrefereRemoteBranchInCandidateRevisionsWithWrongOrderInHashSet() throws Exception {
+		String branchName = "feature/42";
+		String localRef = "refs/heads/" + branchName;
+		String remoteRef = "refs/remotes/origin/" + branchName;
+		createRefsWithPredefinedOrderInHashSet(localRef, remoteRef);
+		DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
+
+		Collection<Revision> candidateRevisions =
+				buildChooser.getCandidateRevisions(false, branchName, testGitClient, null, null, null);
+
+		assertEquals(2, candidateRevisions.size());
+		Revision firstCandidateRevision = candidateRevisions.iterator().next();
+		Branch firstCandidateBranch = firstCandidateRevision.getBranches().iterator().next();
+		assertEquals(remoteRef, firstCandidateBranch.getName());
+	}
+
+	/* was successful also before fix */
+    @Issue("JENKINS-37263")
+	@Test
+	public void testPrefereRemoteBranchInCandidateRevisionsWithCorrectOrderInHashSet() throws Exception {
+		String branchName = "feature/42";
+		String localRef = "refs/heads/" + branchName;
+		String remoteRef = "refs/remotes/origin/" + branchName;
+		createRefsWithPredefinedOrderInHashSet(remoteRef, localRef);
+		DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
+
+		Collection<Revision> candidateRevisions =
+				buildChooser.getCandidateRevisions(false, branchName, testGitClient, null, null, null);
+
+		assertEquals(2, candidateRevisions.size());
+		Revision firstCandidateRevision = candidateRevisions.iterator().next();
+		Branch firstCandidateBranch = firstCandidateRevision.getBranches().iterator().next();
+		assertEquals(remoteRef, firstCandidateBranch.getName());
+	}
+
+    /* was successful also before fix */
+    @Issue("JENKINS-37263")
+	@Test
+	public void testSingleCandidateRevisionWithLocalAndRemoteRefsOnSameCommit() throws Exception {
+		String branchName = "feature/42";
+		String localRef = "refs/heads/" + branchName;
+		String remoteRef = "refs/remotes/origin/" + branchName;
+		testGitClient.ref(localRef);
+		testGitClient.ref(remoteRef);
+		DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
+
+		Collection<Revision> candidateRevisions =
+				buildChooser.getCandidateRevisions(false, branchName, testGitClient, null, null, null);
+
+		assertEquals(1, candidateRevisions.size());
+	}
+
+	private void createRefsWithPredefinedOrderInHashSet(String ref1, String ref2) throws InterruptedException {
+		ObjectId commit1 = testGitClient.revParse("HEAD");
+		testGitClient.ref(ref1);
+		testGitClient.commit("Commit");
+		ObjectId commit2 = testGitClient.revParse("HEAD");
+		HashSet<Revision> set = new HashSet<Revision>();
+		set.add(new Revision(commit1));
+		set.add(new Revision(commit2));
+		if (set.iterator().next().getSha1().equals(commit1)) {
+			// order in HashSet: commit1, commit2
+			// ref1 -> commit1, ref2 -> commit2
+			testGitClient.ref(ref2);
+		} else {
+			// order in HashSet: commit2, commit1
+			// ref1 -> commit2, ref2 -> commit1
+			testGitClient.ref(ref1);
+			testGitClient.checkout().ref(commit1.getName()).execute();
+			testGitClient.ref(ref2);
+		}
+	}
 }


### PR DESCRIPTION
## [JENKINS-37263](https://issues.jenkins-ci.org/browse/JENKINS-37263) - Prefer remote references for checkout

If a branch that contains a slash is configured as branch to build and local branch behaviour is configured, then two candidate revisions will be found in case remote branch is ahead of local: configured local branch name and branch name with prefix 'refs/remotes/<remote>/'. The first result will be taken, which can be a local or remote branch depending on sha1 of the revisions. This causes a problem that sometimes remote changes are ignored on checkout from SCM. See [JENKINS-37263](https://issues.jenkins-ci.org/browse/JENKINS-37263) for more details.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
