### PR TITLE
JENKINS-63487 Clarifying local branch name for detached checkouts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -675,9 +675,10 @@ image:/images/git-checkout-to-specific-local-branch.png[Checkout to specific loc
 Branch name::
 
   If given, checkout the revision to build as HEAD on the named branch.
-  If value is an empty string or "**", then the branch name is computed from the remote branch without the origin. If a specific revision and not branch HEAD is checked out, then 'detached' will be returned as the local branch name.
+  If value is an empty string or "**", then the branch name is computed from the remote branch without the origin. 
   In that case, a remote branch 'origin/master' will be checked out to a local branch named 'master', and a remote branch 'origin/develop/new-feature' will be checked out to a local branch named 'develop/new-feature'.
-
+  If a specific revision and not branch HEAD is checked out, then 'detached' will be returned as the local branch name.
+  
 [#wipe-out-repository-and-force-clone]
 ==== Wipe out repository and force clone
 

--- a/README.adoc
+++ b/README.adoc
@@ -677,7 +677,7 @@ Branch name::
   If given, checkout the revision to build as HEAD on the named branch.
   If value is an empty string or "**", then the branch name is computed from the remote branch without the origin. 
   In that case, a remote branch 'origin/master' will be checked out to a local branch named 'master', and a remote branch 'origin/develop/new-feature' will be checked out to a local branch named 'develop/new-feature'.
-  If a specific revision and not branch HEAD is checked out, then 'detached' will be returned as the local branch name.
+  If a specific revision and not branch HEAD is checked out, then 'detached' will be used as the local branch name.
   
 [#wipe-out-repository-and-force-clone]
 ==== Wipe out repository and force clone

--- a/README.adoc
+++ b/README.adoc
@@ -675,7 +675,7 @@ image:/images/git-checkout-to-specific-local-branch.png[Checkout to specific loc
 Branch name::
 
   If given, checkout the revision to build as HEAD on the named branch.
-  If value is an empty string or "**", then the branch name is computed from the remote branch without the origin.
+  If value is an empty string or "**", then the branch name is computed from the remote branch without the origin. If a specific revision and not branch HEAD is checked out, then 'detached' will be returned as the local branch name.
   In that case, a remote branch 'origin/master' will be checked out to a local branch named 'master', and a remote branch 'origin/develop/new-feature' will be checked out to a local branch named 'develop/new-feature'.
 
 [#wipe-out-repository-and-force-clone]


### PR DESCRIPTION
The documentation doesn't clearly state what the behavior is if you:

1. check out a given revision from a Git repo and
2. set `Checkout to specific local branch` to `**` or blank to get an automatic local branch name

```
16:09:31 Selected Git installation does not exist. Using Default
16:09:31 using credential gh-cred
16:09:31 Cloning the remote Git repository
16:09:32 Cloning repository https://github.com/user/repo.git
16:09:32  > git init /home/build-stage/jenkins/workspace/repo # timeout=10
16:09:32 Fetching upstream changes from https://github.com/user/repo.git
16:09:32  > git --version # timeout=10
16:09:32 using GIT_ASKPASS to set credentials gh-cred
16:09:32  > git fetch --tags --force --progress -- https://github.com/user/repo.git +refs/heads/*:refs/remotes/origin/* # timeout=10
16:10:34  > git config remote.origin.url https://github.com/user/repo.git # timeout=10
16:10:34  > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
16:10:35  > git config remote.origin.url https://github.com/user/repo.git # timeout=10
16:10:35 Fetching upstream changes from https://github.com/user/repo.git
16:10:35 using GIT_ASKPASS to set credentials gh-cred
16:10:35  > git fetch --tags --force --progress -- https://github.com/user/repo.git +refs/heads/*:refs/remotes/origin/* # timeout=10
16:10:35  > git rev-parse de7de0c226225101234567894c51e703730e392c^{commit} # timeout=10
16:10:35 Checking out Revision de7de0c226225101234567894c51e703730e392c (detached)
16:10:35 Enabling Git LFS pull
16:10:35  > git config core.sparsecheckout # timeout=10
16:10:35  > git checkout -f de7de0c226225101234567894c51e703730e392c # timeout=10
16:11:36  > git branch -a -v --no-abbrev # timeout=10
16:11:36  > git checkout -b detached de7de0c226225101234567894c51e703730e392c # timeout=10
16:11:36  > git config --get remote.origin.url # timeout=10
16:11:36 using GIT_ASKPASS to set credentials Jenkins integration user for Artifactory
16:11:36  > git lfs pull origin # timeout=10
```


## Checklist

- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Documentation in README has been updated as necessary

## Types of changes

Doc change only