### PR TITLE
[JENKINS-63539] Use additional repo URL variants to find cache

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -850,11 +850,13 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 url = getParameterString(uc.getUrl(), environment);
                 chooser = new GitToolChooser(url, project, ucCredentialsId, gitExe, unsupportedCommand.determineSupportForJGit());
             }
-            listener.getLogger().println("The recommended git tool for " + url + " is: " + chooser.getGitTool());
-            String updatedGitExe = chooser.getGitTool();
+            if (chooser != null) {
+                listener.getLogger().println("The recommended git tool for " + url + " is: " + chooser.getGitTool());
+                String updatedGitExe = chooser.getGitTool();
 
-            if (!updatedGitExe.equals("NONE")) {
-                gitExe = updatedGitExe;
+                if (!updatedGitExe.equals("NONE")) {
+                    gitExe = updatedGitExe;
+                }
             }
         }
         Git git = Git.with(listener, environment).in(ws).using(gitExe);

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -844,12 +844,13 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 ext.determineSupportForJGit(this, unsupportedCommand);
             }
             GitToolChooser chooser = null;
+            String url = "<unknown>";
             for (UserRemoteConfig uc : getUserRemoteConfigs()) {
                 String ucCredentialsId = uc.getCredentialsId();
-                String url = getParameterString(uc.getUrl(), environment);
+                url = getParameterString(uc.getUrl(), environment);
                 chooser = new GitToolChooser(url, project, ucCredentialsId, gitExe, unsupportedCommand.determineSupportForJGit());
             }
-            listener.getLogger().println("The recommended git tool is: " + chooser.getGitTool());
+            listener.getLogger().println("The recommended git tool for " + url + " is: " + chooser.getGitTool());
             String updatedGitExe = chooser.getGitTool();
 
             if (!updatedGitExe.equals("NONE")) {

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -185,7 +185,9 @@ public class GitToolChooser {
             if (repositorySizeCache.containsKey(repoUrl)) {
                 sizeOfRepo = repositorySizeCache.get(repoUrl);
                 useCache = true;
-                LOGGER.log(Level.FINER, "Found cached size estimate {0} for remote {1}", new Object[]{sizeOfRepo, repoUrl});
+                LOGGER.log(Level.INFO,
+                           "Found cache for {0} with size {1}",
+                           new Object[]{remoteName, sizeOfRepo});
                 break;
             }
             String cacheEntry = AbstractGitSCMSource.getCacheEntry(repoUrl);

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -87,7 +87,6 @@ public class GitToolChooser {
             LOGGER.log(Level.INFO, "GitToolChooser not using cache in constructor");
             decideAndUseAPI(remoteName, projectContext, credentialsId, gitExe);
         }
-        determineGitTool(implementation, gitExe);
         LOGGER.log(Level.INFO,
                    "GitToolChooser constructor sizeOfRepo {0}, implementation {1}, gitTool {2}, JGIT_SUPPORTED {3}",
                    new Object[]{sizeOfRepo, implementation, gitTool, JGIT_SUPPORTED});

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -77,7 +77,7 @@ public class GitToolChooser {
         String cacheEntry = AbstractGitSCMSource.getCacheEntry(remoteName);
         File cacheDir = AbstractGitSCMSource.getCacheDir(cacheEntry, false);
         if (cacheDir != null) {
-            Git git = Git.with(TaskListener.NULL, new EnvVars(EnvVars.masterEnvVars)).in(cacheDir).using("git");
+            Git git = Git.with(TaskListener.NULL, new EnvVars(EnvVars.masterEnvVars)).in(cacheDir).using("jgit");
             GitClient client = git.getClient();
             if (client.hasGitRepo()) {
                 sizeOfRepo = FileUtils.sizeOfDirectory(cacheDir);

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -100,6 +100,7 @@ public class GitToolChooser {
     /* package */ @NonNull Set<String> remoteAlternatives(String remoteURL) {
         Set<String> alternatives = new LinkedHashSet<>(10); // Known to be a small list
         if (remoteURL == null || remoteURL.isEmpty()) {
+            LOGGER.log(Level.FINE, "Null or empty remote URL not cached");
             return alternatives;
         }
 

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -98,7 +98,7 @@ public class GitToolChooser {
      * Package protected for testing
      */
     /* package */ @NonNull Set<String> remoteAlternatives(String remoteURL) {
-        Set<String> alternatives = new LinkedHashSet<>(10); // Known to be a small list
+        Set<String> alternatives = new LinkedHashSet<>();
         if (remoteURL == null || remoteURL.isEmpty()) {
             LOGGER.log(Level.FINE, "Null or empty remote URL not cached");
             return alternatives;

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -333,5 +333,12 @@ public class GitToolChooser {
         }
     }
 
+    /**
+     * Clear the cache of repository sizes.
+     */
+    public static void clearRepositorySizeCache() {
+        repositorySizeCache = new ConcurrentHashMap<>();
+    }
+
     private static final Logger LOGGER = Logger.getLogger(GitToolChooser.class.getName());
 }

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -64,15 +64,20 @@ public class GitToolChooser {
             JGIT_SUPPORTED = useJGit;
         }
 
+        LOGGER.log(Level.INFO, "GitToolChooser constructor remote {0}, gitExe {1}, useJGit {2}", new Object[]{remoteName, gitExe, useJGit});
+
         implementation = "NONE";
         useCache = decideAndUseCache(remoteName);
 
         if (useCache) {
+            LOGGER.log(Level.INFO, "GitToolChooser using cache in constructor");
             implementation = determineSwitchOnSize(sizeOfRepo, gitExe);
         } else {
+            LOGGER.log(Level.INFO, "GitToolChooser not using cache in constructor");
             decideAndUseAPI(remoteName, projectContext, credentialsId, gitExe);
         }
         determineGitTool(implementation, gitExe);
+        LOGGER.log(Level.INFO, "GitToolChooser constructor sizeOfRepo {0}, implementation {1}, gitTool {2}, JGIT_SUPPORTED", new Object[]{sizeOfRepo, implementation, gitTool, JGIT_SUPPORTED});
     }
 
     /* Git repository URLs frequently end with the ".git" suffix.

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -186,7 +186,7 @@ public class GitToolChooser {
                 sizeOfRepo = repositorySizeCache.get(repoUrl);
                 useCache = true;
                 LOGGER.log(Level.INFO,
-                           "Found cache for {0} with size {1}",
+                           "Found cache key for {0} with size {1}",
                            new Object[]{remoteName, sizeOfRepo});
                 break;
             }

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -64,7 +64,9 @@ public class GitToolChooser {
             JGIT_SUPPORTED = useJGit;
         }
 
-        LOGGER.log(Level.INFO, "GitToolChooser constructor remote {0}, gitExe {1}, useJGit {2}", new Object[]{remoteName, gitExe, useJGit});
+        LOGGER.log(Level.INFO,
+                   "GitToolChooser constructor remote {0}, gitExe {1}, useJGit {2}, JGIT_SUPPORTED {3}",
+                   new Object[]{remoteName, gitExe, useJGit, JGIT_SUPPORTED});
 
         implementation = "NONE";
         useCache = decideAndUseCache(remoteName);
@@ -77,7 +79,9 @@ public class GitToolChooser {
             decideAndUseAPI(remoteName, projectContext, credentialsId, gitExe);
         }
         determineGitTool(implementation, gitExe);
-        LOGGER.log(Level.INFO, "GitToolChooser constructor sizeOfRepo {0}, implementation {1}, gitTool {2}, JGIT_SUPPORTED", new Object[]{sizeOfRepo, implementation, gitTool, JGIT_SUPPORTED});
+        LOGGER.log(Level.INFO,
+                   "GitToolChooser constructor sizeOfRepo {0}, implementation {1}, gitTool {2}, JGIT_SUPPORTED {3}",
+                   new Object[]{sizeOfRepo, implementation, gitTool, JGIT_SUPPORTED});
     }
 
     /* Git repository URLs frequently end with the ".git" suffix.

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -93,13 +93,6 @@ public class GitToolChooser {
     private static Pattern sshAltProtocolPattern = Pattern.compile("^[\\w]+@(.+):(.+)$");
     private static Pattern sshProtocolPattern = Pattern.compile("^ssh://[\\w]+@([^/]+)/(.+)$");
 
-    private static Pattern [] protocolPatterns = {
-        gitProtocolPattern,
-        httpProtocolPattern,
-        sshAltProtocolPattern,
-        sshProtocolPattern,
-    };
-
     /* Return a list of alternate remote URL's based on permutations of remoteURL.
      * Varies the protocol (https, git, ssh) and the suffix of the repository URL.
      * Package protected for testing
@@ -113,6 +106,13 @@ public class GitToolChooser {
         // Must include original remote in case none of the protocol patterns match
         // For example, file://srv/git/repo.git is matched by none of the patterns
         addSuffixVariants(remoteURL, alternatives); // First preference to original URL
+
+        Pattern [] protocolPatterns = {
+            gitProtocolPattern,
+            httpProtocolPattern,
+            sshAltProtocolPattern,
+            sshProtocolPattern,
+        };
 
         String[] matcherReplacements = {
             "git://$1/$2",     // git protocol

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -584,8 +584,8 @@ public class GitToolChooserTest {
     private void buildAProject(GitSampleRepoRule sampleRepo, boolean noCredentials) throws Exception {
         WorkflowJob p = jenkins.jenkins.createProject(WorkflowJob.class, "p");
         String remoteConfig = noCredentials ?
-            "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]]\n" :
-            "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$, credentialsId: 'github']]]\n";
+            "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]\n" :
+            "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$, credentialsId: 'github']]\n";
         p.setDefinition(new CpsFlowDefinition(
                 "node {\n"
                         + "  checkout(\n"

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -562,11 +562,15 @@ public class GitToolChooserTest {
 
     private void buildAProject(GitSampleRepoRule sampleRepo, boolean noCredentials) throws Exception {
         WorkflowJob p = jenkins.jenkins.createProject(WorkflowJob.class, "p");
+        String userRemoteConfig = noCredentials ?
+            "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]]\n" :
+            "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$, credentialsId: 'github']]]\n";
+        
         p.setDefinition(new CpsFlowDefinition(
                 "node {\n"
                         + "  checkout(\n"
                         + "    [$class: 'GitSCM', \n"
-                        + "      userRemoteConfigs: [[credentialsId: 'github', url: $/" + sampleRepo + "/$]]]\n"
+                        + userRemoteConfig
                         + "  )"
                         + "}", true));
         WorkflowRun b = jenkins.assertBuildStatusSuccess(p.scheduleBuild2(0));

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -162,6 +162,7 @@ public class GitToolChooserTest {
 
         GitToolChooser nullRemoteSizeEstimator = new GitToolChooser("git://github.com/git/git.git", null, null, gitExe, null);
         assertThat(nullRemoteSizeEstimator.remoteAlternatives(null), is(empty()));
+        assertThat(nullRemoteSizeEstimator.remoteAlternatives(""), is(empty()));
 
         /* Borrow the nullRemoteSizer to also test determineSwitchOnSize a little more */
         long sizeOfRepo = 1 + random.nextInt(4000);

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -186,6 +186,14 @@ public class GitToolChooserTest {
             Set<String> alternatives = sizeEstimator.remoteAlternatives(remote);
             assertThat("Remote: " + remote, alternatives, containsInAnyOrder(remoteAlternatives));
         }
+
+        /* Test remote that ends with '/' */
+        for (String remote : remoteAlternatives) {
+            remote = remote + "/";
+            GitToolChooser sizeEstimator = new GitToolChooser(remote, null, null, gitExe, random.nextBoolean());
+            Set<String> alternatives = sizeEstimator.remoteAlternatives(remote);
+            assertThat("Remote+'/': " + remote, alternatives, containsInAnyOrder(remoteAlternatives));
+        }
     }
 
     /*

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -54,7 +54,7 @@ public class GitToolChooserTest {
 
     private CredentialsStore store = null;
 
-    private Random random = new Random();
+    private static Random random = new Random();
 
     @Before
     public void enableSystemCredentialsProvider() {
@@ -210,7 +210,7 @@ public class GitToolChooserTest {
     }
 
     /*
-    In the event of having an extension which returns the size of repository as 500 KiB, the estimator should
+    In the event of having an extension which returns the size of repository as less than 1000 KiB, the estimator should
     recommend "jgit" as the optimal implementation from the heuristics
      */
     @Test
@@ -510,8 +510,7 @@ public class GitToolChooserTest {
 
         @Override
         public Long getSizeOfRepository(String remote, Item context, String credentialsId) {
-            // from remote, remove .git and https://github.com
-            return (long) 500;
+            return (long) 100 + random.nextInt(800);
         }
     }
 
@@ -529,8 +528,7 @@ public class GitToolChooserTest {
 
         @Override
         public Long getSizeOfRepository(String remote, Item context, String credentialsId) {
-            // from remote, remove .git and https://github.com
-            return (long) 10000;
+            return (long) 10000 + random.nextInt(5000);
         }
     }
 

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -252,7 +252,7 @@ public class GitToolChooserTest {
         } else {
             permutedRemote = permutedRemote + suffix; // Add trailing ".git" suffix
         }
-        GitToolChooser permutedRepoSizeEstimator = new GitToolChooser(permutedRemote, list.get(0), "github", tool.getGitExe(), true);
+        GitToolChooser permutedRepoSizeEstimator = new GitToolChooser(permutedRemote, list.get(0), "github", tool, null, TaskListener.NULL, true);
         assertThat("Alternative repository name should find the cache",
                    permutedRepoSizeEstimator.getGitTool(), containsString("jgit"));
     }
@@ -261,15 +261,15 @@ public class GitToolChooserTest {
     @Test
     @Issue("JENKINS-63539")
     public void testRemoteAlternatives() throws Exception {
-        String gitExe = "git";
+        GitTool tool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
 
-        GitToolChooser nullRemoteSizeEstimator = new GitToolChooser("git://github.com/git/git.git", null, null, gitExe, null);
+        GitToolChooser nullRemoteSizeEstimator = new GitToolChooser("git://github.com/git/git.git", null, null, tool, null, TaskListener.NULL, true);
         assertThat(nullRemoteSizeEstimator.remoteAlternatives(null), is(empty()));
         assertThat(nullRemoteSizeEstimator.remoteAlternatives(""), is(empty()));
 
         /* Borrow the nullRemoteSizer to also test determineSwitchOnSize a little more */
         long sizeOfRepo = 1 + random.nextInt(4000);
-        assertThat(nullRemoteSizeEstimator.determineSwitchOnSize(sizeOfRepo, "any"), is("NONE"));
+        assertThat(nullRemoteSizeEstimator.determineSwitchOnSize(sizeOfRepo, tool), is("NONE"));
 
         /* Each of these alternatives is expected to be interpreted as
          * a valid alias for every other alternative in the list.
@@ -286,7 +286,7 @@ public class GitToolChooserTest {
         };
 
         for (String remote : remoteAlternatives) {
-            GitToolChooser sizeEstimator = new GitToolChooser(remote, null, null, gitExe, random.nextBoolean());
+            GitToolChooser sizeEstimator = new GitToolChooser(remote, null, null, tool, null, TaskListener.NULL, random.nextBoolean());
             Set<String> alternatives = sizeEstimator.remoteAlternatives(remote);
             assertThat("Remote: " + remote, alternatives, containsInAnyOrder(remoteAlternatives));
         }
@@ -294,7 +294,7 @@ public class GitToolChooserTest {
         /* Test remote that ends with '/' */
         for (String remote : remoteAlternatives) {
             remote = remote + "/";
-            GitToolChooser sizeEstimator = new GitToolChooser(remote, null, null, gitExe, random.nextBoolean());
+            GitToolChooser sizeEstimator = new GitToolChooser(remote, null, null, tool, null, TaskListener.NULL, random.nextBoolean());
             Set<String> alternatives = sizeEstimator.remoteAlternatives(remote);
             assertThat("Remote+'/': " + remote, alternatives, containsInAnyOrder(remoteAlternatives));
         }
@@ -408,7 +408,7 @@ public class GitToolChooserTest {
             hudson.Util.deleteRecursive(cacheDir);
         }
 
-        GitToolChooser sizeEstimator = new GitToolChooser(sampleRepo.toString(), list.get(0), null, gitExe, true);
+        GitToolChooser sizeEstimator = new GitToolChooser(sampleRepo.toString(), list.get(0), null, tool, null, TaskListener.NULL, true);
 
         assertThat(sizeEstimator.getGitTool(), is("NONE"));
     }
@@ -424,7 +424,7 @@ public class GitToolChooserTest {
         List<TopLevelItem> list = jenkins.jenkins.getItems();
 
         // Assuming no tool is installed by user and git is present in the machine
-        String gitExe = "git";
+        GitTool tool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
 
         GitToolChooser sizeEstimator = new GitToolChooser(sampleRepo.toString(), list.get(0), null, tool, null, TaskListener.NULL,true);
 

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -69,6 +69,11 @@ public class GitToolChooserTest {
         assertThat("The system credentials provider is enabled", store, notNullValue());
     }
 
+    @Before
+    public void resetRepositorySizeCache() {
+        GitToolChooser.clearRepositorySizeCache();
+    }
+
     /*
     In the event of having no cache but extension APIs in the ExtensionList, the estimator should recommend a tool
     instead of recommending no git implementation.

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -297,6 +297,14 @@ public class GitToolChooserTest {
         // Assuming no tool is installed by user and git is present in the machine
         String gitExe = "git";
 
+        String remoteName = sampleRepo.toString();
+        String cacheEntry = AbstractGitSCMSource.getCacheEntry(remoteName);
+        File cacheDir = AbstractGitSCMSource.getCacheDir(cacheEntry, false);
+        if (cacheDir != null) {
+            System.out.println("**** Unexpected cache directory at " + cacheDir.getAbsolutePath() + " for " + remoteName);
+            hudson.Util.deleteRecursive(cacheDir);
+        }
+
         GitToolChooser sizeEstimator = new GitToolChooser(sampleRepo.toString(), list.get(0), null, gitExe, true);
 
         assertThat(sizeEstimator.getGitTool(), is("NONE"));

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -405,7 +405,6 @@ public class GitToolChooserTest {
         String cacheEntry = AbstractGitSCMSource.getCacheEntry(remoteName);
         File cacheDir = AbstractGitSCMSource.getCacheDir(cacheEntry, false);
         if (cacheDir != null) {
-            System.out.println("**** Unexpected cache directory at " + cacheDir.getAbsolutePath() + " for " + remoteName);
             hudson.Util.deleteRecursive(cacheDir);
         }
 

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -583,7 +583,7 @@ public class GitToolChooserTest {
 
     private void buildAProject(GitSampleRepoRule sampleRepo, boolean noCredentials) throws Exception {
         WorkflowJob p = jenkins.jenkins.createProject(WorkflowJob.class, "p");
-        String userRemoteConfig = noCredentials ?
+        String remoteConfig = noCredentials ?
             "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]]\n" :
             "      userRemoteConfigs: [[url: $/" + sampleRepo + "/$, credentialsId: 'github']]]\n";
         p.setDefinition(new CpsFlowDefinition(


### PR DESCRIPTION
## [JENKINS-63539](https://issues.jenkins-ci.org/browse/JENKINS-63539) Use additional repo URL variants to find cache

Estimation of repository size uses a cache key based on the repository URL.  There are several different forms of repository URL that can represent the same git repository.

For example, the following URL's all point to the same repository

* git://github.com/jenkinsci/git-plugin
* git@github.com:jenkinsci/git-plugin.git
* https://github.com/jenkinsci/git-plugin
* https://github.com/jenkinsci/git-plugin.git
* ssh://git@github.com/jenkinsci/git-plugin.git

This pull request permutes the repository URL provided by the user into several other forms in hopes that one of the forms already has a cached copy that can be used for local estimation of repository size.  This assumes that local Java processing of strings is much faster than a REST API call to the hosting provider to request the size of the repository.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)