### PR TITLE
[JENKINS-63541] Don't create empty dirs in chooser

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -1219,15 +1219,23 @@ public abstract class AbstractGitSCMSource extends SCMSource {
     }
 
     protected static File getCacheDir(String cacheEntry) {
+        return getCacheDir(cacheEntry, true);
+    }
+
+    protected static File getCacheDir(String cacheEntry, boolean createDirectory) {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins == null) {
             return null;
         }
         File cacheDir = new File(new File(jenkins.getRootDir(), "caches"), cacheEntry);
         if (!cacheDir.isDirectory()) {
-            boolean ok = cacheDir.mkdirs();
-            if (!ok) {
-                LOGGER.log(Level.WARNING, "Failed mkdirs of {0}", cacheDir);
+            if (createDirectory) {
+                boolean ok = cacheDir.mkdirs();
+                if (!ok) {
+                    LOGGER.log(Level.WARNING, "Failed mkdirs of {0}", cacheDir);
+                }
+            } else {
+                cacheDir = null;
             }
         }
         return cacheDir;

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -75,7 +75,7 @@ public class GitToolChooser {
     private boolean decideAndUseCache(String remoteName) throws IOException, InterruptedException {
         boolean useCache = false;
         String cacheEntry = AbstractGitSCMSource.getCacheEntry(remoteName);
-        File cacheDir = AbstractGitSCMSource.getCacheDir(cacheEntry);
+        File cacheDir = AbstractGitSCMSource.getCacheDir(cacheEntry, false);
         if (cacheDir != null) {
             Git git = Git.with(TaskListener.NULL, new EnvVars(EnvVars.masterEnvVars)).in(cacheDir).using("git");
             GitClient client = git.getClient();


### PR DESCRIPTION
## [JENKINS-63541](https://issues.jenkins-ci.org/browse/JENKINS-63541) - Don't create empty dirs in chooser

The git plugin previously created an empty directory in the $JENKINS_HOME/caches directory for any repository URL that it checked for size. Those empty directories are not likely to use too much disc space, but a large installation that clones many different repositories will have many empty directories in the caches directory.

Provides a new getCacheDir API that returns null if the directory does not already exist.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)