### PR TITLE
[JENKINS-63519] Create a better mechanism to detect node-specific git implementations

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -838,6 +838,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         String gitExe = getGitExe(n, listener);
 
+        GitTool gitTool = getGitTool(n, null, listener);
+
         if (!isDisableGitToolChooser()) {
             UnsupportedCommand unsupportedCommand = new UnsupportedCommand();
             for (GitSCMExtension ext : extensions) {
@@ -847,7 +849,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             for (UserRemoteConfig uc : getUserRemoteConfigs()) {
                 String ucCredentialsId = uc.getCredentialsId();
                 String url = getParameterString(uc.getUrl(), environment);
-                chooser = new GitToolChooser(url, project, ucCredentialsId, gitExe, unsupportedCommand.determineSupportForJGit());
+                chooser = new GitToolChooser(url, project, ucCredentialsId, gitTool, unsupportedCommand.determineSupportForJGit());
             }
             listener.getLogger().println("The recommended git tool is: " + chooser.getGitTool());
             String updatedGitExe = chooser.getGitTool();
@@ -998,6 +1000,14 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             return null;
         }
         return tool.getGitExe();
+    }
+
+    public GitTool getGitTool(Node builtOn, EnvVars env, TaskListener listener) {
+        GitTool tool = GitUtils.resolveGitTool(gitTool, builtOn, env, listener);
+        if(tool == null) {
+            return null;
+        }
+        return tool;
     }
 
     /*package*/ static class BuildChooserContextImpl implements BuildChooserContext, Serializable {

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -849,7 +849,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             for (UserRemoteConfig uc : getUserRemoteConfigs()) {
                 String ucCredentialsId = uc.getCredentialsId();
                 String url = getParameterString(uc.getUrl(), environment);
-                chooser = new GitToolChooser(url, project, ucCredentialsId, gitTool, unsupportedCommand.determineSupportForJGit());
+                chooser = new GitToolChooser(url, project, ucCredentialsId, gitTool, n, listener,unsupportedCommand.determineSupportForJGit());
             }
             listener.getLogger().println("The recommended git tool is: " + chooser.getGitTool());
             String updatedGitExe = chooser.getGitTool();
@@ -1004,9 +1004,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
     public GitTool getGitTool(Node builtOn, EnvVars env, TaskListener listener) {
         GitTool tool = GitUtils.resolveGitTool(gitTool, builtOn, env, listener);
-        if(tool == null) {
-            return null;
-        }
         return tool;
     }
 

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -183,7 +183,7 @@ public class GitToolChooser {
 
     public GitTool recommendGitToolOnAgent(GitTool userChoice) {
         List<GitTool> preferredToolList = new ArrayList<>();
-        GitTool correctTool = null;
+        GitTool correctTool = GitTool.getDefaultInstallation();
         String toolName = userChoice.getName();
         if (toolName.equals(JGitTool.MAGIC_EXENAME) || toolName.equals(JGitApacheTool.MAGIC_EXENAME)) {
             GitTool[] toolList = Jenkins.get().getDescriptorByType(GitTool.DescriptorImpl.class).getInstallations();

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -149,9 +149,6 @@ public class GitToolChooser {
                 return rTool.getGitExe();
             } else {
                 GitTool rTool = resolveGitToolForRecommendation(tool, "git");
-                if (rTool == null) {
-                    return "NONE";
-                }
                 return rTool.getGitExe();
             }
         }

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -47,7 +47,9 @@ public class GitToolChooser {
      * @param remoteName the repository url
      * @param projectContext the context where repository size is being estimated
      * @param credentialsId credential used to access the repository or null if no credential is required
-     * @param gitExe name of the git tool ('git', 'jgit', 'jgitapache') to be used as the default tool
+     * @param gitExe Git tool ('git', 'jgit', 'jgitapache') to be used as the default tool
+     * @param n A Jenkins agent used to check validity of git installation
+     * @param listener TaskListener required by GitUtils.resolveGitTool()
      * @param useJGit if true the JGit is allowed as an implementation
      * @throws IOException on error
      * @throws InterruptedException on error

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -200,6 +200,11 @@ public class GitToolChooser {
         return correctTool;
     }
 
+    /**
+     * Provide a git tool considering the node specific installations
+     * @param recommendation: Tool name
+     * @return resolved git tool
+     */
     private GitTool getResolvedGitTool(String recommendation) {
         if (currentNode == null) {
             currentNode = Jenkins.get();

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -467,7 +467,7 @@ public class GitToolChooserTest {
         String gitExe = jGitTool.getGitExe();
 
         GitToolChooser sizeEstimator = new GitToolChooser(remote, list.get(0), "github", jGitTool, null, TaskListener.NULL,true);
-        assertThat(sizeEstimator.getGitTool(), is("NONE")); // Since git is not available and that should be the recommendation
+        assertThat(sizeEstimator.getGitTool(), is("jgit")); // Since git is not available, we suggest `jgit` which doesn't make any difference
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -76,8 +76,8 @@ public class GitToolChooserTest {
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
 
-        HelloToolInstaller inst = new HelloToolInstaller("master", "echo Hello", "updated/git");
-        GitTool t = new GitTool("myGit", "default/git", Collections.singletonList(
+        HelloToolInstaller inst = new HelloToolInstaller("master", "echo Hello", SystemUtils.IS_OS_WINDOWS ? "updated/git.exe" : "updated/git");
+        GitTool t = new GitTool("myGit", SystemUtils.IS_OS_WINDOWS ? "default/git.exe" : "default/git", Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
 
         GitTool tool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
@@ -86,7 +86,7 @@ public class GitToolChooserTest {
 
         GitToolChooser r = new GitToolChooser(remote, context, credentialsId, JTool, null, TaskListener.NULL,true);
 
-        assertThat(r.getGitTool().contains("default/git/updated/git"), is(true));
+        assertThat(r.getGitTool(), containsString(SystemUtils.IS_OS_WINDOWS ? "default/git.exe/updated/git.exe" : "default/git/updated/git"));
     }
 
     /*

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -100,8 +100,8 @@ public class GitToolChooserTest {
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
 
-        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", isWindows() ? "updated/git.exe" : "updated/git");
-        GitTool t = new GitTool("myGit", isWindows() ? "default/git.exe" : "default/git", Collections.singletonList(
+        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", isWindows() ? "updated\\git.exe" : "updated/git");
+        GitTool t = new GitTool("myGit", isWindows() ? "default\\git.exe" : "default/git", Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
 
         GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
@@ -110,7 +110,7 @@ public class GitToolChooserTest {
 
         GitToolChooser r = new GitToolChooser(remote, context, credentialsId, JTool, null, TaskListener.NULL,true);
 
-        assertThat(r.getGitTool(), containsString(isWindows() ? "updated/git.exe" : "updated/git"));
+        assertThat(r.getGitTool(), containsString(isWindows() ? "updated\\git.exe" : "updated/git"));
     }
 
     /*
@@ -131,11 +131,11 @@ public class GitToolChooserTest {
         agent.setMode(Node.Mode.NORMAL);
         agent.setLabelString("agent-windows");
 
-        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", isWindows() ? "myGit/git.exe" : "myGit/git");
-        GitTool toolOnMaster = new GitTool("myGit", isWindows() ? "default/git.exe" : "default/git", Collections.singletonList(
+        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", isWindows() ? "myGit\\git.exe" : "myGit/git");
+        GitTool toolOnMaster = new GitTool("myGit", isWindows() ? "default\\git.exe" : "default/git", Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
 
-        TestToolInstaller instonAgent = new TestToolInstaller("agent-windows", "echo Hello", isWindows() ? "my-git/git.exe" : "my-git/git");
+        TestToolInstaller instonAgent = new TestToolInstaller("agent-windows", "echo Hello", isWindows() ? "my-git\\git.exe" : "my-git/git");
         GitTool toolOnAgent = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.singletonList(new InstallSourceProperty(Collections.singletonList(instonAgent))));
 
         GitTool JTool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
@@ -152,7 +152,7 @@ public class GitToolChooserTest {
 
         GitToolChooser r = new GitToolChooser(remote, context, credentialsId, JTool, agent, TaskListener.NULL,true);
 
-        assertThat(r.getGitTool(), containsString(isWindows() ? "my-git/git.exe" : "my-git/git"));
+        assertThat(r.getGitTool(), containsString(isWindows() ? "my-git\\git.exe" : "my-git/git"));
     }
 
     /*

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -96,21 +96,25 @@ public class GitToolChooserTest {
     @Issue("JENKINS-63519")
     @Test
     public void testResolveGitToolWithJenkins() throws IOException, InterruptedException {
+        if (isWindows()) { // Runs on Unix only
+            /* Do not distract warnings system by using assumeThat to skip tests */
+            return;
+        }
         String remote = "https://gitlab.com/rishabhBudhouliya/git-plugin.git";
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
 
-        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", isWindows() ? "updated\\git.exe" : "updated/git");
-        GitTool t = new GitTool("myGit", isWindows() ? "default\\git.exe" : "default/git", Collections.singletonList(
+        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", "updated/git");
+        GitTool t = new GitTool("myGit", "default/git", Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
 
-        GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool tool = new GitTool("my-git", "git", Collections.<ToolProperty<?>>emptyList());
         GitTool JTool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
         jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, JTool, t);
 
         GitToolChooser r = new GitToolChooser(remote, context, credentialsId, JTool, null, TaskListener.NULL,true);
 
-        assertThat(r.getGitTool(), containsString(isWindows() ? "updated\\git.exe" : "updated/git"));
+        assertThat(r.getGitTool(), containsString("updated/git"));
     }
 
     /*
@@ -122,6 +126,10 @@ public class GitToolChooserTest {
     @Issue("JENKINS-63519")
     @Test
     public void testResolutionGitToolOnAgent() throws Exception {
+        if (isWindows()) { // Runs on Unix only
+            /* Do not distract warnings system by using assumeThat to skip tests */
+            return;
+        }
         String remote = "https://gitlab.com/rishabhBudhouliya/git-plugin.git";
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
@@ -131,12 +139,12 @@ public class GitToolChooserTest {
         agent.setMode(Node.Mode.NORMAL);
         agent.setLabelString("agent-windows");
 
-        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", isWindows() ? "myGit\\git.exe" : "myGit/git");
-        GitTool toolOnMaster = new GitTool("myGit", isWindows() ? "default\\git.exe" : "default/git", Collections.singletonList(
+        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", "myGit/git");
+        GitTool toolOnMaster = new GitTool("myGit", "default/git", Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
 
-        TestToolInstaller instonAgent = new TestToolInstaller("agent-windows", "echo Hello", isWindows() ? "my-git\\git.exe" : "my-git/git");
-        GitTool toolOnAgent = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.singletonList(new InstallSourceProperty(Collections.singletonList(instonAgent))));
+        TestToolInstaller instonAgent = new TestToolInstaller("agent-windows", "echo Hello", "my-git/git");
+        GitTool toolOnAgent = new GitTool("my-git", "git", Collections.singletonList(new InstallSourceProperty(Collections.singletonList(instonAgent))));
 
         GitTool JTool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
 
@@ -152,7 +160,7 @@ public class GitToolChooserTest {
 
         GitToolChooser r = new GitToolChooser(remote, context, credentialsId, JTool, agent, TaskListener.NULL,true);
 
-        assertThat(r.getGitTool(), containsString(isWindows() ? "my-git\\git.exe" : "my-git/git"));
+        assertThat(r.getGitTool(), containsString("my-git/git"));
     }
 
     /*

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -15,7 +15,6 @@ import jenkins.model.Jenkins;
 import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.scm.api.trait.SCMSourceTrait;
 
-import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.plugins.gitclient.JGitApacheTool;
 import org.jenkinsci.plugins.gitclient.JGitTool;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -79,13 +78,13 @@ public class GitToolChooserTest {
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
 
-        GitTool tool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
         GitTool JTool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
         jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, JTool);
 
         GitToolChooser r = new GitToolChooser(remote, context, credentialsId, JTool, null, TaskListener.NULL,true);
 
-        assertThat(r.getGitTool(), containsString(SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git"));
+        assertThat(r.getGitTool(), containsString(isWindows() ? "git.exe" : "git"));
     }
 
     /*
@@ -101,17 +100,17 @@ public class GitToolChooserTest {
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
 
-        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", SystemUtils.IS_OS_WINDOWS ? "updated/git.exe" : "updated/git");
-        GitTool t = new GitTool("myGit", SystemUtils.IS_OS_WINDOWS ? "default/git.exe" : "default/git", Collections.singletonList(
+        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", isWindows() ? "updated/git.exe" : "updated/git");
+        GitTool t = new GitTool("myGit", isWindows() ? "default/git.exe" : "default/git", Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
 
-        GitTool tool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
         GitTool JTool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
         jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, JTool, t);
 
         GitToolChooser r = new GitToolChooser(remote, context, credentialsId, JTool, null, TaskListener.NULL,true);
 
-        assertThat(r.getGitTool(), containsString(SystemUtils.IS_OS_WINDOWS ? "updated/git.exe" : "updated/git"));
+        assertThat(r.getGitTool(), containsString(isWindows() ? "updated/git.exe" : "updated/git"));
     }
 
     /*
@@ -132,12 +131,12 @@ public class GitToolChooserTest {
         agent.setMode(Node.Mode.NORMAL);
         agent.setLabelString("agent-windows");
 
-        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", SystemUtils.IS_OS_WINDOWS ? "myGit/git.exe" : "myGit/git");
-        GitTool toolOnMaster = new GitTool("myGit", SystemUtils.IS_OS_WINDOWS ? "default/git.exe" : "default/git", Collections.singletonList(
+        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", isWindows() ? "myGit/git.exe" : "myGit/git");
+        GitTool toolOnMaster = new GitTool("myGit", isWindows() ? "default/git.exe" : "default/git", Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
 
-        TestToolInstaller instonAgent = new TestToolInstaller("agent-windows", "echo Hello", SystemUtils.IS_OS_WINDOWS ? "my-git/git.exe" : "my-git/git");
-        GitTool toolOnAgent = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.singletonList(new InstallSourceProperty(Collections.singletonList(instonAgent))));
+        TestToolInstaller instonAgent = new TestToolInstaller("agent-windows", "echo Hello", isWindows() ? "my-git/git.exe" : "my-git/git");
+        GitTool toolOnAgent = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.singletonList(new InstallSourceProperty(Collections.singletonList(instonAgent))));
 
         GitTool JTool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
 
@@ -153,7 +152,7 @@ public class GitToolChooserTest {
 
         GitToolChooser r = new GitToolChooser(remote, context, credentialsId, JTool, agent, TaskListener.NULL,true);
 
-        assertThat(r.getGitTool(), containsString(SystemUtils.IS_OS_WINDOWS ? "my-git/git.exe" : "my-git/git"));
+        assertThat(r.getGitTool(), containsString(isWindows() ? "my-git/git.exe" : "my-git/git"));
     }
 
     /*
@@ -173,7 +172,7 @@ public class GitToolChooserTest {
         List<TopLevelItem> list = jenkins.jenkins.getItems();
 
         //Since no installation is provided, the gitExe will be git
-        GitTool rTool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool rTool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
 
         GitToolChooser repoSizeEstimator = new GitToolChooser(instance.getRemote(), list.get(0), "github", rTool, null, TaskListener.NULL, true);
         String tool = repoSizeEstimator.getGitTool();
@@ -244,7 +243,7 @@ public class GitToolChooserTest {
         List<TopLevelItem> list = jenkins.jenkins.getItems();
 
         // Assuming no tool is installed and git is present in the machine
-        GitTool tool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
 
 
         GitToolChooser sizeEstimator = new GitToolChooser(remote, list.get(0), "github", tool, null, TaskListener.NULL,true);
@@ -288,7 +287,7 @@ public class GitToolChooserTest {
         List<TopLevelItem> list = jenkins.jenkins.getItems();
 
         // Assuming no tool is installed by user and git is present in the machine
-        GitTool tool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
 
         GitToolChooser sizeEstimator = new GitToolChooser(remote, list.get(0), "github", tool,null, TaskListener.NULL,true);
         assertThat(sizeEstimator.getGitTool(), is("NONE"));
@@ -309,7 +308,7 @@ public class GitToolChooserTest {
         List<TopLevelItem> list = jenkins.jenkins.getItems();
 
         // Assuming no tool is installed by user and git is present in the machine
-        GitTool tool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
 
         GitToolChooser sizeEstimator = new GitToolChooser(remote, list.get(0), "github", tool,null, TaskListener.NULL,true);
 
@@ -328,7 +327,7 @@ public class GitToolChooserTest {
         List<TopLevelItem> list = jenkins.jenkins.getItems();
 
         // Assuming no tool is installed by user and git is present in the machine
-        GitTool tool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
 
         GitToolChooser sizeEstimator = new GitToolChooser(sampleRepo.toString(), list.get(0), null, tool, null, TaskListener.NULL,true);
 
@@ -346,7 +345,7 @@ public class GitToolChooserTest {
         String credentialsId = null;
 
         // With JGit, we don't ask the name and home of the tool
-        GitTool tool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
         jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
 
         GitToolChooser gitToolChooser = new GitToolChooser(remote, context, credentialsId, tool, null, TaskListener.NULL,true);
@@ -364,7 +363,7 @@ public class GitToolChooserTest {
         String credentialsId = null;
 
         // With JGit, we don't ask the name and home of the tool
-        GitTool tool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
         GitTool jgitTool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
         jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, jgitTool);
 
@@ -442,7 +441,7 @@ public class GitToolChooserTest {
         List<TopLevelItem> list = jenkins.jenkins.getItems();
 
         // Assuming no tool is installed and git is present in the machine
-        GitTool tool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
 
         GitToolChooser sizeEstimator = new GitToolChooser(remote, list.get(0), "github", tool, null, TaskListener.NULL,true);
         assertThat(sizeEstimator.getGitTool(), containsString("git"));
@@ -478,7 +477,7 @@ public class GitToolChooserTest {
         store.save();
 
         // With JGit, we don't ask the name and home of the tool
-        GitTool tool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
         jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
 
         buildAProject(sampleRepo, false);
@@ -489,7 +488,7 @@ public class GitToolChooserTest {
         String gitExe = tool.getGitExe();
 
         GitToolChooser sizeEstimator = new GitToolChooser(remote, list.get(0), "github", tool, null, TaskListener.NULL,true);
-        assertThat(sizeEstimator.getGitTool(), is(SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git"));
+        assertThat(sizeEstimator.getGitTool(), is(isWindows() ? "git.exe" : "git"));
     }
 
     @Test
@@ -500,7 +499,7 @@ public class GitToolChooserTest {
         store.save();
 
         // With JGit, we don't ask the name and home of the tool
-        GitTool tool = new GitTool("my-git", SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
+        GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
         GitTool jgitTool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
         GitTool jGitApacheTool = new JGitApacheTool(Collections.<ToolProperty<?>>emptyList());
         jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, jgitTool, jGitApacheTool);
@@ -513,7 +512,7 @@ public class GitToolChooserTest {
         String gitExe = tool.getGitExe();
 
         GitToolChooser sizeEstimator = new GitToolChooser(remote, list.get(0), "github", tool, null, TaskListener.NULL,true);
-        assertThat(sizeEstimator.getGitTool(), is(SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git"));
+        assertThat(sizeEstimator.getGitTool(), is(isWindows() ? "git.exe" : "git"));
     }
 
     @Test
@@ -634,4 +633,8 @@ public class GitToolChooserTest {
         return new UsernamePasswordCredentialsImpl(scope, id, "desc: " + id, "username", "password");
     }
 
+    /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */
+    private boolean isWindows() {
+        return File.pathSeparatorChar==';';
+    }
 }

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -85,7 +85,7 @@ public class GitToolChooserTest {
 
         GitToolChooser r = new GitToolChooser(remote, context, credentialsId, JTool, null, TaskListener.NULL,true);
 
-        assertThat(r.getGitTool(), containsString(SystemUtils.IS_OS_WINDOWS ? "updated/git.exe" : "updated/git"));
+        assertThat(r.getGitTool(), containsString(SystemUtils.IS_OS_WINDOWS ? "git.exe" : "git"));
     }
 
     /*


### PR DESCRIPTION
## [JENKINS-63519](https://issues.jenkins-ci.org/browse/JENKINS-63519) 

Change the current way to suggest a git implementation, the modifications can be broadly described as:

- Earlier, if the system wants to recommend `jgit` and `jgit` is not available in the system, it used to go for `cli git`. We've realised that that is unnecessary. Now the GitToolChooser would recommend nothing ("NONE") if it wants to recommend `jgit` or `jgitapache` but it is not enabled by the user.
- For a repository size > 5 MiB: if the user enables a node-specific git tool (let's say git-for-windows), earlier the GitToolChooser used to recommend `git` whatever that may be perceived by the system, which is wrong.
Now, it will return the same node-specific git tool, `git-for-windows`.
- For a repository size > 5 MiB: if the user enables `jgit` as a git tool, now the GitToolChooser has the responsibility of selecting the right implementation (maybe node-specific). With the help of `recommendGitToolOnAgent` it is able to do so.

**Note**: The current changes have made the decision process a little complex, I'm not proud of the current design and would want to shift to a builder pattern for the initialization of the class considering the increasing number of args required to initialise GitToolChooser.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
