### PR TITLE
[JENKINS-63572] Avoid NPE if remote config is empty

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -851,11 +851,13 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 String url = getParameterString(uc.getUrl(), environment);
                 chooser = new GitToolChooser(url, project, ucCredentialsId, gitTool, n, listener,unsupportedCommand.determineSupportForJGit());
             }
-            listener.getLogger().println("The recommended git tool is: " + chooser.getGitTool());
-            String updatedGitExe = chooser.getGitTool();
-
-            if (!updatedGitExe.equals("NONE")) {
-                gitExe = updatedGitExe;
+            if (chooser != null) {
+                listener.getLogger().println("The recommended git tool is: " + chooser.getGitTool());
+                String updatedGitExe = chooser.getGitTool();
+                
+                if (!updatedGitExe.equals("NONE")) {
+                    gitExe = updatedGitExe;
+                }
             }
         }
         Git git = Git.with(listener, environment).in(ws).using(gitExe);

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -660,7 +660,7 @@ public class GitToolChooserTest {
         WorkflowJob p = jenkins.jenkins.createProject(WorkflowJob.class, "intentionally-failing-job-without-remote-config");
         p.setDefinition(new CpsFlowDefinition("node {\n"
                                               + "  checkout(\n"
-                                              + "    [$class: 'GitSCM'] \n"
+                                              + "    [$class: 'GitSCM']\n"
                                               + "  )\n"
                                               + "}", true));
         WorkflowRun b = jenkins.assertBuildStatus(hudson.model.Result.FAILURE, p.scheduleBuild2(0));


### PR DESCRIPTION
## [JENKINS-63572](https://issues.jenkins-ci.org/browse/JENKINS-63572) - Avoid NPE if remote config is empty

If a pipeline job defines the checkout scm step without including a remote repository, the job will usually fail in other ways.

A null pointer exception is not a friendly way to show a configuration error to a user.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)