### PR TITLE
Hamcrest asseertions, more tests, consistent formatting

### DIFF
--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -100,7 +100,7 @@ public class DefaultBuildChooser extends BuildChooser {
                     fqbn = "refs/remotes/" + repository + "/" + branchSpec;
                     verbose(listener, "Qualifying {0} as a branch in repository {1} -> {2}", branchSpec, repository, fqbn);
                     possibleQualifiedBranches.add(fqbn);
-                    
+
                     //Try branchSpec as it is - e.g. "refs/tags/mytag"
                     fqbn = branchSpec;
                 }

--- a/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
@@ -8,7 +8,10 @@ import java.util.HashSet;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
 import org.eclipse.jgit.lib.ObjectId;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -22,17 +25,17 @@ public class DefaultBuildChooserTest extends AbstractGitRepository {
         String shaHashCommit1 = testGitClient.getBranches().iterator().next().getSHA1String();
         testGitClient.commit("Commit 2");
         String shaHashCommit2 = testGitClient.getBranches().iterator().next().getSHA1String();
-        assertNotSame(shaHashCommit1, shaHashCommit2);
+        assertThat(shaHashCommit1, is(not(shaHashCommit2)));
 
         DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
 
         Collection<Revision> candidateRevisions = buildChooser.getCandidateRevisions(false, shaHashCommit1, testGitClient, null, null, null);
 
-        assertEquals(1, candidateRevisions.size());
-        assertEquals(shaHashCommit1, candidateRevisions.iterator().next().getSha1String());
+        assertThat(candidateRevisions, hasSize(1));
+        assertThat(candidateRevisions.iterator().next().getSha1String(), is(shaHashCommit1));
 
         candidateRevisions = buildChooser.getCandidateRevisions(false, "aaa" + shaHashCommit1.substring(3), testGitClient, null, null, null);
-        assertTrue(candidateRevisions.isEmpty());
+        assertThat(candidateRevisions, is(empty()));
     }
 
     /* RegExp patterns prefixed with : should pass through to DefaultBuildChooser.getAdvancedCandidateRevisions */
@@ -48,79 +51,130 @@ public class DefaultBuildChooserTest extends AbstractGitRepository {
         assertTrue(buildChooser.isAdvancedSpec(":origin/master-\\d{*}"));
     }
 
-	/* always failed before fix */
+    /* always failed before fix */
     @Issue("JENKINS-37263")
-	@Test
-	public void testPrefereRemoteBranchInCandidateRevisionsWithWrongOrderInHashSet() throws Exception {
-		String branchName = "feature/42";
-		String localRef = "refs/heads/" + branchName;
-		String remoteRef = "refs/remotes/origin/" + branchName;
-		createRefsWithPredefinedOrderInHashSet(localRef, remoteRef);
-		DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
+    @Test
+    public void testPreferRemoteBranchInCandidateRevisionsWithWrongOrderInHashSet() throws Exception {
+        String branchName = "feature/42";
+        String localRef = "refs/heads/" + branchName;
+        String remoteRef = "refs/remotes/origin/" + branchName;
+        createRefsWithPredefinedOrderInHashSet(localRef, remoteRef);
+        DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
 
-		Collection<Revision> candidateRevisions =
-				buildChooser.getCandidateRevisions(false, branchName, testGitClient, null, null, null);
+        Collection<Revision> candidateRevisions =
+            buildChooser.getCandidateRevisions(false, branchName, testGitClient, null, null, null);
 
-		assertEquals(2, candidateRevisions.size());
-		Revision firstCandidateRevision = candidateRevisions.iterator().next();
-		Branch firstCandidateBranch = firstCandidateRevision.getBranches().iterator().next();
-		assertEquals(remoteRef, firstCandidateBranch.getName());
-	}
-
-	/* was successful also before fix */
-    @Issue("JENKINS-37263")
-	@Test
-	public void testPrefereRemoteBranchInCandidateRevisionsWithCorrectOrderInHashSet() throws Exception {
-		String branchName = "feature/42";
-		String localRef = "refs/heads/" + branchName;
-		String remoteRef = "refs/remotes/origin/" + branchName;
-		createRefsWithPredefinedOrderInHashSet(remoteRef, localRef);
-		DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
-
-		Collection<Revision> candidateRevisions =
-				buildChooser.getCandidateRevisions(false, branchName, testGitClient, null, null, null);
-
-		assertEquals(2, candidateRevisions.size());
-		Revision firstCandidateRevision = candidateRevisions.iterator().next();
-		Branch firstCandidateBranch = firstCandidateRevision.getBranches().iterator().next();
-		assertEquals(remoteRef, firstCandidateBranch.getName());
-	}
+        assertThat(candidateRevisions, hasSize(2));
+        Revision firstCandidateRevision = candidateRevisions.iterator().next();
+        Branch firstCandidateBranch = firstCandidateRevision.getBranches().iterator().next();
+        assertThat(firstCandidateBranch.getName(), is(remoteRef));
+    }
 
     /* was successful also before fix */
     @Issue("JENKINS-37263")
-	@Test
-	public void testSingleCandidateRevisionWithLocalAndRemoteRefsOnSameCommit() throws Exception {
-		String branchName = "feature/42";
-		String localRef = "refs/heads/" + branchName;
-		String remoteRef = "refs/remotes/origin/" + branchName;
-		testGitClient.ref(localRef);
-		testGitClient.ref(remoteRef);
-		DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
+    @Test
+    public void testPreferRemoteBranchInCandidateRevisionsWithCorrectOrderInHashSet() throws Exception {
+        String branchName = "feature/42";
+        String localRef = "refs/heads/" + branchName;
+        String remoteRef = "refs/remotes/origin/" + branchName;
+        createRefsWithPredefinedOrderInHashSet(remoteRef, localRef);
+        DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
 
-		Collection<Revision> candidateRevisions =
-				buildChooser.getCandidateRevisions(false, branchName, testGitClient, null, null, null);
+        Collection<Revision> candidateRevisions =
+            buildChooser.getCandidateRevisions(false, branchName, testGitClient, null, null, null);
 
-		assertEquals(1, candidateRevisions.size());
-	}
+        assertThat(candidateRevisions, hasSize(2));
+        Revision firstCandidateRevision = candidateRevisions.iterator().next();
+        Branch firstCandidateBranch = firstCandidateRevision.getBranches().iterator().next();
+        assertThat(firstCandidateBranch.getName(), is(remoteRef));
+    }
 
-	private void createRefsWithPredefinedOrderInHashSet(String ref1, String ref2) throws InterruptedException {
-		ObjectId commit1 = testGitClient.revParse("HEAD");
-		testGitClient.ref(ref1);
-		testGitClient.commit("Commit");
-		ObjectId commit2 = testGitClient.revParse("HEAD");
-		HashSet<Revision> set = new HashSet<Revision>();
-		set.add(new Revision(commit1));
-		set.add(new Revision(commit2));
-		if (set.iterator().next().getSha1().equals(commit1)) {
-			// order in HashSet: commit1, commit2
-			// ref1 -> commit1, ref2 -> commit2
-			testGitClient.ref(ref2);
-		} else {
-			// order in HashSet: commit2, commit1
-			// ref1 -> commit2, ref2 -> commit1
-			testGitClient.ref(ref1);
-			testGitClient.checkout().ref(commit1.getName()).execute();
-			testGitClient.ref(ref2);
-		}
-	}
+    /* was successful also before fix */
+    @Issue("JENKINS-37263")
+    @Test
+    public void testSingleCandidateRevisionWithLocalAndRemoteRefsOnSameCommit() throws Exception {
+        String branchName = "feature/42";
+        String localRef = "refs/heads/" + branchName;
+        String remoteRef = "refs/remotes/origin/" + branchName;
+        testGitClient.ref(localRef);
+        testGitClient.ref(remoteRef);
+        DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
+
+        Collection<Revision> candidateRevisions =
+            buildChooser.getCandidateRevisions(false, branchName, testGitClient, null, null, null);
+
+        assertThat(candidateRevisions, hasSize(1));
+    }
+
+    /* was successful also before fix */
+    @Issue("JENKINS-37263")
+    @Test
+    public void testSingleCandidateRevisionWithLocalAndRemoteRefsOnSameCommitWithOriginPrefix() throws Exception {
+        String baseBranchName = "feature/42";
+        String branchName = "origin/" + baseBranchName;
+        String localRef = "refs/heads/" + baseBranchName;
+        String remoteRef = "refs/remotes/" + branchName;
+        createRefsWithPredefinedOrderInHashSet(localRef, remoteRef);
+        DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
+
+        Collection<Revision> candidateRevisions
+                = buildChooser.getCandidateRevisions(false, branchName, testGitClient, null, null, null);
+
+        assertThat(candidateRevisions, hasSize(1));
+    }
+
+    /* was successful also before fix */
+    @Issue("JENKINS-37263")
+    @Test
+    public void testSingleCandidateRevisionWithLocalAndRemoteRefsOnSameCommitWithRemotesOriginPrefix() throws Exception {
+        String baseBranchName = "feature/42";
+        String branchName = "remotes/origin/" + baseBranchName;
+        String localRef = "refs/heads/" + baseBranchName;
+        String remoteRef = "refs/" + branchName;
+        createRefsWithPredefinedOrderInHashSet(localRef, remoteRef);
+        DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
+
+        Collection<Revision> candidateRevisions =
+            buildChooser.getCandidateRevisions(false, branchName, testGitClient, null, null, null);
+
+        assertThat(candidateRevisions, hasSize(1));
+    }
+
+    /* was successful also before fix */
+    @Issue("JENKINS-37263")
+    @Test
+    public void testSingleCandidateRevisionWithLocalAndRemoteRefsOnSameCommitWithRefsHeadsPrefix() throws Exception {
+        String baseBranchName = "feature/42";
+        String branchName = "refs/heads/" + baseBranchName;
+        String localRef = "refs/heads/" + baseBranchName;
+        String remoteRef = "refs/remotes/origin/" + baseBranchName;
+        createRefsWithPredefinedOrderInHashSet(localRef, remoteRef);
+        DefaultBuildChooser buildChooser = (DefaultBuildChooser) new GitSCM("foo").getBuildChooser();
+
+        Collection<Revision> candidateRevisions =
+            buildChooser.getCandidateRevisions(false, branchName, testGitClient, null, null, null);
+
+        assertThat(candidateRevisions, hasSize(1));
+    }
+
+    private void createRefsWithPredefinedOrderInHashSet(String ref1, String ref2) throws InterruptedException {
+        ObjectId commit1 = testGitClient.revParse("HEAD");
+        testGitClient.ref(ref1);
+        testGitClient.commit("Commit");
+        ObjectId commit2 = testGitClient.revParse("HEAD");
+        HashSet<Revision> set = new HashSet<>();
+        set.add(new Revision(commit1));
+        set.add(new Revision(commit2));
+        if (set.iterator().next().getSha1().equals(commit1)) {
+            // order in HashSet: commit1, commit2
+            // ref1 -> commit1, ref2 -> commit2
+            testGitClient.ref(ref2);
+        } else {
+            // order in HashSet: commit2, commit1
+            // ref1 -> commit2, ref2 -> commit1
+            testGitClient.ref(ref1);
+            testGitClient.checkout().ref(commit1.getName()).execute();
+            testGitClient.ref(ref2);
+        }
+    }
 }


### PR DESCRIPTION
## Hamcrest asseertions, more tests, consistent formatting

Use hamcrest assertions for clarity

Spelling fixes for method names

Use consistent white space

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update