### PR TITLE
Catch IOException by printCommitMessageToLog

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1316,7 +1316,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         // Needs to be after the checkout so that revToBuild is in the workspace
         try {
             printCommitMessageToLog(listener, git, revToBuild);
-        } catch (ArithmeticException | GitException ge) {
+        } catch (IOException | ArithmeticException | GitException ge) {
             // JENKINS-45729 reports a git exception when revToBuild cannot be found in the workspace.
             // JENKINS-46628 reports a git exception when revToBuild cannot be found in the workspace.
             // JENKINS-62710 reports a JGit arithmetic exception on an older Java 8 system.


### PR DESCRIPTION
It is possible that node running git operation is having memory issues and frequently fail
with a stack trace similar to below. Since printCommitMessageToLog is considered informational
avoid such issues.

09:28:57 java.lang.OutOfMemoryError: Java heap space
09:28:57 Caused: java.io.IOException: Remote call on XXXX failed
09:28:57        at hudson.remoting.Channel.call(Channel.java:1007)
09:28:57        at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInv=
ocationHandler.java:286)
09:28:57        at com.sun.proxy.$Proxy82.withRepository(Unknown Source)
09:28:57        at org.jenkinsci.plugins.gitclient.RemoteGitImpl.withReposi=
tory(RemoteGitImpl.java:237)
09:28:57        at hudson.plugins.git.GitSCM.printCommitMessageToLog(GitSCM=
.java:1347)
09:28:57        at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1316)
09:28:57        at org.jenkinsci.plugins.multiplescms.MultiSCM.checkout(Mul=
tiSCM.java:143)
09:28:57        at hudson.scm.SCM.checkout(SCM.java:505)
09:28:57        at hudson.model.AbstractProject.checkout(AbstractProject.ja=
va:1206)
09:28:57        at hudson.model.AbstractBuild$AbstractBuildExecution.defaul=
tCheckout(AbstractBuild.java:574)
09:28:57        at jenkins.scm.SCMCheckoutStrategy.checkout(SCMCheckoutStra=
tegy.java:86)
09:28:57        at hudson.model.AbstractBuild$AbstractBuildExecution.run(Ab=
stractBuild.java:499)
09:28:57        at hudson.model.Run.execute(Run.java:1894)
09:28:57        at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
09:28:57        at hudson.model.ResourceController.execute(ResourceControll=
er.java:97)
09:28:57        at hudson.model.Executor.run(Executor.java:428)

## [JENKINS-xxxxx](https://issues.jenkins-ci.org/browse/JENKINS-xxxxx) - summarize pull request in one line

Describe the big picture of your changes here to explain to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, include a link to the issue.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [ ] Dependency or infrastructure update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
