### PR TITLE
[JENKINS-63539] Expand repo cache lookup for better size estimates

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.git;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
@@ -17,11 +18,12 @@ import org.jenkinsci.plugins.gitclient.JGitTool;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -40,6 +42,9 @@ public class GitToolChooser {
      */
     private static final int SIZE_TO_SWITCH = 5000;
     private boolean JGIT_SUPPORTED = false;
+
+    /** Cache of repository sizes based on remoteURL. **/
+    private static ConcurrentHashMap<String, Long> repositorySizeCache = new ConcurrentHashMap<>();
 
     /**
      * Instantiate class using the remote name. It looks for a cached .git directory first, calculates the
@@ -73,10 +78,6 @@ public class GitToolChooser {
         gitTool = implementation;
     }
 
-    public void addListener(TaskListener listener) {
-        this.listener = listener;
-    }
-
     /**
      * Determine and estimate the size of a .git cached directory
      * @param remoteName: Use the repository url to access a cached Jenkins directory, we do not lock it.
@@ -86,16 +87,45 @@ public class GitToolChooser {
      */
     private boolean decideAndUseCache(String remoteName) throws IOException, InterruptedException {
         boolean useCache = false;
-        String cacheEntry = AbstractGitSCMSource.getCacheEntry(remoteName);
-        File cacheDir = AbstractGitSCMSource.getCacheDir(cacheEntry, false);
-        if (cacheDir != null) {
-            Git git = Git.with(TaskListener.NULL, new EnvVars(EnvVars.masterEnvVars)).in(cacheDir).using("git");
-            GitClient client = git.getClient();
-            if (client.hasGitRepo()) {
-                sizeOfRepo = FileUtils.sizeOfDirectory(cacheDir);
-                sizeOfRepo = (sizeOfRepo/1000); // Conversion from Bytes to Kilo Bytes
-                useCache = true;
+        if (setSizeFromInternalCache(remoteName)) {
+            LOGGER.log(Level.INFO,
+                    "Found cache key for {0} with size {1}",
+                    new Object[]{remoteName, sizeOfRepo});
+            useCache = true;
+            return useCache;
+        }
+        for (String repoUrl : remoteAlternatives(remoteName)) {
+            String cacheEntry = AbstractGitSCMSource.getCacheEntry(repoUrl);
+            File cacheDir = AbstractGitSCMSource.getCacheDir(cacheEntry, false);
+            if (cacheDir != null) {
+                Git git = Git.with(TaskListener.NULL, new EnvVars(EnvVars.masterEnvVars)).in(cacheDir).using("git");
+                GitClient client = git.getClient();
+                if (client.hasGitRepo()) {
+                    long clientRepoSize = FileUtils.sizeOfDirectory(cacheDir) / 1024; // Conversion from Bytes to Kilo Bytes
+                    if (clientRepoSize > sizeOfRepo) {
+                        if (sizeOfRepo > 0) {
+                            LOGGER.log(Level.FINE, "Replacing prior size estimate {0} with new size estimate {1} for remote {2} from cache {3}",
+                                    new Object[]{sizeOfRepo, clientRepoSize, remoteName, cacheDir});
+                        }
+                        sizeOfRepo = clientRepoSize;
+                        assignSizeToInternalCache(remoteName, sizeOfRepo);
+                    }
+                    useCache = true;
+                    if (remoteName.equals(repoUrl)) {
+                        LOGGER.log(Level.FINE, "Remote URL {0} found cache {1} with size {2}",
+                                new Object[]{remoteName, cacheDir, sizeOfRepo});
+                    } else {
+                        LOGGER.log(Level.FINE, "Remote URL {0} found cache {1} with size {2}, alternative URL {3}",
+                                new Object[]{remoteName, cacheDir, sizeOfRepo, repoUrl});
+                    }
+                } else {
+                    // Log the surprise but continue looking for a cache
+                    LOGGER.log(Level.FINE, "Remote URL {0} cache {1} has no git dir", new Object[]{remoteName, cacheDir});
+                }
             }
+        if (!useCache) {
+            LOGGER.log(Level.FINE, "Remote URL {0} cache not found", remoteName);
+        }
         }
         return useCache;
     }
@@ -103,6 +133,150 @@ public class GitToolChooser {
     private void decideAndUseAPI(String remoteName, Item context, String credentialsId, GitTool gitExe) {
         if (setSizeFromAPI(remoteName, context, credentialsId)) {
             implementation = determineSwitchOnSize(sizeOfRepo, gitExe);
+        }
+    }
+
+    /* Git repository URLs frequently end with the ".git" suffix.
+     * However, many repositories (especially https) do not require the ".git" suffix.
+     *
+     * Add remoteURL with the ".git" suffix and without the ".git" suffix to the
+     * list of alternatives.
+     */
+    private void addSuffixVariants(@NonNull String remoteURL, @NonNull Set<String> alternatives) {
+        alternatives.add(remoteURL);
+        String suffix = ".git";
+        if (remoteURL.endsWith(suffix)) {
+            alternatives.add(remoteURL.substring(0, remoteURL.length() - suffix.length()));
+        } else {
+            alternatives.add(remoteURL + suffix);
+        }
+    }
+
+    /* Git repository URLs frequently end with the ".git" suffix.
+     * However, many repositories (especially https) do not require the ".git" suffix.
+     *
+     * Add remoteURL with the ".git" suffix if not present
+     */
+    private String addSuffixVariant(@NonNull String canonicalURL) {
+        String suffix = ".git";
+        if (!canonicalURL.endsWith(suffix)) {
+            canonicalURL = canonicalURL + suffix;
+        }
+        return canonicalURL;
+    }
+
+    /* Protocol patterns to extract hostname and path from typical repository URLs */
+    private static Pattern gitProtocolPattern = Pattern.compile("^git://([^/]+)/(.+?)/*$");
+    private static Pattern httpProtocolPattern = Pattern.compile("^https?://([^/]+)/(.+?)/*$");
+    private static Pattern sshAltProtocolPattern = Pattern.compile("^[\\w]+@(.+):(.+?)/*$");
+    private static Pattern sshProtocolPattern = Pattern.compile("^ssh://[\\w]+@([^/]+)/(.+?)/*$");
+
+    /* Return a list of alternate remote URL's based on permutations of remoteURL.
+     * Varies the protocol (https, git, ssh) and the suffix of the repository URL.
+     * Package protected for testing
+     */
+    /* package */ @NonNull String convertToCanonicalURL(String remoteURL) {
+        if (remoteURL == null || remoteURL.isEmpty()) {
+            LOGGER.log(Level.FINE, "Null or empty remote URL not cached");
+            return ""; // return an empty string
+        }
+
+        Pattern [] protocolPatterns = {
+                gitProtocolPattern,
+                sshAltProtocolPattern,
+                sshProtocolPattern,
+        };
+
+        String matcherReplacement = "https://$1/$2";
+        /* For each matching protocol, convert alternatives to canonical form by https replacement */
+        remoteURL = addSuffixVariant(remoteURL);
+        String canonicalURL = remoteURL;
+        if (httpProtocolPattern.matcher(remoteURL).matches()) {
+            canonicalURL = remoteURL;
+        } else {
+            for (Pattern protocolPattern: protocolPatterns) {
+                Matcher protocolMatcher = protocolPattern.matcher(remoteURL);
+                if (protocolMatcher.matches()) {
+                    canonicalURL = protocolMatcher.replaceAll(matcherReplacement);
+                }
+            }
+        }
+
+        LOGGER.log(Level.FINE, "Cache repo URL: {0}", canonicalURL);
+        return canonicalURL;
+    }
+
+    private boolean setSizeFromInternalCache(String repoURL) {
+        repoURL = convertToCanonicalURL(repoURL);
+        if (repositorySizeCache.containsKey(repoURL)) {
+            sizeOfRepo = repositorySizeCache.get(repoURL);
+            return true;
+        }
+        return false;
+    }
+
+    /* Return a list of alternate remote URL's based on permutations of remoteURL.
+     * Varies the protocol (https, git, ssh) and the suffix of the repository URL.
+     * Package protected for testing
+     */
+    /* package */ @NonNull Set<String> remoteAlternatives(String remoteURL) {
+        Set<String> alternatives = new LinkedHashSet<>();
+        if (remoteURL == null || remoteURL.isEmpty()) {
+            LOGGER.log(Level.FINE, "Null or empty remote URL not cached");
+            return alternatives;
+        }
+
+        Pattern [] protocolPatterns = {
+                gitProtocolPattern,
+                httpProtocolPattern,
+                sshAltProtocolPattern,
+                sshProtocolPattern,
+        };
+
+        String[] matcherReplacements = {
+                "git://$1/$2",     // git protocol
+                "git@$1:$2",       // ssh protocol alternate URL
+                "https://$1/$2",   // https protocol
+                "ssh://git@$1/$2", // ssh protocol
+        };
+
+        /* For each matching protocol, form alternatives by iterating over replacements */
+        boolean matched = false;
+        for (Pattern protocolPattern : protocolPatterns) {
+            Matcher protocolMatcher = protocolPattern.matcher(remoteURL);
+            if (protocolMatcher.matches()) {
+                for (String replacement : matcherReplacements) {
+                    String alternativeURL = protocolMatcher.replaceAll(replacement);
+                    addSuffixVariants(alternativeURL, alternatives);
+                }
+                matched = true;
+            }
+        }
+
+        // Must include original remote in case none of the protocol patterns match
+        // For example, file://srv/git/repo.git is matched by none of the patterns
+        if (!matched) {
+            addSuffixVariants(remoteURL, alternatives);
+        }
+
+        LOGGER.log(Level.FINE, "Cache repo alternative URLs: {0}", alternatives);
+        return alternatives;
+    }
+
+    /** Cache the estimated repository size for variants of repository URL */
+    private void assignSizeToInternalCache(String repoURL, long repoSize) {
+        repoURL = convertToCanonicalURL(repoURL);
+        if (repositorySizeCache.containsKey(repoURL)) {
+            long oldSize = repositorySizeCache.get(repoURL);
+            if (oldSize < repoSize) {
+                LOGGER.log(Level.FINE, "Replacing old repo size {0} with new size {1} for repo {2}", new Object[]{oldSize, repoSize, repoURL});
+                repositorySizeCache.put(repoURL, repoSize);
+            } else if (oldSize > repoSize) {
+                LOGGER.log(Level.FINE, "Ignoring new size {1} in favor of old size {0} for repo {2}", new Object[]{oldSize, repoSize, repoURL});
+            }
+        } else {
+            LOGGER.log(Level.FINE, "Caching repo size {0} for repo {1}", new Object[]{repoSize, repoURL});
+            repositorySizeCache.put(repoURL, repoSize);
         }
     }
 
@@ -121,7 +295,10 @@ public class GitToolChooser {
             try {
                 for (RepositorySizeAPI repo: acceptedRepository) {
                     long size = repo.getSizeOfRepository(repoUrl, context, credentialsId);
-                    if (size != 0) { sizeOfRepo = size; }
+                    if (size != 0) {
+                        sizeOfRepo = size;
+                        assignSizeToInternalCache(repoUrl, size);
+                    }
                 }
             } catch (Exception e) {
                 LOGGER.log(Level.INFO, "Not using performance improvement from REST API: {0}", e.getMessage());
@@ -235,5 +412,11 @@ public class GitToolChooser {
         }
     }
 
+    /**
+     * Clear the cache of repository sizes.
+     */
+    public static void clearRepositorySizeCache() {
+        repositorySizeCache = new ConcurrentHashMap<>();
+    }
     private static final Logger LOGGER = Logger.getLogger(GitToolChooser.class.getName());
 }

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -88,7 +88,7 @@ public class GitToolChooser {
     private boolean decideAndUseCache(String remoteName) throws IOException, InterruptedException {
         boolean useCache = false;
         if (setSizeFromInternalCache(remoteName)) {
-            LOGGER.log(Level.INFO,
+            LOGGER.log(Level.FINE,
                     "Found cache key for {0} with size {1}",
                     new Object[]{remoteName, sizeOfRepo});
             useCache = true;
@@ -123,9 +123,9 @@ public class GitToolChooser {
                     LOGGER.log(Level.FINE, "Remote URL {0} cache {1} has no git dir", new Object[]{remoteName, cacheDir});
                 }
             }
+        }
         if (!useCache) {
             LOGGER.log(Level.FINE, "Remote URL {0} cache not found", remoteName);
-        }
         }
         return useCache;
     }
@@ -157,7 +157,7 @@ public class GitToolChooser {
      *
      * Add remoteURL with the ".git" suffix if not present
      */
-    private String addSuffixVariant(@NonNull String canonicalURL) {
+    private String addSuffix(@NonNull String canonicalURL) {
         String suffix = ".git";
         if (!canonicalURL.endsWith(suffix)) {
             canonicalURL = canonicalURL + suffix;
@@ -182,14 +182,14 @@ public class GitToolChooser {
         }
 
         Pattern [] protocolPatterns = {
-                gitProtocolPattern,
                 sshAltProtocolPattern,
                 sshProtocolPattern,
+                gitProtocolPattern,
         };
 
         String matcherReplacement = "https://$1/$2";
         /* For each matching protocol, convert alternatives to canonical form by https replacement */
-        remoteURL = addSuffixVariant(remoteURL);
+        remoteURL = addSuffix(remoteURL);
         String canonicalURL = remoteURL;
         if (httpProtocolPattern.matcher(remoteURL).matches()) {
             canonicalURL = remoteURL;
@@ -198,6 +198,7 @@ public class GitToolChooser {
                 Matcher protocolMatcher = protocolPattern.matcher(remoteURL);
                 if (protocolMatcher.matches()) {
                     canonicalURL = protocolMatcher.replaceAll(matcherReplacement);
+                    break;
                 }
             }
         }

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -300,6 +300,36 @@ public class GitToolChooserTest {
         }
     }
 
+    /* Test conversion of any remote alternative of git repo URLs to a standard URL */
+    @Test
+    public void testConvertToCanonicalURL() throws Exception {
+        GitTool tool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
+
+        String[] remoteAlternatives = {
+                "git://github.com/jenkinsci/git-plugin",
+                "git://github.com/jenkinsci/git-plugin.git",
+                "git@github.com:jenkinsci/git-plugin",
+                "git@github.com:jenkinsci/git-plugin.git",
+                "https://github.com/jenkinsci/git-plugin",
+                "https://github.com/jenkinsci/git-plugin.git",
+                "ssh://git@github.com/jenkinsci/git-plugin",
+                "ssh://git@github.com/jenkinsci/git-plugin.git",
+        };
+
+        String actualNormalizedURL = "https://github.com/jenkinsci/git-plugin.git";
+
+        for (String remote : remoteAlternatives) {
+            GitToolChooser sizeEstimator = new GitToolChooser(remote, null, null, tool, null, TaskListener.NULL, random.nextBoolean());
+            String expectedNormalizedURL = sizeEstimator.convertToCanonicalURL(remote);
+            assertThat("Remote: " + remote, expectedNormalizedURL, is(actualNormalizedURL));
+        }
+
+        /* Check behavior in case of any other format of git repo URL*/
+        String otherRemote = "file://srv/git/repo";
+        GitToolChooser sizeEstimator = new GitToolChooser(otherRemote, null, null, tool, null, TaskListener.NULL, random.nextBoolean());
+        assertThat("Remote: " + otherRemote, sizeEstimator.convertToCanonicalURL(otherRemote), is(otherRemote + ".git"));
+    }
+
     /*
     In the event of having an extension which returns the size of repository as 10000 KiB, the estimator should
     recommend "git" as the optimal implementation from the heuristics

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -32,6 +32,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
+import java.util.Set;
 
 import static org.hamcrest.io.FileMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -54,6 +56,8 @@ public class GitToolChooserTest {
 
     private CredentialsStore store = null;
 
+    private static Random random = new Random();
+
     @Before
     public void enableSystemCredentialsProvider() {
         SystemCredentialsProvider.getInstance().setDomainCredentialsMap(
@@ -65,6 +69,11 @@ public class GitToolChooserTest {
             }
         }
         assertThat("The system credentials provider is enabled", store, notNullValue());
+    }
+
+    @Before
+    public void resetRepositorySizeCache() {
+        GitToolChooser.clearRepositorySizeCache();
     }
 
     /*
@@ -234,6 +243,61 @@ public class GitToolChooserTest {
         Since the size of repository is 21.785 KiBs, the estimator should suggest "jgit" as an implementation
          */
         assertThat(repoSizeEstimator.getGitTool(), containsString("jgit"));
+
+        /* Confirm that a remote with a different name still finds the git cache */
+        String permutedRemote = source.getRemote();
+        String suffix = ".git";
+        if (permutedRemote.endsWith(suffix)) {
+            permutedRemote = permutedRemote.substring(0, permutedRemote.length() - suffix.length()); // Remove trailing ".git" suffix
+        } else {
+            permutedRemote = permutedRemote + suffix; // Add trailing ".git" suffix
+        }
+        GitToolChooser permutedRepoSizeEstimator = new GitToolChooser(permutedRemote, list.get(0), "github", tool, null, TaskListener.NULL, true);
+        assertThat("Alternative repository name should find the cache",
+                permutedRepoSizeEstimator.getGitTool(), containsString("jgit"));
+    }
+
+    /* Test the remoteAlternatives permutation of git repo URLs */
+    @Test
+    @Issue("JENKINS-63539")
+    public void testRemoteAlternatives() throws Exception {
+        GitTool tool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
+
+        GitToolChooser nullRemoteSizeEstimator = new GitToolChooser("git://github.com/git/git.git", null, null, tool, null, TaskListener.NULL, true);
+        assertThat(nullRemoteSizeEstimator.remoteAlternatives(null), is(empty()));
+        assertThat(nullRemoteSizeEstimator.remoteAlternatives(""), is(empty()));
+
+        /* Borrow the nullRemoteSizer to also test determineSwitchOnSize a little more */
+        long sizeOfRepo = 1 + random.nextInt(4000);
+        assertThat(nullRemoteSizeEstimator.determineSwitchOnSize(sizeOfRepo, tool), is("NONE"));
+
+        /* Each of these alternatives is expected to be interpreted as
+         * a valid alias for every other alternative in the list.
+         */
+        String[] remoteAlternatives = {
+                "git://github.com/jenkinsci/git-plugin",
+                "git://github.com/jenkinsci/git-plugin.git",
+                "git@github.com:jenkinsci/git-plugin",
+                "git@github.com:jenkinsci/git-plugin.git",
+                "https://github.com/jenkinsci/git-plugin",
+                "https://github.com/jenkinsci/git-plugin.git",
+                "ssh://git@github.com/jenkinsci/git-plugin",
+                "ssh://git@github.com/jenkinsci/git-plugin.git",
+        };
+
+        for (String remote : remoteAlternatives) {
+            GitToolChooser sizeEstimator = new GitToolChooser(remote, null, null, tool, null, TaskListener.NULL, random.nextBoolean());
+            Set<String> alternatives = sizeEstimator.remoteAlternatives(remote);
+            assertThat("Remote: " + remote, alternatives, containsInAnyOrder(remoteAlternatives));
+        }
+
+        /* Test remote that ends with '/' */
+        for (String remote : remoteAlternatives) {
+            remote = remote + "/";
+            GitToolChooser sizeEstimator = new GitToolChooser(remote, null, null, tool, null, TaskListener.NULL, random.nextBoolean());
+            Set<String> alternatives = sizeEstimator.remoteAlternatives(remote);
+            assertThat("Remote+'/': " + remote, alternatives, containsInAnyOrder(remoteAlternatives));
+        }
     }
 
     /*


### PR DESCRIPTION
## [JENKINS-63539](https://issues.jenkins-ci.org/browse/JENKINS-63539) - Expand repo cache lookup for better size estimates

Extend the cache lookup process to better use the cached copies.
- An in-memory cache that uses a canonical repository URL as its key and stores the repo size
- A lookup method which takes the repository URL, converts it into the canonical form and then finds it in the internal cache
- A cache assignment method which takes the repository URL, converts it to normalized repository URL format, then stores the size of the repository if the size is larger than the size (optionally) stored in that cache entry already
- Look at the internal cache before looking for stored cache in Jenkins.

**Note:** To avoid potential confusion between the GitToolChooser in-memory cache and the Jenkins cache directory, I have used the term `internal-cache` for the in-memory GitToolChooser cache. We could also name it `in-memory` cache if you find that more suitable.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

I need to clean/simplify the code, right now it contains duplicated code (most from @MarkEWaite's PR-947).
