### PR TITLE
Early exit testHideCredentials if Windows long path

### DIFF
--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1716,6 +1716,13 @@ public class GitSCMTest extends AbstractGitTestCase {
         descriptor.setHideCredentials(true);
         assertTrue("Hide credentials not set", scm.isHideCredentials());
 
+        /* Exit test early if running on Windows and path will be too long */
+        /* Known limitation of git for Windows 2.28.0 and earlier */
+        /* Needs a longpath fix in git for Windows */
+        String currentDirectoryPath = new File(".").getCanonicalPath();
+        if (isWindows() && currentDirectoryPath.length() > 95) {
+            return;
+        }
 
         descriptor.setHideCredentials(false);
         final String commitFile1 = "commitFile1";


### PR DESCRIPTION
## Early exit testHideCredentials if Windows long path

Git for Windows does not like working with long paths

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields

## Types of changes

- [x] Test