### PR TITLE
[JENKINS-63727] GitToolChooser should not recommend JGit if Git Publisher is present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.5.1-SNAPSHOT</version>
+      <version>3.5.1-rc2571.b85fc89d5173</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.4.2</version>
+      <version>3.5.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -26,6 +26,7 @@ import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.PushCommand;
+import org.jenkinsci.plugins.gitclient.UnsupportedCommand;
 import org.kohsuke.stapler.*;
 
 import javax.servlet.ServletException;
@@ -178,7 +179,9 @@ public class GitPublisher extends Recorder implements Serializable {
         else {
             EnvVars environment = build.getEnvironment(listener);
 
-            final GitClient git  = gitSCM.createClient(listener, environment, build, build.getWorkspace());
+            UnsupportedCommand cmd = new UnsupportedCommand();
+            cmd.gitPublisher(true);
+            final GitClient git  = gitSCM.createClient(listener, environment, build, build.getWorkspace(), cmd);
 
             URIish remoteURI;
 

--- a/src/test/java/hudson/plugins/git/GitPublisherTest.java
+++ b/src/test/java/hudson/plugins/git/GitPublisherTest.java
@@ -136,9 +136,8 @@ public class GitPublisherTest extends AbstractGitProject {
         List<UserRemoteConfig> repoList = new ArrayList<>();
         repoList.add(new UserRemoteConfig(testGitDir.getAbsolutePath(), null, null, null));
 
-        GitTool toolGit = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.<ToolProperty<?>>emptyList());
         GitTool tool = new JGitTool(Collections.<ToolProperty<?>>emptyList()); //testGitDir.getAbsolutePath()
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, toolGit);
+        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
 
         MatrixProject mp = jenkins.createProject(MatrixProject.class, "xyz");
         mp.setAxes(new AxisList(new Axis("VAR","a","b")));
@@ -174,7 +173,7 @@ public class GitPublisherTest extends AbstractGitProject {
         MatrixBuild b = jenkins.assertBuildStatusSuccess(mp.scheduleBuild2(0).get());
 
         /* Since jgit doesn't support the GitPublisher, this should be false instead of true */
-        assertTrue(existsTag("foo"));
+        assertFalse(existsTag("foo"));
     }
 
     @Test


### PR DESCRIPTION
## [JENKINS-63727](https://issues.jenkins-ci.org/browse/JENKINS-63727) - GitToolChooser should not suggest JGit as a viable git implementation if Git Publisher is chosen as a post build action

The current implementation of the GitToolChooser is not aware of the fact that JGit is not compatible with GitPublisher. To do so:
- Added a new UnsupportedCommand feature which would convey if JGit should be used in
the scenario where Git Publisher is being used
- Instantiated that command within the GitPublisher to pass down that info of compatibility
- Changed the CreateClient API to add UnsupportedCommand as a new parameter

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged in upstream modules (like git-client-plugin)
- [ ] Any dependent changes have been published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

This PR is dependent upon: https://github.com/jenkinsci/git-client-plugin/pull/615
