### PR TITLE
[JENKINS-63744] Show changeset author with displayName, not toString

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitChangeSetList/index.jelly
+++ b/src/main/resources/hudson/plugins/git/GitChangeSetList/index.jelly
@@ -25,7 +25,7 @@
               <j:if test="${cslink==null}">
                 ${cs.id}
               </j:if>
-              by <a href="${rootURL}/${cs.author.url}/">${cs.author}</a>
+              by <a href="${rootURL}/${cs.author.url}/">${cs.author.displayName}</a>
             </strong>
             <j:if test="${cs.branch!=null}">
               <j:whitespace trim="false"> in ${cs.branch}</j:whitespace>

--- a/src/main/resources/hudson/plugins/git/GitSCM/project-changes.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/project-changes.jelly
@@ -54,7 +54,7 @@ THE SOFTWARE.
 
                 &#8212;
 
-                <a href="${rootURL}/${c.author.url}/">${c.author}</a> /
+                <a href="${rootURL}/${c.author.url}/">${c.author.displayName}</a> /
 
                 <j:set var="cslink" value="${browser.getChangeSetLink(c)}"/>
                 <j:choose>


### PR DESCRIPTION
## [JENKINS-63744](https://issues.jenkins-ci.org/browse/JENKINS-63744) - Show changeset author with displayName, not toString

Recent change in Jenkins core is now returning the login id for author.toString().  Previously it returned author.getFullName().  Trust that displayName is probably more useful to a person in the user interface.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Additional information

An automated test to check the content of the changes page for this string was much more work than I was willing to do for this fix.  I confirmed interactively that I could see the problem before this change.  I confirmed interactively that after this change, the problem was no longer visible.

I confirmed that the changes in Jenkins core to [show display names in change list](https://github.com/jenkinsci/jenkins/pull/4943) did not resolve this issue.  The issue is visible in Jenkins 2.258 and is still visible in the pre-release build containing [PR-4943](https://github.com/jenkinsci/jenkins/pull/4943).