### PR TITLE
 Fixing a bug due to which Pass-through Git Commit that was failing when the downstream build has multiple repo

### DIFF
--- a/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
+++ b/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
@@ -71,7 +71,14 @@ public class GitRevisionBuildParameters extends AbstractBuildParameters {
 			return null;
 		}
 
-		return new RevisionParameterAction(lastBuiltRevision, getCombineQueuedCommits());
+		// This code is required when using option Pass-through Git Commit that was built and if the build is cloning two different repo
+		URIish repoURL = null;
+		try {
+			repoURL = new URIish(data.remoteUrls.iterator().next());
+			return new RevisionParameterAction(data.getLastBuiltRevision(), getCombineQueuedCommits(), repoURL);
+		} catch (URISyntaxException e) {
+			return new RevisionParameterAction(data.getLastBuiltRevision(), getCombineQueuedCommits());
+		}
 	}
 
 	public boolean getCombineQueuedCommits() {

--- a/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
+++ b/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
@@ -32,6 +32,7 @@ import hudson.plugins.git.util.BuildData;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.eclipse.jgit.transport.URIish;
 
 /**
  * Build parameter in the parameterized build trigger to pass the Git commit to the downstream build

--- a/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
+++ b/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
@@ -33,6 +33,7 @@ import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.eclipse.jgit.transport.URIish;
+import java.net.URISyntaxException;
 
 /**
  * Build parameter in the parameterized build trigger to pass the Git commit to the downstream build

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -146,6 +146,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     public static final String GIT_LOCAL_BRANCH = "GIT_LOCAL_BRANCH";
     public static final String GIT_CHECKOUT_DIR = "GIT_CHECKOUT_DIR";
     public static final String GIT_COMMIT = "GIT_COMMIT";
+    public static final String GIT_COMMIT_SHORT = "GIT_COMMIT_SHORT";
     public static final String GIT_PREVIOUS_COMMIT = "GIT_PREVIOUS_COMMIT";
     public static final String GIT_PREVIOUS_SUCCESSFUL_COMMIT = "GIT_PREVIOUS_SUCCESSFUL_COMMIT";
 
@@ -1282,6 +1283,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         environment.put(GIT_COMMIT, revToBuild.revision.getSha1String());
+        environment.put(GIT_COMMIT_SHORT, revToBuild.revision.getSha1().abbreviate(7).name());
         Branch localBranch = Iterables.getFirst(revToBuild.revision.getBranches(),null);
         String localBranchName = getParamLocalBranch(build, listener);
         if (localBranch != null && localBranch.getName() != null) { // null for a detached HEAD
@@ -1478,8 +1480,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
 
             String sha1 = Util.fixEmpty(rev.getSha1String());
+            String shortsha1 = Util.fixEmpty(rev.getSha1().abbreviate(7).name());
             if (sha1 != null && !sha1.isEmpty()) {
                 env.put(GIT_COMMIT, sha1);
+                env.put(GIT_COMMIT_SHORT, shortsha1);
             }
         }
 

--- a/src/main/java/hudson/plugins/git/RevisionParameterAction.java
+++ b/src/main/java/hudson/plugins/git/RevisionParameterAction.java
@@ -79,6 +79,13 @@ public class RevisionParameterAction extends InvisibleAction implements Serializ
         this(revision, false);
     }   
 
+    public RevisionParameterAction(Revision revision, boolean combineCommits, URIish repoURL) {
+        this.revision = revision;
+        this.commit = revision.getSha1String();
+        this.combineCommits = combineCommits;
+        this.repoURL = repoURL;
+    }
+
     public RevisionParameterAction(Revision revision, boolean combineCommits) {
     	this.revision = revision;
     	this.commit = revision.getSha1String();

--- a/src/main/resources/hudson/plugins/git/GitSCM/buildEnv.properties
+++ b/src/main/resources/hudson/plugins/git/GitSCM/buildEnv.properties
@@ -1,4 +1,5 @@
 GIT_COMMIT.blurb=The commit hash being checked out.
+GIT_COMMIT_SHORT.blurb=The short commit hash being checked out.
 GIT_PREVIOUS_COMMIT.blurb=The hash of the commit last built on this branch, if any.
 GIT_PREVIOUS_SUCCESSFUL_COMMIT.blurb=The hash of the commit last successfully built on this branch, if any.
 GIT_BRANCH.blurb=The remote branch name, if any.


### PR DESCRIPTION
## Pass the commit URL to the git revision parameter

After upgrading to the latest version of git plugin 4.4.3, we realised that downstream jobs which were part of multi-job configuration started failing, as it couldn't find the commit that was pass-through.
On investigation, we found that the commit that was pass through was getting checkout for different git-repo.
In our case we have two repo's one is for shared pipeline library and the other actual source code git repo that we want to build.
git pass-through commit was for the source code repo but it was being used by shared pipeline library to checkout and that failed as the commit didn't exist in that repo.

Changes I have done were already there before but was removed in the later version, as this change fixes the issue I mentioned above.

Hope this explains why this pull request should be accepted.

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [X] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
