### PR TITLE
[JENKINS-62261] Allow URL validation to accept custom TLDs

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -12,7 +12,6 @@ import hudson.scm.RepositoryBrowser;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.URLCheck;
 import net.sf.json.JSONObject;
-import org.apache.commons.validator.routines.UrlValidator;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -126,7 +125,7 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                             return FormValidation.error("This is a valid URL but it does not look like Assembla");
                         }
                     } catch (IOException e) {
-                        return handleIOException(v, e);
+                        return FormValidation.error("Exception reading from Assembla URL " + cleanUrl + " : " + handleIOException(v, e));
                     }
                 }
             }.check();
@@ -134,10 +133,8 @@ public class AssemblaWeb extends GitRepositoryBrowser {
 
         private boolean checkURIFormatAndHostName(String url, String hostNameFragment) throws URISyntaxException {
             URI uri = new URI(url);
-            String[] schemes = {"http", "https"};
-            UrlValidator urlValidator = new UrlValidator(schemes);
             hostNameFragment = hostNameFragment + ".";
-            return urlValidator.isValid(uri.toString()) && uri.getHost().contains(hostNameFragment);
+            return validateUrl(uri.toString()) && uri.getHost().contains(hostNameFragment);
         }
     }
 }

--- a/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
@@ -93,7 +93,7 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
             {
                 return FormValidation.ok();
             }
-            if (!checkURIFormat(cleanUrl))
+            if (!validateUrl(cleanUrl))
             {
                 return FormValidation.error(Messages.invalidUrl());
             }

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -8,6 +8,7 @@ import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSet.Path;
 import hudson.scm.RepositoryBrowser;
 
+import org.apache.commons.validator.routines.DomainValidator;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
@@ -17,6 +18,8 @@ import java.net.IDN;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSet> {
 
@@ -133,9 +136,15 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
         return false;
     }
 
-    protected static boolean checkURIFormat(String url) throws URISyntaxException {
+    /* Browser URL validation of remote/local urls */
+    protected static boolean validateUrl(String url) throws URISyntaxException {
+        /* Any TLDs defined by IANA not included in the generic list can be added to this item list */
+        DomainValidator.Item item = new DomainValidator.Item(DomainValidator.ArrayType.GENERIC_PLUS, new String[] { "corp", "home", "local", "localnet" });
+        List<DomainValidator.Item> itemList = new ArrayList<>();
+        itemList.add(item);
+        DomainValidator domainValidator = DomainValidator.getInstance(true, itemList);
         String[] schemes = {"http", "https"};
-        UrlValidator urlValidator = new UrlValidator(schemes);
+        UrlValidator urlValidator = new UrlValidator(schemes, null, UrlValidator.ALLOW_LOCAL_URLS, domainValidator);
         return urlValidator.isValid(url);
     }
 

--- a/src/main/java/hudson/plugins/git/browser/Gitiles.java
+++ b/src/main/java/hudson/plugins/git/browser/Gitiles.java
@@ -80,7 +80,7 @@ public class Gitiles extends GitRepositoryBrowser {
             if(initialChecksAndReturnOk(project, cleanUrl)){
                 return FormValidation.ok();
             }
-            if (!checkURIFormat(cleanUrl)) {
+            if (!validateUrl(cleanUrl)) {
                 return FormValidation.error(Messages.invalidUrl());
             }
             return new URLCheck() {

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -100,7 +100,7 @@ public class ViewGitWeb extends GitRepositoryBrowser {
             // Connect to URL and check content only if we have admin permission
             if (initialChecksAndReturnOk(project, cleanUrl))
                 return FormValidation.ok();
-            if (!checkURIFormat(cleanUrl)) {
+            if (!validateUrl(cleanUrl)) {
                 return FormValidation.error(Messages.invalidUrl());
             }
             return new URLCheck() {

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -47,7 +47,8 @@ public class AssemblaWebDoCheckURLTest {
     public void testDomainLevelChecksOnRepoUrl() throws Exception {
         // Invalid URL, missing '/' character - Earlier it would open connection for such mistakes but now check resolves it beforehand.
         String url = "https:/assembla.com";
-        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is("Invalid URL"));
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
+                is("Invalid URL"));
     }
 
     @Test
@@ -60,7 +61,8 @@ public class AssemblaWebDoCheckURLTest {
     @Test
     public void testPathLevelChecksOnRepoUrlInvalidPathSyntax() throws Exception {
         // Invalid hostname in URL
-        String url = "https://assembla.comspaces/git-plugin/git/source";
+        String hostname = "assembla.comspaces";
+        String url = "https://" + hostname + "/git-plugin/git/source";
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(), is("Invalid URL"));
     }
 
@@ -73,9 +75,9 @@ public class AssemblaWebDoCheckURLTest {
     @Test
     public void testPathLevelChecksOnRepoUrlUnableToConnect() throws Exception {
         // Syntax issue related specific to Assembla
-        String url = "https://app.assembla.com/space/git-plugin/git/source";
+        String url = "https://app.assembla.com/space/git-plugin/git/source/";
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
-                is("Unable to connect https://app.assembla.com/space/git-plugin/git/source/"));
+                is("Exception reading from Assembla URL " + url + " : ERROR: Unable to connect " + url));
     }
 
     @Test
@@ -100,5 +102,38 @@ public class AssemblaWebDoCheckURLTest {
         String url = urls[random.nextInt(urls.length)]; // Don't abuse a single web site with tests
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
                 is("Invalid URL"));
+    }
+
+    @Test
+    public void testInitialChecksOnRepoUrlWithEmptyPath() throws Exception {
+        String url = "https://www.assembla.com";
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url), is(FormValidation.ok()));
+    }
+
+    @Test
+    public void testDomainLevelChecksOnRepoUrlAllowDNSLocalHostnamesLocalNet() throws Exception {
+        String hostname = "assembla.example.localnet";
+        String url = "https://" + hostname + "/space/git-plugin/git/source";
+        FormValidation validation = assemblaWebDescriptor.doCheckRepoUrl(project, url);
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
+                is("Exception reading from Assembla URL " + url + " : ERROR: " + hostname));
+    }
+
+    @Test
+    public void testDomainLevelChecksOnRepoUrlAllowDNSLocalHostnamesHome() throws Exception {
+        String hostname = "assembla.example.home";
+        String url = "https://" + hostname + "/space/git-plugin/git/source";
+        FormValidation validation = assemblaWebDescriptor.doCheckRepoUrl(project, url);
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
+                is("Exception reading from Assembla URL " + url + " : ERROR: " + hostname));
+    }
+
+    @Test
+    public void testDomainLevelChecksOnRepoUrlCorpDomainMustBeValid() throws Exception {
+        String hostname = "assembla.myorg.corp";
+        String url = "https://" + hostname + "/space/git-plugin/git/source";
+        FormValidation validation = assemblaWebDescriptor.doCheckRepoUrl(project, url);
+        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
+                is("Exception reading from Assembla URL " + url + " : ERROR: " + hostname));
     }
 }


### PR DESCRIPTION
## [JENKINS-62261](https://issues.jenkins-ci.org/browse/JENKINS-62261) -Allow local domain names to be validated by the UrlValidator

The URL validation in the the repository browser settings was too strict and it treats e.g *.corp domains as invalid. To fix this, we have introduced the [DomainValidator](http://commons.apache.org/proper/commons-validator/apidocs/org/apache/commons/validator/routines/DomainValidator.html) with custom domain names (.corp, .local etc) to allow the possibility of validating urls with such custom local urls as well.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)


## Further comments

This is a continuation on the great work done in https://github.com/jenkinsci/git-plugin/pull/890 by @sratz and @MarkEWaite .
