### PR TITLE
Add GitPublisher freestyle test

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -834,8 +834,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     }
 
     /**
-     * Allows {@link Publisher} to access a configured {@link GitClient} object supported with the UnsupportedCommand
-     * to perform additional git operations.
+     * Allows {@link Publisher} and other post build actions to access a configured {@link GitClient}.
+     * The post build action can use the {@code postBuildUnsupportedCommand} argument to control the
+     * selection of a git tool by {@link GitToolChooser}.
      * @param listener build log
      * @param environment environment variables to be used
      * @param build run context for the returned GitClient

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -25,6 +25,8 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * A class which allows Git Plugin to choose a git implementation by estimating the size of a repository from a distance
@@ -419,5 +421,22 @@ public class GitToolChooser {
     public static void clearRepositorySizeCache() {
         repositorySizeCache = new ConcurrentHashMap<>();
     }
+
+    /**
+     * Insert an entry into the cache of repository sizes.
+     * For testing only - not to be used outside the git plugin.
+     *
+     * @param repoURL repository URL to be added as a cache key
+     * @param repoSize repository size in kilobytes
+     */
+    @Restricted(NoExternalUse.class)
+    public static void putRepositorySizeCache(String repoURL, long repoSize) {
+        /* Half-baked conversion to canonical URL for test use */
+        if (!repoURL.endsWith(".git")) {
+            repoURL = repoURL + ".git";
+        }
+        repositorySizeCache.put(repoURL, repoSize);
+    }
+
     private static final Logger LOGGER = Logger.getLogger(GitToolChooser.class.getName());
 }


### PR DESCRIPTION
## Add GitPublisher freestyle test

Assert contents of build log in GitPublisherTest

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [x] Test

## Further comments

Unclear why the JGit test case is using JGit correctly, logging that the tag has been pushed, yet not detecting the tag in the destination repository and not reporting any exception.