### PR TITLE
[JENKINS-62905] Git Publisher may be impacted by tables-to-div changes

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
@@ -1,5 +1,22 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
+  <d:taglib uri="local">
+  <d:tag name="blockWrapper">
+        <j:choose>
+            <j:when test="${divBasedFormLayout}">
+                <div>
+                    <d:invokeBody/>
+                </div>
+            </j:when>
+            <j:otherwise>
+                <table style="width:100%">
+                    <d:invokeBody/>
+                </table>
+            </j:otherwise>
+        </j:choose>
+    </d:tag>
+  </d:taglib>
+
     <f:entry field="pushOnlyIfSuccess">
       <f:checkbox title="${%Push Only If Build Succeeds}" />
     </f:entry>
@@ -16,7 +33,7 @@
              description="${%Tags to push to remote repositories}">
       <f:repeatable field="tagsToPush"
                     add="${%Add Tag}">
-        <table width="100%">
+        <local:blockWrapper width="100%">
           <br/>
           <f:entry field="tagName"
                    title="${%Tag to push}">
@@ -37,7 +54,7 @@
             <f:textbox
                 checkUrl="'descriptorByName/GitPublisher/checkRemote?value='+escape(this.value)"/>
           </f:entry>
-        </table>
+        </local:blockWrapper>
         <div align="right">
           <input type="button" value="${%Delete Tag}" class="repeatable-delete" style="margin-left: 1em;" />
         </div>
@@ -48,7 +65,7 @@
              description="${%Branches to push to remote repositories}">
       <f:repeatable field="branchesToPush"
                     add="${%Add Branch}">
-        <table width="100%">
+        <local:blockWrapper width="100%">
           <br/>
           <f:entry field="branchName"
                    title="${%Branch to push}">
@@ -62,7 +79,7 @@
           <f:entry field="rebaseBeforePush">
             <f:checkbox title="${%Rebase before push}" />
           </f:entry>
-        </table>
+        </local:blockWrapper>
         <div align="right">
           <input type="button" value="${%Delete Branch}" class="repeatable-delete" style="margin-left: 1em;" />
         </div>
@@ -73,7 +90,7 @@
     
       <f:repeatable field="notesToPush"  add="${%Add Note}">
       
-        <table width="100%">
+        <local:blockWrapper width="100%">
           <br/>
           <f:entry title="${%Note to push}"    field="noteMsg" >
             <f:textarea checkUrl="'descriptorByName/GitPublisher/checkNoteMsg?value='+escape(this.value)" />
@@ -91,7 +108,7 @@
             <f:checkbox title="${%Abort if note exists}" />
           </f:entry>
           
-        </table>
+        </local:blockWrapper>
         <div align="right">
           <input type="button" value="${%Delete Note}" class="repeatable-delete" style="margin-left: 1em;" />
         </div>


### PR DESCRIPTION
## [JENKINS-62905](https://issues.jenkins-ci.org/browse/JENKINS-62905) - Adapt to the new tables-to-div changes within the git plugin

The plugin contains tabular markup on some form elements and that could be a potential conflict with the new tables-to-div changes in the Jenkins core (https://issues.jenkins-ci.org/browse/JENKINS-62437)


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

