### PR TITLE
Check target of promoted build is not null

### DIFF
--- a/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
+++ b/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
@@ -57,7 +57,10 @@ public class GitRevisionBuildParameters extends AbstractBuildParameters {
 		if (data == null && Jenkins.get().getPlugin("promoted-builds") != null) {
             if (build instanceof hudson.plugins.promoted_builds.Promotion) {
                 // We are running as a build promotion, so have to retrieve the git scm from target job
-                data = ((hudson.plugins.promoted_builds.Promotion) build).getTarget().getAction(BuildData.class);
+                AbstractBuild<?,?> targetBuild = ((hudson.plugins.promoted_builds.Promotion) build).getTarget();
+                if (targetBuild != null) {
+                    data = targetBuild.getAction(BuildData.class);
+                }
             }
         }
         if (data == null) {


### PR DESCRIPTION
## Check target of promoted build is not null

Spotbugs report from the newest version of the promoted builds plugin correctly warns that the target of a promoted build might be null and needs to be checked.  See the output in #975.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update