### PR TITLE
Skip repo size calculation in GitToolChooser if JGit is not available

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -70,13 +70,18 @@ public class GitToolChooser {
         currentNode = n;
         this.listener = listener;
         implementation = "NONE";
-        useCache = decideAndUseCache(remoteName);
 
-        if (useCache) {
-            implementation = determineSwitchOnSize(sizeOfRepo, gitExe);
-        } else {
-            decideAndUseAPI(remoteName, projectContext, credentialsId, gitExe);
+        // Skip expensive checks if there is only one available implementation to choose from
+        if (JGIT_SUPPORTED) {
+            useCache = decideAndUseCache(remoteName);
+
+            if (useCache) {
+                implementation = determineSwitchOnSize(sizeOfRepo, gitExe);
+            } else {
+                decideAndUseAPI(remoteName, projectContext, credentialsId, gitExe);
+            }
         }
+
         gitTool = implementation;
     }
 


### PR DESCRIPTION
This commit stops GitToolChooser from doing useless expensive work when there's only one Git implementation to choose from.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

I need to say that we had to completely disable GitToolChooser because of its awful performance. There is no need to calculate full size of 100+ GB repository in order to understand that is it bigger than 5MB. `FileUtils.sizeOfDirectory` call in `GitToolChooser.decideAndUseCache` has to be replaced with something that will exit early, as soon as calculated size exceeds threshold.