### PR TITLE
[JENKINS-64149] User exclusion compares strings, not wildcards

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -844,7 +844,8 @@ Excluded Users::
   Using this behavior prevents the faster `git ls-remote` polling mechanism.
   It forces polling to require a workspace, as if you had selected the <<force-polling-using-workspace,Force polling using workspace>> extension.
 
-  Each exclusion uses literal pattern matching, and must be separated by a new line.
+  Each exclusion uses exact string comparison and must be separated by a new line.
+  User names are only excluded if they exactly match one of the names in this list.
 
 [#polling-ignores-commits-in-certain-paths]
 ==== Polling ignores commits in certain paths

--- a/src/main/resources/hudson/plugins/git/extensions/impl/UserExclusion/help-excludedUsers.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/UserExclusion/help-excludedUsers.html
@@ -2,7 +2,8 @@
   If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed by users in this list when determining if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build, assuming the build server commits the change with a distinct SCM user.
   <p/>
   Using this behaviour will preclude the faster git ls-remote polling mechanism, forcing polling to require a workspace thus sometimes triggering unwanted builds, as if you had selected the <strong>Force polling using workspace</strong> extension as well.
-  <p/>Each exclusion uses literal pattern matching, and must be separated by a new line.
+  <p/>Each exclusion uses exact string comparison and must be separated by a new line.
+      User names are only excluded if they exactly match one of the names in this list.
   <p/>
   <pre>auto_build_user</pre>
   The example above illustrates that if only revisions by "auto_build_user" have been committed to the SCM a build will not occur.


### PR DESCRIPTION
## [JENKINS-64149](https://issues.jenkins-ci.org/browse/JENKINS-64149) - Clarify user exclusion help text

Clarify online help that was written in 2010.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Help and documentation
