### PR TITLE
Avoid NPE in git tag action

### DIFF
--- a/src/main/java/hudson/plugins/git/GitTagAction.java
+++ b/src/main/java/hudson/plugins/git/GitTagAction.java
@@ -43,8 +43,10 @@ public class GitTagAction extends AbstractScmTagAction implements Describable<Gi
     protected GitTagAction(Run build, FilePath workspace, Revision revision) {
         super(build);
         this.ws = workspace.getRemote();
-        for (Branch b : revision.getBranches()) {
-            tags.put(b.getName(), new ArrayList<>());
+        if (revision.getBranches() != null) {
+            for (Branch b : revision.getBranches()) {
+                tags.put(b.getName(), new ArrayList<>());
+            }
         }
     }
 

--- a/src/test/java/hudson/plugins/git/GitTagActionTest.java
+++ b/src/test/java/hudson/plugins/git/GitTagActionTest.java
@@ -65,6 +65,8 @@ public class GitTagActionTest {
 
     private static final Random random = new Random();
 
+    private static final String NO_BRANCHES = "tagRevision-with-no-branches";
+
     @ClassRule
     public static JenkinsRule r = new JenkinsRule();
 
@@ -148,6 +150,10 @@ public class GitTagActionTest {
         waitForTagCreation(tagTwoAction, "v2");
 
         assertThat(getMatchingTagNames(), hasItems(getTagValue("v1"), getTagValue("v2")));
+
+        /* Create tag action with special message that tells tag action to create a null list of branches */
+        /* JENKINS-64279 reports a null pointer exception in this case */
+        GitTagAction tagNullBranchesAction = createTagAction(NO_BRANCHES);
     }
 
     @AfterClass
@@ -232,7 +238,11 @@ public class GitTagActionTest {
         assertTrue("master branch not found, last branch name was " + lastBranchName, foundMasterBranch);
 
         /* Create the GitTagAction */
-        GitTagAction tagAction = new GitTagAction(tagRun, workspace, tagRevision);
+        GitTagAction tagAction;
+        if (NO_BRANCHES.equals(message)) {
+            tagRevision.setBranches(null);
+        }
+        tagAction = new GitTagAction(tagRun, workspace, tagRevision);
 
         /* Schedule tag creation if message is not null */
         if (message != null) {


### PR DESCRIPTION
## [JENKINS-64279](https://issues.jenkins-ci.org/browse/JENKINS-64279) - Fix git tag action null pointer exception

Fix a null pointer exception detected during checkout when the branches property is null.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
