### PR TITLE
Require Jenkins 2.222.4 as minimum version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,12 @@
       <artifactId>xmlunit-matchers</artifactId>
       <version>2.8.1</version>
       <scope>test</scope>
+      <exclusions> <!-- Rely on version from junit plugin 1.43 -->
+        <exclusion>
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,11 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.204.1</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version> <!-- credentials requires 2.222.4 or higher -->
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
     <linkXRef>false</linkXRef>
-    <configuration-as-code.version>1.36</configuration-as-code.version>
     <slf4jVersion>1.7.26</slf4jVersion>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
@@ -118,6 +117,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
+      <exclusions>
+        <exclusion> <!-- script-security plugin depends on error_prone_annotations:2.3.4, others 2.4.0 -->
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -141,6 +146,12 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion> <!-- junit plugin depends on error_prone_annotations:2.3.4, others 2.4.0 -->
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -247,13 +258,11 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${configuration-as-code.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -267,8 +276,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.204.x</artifactId>
-        <version>17</version>
+        <artifactId>bom-2.222.x</artifactId>
+        <version>18</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.222.4 as minimum version

Require Jenkins 2.222.4 so that the plugin continues to use the Jenkins plugin bom.  Would have chosen 2.222.1 except that the credentials plugin requires 2.222.4.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update

## Further comments

See the Jenkins developer mailing list at
https://groups.google.com/g/jenkinsci-dev/c/hVS6MtLduJ8/m/ATu7uOsiAQAJ

The git plugin currently requires Jenkins 2.204.1 and uses the plugin bom to simplify dependency management.  I like the results of that simplification very much.

A dependabot pull request has proposed to update the git plugin use of bom-2.204.x from 17 to 18.  However, the build of that proposed update fails because one of the dependent plugins requires Jenkins 2.204.6 rather than 2.204.1.

I believe my options are:

* Update the  minimum Jenkins version required by the git plugin from 2.204.1 to 2.222.4 to retain the benefits of the plugin bom and move the minimum version forward to one of the currently recommended minimum versions - few users affected, reduces maintenance by reducing number of older Jenkins versions allowed to use the plugin
* Update the minimum Jenkins version required by the git plugin from 2.204.1 to 2.204.6 to retain the benefits of the plugin bom with least chance of disrupting existing users (though the number of users of Jenkins 2.204.x using newer versions of the git plugin is quite small based on stats.jenkins.io - even fewer users affected, retains benefits of the bom
* Close the pull request updating bom-2.204.x from 17 to 18 and make that change at some other time - suspends benefits of plugin bom until the next time the Jenkins minimum version is incremented

This pull request implements the first option (update from 2.204.1 to 2.222.4 as minimum version).