### PR TITLE
[JENKINS-64320] Fix git step default branch docs

### DIFF
--- a/src/main/resources/jenkins/plugins/git/GitStep/help-branch.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help-branch.html
@@ -1,6 +1,7 @@
 <div>
     <p>
-    Branch to be checked out in the workspace.  Default is the remote repository's default branch (typically '<code>master</code>').
+    Branch to be checked out in the workspace.
+    Default is '<code>master</code>'.
     </p>
     <p>
     Note that this must be a local branch name like 'master' or 'develop' or a tag name.


### PR DESCRIPTION
## [JENKINS-64320](https://issues.jenkins-ci.org/browse/JENKINS-64320) - Fix help text for git step default branch

The plugin uses a `checkout` operation rather than `clone`.  The checkout operation is not smart enough to use the default remote branch.  Since the `git` step is not receiving further investment, correct the documentation to accurately describe the implmenentation.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
