### PR TITLE
Enable Git Build Data to be customized

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -446,6 +446,11 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         return (gitDescriptor != null && gitDescriptor.isAddGitTagAction());
     }
 
+    public String getDisplayPrefix() {
+        DescriptorImpl gitDescriptor = getDescriptor();
+        return (gitDescriptor == null ? "" : gitDescriptor.getDisplayPrefix());
+    }
+
     @Whitelisted
     public BuildChooser getBuildChooser() {
         BuildChooser bc;
@@ -964,7 +969,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     private BuildData fixNull(BuildData bd) {
         ScmName sn = getExtensions().get(ScmName.class);
         String scmName = sn == null ? null : sn.getName();
-        return bd != null ? bd : new BuildData(scmName, getUserRemoteConfigs());
+        return bd != null ? bd : new BuildData(scmName, getUserRemoteConfigs(),getDisplayPrefix());
     }
 
     /**
@@ -1619,6 +1624,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         private boolean allowSecondFetch;
         private boolean disableGitToolChooser;
         private boolean addGitTagAction;
+        private String displayPrefix;
 
         public DescriptorImpl() {
             super(GitSCM.class, GitRepositoryBrowser.class);
@@ -1761,6 +1767,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         public boolean isAddGitTagAction() { return addGitTagAction; }
 
         public void setAddGitTagAction(boolean addGitTagAction) { this.addGitTagAction = addGitTagAction; }
+
+        public String getDisplayPrefix() { return displayPrefix; }
+
+        public void setDisplayPrefix(String displayPrefix) { this.displayPrefix = displayPrefix; }
 
         /**
          * Old configuration of git executable - exposed so that we can
@@ -1957,7 +1967,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         ScmName sn = getExtensions().get(ScmName.class);
         String scmName = sn == null ? null : sn.getName();
         if (base==null)
-            return new BuildData(scmName, getUserRemoteConfigs());
+            return new BuildData(scmName, getUserRemoteConfigs(),getDisplayPrefix());
         else {
            BuildData buildData = base.clone();
            buildData.setScmName(scmName);

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -90,7 +90,9 @@ public class BuildData implements Action, Serializable, Cloneable {
     }
 
     private final static String DEFAULT_DISPLAY_PREFIX = "Git Build Data";
-    private String displayPrefix = DEFAULT_DISPLAY_PREFIX;
+
+    private transient String displayPrefix = DEFAULT_DISPLAY_PREFIX;
+
     @Exported
     public String getDisplayPrefix() {
         return displayPrefix;

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -84,6 +84,22 @@ public class BuildData implements Action, Serializable, Cloneable {
         }
     }
 
+    public BuildData(String scmName, Collection<UserRemoteConfig> remoteConfigs, String displayPrefix) {
+        this(scmName,remoteConfigs);
+        this.displayPrefix = displayPrefix;
+    }
+
+    private final static String DEFAULT_DISPLAY_PREFIX = "Git Build Data";
+    private String displayPrefix = DEFAULT_DISPLAY_PREFIX;
+    @Exported
+    public String getDisplayPrefix() {
+        return displayPrefix;
+    }
+
+    public void setDisplayPrefix(String displayPrefix) {
+        this.displayPrefix = fixNull(displayPrefix);
+    }
+
     /**
      * Returns the build data display name, optionally with SCM name.
      * This string needs to be relatively short because it is
@@ -95,8 +111,8 @@ public class BuildData implements Action, Serializable, Cloneable {
      */
     public String getDisplayName() {
         if (scmName != null && !scmName.isEmpty())
-            return "Git Build Data:" + scmName;
-        return "Git Build Data";
+            return displayPrefix+":" + scmName;
+        return displayPrefix;
     }
 
     public String getIconFileName() {

--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -28,6 +28,9 @@
     <f:entry field="addGitTagAction">
       <f:checkbox title="${%Add git tag action to jobs}" name="addGitTagAction" checked="${descriptor.addGitTagAction}"/>
     </f:entry>
+    <f:entry title="${%Build data display prefix}" field="displayPrefix">
+      <f:textbox />
+    </f:entry>
     <!--
     <f:entry title="${%Default git client implementation}" field="defaultClientType">
         <select>


### PR DESCRIPTION
'Git Build Data: Loooong-scm-name' makes the end of scm-name hidden in job's build view

