### PR TITLE
Replace commons validator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,25 +261,6 @@
       <artifactId>jenkins-test-harness</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>commons-validator</groupId>
-      <artifactId>commons-validator</artifactId>
-      <version>1.7</version>
-      <exclusions> <!-- rely on components from Jenkins war file -->
-        <exclusion> <!-- Jenkins 2.204.1 provides a newer version than commons-digester mandates -->
-          <groupId>commons-digester</groupId>
-          <artifactId>commons-digester</artifactId>
-        </exclusion>
-        <exclusion> <!-- Jenkins 2.204.1 provides a newer version than commons-validator mandates -->
-          <groupId>commons-beanutils</groupId>
-          <artifactId>commons-beanutils</artifactId>
-        </exclusion>
-        <exclusion> <!-- Jenkins 2.204.1 provides commons-collections, no need to bundle it -->
-          <groupId>commons-collections</groupId>
-          <artifactId>commons-collections</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-multibranch</artifactId>
-      <version>2.22</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.1.4</version>
         <dependencies>
           <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -134,7 +134,8 @@ public class AssemblaWeb extends GitRepositoryBrowser {
         private boolean checkURIFormatAndHostName(String url, String hostNameFragment) throws URISyntaxException {
             URI uri = new URI(url);
             hostNameFragment = hostNameFragment + ".";
-            return validateUrl(uri.toString()) && uri.getHost().contains(hostNameFragment);
+            String uriHost = uri.getHost();
+            return uriHost != null && validateUrl(uri.toString()) && uriHost.contains(hostNameFragment);
         }
     }
 }


### PR DESCRIPTION
## Remove commons-validator dependency

The most recent release of commons validator requires commons-beanutils 1.9.4.  When commons-beanutils 1.9.4 is included in Jenkins 2.222.1 and later, it causes JavaScript errors in the round trip configuration tests.

The round trip configuration tests are much more valuable than the little bit of code that was avoided by not implementing the URL convenience validation checks directly.

See https://groups.google.com/g/jenkinsci-dev/c/0WHC_RJ4n7U/m/E0-fxSLnAQAJ

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update

## Additional details

- Use plugin pom for spotbugs maven plugin version
- Use bom for workflow multibranch plugin version
- Avoid NPE in URI format check

@rishabhBudhouliya if you're available, I'd love to have your review of the changes and the summary email linked above.