### PR TITLE
Adapt to xstream changes: change readResolve() from private to protected

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -371,7 +371,7 @@ public class GitPublisher extends Recorder implements Serializable {
      * instantiated but tagsToPush will be null rather than empty.
      * @return This.
      */
-    private Object readResolve() {
+    protected Object readResolve() {
         // Default unspecified to v0
         if(configVersion == null)
             this.configVersion = 0L;

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -200,7 +200,7 @@ public class GitSCMSource extends AbstractGitSCMSource {
         this(id, remote, credentialsId, null, null, includes, excludes, ignoreOnPushNotifications);
     }
 
-    private Object readResolve() throws ObjectStreamException {
+    protected Object readResolve() throws ObjectStreamException {
         if (traits == null) {
             List<SCMSourceTrait> traits = new ArrayList<>();
             traits.add(new BranchDiscoveryTrait());


### PR DESCRIPTION
Stemming from IRC discussion with @timja, it seems that for codebase running on Jenkins core after xstream changes (2.266+) the inherited private `readResolve()` methods that are a problem solved by making them protected: https://github.com/jenkinsci/jep/blob/f52f17b085293543a515f8c62fe458491f8e45c9/jep/228/README.adoc#inherited-private-serialization-methods

I do not know if this change really solves any issues, at least it did not fix one I was hunting for (legacy freestyle jobs no longer see my Git SCM that is present in config.xml and state None instead).

Suggested by work and discussion on https://github.com/jenkinsci/envinject-plugin/pull/154