### PR TITLE
[JENKINS-56063] Fix refSpec with expanded variables on first clone

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -512,12 +512,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     }
 
     /**
-     * Expand Parameters in the supplied remote repository with the parameter values provided in the given environment variables }
+     * Expand Parameters in the supplied remote repository with the parameter values provided in the given environment variables
      * @param env Environment variables with parameter values
      * @param remoteRepository Remote repository with parameters
      * @return remote repository with expanded parameters
      */
-    public RemoteConfig getParamExpandedRepo(EnvVars env, RemoteConfig remoteRepository){
+    public RemoteConfig getParamExpandedRepo(EnvVars env, RemoteConfig remoteRepository) {
         List<RefSpec> refSpecs = getRefSpecs(remoteRepository, env);
     	return newRemoteConfig(
                 getParameterString(remoteRepository.getName(), env),

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -160,6 +160,10 @@ public class CloneOption extends GitSCMExtension {
             // in a single job definition.
             RemoteConfig rc = scm.getRepositories().get(0);
             cmd.refspecs(getRefSpecs(rc, env));
+
+            // TODO: Debug output
+            listener.getLogger().println(String.join(";", env.keySet()));
+            listener.getLogger().println(String.join(";", env.values()));
         }
         cmd.timeout(timeout);
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -14,6 +14,7 @@ import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.plugins.git.util.GitUtils;
 import hudson.slaves.NodeProperty;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.eclipse.jgit.transport.RefSpec;
@@ -26,6 +27,7 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -139,6 +141,14 @@ public class CloneOption extends GitSCMExtension {
             listener.getLogger().println("Avoid fetching tags");
             cmd.tags(false);
         }
+
+        Node node = GitUtils.workspaceToNode(git.getWorkTree());
+        EnvVars env = build.getEnvironment(listener);
+        Computer comp = node.toComputer();
+        if (comp != null) {
+            env.putAll(comp.getEnvironment());
+        }
+
         if (honorRefspec) {
             listener.getLogger().println("Honoring refspec on initial clone");
             // Read refspec configuration from the first configured repository.
@@ -149,21 +159,27 @@ public class CloneOption extends GitSCMExtension {
             // Git plugin does not support multiple independent repositories
             // in a single job definition.
             RemoteConfig rc = scm.getRepositories().get(0);
-            List<RefSpec> refspecs = rc.getFetchRefSpecs();
-            cmd.refspecs(refspecs);
+            cmd.refspecs(getRefSpecs(rc, env));
         }
         cmd.timeout(timeout);
 
-        Node node = GitUtils.workspaceToNode(git.getWorkTree());
-        EnvVars env = build.getEnvironment(listener);
-        Computer comp = node.toComputer();
-        if (comp != null) {
-            env.putAll(comp.getEnvironment());
-        }
         for (NodeProperty nodeProperty: node.getNodeProperties()) {
             nodeProperty.buildEnvVars(env, listener);
         }
         cmd.reference(env.expand(reference));
+    }
+
+    @NonNull
+    private static String getParameterString(@CheckForNull String original, @NonNull EnvVars env) {
+        return env.expand(original);
+    }
+
+    private static List<RefSpec> getRefSpecs(RemoteConfig repo, EnvVars env) {
+        List<RefSpec> refSpecs = new ArrayList<>();
+        for (RefSpec refSpec : repo.getFetchRefSpecs()) {
+            refSpecs.add(new RefSpec(getParameterString(refSpec.toString(), env)));
+        }
+        return refSpecs;
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -169,7 +169,6 @@ public class CloneOption extends GitSCMExtension {
         cmd.reference(env.expand(reference));
     }
 
-    @NonNull
     private static String getParameterString(@CheckForNull String original, @NonNull EnvVars env) {
         return env.expand(original);
     }

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -16,6 +16,7 @@ import hudson.slaves.NodeProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteConfig;
@@ -143,11 +144,6 @@ public class CloneOption extends GitSCMExtension {
         }
 
         Node node = GitUtils.workspaceToNode(git.getWorkTree());
-        EnvVars env = build.getEnvironment(listener);
-        Computer comp = node.toComputer();
-        if (comp != null) {
-            env.putAll(comp.getEnvironment());
-        }
 
         if (honorRefspec) {
             listener.getLogger().println("Honoring refspec on initial clone");
@@ -158,15 +154,17 @@ public class CloneOption extends GitSCMExtension {
             // configuration is treated as authoritative.
             // Git plugin does not support multiple independent repositories
             // in a single job definition.
+            EnvVars buildEnv = build.getEnvironment(listener);
             RemoteConfig rc = scm.getRepositories().get(0);
-            cmd.refspecs(getRefSpecs(rc, env));
-
-            // TODO: Debug output
-            listener.getLogger().println(String.join(";", env.keySet()));
-            listener.getLogger().println(String.join(";", env.values()));
+            cmd.refspecs(getRefSpecs(rc, buildEnv));
         }
         cmd.timeout(timeout);
 
+        EnvVars env = build.getEnvironment(listener);
+        Computer comp = node.toComputer();
+        if (comp != null) {
+            env.putAll(comp.getEnvironment());
+        }
         for (NodeProperty nodeProperty: node.getNodeProperties()) {
             nodeProperty.buildEnvVars(env, listener);
         }

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
@@ -32,8 +32,7 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
     @Parameterized.Parameters(name = "{0}")
     public static Collection permuteRefSpecVariable() {
         List<Object[]> values = new ArrayList<>();
-        String[] allowed = {"${BUILD_NUMBER}","${BUILD_ID}",
-                "${GIT_COMMIT}"};
+        String[] allowed = {"${GIT_REVISION}", "${GIT_COMMIT}"};
         for (String refSpecValue : allowed) {
             Object[] combination = {refSpecValue};
             values.add(combination);

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.Issue;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -137,6 +138,6 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
     }
 
     private static boolean isWindows() {
-        return false;
+        return File.pathSeparatorChar == ';';
     }
 }

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
@@ -3,73 +3,118 @@ package hudson.plugins.git.extensions.impl;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
-import org.jvnet.hudson.test.Issue;
 import hudson.plugins.git.AbstractGitTestCase;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserRemoteConfig;
-import org.eclipse.jgit.transport.RefSpec;
-import org.jenkinsci.plugins.gitclient.CloneCommand;
-import org.junit.Before;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.Issue;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
 
 @RunWith(Parameterized.class)
 public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
 
-    private String refSpecVar;
+    private final String refSpecName;
+    private final String refSpecExpectedValue;
+    private final Boolean honorRefSpec;
 
-    public CloneOptionHonorRefSpecTest(String useRefSpecVariable) {
-        this.refSpecVar = useRefSpecVariable;
+    private static final Random random = new Random();
+
+    public CloneOptionHonorRefSpecTest(String refSpecName, String refSpecExpectedValue, Boolean honorRefSpec) {
+        this.refSpecName = refSpecName;
+        this.refSpecExpectedValue = refSpecExpectedValue;
+        this.honorRefSpec = honorRefSpec;
     }
 
-    @Parameterized.Parameters(name = "{0}")
+    private static String getExpectedValue(String reference) {
+        if (reference.startsWith("JOB_")) {
+            return "test0";
+        }
+        if (reference.contains("USER")) {
+            return System.getProperty("user.name", "java-user.name-property-not-found");
+        }
+        return "not-master"; // fake value for other variables
+    }
+
+    @Parameterized.Parameters(name = "{0}-{1}-{2}")
     public static Collection permuteRefSpecVariable() {
         List<Object[]> values = new ArrayList<>();
-        String[] allowed = {"${GIT_REVISION}", "${GIT_COMMIT}"};
-        for (String refSpecValue : allowed) {
-            Object[] combination = {refSpecValue};
+        /* Should behave same with honor refspec enabled or disabled */
+        boolean honorRefSpec = random.nextBoolean();
+
+        /* Variables set by Jenkins */
+        String[] allowed = {"JOB_BASE_NAME", "JOB_NAME", "JENKINS_USERNAME"};
+        for (String refSpecName : allowed) {
+            String refSpecExpectedValue = getExpectedValue(refSpecName);
+            Object[] combination = {refSpecName, refSpecExpectedValue, honorRefSpec};
             values.add(combination);
+            honorRefSpec = !honorRefSpec;
         }
+
+        /* Variable set by the operating system */
+        String refSpecName = isWindows() ? "USERNAME" : "USER";
+        String refSpecExpectedValue = getExpectedValue(refSpecName);
+        Object[] combination = {refSpecName, refSpecExpectedValue, honorRefSpec};
+        values.add(combination);
+
         return values;
     }
 
     /**
-     * This test confirms behavior of refspecs on initial clone with expanded variables.
+     * This test confirms behavior of refspecs on initial clone with expanded
+     * variables. When an environment variable reference is embedded in the
+     * refspec, it should be expanded in all cases.
+     *
      * @throws Exception on error
      */
     @Test
     @Issue("JENKINS-56063")
     public void testRefSpecWithExpandedVariables() throws Exception {
-        List<UserRemoteConfig> repos = new ArrayList<>();
-        repos.add(new UserRemoteConfig(testRepo.gitDir.getAbsolutePath(), "origin", "+refs/heads/master:refs/remotes/origin/master" + refSpecVar, null));
-
-        /* Set CloneOption to honor refspec on initial clone with expanded var */
-        FreeStyleProject projectWithMasterExpanded = setupProject(repos, Collections.singletonList(new BranchSpec("master" + refSpecVar)), null, false, null);
-        CloneOption cloneOptionMasterExpanded = new CloneOption(false, null, null);
-        cloneOptionMasterExpanded.setHonorRefspec(true);
-        ((GitSCM)projectWithMasterExpanded.getScm()).getExtensions().add(cloneOptionMasterExpanded);
-
-        /* Set CloneOption to honor refspec on initial clone without expanded var, should fail */
-        FreeStyleProject projectWithMaster = setupProject(repos, Collections.singletonList(new BranchSpec("master")), null, false, null);
-        CloneOption cloneOptionMaster = new CloneOption(false, null, null);
-        cloneOptionMaster.setHonorRefspec(true);
-        ((GitSCM)projectWithMaster.getScm()).getExtensions().add(cloneOptionMaster);
 
         // create initial commit
         final String commitFile1 = "commitFile1";
-        commit(commitFile1, johnDoe, "Commit in master");
-        // create branch and make initial commit
-        git.checkout().ref("master").branch("foo").execute();
-        commit(commitFile1, johnDoe, "Commit in foo");
+        commit(commitFile1, johnDoe, "Commit in master branch");
 
-        build(projectWithMaster, Result.FAILURE);
-        build(projectWithMasterExpanded, Result.SUCCESS, commitFile1);
+        // create branch and make initial commit
+        git.checkout().ref("master").branch(refSpecExpectedValue).execute();
+        commit(commitFile1, johnDoe, "Commit in '" + refSpecExpectedValue + "' branch");
+
+        // Use the variable reference in the refspec
+        // Should be expanded by the clone option whether or not honor refspec is enabled
+        List<UserRemoteConfig> repos = new ArrayList<>();
+        repos.add(new UserRemoteConfig(
+                testRepo.gitDir.getAbsolutePath(),
+                "origin",
+                "+refs/heads/${" + refSpecName + "}:refs/remotes/origin/${" + refSpecName + "}", null));
+
+        /* Use the variable or its value as the branch name.
+         * Same result expected in either case.
+         */
+        String branchName = random.nextBoolean() ? "${" + refSpecName + "}" : refSpecExpectedValue;
+        FreeStyleProject project = setupProject(repos, Collections.singletonList(new BranchSpec(branchName)), null, false, null);
+
+        /* Same result expected whether refspec honored or not */
+        CloneOption cloneOption = new CloneOption(false, null, null);
+        cloneOption.setHonorRefspec(honorRefSpec);
+        ((GitSCM) project.getScm()).getExtensions().add(cloneOption);
+
+        FreeStyleBuild b = build(project, Result.SUCCESS, commitFile1);
+        /* Check that unexpanded refspec name is not in the log */
+        List<String> buildLog = b.getLog(50);
+        assertThat(buildLog, not(hasItem(containsString("${" + refSpecName + "}"))));
+    }
+
+    private static boolean isWindows() {
+        return false;
     }
 }

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
@@ -1,0 +1,76 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import org.jvnet.hudson.test.Issue;
+import hudson.plugins.git.AbstractGitTestCase;
+import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
+import org.eclipse.jgit.transport.RefSpec;
+import org.jenkinsci.plugins.gitclient.CloneCommand;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
+
+    private String refSpecVar;
+
+    public CloneOptionHonorRefSpecTest(String useRefSpecVariable) {
+        this.refSpecVar = useRefSpecVariable;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection permuteRefSpecVariable() {
+        List<Object[]> values = new ArrayList<>();
+        String[] allowed = {"${BUILD_NUMBER}","${BUILD_ID}",
+                "${GIT_COMMIT}"};
+        for (String refSpecValue : allowed) {
+            Object[] combination = {refSpecValue};
+            values.add(combination);
+        }
+        return values;
+    }
+
+    /**
+     * This test confirms behavior of refspecs on initial clone with expanded variables.
+     * @throws Exception on error
+     */
+    @Test
+    @Issue("JENKINS-56063")
+    public void testRefSpecWithExpandedVariables() throws Exception {
+        List<UserRemoteConfig> repos = new ArrayList<>();
+        repos.add(new UserRemoteConfig(testRepo.gitDir.getAbsolutePath(), "origin", "+refs/heads/master:refs/remotes/origin/master" + refSpecVar, null));
+
+        /* Set CloneOption to honor refspec on initial clone with expanded var */
+        FreeStyleProject projectWithMasterExpanded = setupProject(repos, Collections.singletonList(new BranchSpec("master" + refSpecVar)), null, false, null);
+        CloneOption cloneOptionMasterExpanded = new CloneOption(false, null, null);
+        cloneOptionMasterExpanded.setHonorRefspec(true);
+        ((GitSCM)projectWithMasterExpanded.getScm()).getExtensions().add(cloneOptionMasterExpanded);
+
+        /* Set CloneOption to honor refspec on initial clone without expanded var, should fail */
+        FreeStyleProject projectWithMaster = setupProject(repos, Collections.singletonList(new BranchSpec("master")), null, false, null);
+        CloneOption cloneOptionMaster = new CloneOption(false, null, null);
+        cloneOptionMaster.setHonorRefspec(true);
+        ((GitSCM)projectWithMaster.getScm()).getExtensions().add(cloneOptionMaster);
+
+        // create initial commit
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit in master");
+        // create branch and make initial commit
+        git.checkout().ref("master").branch("foo").execute();
+        commit(commitFile1, johnDoe, "Commit in foo");
+
+        build(projectWithMaster, Result.FAILURE);
+        build(projectWithMasterExpanded, Result.SUCCESS, commitFile1);
+    }
+}

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
@@ -1,8 +1,14 @@
 package hudson.plugins.git.extensions.impl;
 
-import hudson.model.*;
-import hudson.plugins.git.*;
-
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
+import hudson.plugins.git.AbstractGitTestCase;
+import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import org.jenkinsci.plugins.gitclient.JGitTool;
 import org.junit.Test;
@@ -113,8 +119,8 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                 repos,
                 Collections.singletonList(new BranchSpec(branchName)),
-                false, Collections.<SubmoduleConfig>emptyList(),
-                null, JGitTool.MAGIC_EXENAME,
+                false, Collections.emptyList(),
+                null, random.nextBoolean() ? JGitTool.MAGIC_EXENAME : null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(scm);
         project.save();


### PR DESCRIPTION
## [JENKINS-56063](https://issues.jenkins-ci.org/browse/JENKINS-56063) - Fix refSpec with expanded variables on first clone

RefSpecs passed down from build parameters or environments are not being respected on initial checkout, but are on the subsequent ones. This pull request uses the same process used in those subsequent checkouts to resolve the refspecs on the initial checkout.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

Test derived from https://github.com/jenkinsci/git-plugin/pull/830