### PR TITLE
Refine the honor refspec test

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -133,7 +133,10 @@ public class CloneOption extends GitSCMExtension {
     public void decorateCloneCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, CloneCommand cmd) throws IOException, InterruptedException, GitException {
         cmd.shallow(shallow);
         if (shallow) {
-            int usedDepth = depth == null || depth < 1 ? 1 : depth;
+            int usedDepth = 1;
+            if (depth != null && depth > 0) {
+                usedDepth = depth;
+            }
             listener.getLogger().println("Using shallow clone with depth " + usedDepth);
             cmd.depth(usedDepth);
         }
@@ -190,7 +193,10 @@ public class CloneOption extends GitSCMExtension {
     public void decorateFetchCommand(GitSCM scm, GitClient git, TaskListener listener, FetchCommand cmd) throws IOException, InterruptedException, GitException {
         cmd.shallow(shallow);
         if (shallow) {
-            int usedDepth = depth == null || depth < 1 ? 1 : depth;
+            int usedDepth = 1;
+            if (depth != null && depth > 0) {
+                usedDepth = depth;
+            }
             listener.getLogger().println("Using shallow fetch with depth " + usedDepth);
             cmd.depth(usedDepth);
         }

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -16,7 +16,6 @@ import hudson.slaves.NodeProperty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteConfig;

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
@@ -32,22 +32,18 @@ import static org.hamcrest.Matchers.*;
 public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
 
     private final String refSpecName;
-    private final Boolean honorRefSpec;
 
     private static final Random random = new Random();
     private FreeStyleProject project;
     private String refSpecExpectedValue;
 
-    public CloneOptionHonorRefSpecTest(String refSpecName, Boolean honorRefSpec) {
+    public CloneOptionHonorRefSpecTest(String refSpecName) {
         this.refSpecName = refSpecName;
-        this.honorRefSpec = honorRefSpec;
     }
 
-    @Parameterized.Parameters(name = "{0}-{1}")
+    @Parameterized.Parameters(name = "{0}")
     public static Collection permuteRefSpecVariable() {
         List<Object[]> values = new ArrayList<>();
-        // Should behave same with honor refspec enabled or disabled
-        boolean honorRefSpec = random.nextBoolean();
 
         String[] keys = {
                 "JOB_NAME", // Variable set by Jenkins
@@ -56,9 +52,8 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
         };
 
         for (String refSpecName : keys) {
-            Object[] combination = {refSpecName, true};
+            Object[] combination = {refSpecName};
             values.add(combination);
-            honorRefSpec = !honorRefSpec;
         }
 
         return values;
@@ -137,7 +132,7 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
 
         // Same result expected whether refspec honored or not
         CloneOption cloneOption = new CloneOption(false, null, null);
-        cloneOption.setHonorRefspec(honorRefSpec);
+        cloneOption.setHonorRefspec(true);
         scm.getExtensions().add(cloneOption);
 
         FreeStyleBuild b = build(project, Result.SUCCESS, commitFile1);

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
@@ -67,6 +67,7 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
     }
 
     @Before
+    @Override
     public void setUp() throws Exception {
         super.setUp();
 

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
@@ -1,6 +1,5 @@
 package hudson.plugins.git.extensions.impl;
 
-import hudson.Functions;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersDefinitionProperty;
@@ -20,6 +19,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.Issue;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -51,7 +51,7 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
 
         String[] keys = {
                 "JOB_NAME", // Variable set by Jenkins
-                (Functions.isWindows() ? "USERNAME" : "USER"), // Variable set by the operating system
+                (isWindows() ? "USERNAME" : "USER"), // Variable set by the operating system
                 "USER_SELECTED_BRANCH_NAME" // Parametrised build param
         };
 
@@ -65,7 +65,7 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
     }
 
     private static Builder createEnvEchoBuilder(String envVarName) {
-        if (Functions.isWindows()) {
+        if (isWindows()) {
             return new BatchFile(String.format("echo %s=%%%s%%", envVarName, envVarName));
         }
         return new Shell(String.format("echo \"%s=${%s}\"", envVarName, envVarName));
@@ -145,5 +145,9 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
         // Check that unexpanded refspec name is not in the log
         List<String> buildLog = b.getLog(50);
         assertThat(buildLog, not(hasItem(containsString("${" + refSpecName + "}"))));
+    }
+
+    private static boolean isWindows() {
+        return File.pathSeparatorChar == ';';
     }
 }


### PR DESCRIPTION
## Refine the honor refspec test further

﻿- Use local isWindows for consistency in tests
- Remove dead code randomizing honor refSpec test
- Add override annotation
- Remove unused import
- Silence Netbeans warning about unboxing possible null

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
