### PR TITLE
[JENKINS-64382] Exclude JGit if submodule extension added

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -185,7 +185,14 @@ public class SubmoduleOption extends GitSCMExtension {
 
     @Override
     public void determineSupportForJGit(GitSCM scm, @NonNull UnsupportedCommand cmd) {
-        cmd.threads(threads);
+        /* Prevent JGit with ANY use of SubmoduleOption by always setting a value
+         * for threads.  See JENKINS-64382.
+         */
+        if (threads == null) {
+            cmd.threads(1);
+        } else {
+            cmd.threads(threads);
+        }
         cmd.depth(depth);
         cmd.shallow(shallow);
         cmd.timeout(timeout);

--- a/src/test/java/hudson/plugins/git/extensions/impl/SubmoduleOptionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/SubmoduleOptionTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import java.io.IOException;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.fail;
 import org.jvnet.hudson.test.Issue;
 
 import hudson.model.Run;
@@ -18,17 +17,39 @@ import hudson.plugins.git.GitException;
 import hudson.model.TaskListener;
 import hudson.plugins.git.util.BuildData;
 import hudson.plugins.git.util.Build;
+import static org.junit.Assert.assertThrows;
+import org.junit.Before;
 
 import org.mockito.Mockito;
 
-
 public class SubmoduleOptionTest {
+
+    private SubmoduleOption submoduleOption;
+
+    private static final boolean DISABLE_SUBMODULES_FALSE = false;
+    private static final boolean RECURSIVE_SUBMODULES_FALSE = false;
+    private static final boolean TRACKING_SUBMODULES_FALSE = false;
+    private static final boolean USE_PARENT_CREDENTIALS_FALSE = false;
+    private static final String SUBMODULES_REFERENCE_REPOSITORY = null;
+    private static final Integer SUBMODULES_TIMEOUT = null;
+
+    private SubmoduleOption newSubmoduleOption() {
+        return new SubmoduleOption(DISABLE_SUBMODULES_FALSE,
+                RECURSIVE_SUBMODULES_FALSE,
+                TRACKING_SUBMODULES_FALSE,
+                SUBMODULES_REFERENCE_REPOSITORY,
+                SUBMODULES_TIMEOUT,
+                USE_PARENT_CREDENTIALS_FALSE);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        submoduleOption = newSubmoduleOption();
+    }
 
     @Issue("JENKINS-31934")
     @Test
     public void testSubmoduleUpdateThrowsIOException() throws Exception {
-        SubmoduleOption submoduleOption = new SubmoduleOption(false, false, false, null, null, false);
-
         // In order to verify that the submodule option correctly converts
         // GitExceptions into IOExceptions, setup a SubmoduleOption, and run
         // it's onCheckoutCompleted extension point with a mocked git client
@@ -44,12 +65,15 @@ public class SubmoduleOptionTest {
         Mockito.when(client.hasGitModules()).thenReturn(true);
         Mockito.when(client.submoduleUpdate()).thenThrow(new GitException("a git exception"));
 
-        try {
+        Exception e = assertThrows(IOException.class, () -> {
             submoduleOption.onCheckoutCompleted(scm, build, client, listener);
-            fail("Expected IOException to be thrown");
-        } catch (IOException e) {
-            assertThat(e.getMessage(), is("Could not perform submodule update"));
-        }
+        });
+        assertThat(e.getMessage(), is("Could not perform submodule update"));
+    }
+
+    @Test
+    public void testOnCheckoutCompleted() throws Exception {
+        /* See testSubmoduleUpdateThrowsIOException */
     }
 
     @Test
@@ -58,5 +82,169 @@ public class SubmoduleOptionTest {
                 .usingGetClass()
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
+    }
+
+    @Test
+    public void testIsDisableSubmodules() {
+        assertThat(submoduleOption.isDisableSubmodules(), is(false));
+    }
+
+    @Test
+    public void testIsDisableSubmodulesTrue() {
+        submoduleOption = new SubmoduleOption(true,
+                RECURSIVE_SUBMODULES_FALSE,
+                TRACKING_SUBMODULES_FALSE,
+                SUBMODULES_REFERENCE_REPOSITORY,
+                SUBMODULES_TIMEOUT,
+                USE_PARENT_CREDENTIALS_FALSE);
+        assertThat(submoduleOption.isDisableSubmodules(), is(true));
+    }
+
+    @Test
+    public void testIsRecursiveSubmodules() {
+        assertThat(submoduleOption.isRecursiveSubmodules(), is(false));
+    }
+
+    @Test
+    public void testIsRecursiveSubmodulesTrue() {
+        submoduleOption = new SubmoduleOption(DISABLE_SUBMODULES_FALSE,
+                true,
+                TRACKING_SUBMODULES_FALSE,
+                SUBMODULES_REFERENCE_REPOSITORY,
+                SUBMODULES_TIMEOUT,
+                USE_PARENT_CREDENTIALS_FALSE);
+        assertThat(submoduleOption.isRecursiveSubmodules(), is(true));
+    }
+
+    @Test
+    public void testIsTrackingSubmodules() {
+        assertThat(submoduleOption.isTrackingSubmodules(), is(false));
+    }
+
+    @Test
+    public void testIsTrackingSubmodulesTrue() {
+        submoduleOption = new SubmoduleOption(DISABLE_SUBMODULES_FALSE,
+                RECURSIVE_SUBMODULES_FALSE,
+                true,
+                SUBMODULES_REFERENCE_REPOSITORY,
+                SUBMODULES_TIMEOUT,
+                USE_PARENT_CREDENTIALS_FALSE);
+        assertThat(submoduleOption.isTrackingSubmodules(), is(true));
+    }
+
+    @Test
+    public void testIsParentCredentials() {
+        assertThat(submoduleOption.isParentCredentials(), is(false));
+    }
+
+    @Test
+    public void testIsParentCredentialsTrue() {
+        submoduleOption = new SubmoduleOption(DISABLE_SUBMODULES_FALSE,
+                RECURSIVE_SUBMODULES_FALSE,
+                TRACKING_SUBMODULES_FALSE,
+                SUBMODULES_REFERENCE_REPOSITORY,
+                SUBMODULES_TIMEOUT,
+                true);
+        assertThat(submoduleOption.isParentCredentials(), is(true));
+    }
+
+    @Test
+    public void testGetReference() {
+        assertThat(submoduleOption.getReference(), is(nullValue()));
+    }
+
+    @Test
+    public void testGetReferenceNotNull() {
+        final String referenceRepoDirName = "/repo.git";
+        submoduleOption = new SubmoduleOption(DISABLE_SUBMODULES_FALSE,
+                RECURSIVE_SUBMODULES_FALSE,
+                TRACKING_SUBMODULES_FALSE,
+                referenceRepoDirName,
+                SUBMODULES_TIMEOUT,
+                true);
+        assertThat(submoduleOption.getReference(), is(referenceRepoDirName));
+    }
+
+    @Test
+    public void testGetTimeout() {
+        assertThat(submoduleOption.getTimeout(), is(nullValue()));
+    }
+
+    @Test
+    public void testGetTimeoutNotNull() {
+        Integer timeout = 3;
+        submoduleOption = new SubmoduleOption(DISABLE_SUBMODULES_FALSE,
+                RECURSIVE_SUBMODULES_FALSE,
+                TRACKING_SUBMODULES_FALSE,
+                SUBMODULES_REFERENCE_REPOSITORY,
+                timeout,
+                true);
+        assertThat(submoduleOption.getTimeout(), is(timeout));
+    }
+
+    @Test
+    public void testSetShallow() {
+        submoduleOption.setShallow(true);
+        assertThat(submoduleOption.getShallow(), is(true));
+    }
+
+    @Test
+    public void testGetShallow() {
+        assertThat(submoduleOption.getShallow(), is(false));
+    }
+
+    private Integer randomSmallNonNegativeIntegerOrNull() {
+        java.util.Random random = new java.util.Random();
+        Integer value = random.nextInt(131);
+        if (value == 0) {
+            value = null;
+        }
+        return value;
+    }
+
+    @Test
+    public void testSetDepth() {
+        Integer depthValue = randomSmallNonNegativeIntegerOrNull();
+        submoduleOption.setDepth(depthValue);
+        assertThat(submoduleOption.getDepth(), is(depthValue));
+    }
+
+    @Test
+    public void testGetDepth() {
+        assertThat(submoduleOption.getDepth(), is(nullValue()));
+    }
+
+    @Test
+    public void testGetThreads() {
+        assertThat(submoduleOption.getThreads(), is(nullValue()));
+    }
+
+    @Test
+    public void testSetThreads() {
+        Integer threads = randomSmallNonNegativeIntegerOrNull();
+        submoduleOption.setThreads(threads);
+        assertThat(submoduleOption.getThreads(), is(threads));
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(submoduleOption.toString(), is("SubmoduleOption{"
+                + "disableSubmodules=false"
+                + ", recursiveSubmodules=false"
+                + ", trackingSubmodules=false"
+                + ", reference='null'"
+                + ", parentCredentials=false"
+                + ", timeout=null"
+                + ", shallow=false"
+                + ", depth=null"
+                + ", threads=null"
+                + '}'));
+    }
+
+    @Test
+    public void testDetermineSupportForJGit() {
+        GitSCM scm = null;
+        UnsupportedCommand cmd = new UnsupportedCommand();
+        submoduleOption.determineSupportForJGit(scm, cmd);
     }
 }


### PR DESCRIPTION
## [JENKINS-64382](https://issues.jenkins-ci.org/browse/JENKINS-64382) - Exclude JGit if submodule extension has been added

The git tool chooser incorrectly selected the JGit implementation for jobs with the submodule option enabled with no other options.  It also incorrectly selected the JGit implementation for jobs with the submodule option enabled and recursive submodules checked.

Fix the issue by always rejecting JGit as a tool if the submodule extension is enabled.

Wrote the test to show the problem.  Initial commit does not include the fix so that the first run of this pull request will show that 2 new tests are failing.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

Could have fixed it by making a change to the git client plugin and git plugin both.  It seemed easier to only change the git plugin.