### PR TITLE
[JENKINS-33984] Get branch for build from parameter of notifyCommit callback

### DIFF
--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -371,6 +371,8 @@ public class GitStatus implements UnprotectedRootAction {
 
                             boolean branchFound = false,
                                     parametrizedBranchSpec = false;
+                            String branchName = null;
+
                             if (branches.length == 0) {
                                 branchFound = true;
                             } else {
@@ -389,6 +391,7 @@ public class GitStatus implements UnprotectedRootAction {
                                                     LOGGER.log(Level.FINE, "Branch Spec {0} matches modified branch {1} for {2}", new Object[]{branchSpec, branch, project.getFullDisplayName()});
                                                 }
                                                 branchFound = true;
+                                                branchName = branch;
                                                 break OUT;
                                             }
                                         }
@@ -424,7 +427,7 @@ public class GitStatus implements UnprotectedRootAction {
                                     LOGGER.log(Level.INFO, "Scheduling {0} to build commit {1}", new Object[]{project.getFullDisplayName(), sha1});
                                     scmTriggerItem.scheduleBuild2(scmTriggerItem.getQuietPeriod(),
                                             new CauseAction(new CommitHookCause(sha1)),
-                                            new RevisionParameterAction(sha1, matchedURL), new ParametersAction(allBuildParameters));
+                                            new RevisionParameterAction(sha1, matchedURL, branchName), new ParametersAction(allBuildParameters));
                                     result.add(new ScheduledResponseContributor(project));
                                 } else {
                                     /* Poll the repository for changes

--- a/src/main/java/hudson/plugins/git/RevisionParameterAction.java
+++ b/src/main/java/hudson/plugins/git/RevisionParameterAction.java
@@ -55,6 +55,7 @@ public class RevisionParameterAction extends InvisibleAction implements Serializ
     public final boolean combineCommits;
     public final Revision revision;
     private final URIish repoURL;
+    private final String branchName;
 
     public RevisionParameterAction(String commit) {
         this(commit, false, null);
@@ -64,27 +65,37 @@ public class RevisionParameterAction extends InvisibleAction implements Serializ
         this(commit, false, repoURL);
     }
 
+    public RevisionParameterAction(String commit, URIish repoURL, String branchName) {
+        this(commit, false, repoURL, branchName);
+    }
+
     public RevisionParameterAction(String commit, boolean combineCommits) {
         this(commit, combineCommits, null);
     }
 
     public RevisionParameterAction(String commit, boolean combineCommits, URIish repoURL) {
+        this(commit, combineCommits, repoURL, null);
+    }
+
+    public RevisionParameterAction(String commit, boolean combineCommits, URIish repoURL, String branchName) {
         this.commit = commit;
         this.combineCommits = combineCommits;
         this.revision = null;
         this.repoURL = repoURL;
+        this.branchName = branchName;
     }
-    
+
     public RevisionParameterAction(Revision revision) {
         this(revision, false);
-    }   
+    }
 
     public RevisionParameterAction(Revision revision, boolean combineCommits) {
-    	this.revision = revision;
-    	this.commit = revision.getSha1String();
-    	this.combineCommits = combineCommits;
+        this.revision = revision;
+        this.commit = revision.getSha1String();
+        this.combineCommits = combineCommits;
         this.repoURL = null;
-    }   
+        this.branchName = null;
+    }
 
     @Deprecated
     public Revision toRevision(IGitAPI git) throws InterruptedException {
@@ -92,16 +103,24 @@ public class RevisionParameterAction extends InvisibleAction implements Serializ
     }
 
     public Revision toRevision(GitClient git) throws InterruptedException {
-    	if (revision != null) {
-    		return revision;
-    	}
+        if (revision != null) {
+            return revision;
+        }
         ObjectId sha1 = git.revParse(commit);
         Revision revision = new Revision(sha1);
-        // Here we do not have any local branches, containing the commit. So...
-        // we are to get all the remote branches, and show them to users, as
-        // they are local
-        final List<Branch> branches = normalizeBranches(git.getBranchesContaining(
-                ObjectId.toString(sha1), true));
+
+        List<Branch> branches = null;
+
+        if (branchName != null) {
+            branches = new ArrayList<Branch>(1);
+            branches.add(new Branch(branchName, sha1));
+        } else {
+            // Here we do not have any local branches, containing the commit. So...
+            // we are to get all the remote branches, and show them to users, as
+            // they are local
+            branches = normalizeBranches(git.getBranchesContaining(
+                    ObjectId.toString(sha1), true));
+        }
         revision.getBranches().addAll(branches);
         return revision;
     }


### PR DESCRIPTION
## [JENKINS-33984](https://issues.jenkins-ci.org/browse/JENKINS-33984) - Get branch for build from parameter of notifyCommit callback when it's possible

When Jenkins receives notification about new commit it checks `branch` and `sha1` parameters but schedules build using `sha1` only. Due to this fact Jenkins has to determine the branch name when build starts. When there are several branches with the same commit it's possible that Jenkins uses branch name different from the branch parameter from the notification. For my projects it's very important to use branch name from the notification in the build. This PR saves branch name from the notification parameter and uses it later for the build.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)