### PR TITLE
Skip honor refspec test if env is an empty value

### DIFF
--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
@@ -84,7 +84,7 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
         List<String> logs = b.getLog(50);
         for (String line : logs) {
             if (line.startsWith(refSpecName + '=')) {
-                refSpecExpectedValue = line.split("=")[1];
+                refSpecExpectedValue = line.substring(refSpecName.length() + 1, line.length());
             }
         }
 
@@ -103,6 +103,12 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
     @Test
     @Issue("JENKINS-56063")
     public void testRefSpecWithExpandedVariables() throws Exception {
+        if (refSpecExpectedValue == null || refSpecExpectedValue.isEmpty()) {
+            /* Test does not support an empty or null expected value.
+               Skip the test if the expected value is empty or null */
+            System.out.println("*** testRefSpecWithExpandedVariables empty expected value for '" + refSpecName + "' ***");
+            return;
+        }
         // Create initial commit
         final String commitFile1 = "commitFile1";
         commit(commitFile1, johnDoe, "Commit in master branch");


### PR DESCRIPTION
## Fix array bounds exception in test run by PCT

Fixes an array out of bounds exception when the environment variable being tested is an empty string.  The test is checking that the variable is correctly expanded in the refspec but is not designed to test the case where the expanded string is empty.  Testing for an empty string expansion does not add enough value to the already existing tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update

## Further comments

It is possible to create a refspec that would work with the empty string value of the environment variable, but it is more complicated and does not add value to the scenarios evaluated by the test.

The plugin bom tests of the most recent git plugin release are failing because the plugin bom test environment has the value of the environment variable `USER` as the empty string.

See https://github.com/jenkinsci/git-plugin/pull/1013#discussion_r551355262 for more details