### PR TITLE
[JENKINS-64720] Fix docs to not reference tag checkout by git step

### DIFF
--- a/src/main/resources/jenkins/plugins/git/GitStep/help-branch.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help-branch.html
@@ -8,6 +8,6 @@
     Remote branch names like 'origin/master' and 'origin/develop' are <strong>not supported</strong> as the branch argument.
     Tag names are <strong>not supported</strong> as the branch argument.
     SHA-1 hashes are <strong>not supported</strong> as the branch argument.
-    Remote branch names and SHA-1 hashes are supported by the general purpose <code>checkout</code> step.
+    Remote branch names, tag names, and SHA-1 hashes are supported by the general purpose <code>checkout</code> step.
     </p>
 </div>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help-branch.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help-branch.html
@@ -4,8 +4,9 @@
     Default is '<code>master</code>'.
     </p>
     <p>
-    Note that this must be a local branch name like 'master' or 'develop' or a tag name.
+    Note that this must be a local branch name like 'master' or 'develop'.
     Remote branch names like 'origin/master' and 'origin/develop' are <strong>not supported</strong> as the branch argument.
+    Tag names are <strong>not supported</strong> as the branch argument.
     SHA-1 hashes are <strong>not supported</strong> as the branch argument.
     Remote branch names and SHA-1 hashes are supported by the general purpose <code>checkout</code> step.
     </p>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help.html
@@ -66,7 +66,7 @@ git 'https://github.com/jenkinsci/git-plugin'
     <strong><a id="git-step-with-https-and-branch">Example: Git step with https and a specific branch</a></strong>
     <p>
     Checkout from the Jenkins source repository using https protocol, no credentials, and a specific branch (stable-2.204).
-    Note that this must be a local branch name like 'master' or 'develop' or a tag name.
+    Note that this must be a local branch name like 'master' or 'develop'.
     </p>
     <p>
     <strong>Branch names that are not supported by the <code>git</code> step</strong>


### PR DESCRIPTION
## [JENKINS-64720](https://issues.jenkins-ci.org/browse/JENKINS-64720) - Fix docs to not reference tag checkout by git step

The documentation previously stated that tag checkout is not supported in one list but then suggested a tag name was a valid branch name elsewhere in the same help text.  In the arguments help text it suggested a tag name was a valid branch name and did not state that tag names are not supported as a branch name in the `git` Pipeline step.  Fix those two documentation mistakes.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

The git Pipeline step is a simplified shorthand for a subset of the more powerful checkout step.

The checkout step is the **preferred SCM checkout method**. It provides significantly more functionality than the git step.
