### PR TITLE
Update optional parameterized trigger plugin to 2.39

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
     <linkXRef>false</linkXRef>
-    <slf4jVersion>1.7.26</slf4jVersion>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotbugs.threshold>Medium</spotbugs.threshold>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <dependency><!-- we contribute AbstractBuildParameters for Git if it's available -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>parameterized-trigger</artifactId>
-      <version>2.36</version>
+      <version>2.39</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Update optional parameterized trigger plugin to 2.39

- Optional parameterized trigger plugin at least 2.39
- Remove unused slf4jVersion pom property

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update

## Further comments

The parmeterized trigger plugin was updated in 2.38 for compatibility with the change from acegi to spring security framework.  The change to spring security has been in weekly releases since 2.266 and will be in the March 2021 LTS release.

The [parameterized trigger plugin installation statistics](https://stats.jenkins.io/pluginversions/parameterized-trigger.html) shows that users are upgrading parameterized trigger plugin when they upgrade their Jenkins version.  39% of 2.36 installations are running at least Jenkins 2.222.4 (the minimum version supported by the git plugin) and that over 90% of 2.39 installations are running on 2.235.3 or newer.  When users upgrade Jenkins, they seem to also upgrade parameterized trigger plugin.  Users that don't upgrade Jenkins, also don't seem to upgrade parameterized trigger plugin (or the git plugin).
