### PR TITLE
Add help for deprecated submodule config generator

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitSCM/help-doGenerateSubmoduleConfigurations.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-doGenerateSubmoduleConfigurations.html
@@ -1,0 +1,8 @@
+<p>
+  Deprecated facility that was intended to test combinations of git submodule versions.
+  Will be <strong>removed</strong> in a future git plugin release.
+</p>
+<p>
+  When set to <code>true</code>, invokes <i>untested code</i> that attempts to permute submodule combinations.
+  <strong>Future behavior will ignore the user provided value</strong> and will assume <code>false</code> always.
+</p>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-submoduleCfg.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-submoduleCfg.html
@@ -1,0 +1,4 @@
+<p>
+  Deprecated facility that was intended to test combinations of git submodule versions.
+  Will be <strong>removed</strong> in a future git plugin release.
+</p>

--- a/src/main/resources/hudson/plugins/git/SubmoduleConfig/help-branches.html
+++ b/src/main/resources/hudson/plugins/git/SubmoduleConfig/help-branches.html
@@ -1,0 +1,4 @@
+<p>
+  Deprecated argument to a facility that was intended to test combinations of git submodule versions.
+  Will be <strong>removed</strong> in a future git plugin release.
+</p>

--- a/src/main/resources/hudson/plugins/git/SubmoduleConfig/help-submoduleName.html
+++ b/src/main/resources/hudson/plugins/git/SubmoduleConfig/help-submoduleName.html
@@ -1,0 +1,4 @@
+<p>
+  Deprecated argument to a facility that was intended to test combinations of git submodule versions.
+  Will be <strong>removed</strong> in a future git plugin release.
+</p>


### PR DESCRIPTION
## Announce eventual removal of submodule config generator

The `doGenerateSubmoduleConfigurations` and `submoduleCfg` arguments are not available from Freestyle projects, matrix projects, or other legacy projects.  They are available from the Pipeline Syntax Editor, the configuration as code plugin, and the JobDSL plugin.  They are intentionally undocumented and will remain undocumented except to declare that they will be removed in a future release.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Online help

## Further comments

The settings are not tested in anything other than their default values (`doGenerateSubmoduleConfigurations: false` and `submoduleCfg: []`).

Set expectations that user provided values will be ignored in a future release.
