### PR TITLE
JENKINS-60630: Add GitSCMFileSystem support for EnvVar expansion

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -254,7 +254,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
 
         @Override
         public boolean supports(SCM source) {
-            if (source instanceof GitSCM && ((GitSCM) source).getBranches().size() > 0) {
+            if (source instanceof GitSCM) {
                 for (BranchSpec branchSpec : ((GitSCM) source).getBranches()) {
                     String branch = branchSpec.getName();
 

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -218,7 +218,7 @@ public class GitSCMFileSystemTest {
         sampleRepo.git("checkout", "-b", "bug/envBranch");
         sampleRepo.write("file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
-        SCMFileSystem fs = SCMFileSystem.of(projectSpy, new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), Collections.singletonList(new BranchSpec("*/${BRANCH_SOURCE}")), false, Collections.<SubmoduleConfig>emptyList(), null, null, Collections.<GitSCMExtension>emptyList()));
+        SCMFileSystem fs = SCMFileSystem.of(projectSpy, new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), Collections.singletonList(new BranchSpec("*/${BRANCH_SOURCE}")), null, null, Collections.<GitSCMExtension>emptyList()));
         assertThat(fs, notNullValue());
         SCMFile root = fs.getRoot();
         assertThat(root, notNullValue());
@@ -252,7 +252,7 @@ public class GitSCMFileSystemTest {
         List<BranchSpec> branches = new ArrayList<BranchSpec>();
         branches.add(new BranchSpec("*/${BRANCH_SOURCE}"));
         branches.add(new BranchSpec("*/${BRANCH_TARGET}"));
-        SCMFileSystem fs = SCMFileSystem.of(projectSpy, new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), branches, false, Collections.<SubmoduleConfig>emptyList(), null, null, Collections.<GitSCMExtension>emptyList()));
+        SCMFileSystem fs = SCMFileSystem.of(projectSpy, new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), branches, null, null, Collections.<GitSCMExtension>emptyList()));
         assertThat(fs, notNullValue());
         SCMFile root = fs.getRoot();
         assertThat(root, notNullValue());
@@ -286,7 +286,7 @@ public class GitSCMFileSystemTest {
         List<BranchSpec> branches = new ArrayList<BranchSpec>();
         branches.add(new BranchSpec("*/${BRANCH_SOURCE}"));
         branches.add(new BranchSpec("*/${BRANCH_TARGET}"));
-        SCMFileSystem fs = SCMFileSystem.of(projectSpy, new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), branches, false, Collections.<SubmoduleConfig>emptyList(), null, null, Collections.<GitSCMExtension>emptyList()));
+        SCMFileSystem fs = SCMFileSystem.of(projectSpy, new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), branches, null, null, Collections.<GitSCMExtension>emptyList()));
         assertThat(fs, notNullValue());
         SCMFile root = fs.getRoot();
         assertThat(root, notNullValue());
@@ -321,7 +321,7 @@ public class GitSCMFileSystemTest {
         List<BranchSpec> branches = new ArrayList<BranchSpec>();
         branches.add(new BranchSpec("*/${BRANCH_SOURCE}"));
         branches.add(new BranchSpec("*/${BRANCH_TARGET}"));
-        SCMFileSystem fs = SCMFileSystem.of(projectSpy, new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), branches, false, Collections.<SubmoduleConfig>emptyList(), null, null, Collections.<GitSCMExtension>emptyList()));
+        SCMFileSystem fs = SCMFileSystem.of(projectSpy, new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), branches, null, null, Collections.<GitSCMExtension>emptyList()));
         assertThat(fs, notNullValue());
         SCMFile root = fs.getRoot();
         assertThat(root, notNullValue());
@@ -341,7 +341,7 @@ public class GitSCMFileSystemTest {
         sampleRepo.git("checkout", "-b", "dev");
         sampleRepo.write("file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
-        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(), new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), Collections.singletonList(new BranchSpec("refs/heads/dev")), false, Collections.<SubmoduleConfig>emptyList(), null, null, Collections.<GitSCMExtension>emptyList()));
+        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(), new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), Collections.singletonList(new BranchSpec("refs/heads/dev")), null, null, Collections.<GitSCMExtension>emptyList()));
         assertThat(fs, notNullValue());
         SCMFile root = fs.getRoot();
         assertThat(root, notNullValue());

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -335,6 +335,26 @@ public class GitSCMFileSystemTest {
         assertThat(file.contentAsString(), is("modified"));
     }
 
+    @Test
+    public void branchSpecRefHeads() throws Exception {
+        sampleRepo.init();
+        sampleRepo.git("checkout", "-b", "dev");
+        sampleRepo.write("file", "modified");
+        sampleRepo.git("commit", "--all", "--message=dev");
+        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(), new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), Collections.singletonList(new BranchSpec("refs/heads/dev")), false, Collections.<SubmoduleConfig>emptyList(), null, null, Collections.<GitSCMExtension>emptyList()));
+        assertThat(fs, notNullValue());
+        SCMFile root = fs.getRoot();
+        assertThat(root, notNullValue());
+        assertTrue(root.isRoot());
+        Iterable<SCMFile> children = root.children();
+        Iterator<SCMFile> iterator = children.iterator();
+        assertThat(iterator.hasNext(), is(true));
+        SCMFile file = iterator.next();
+        assertThat(iterator.hasNext(), is(false));
+        assertThat(file.getName(), is("file"));
+        assertThat(file.contentAsString(), is("modified"));
+    }
+
     @Issue("JENKINS-57587")
     @Test
     public void wildcardBranchNameCausesNPE() throws Exception {


### PR DESCRIPTION
## [JENKINS-60630](https://issues.jenkins-ci.org/browse/JENKINS-60630) - Perform EnvVars expansion on GitSCMFileSystem BranchSpecs

Updates the GitSCMFileSystem class to support expanding environment variables on provided BranchSpecs.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [ ] Dependency or infrastructure update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

One concern that I have is the approach for retrieving Environment Variables for the running job.  I referenced the `lastBuild` when `isBuilding()` is true.  This will create a race condition during concurrent builds (depending on how the SCM API is used) where all running builds will only use the environment variables for the last one initiated. I've confirmed this on my local Jenkins server.

The only way I see to resolve this is to update the SCM API's [SCMFileSystem.Builder.build](https://github.com/jenkinsci/scm-api-plugin/blob/ac51da4da045c810703d4d4aaa51185e89db4267/src/main/java/jenkins/scm/api/SCMFileSystem.java#L502) api to allow for a new override:

```
public abstract SCMFileSystem build(@NonNull Run<?,?> run, @NonNull SCM scm, @CheckForNull SCMRevision rev)
                throws IOException, InterruptedException;
```

This would allow anyone to reference the exact build that's being executed and easily infer the Item needed as well.  In addition, the existing method can use the lastBuild as a `best effort`.

Before diving into dependent libraries, I wanted to get another eye on this.  As is, this works great aside from the potential issue of concurrent jobs.