### PR TITLE
Provide online help for submodule threads arg

### DIFF
--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/help-threads.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/help-threads.html
@@ -1,0 +1,4 @@
+<div>
+  Specify the number of threads that will be used to update submodules.<br/>
+  If unspecified, the command line git default thread count is used.<br/>
+</div>


### PR DESCRIPTION
## Provide online help for submodule threads option

The online help was missing for the submodule threads option.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes

## Types of changes

- [x] Documentation
