### PR TITLE
[JENKINS-62052] Remove submodule configurator to improve pipeline snippets

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1007,6 +1007,51 @@ Unique name for this SCM.
 Was needed when using Git within the Multi SCM plugin.
 Pipeline is the robust and feature-rich way to checkout from multiple repositories in a single job.
 
+[#submodule-combinator---removed]
+==== Submodule Combinator - *Removed*
+
+An experiment was created many years ago that attempted to create combinations of submodules within the Jenkins job.
+The experiment was never available to Freestyle projects or other legacy projects like multi-configuration projects.
+It was visible in Pipeline, configuration as code, and JobDSL.
+
+The implementation of the experiment has been removed.
+Dependabot and other configuration tools are better suited to evaluate submodule combinations.
+
+There are no known uses of the submodule combinator and no open Jira issues reported against the submodule combinator.
+Those who were using submodule combinator should remain with git plugin versions prior to 4.6.0.
+
+The submodule combinator ignores any user provided value of the following arguments to git's `checkout scm`:
+
+doGenerateSubmoduleConfigurations::
+
+  A boolean that is now always set to `false`.
+  Submodule configurations are no longer evaluated by the git plugin.
+
+submoduleCfg::
+
+  A list of submodule names and branches that is now always empty.
+  Submodule configurations are no longer evaluated by the git plugin.
+
+Previous Pipeline syntax looked like this:
+
+```groovy
+checkout([$class: 'GitSCM',
+          branches: [[name: 'master']],
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [],
+          submoduleCfg: [],
+          userRemoteConfigs: [[url: 'https://github.com/jenkinsci/git-plugin']]])
+```
+
+Current Pipeline Syntax looks like this:
+
+```groovy
+checkout([$class: 'GitSCM',
+          branches: [[name: 'master']],
+          extensions: [],
+          userRemoteConfigs: [[url: 'https://github.com/jenkinsci/git-plugin']]])
+```
+
 [#environment-variables]
 == Environment Variables
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <inceptionYear>2007</inceptionYear>
 
   <properties>
-    <revision>4.5.3</revision>
+    <revision>4.6.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/hudson/plugins/git/SubmoduleCombinator.java
+++ b/src/main/java/hudson/plugins/git/SubmoduleCombinator.java
@@ -1,28 +1,38 @@
 package hudson.plugins.git;
 
 import hudson.model.TaskListener;
-import hudson.plugins.git.util.GitUtils;
-import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.gitclient.GitClient;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
- * A common use case for git submodules is to have child submodules, and a parent 'configuration' project that ties the
- * correct versions together. It is useful to be able to speculatively compile all combinations of submodules, so that
- * you can _know_ if a particular combination is no longer compatible.
+ * Deprecated as inaccessible in git plugin 4.6.0.  Class retained for
+ * binary compatibility.
  * 
  * @author nigelmagnay
+ * @deprecated
  */
+@Deprecated
 public class SubmoduleCombinator {
+    @SuppressFBWarnings(value="URF_UNREAD_FIELD", justification="Deprecated, retained for compatibility")
     GitClient git;
+    @SuppressFBWarnings(value="URF_UNREAD_FIELD", justification="Deprecated, retained for compatibility")
     TaskListener listener;
 
+    @SuppressFBWarnings(value="URF_UNREAD_FIELD", justification="Deprecated, retained for compatibility")
     long         tid = new Date().getTime();
+    @SuppressFBWarnings(value="URF_UNREAD_FIELD", justification="Deprecated, retained for compatibility")
     long         idx = 1;
   
+    @SuppressFBWarnings(value="URF_UNREAD_FIELD", justification="Deprecated, retained for compatibility")
     Collection<SubmoduleConfig> submoduleConfig;
   
     public SubmoduleCombinator(GitClient git, TaskListener listener, Collection<SubmoduleConfig> cfg) {
@@ -32,193 +42,21 @@ public class SubmoduleCombinator {
     }
 
     public void createSubmoduleCombinations() throws GitException, IOException, InterruptedException {
-        Map<IndexEntry, Collection<Revision>> moduleBranches = new HashMap<>();
-
-        for (IndexEntry submodule : git.getSubmodules("HEAD")) {
-            GitClient subGit = git.subGit(submodule.getFile());
-
-            GitUtils gu = new GitUtils(listener, subGit);
-            Collection<Revision> items = gu.filterTipBranches(gu.getAllBranchRevisions());
-      
-            filterRevisions(submodule.getFile(), items);
-      
-            moduleBranches.put(submodule, items);
-        }
-
-        // Remove any uninteresting branches
-
-
-
-        for (Entry<IndexEntry, Collection<Revision>> submodule : moduleBranches
-                .entrySet()) {
-            listener.getLogger().print(
-                    "Submodule " + submodule.getKey().getFile() + " branches");
-            for (Revision br : submodule.getValue())
-                listener.getLogger().print(" " + br.toString());
-            listener.getLogger().print('\n');
-        }
-
-        // Make all the possible combinations
-        List<Map<IndexEntry, Revision>> combinations = createCombinations(moduleBranches);
-
-        listener.getLogger().println("There are " + combinations.size() + " submodule/revision combinations possible");
-
-        // Create a map which is SHA1 -> Submodule IDs that were present
-        Map<ObjectId, List<IndexEntry>> entriesMap = new HashMap<>();
-        // Knock out already-defined configurations
-        for (ObjectId sha1 : git.revListAll()) {
-            // What's the submodule configuration
-            List<IndexEntry> entries = git.getSubmodules(sha1.name());
-            entriesMap.put(sha1, entries);
-
-        }
-
-        for (List<IndexEntry> entries : entriesMap.values()) {
-            for (Iterator<Map<IndexEntry, Revision>> it = combinations.iterator(); it.hasNext();) {
-                Map<IndexEntry, Revision> item = it.next();
-                if (matches(item, entries)) {
-                    it.remove();
-                    break;
-                }
-
-            }
-        }
-    
-        listener.getLogger().println("There are " + combinations.size() + " configurations that could be generated.");
-  
-        ObjectId headSha1 = git.revParse("HEAD");
-
-    
-        // Make up the combinations
-    
-        for (Map<IndexEntry, Revision> combination : combinations) {
-            // By default, use the head sha1
-            ObjectId sha1 = headSha1;
-            int min = Integer.MAX_VALUE;
-
-            // But let's see if we can find the most appropriate place to create the branch
-            for (Entry<ObjectId, List<IndexEntry>> entry : entriesMap
-                    .entrySet()) {
-                int value = difference(combination, entry.getValue());
-                if (value > 0 && value < min) {
-                    min = value;
-                    sha1 = entry.getKey();
-                }
-
-                if (min == 1) break; // look no further
-            }
-      
-            git.checkout().ref(sha1.name()).execute();
-            makeCombination(combination);
-        }
-    
-    }
-
-    private Collection<Revision> filterRevisions(String name, Collection<Revision> items) {
-        SubmoduleConfig config = getSubmoduleConfig(name);
-        if (config == null) return items;
-
-        for (Iterator<Revision> it = items.iterator(); it.hasNext();) {
-            Revision r = it.next();
-            if (!config.revisionMatchesInterest(r)) it.remove();
-        }
-
-        return items;
-    }
-
-    private SubmoduleConfig getSubmoduleConfig(String name) {
-        for (SubmoduleConfig config : this.submoduleConfig) {
-            if (config.getSubmoduleName().equals(name)) return config;
-        }
-        return null;
     }
 
     protected void makeCombination(Map<IndexEntry, Revision> settings) throws InterruptedException {
-        // Assume we are checked out
-        String name = "combine-" + tid + "-" + (idx++); 
-        git.branch(name);
-        git.checkout().ref(name).execute();
-
-        StringBuilder commit = new StringBuilder(
-                "Jenkins generated combination of:\n");
-
-        for (Entry<IndexEntry, Revision> setting : settings.entrySet()) {
-            commit.append(' ').append(' ');
-            commit.append(setting.getKey().getFile());
-            commit.append(' ');
-            commit.append(setting.getValue());
-            commit.append('\n');
-        }
-
-        listener.getLogger().print(commit);
-
-        for (Entry<IndexEntry, Revision> setting : settings.entrySet()) {
-            IndexEntry submodule = setting.getKey();
-            Revision branch = setting.getValue();
-            GitClient subGit = git.subGit(submodule.getFile());
-            subGit.checkout().ref(branch.getSha1().name()).execute();
-            git.add(submodule.getFile());
-        }
-    
-        git.commit(commit.toString());
     }
 
     public int difference(Map<IndexEntry, Revision> item, List<IndexEntry> entries) {
-        int difference = 0;
-        if (entries.size() != item.keySet().size()) return -1;
-
-        for (IndexEntry entry : entries) {
-            Revision b = null;
-            for (Map.Entry<IndexEntry, Revision> entryAndRevision : item.entrySet()) {
-                IndexEntry e = entryAndRevision.getKey();
-                if (e.getFile().equals(entry.getFile())) b = entryAndRevision.getValue();
-            }
-
-            if (b == null) return -1;
-
-            if (!entry.getObject().equals(b.getSha1().getName())) difference++;
-
-        }
-        return difference;
+        return 0;
     }
 
     protected boolean matches(Map<IndexEntry, Revision> item, List<IndexEntry> entries) {
-        return (difference(item, entries) == 0);
+        return false;
     }
 
     public List<Map<IndexEntry, Revision>> createCombinations(Map<IndexEntry, Collection<Revision>> moduleBranches) {
-    
-        if (moduleBranches.keySet().isEmpty()) return new ArrayList<>();
-
-        // Get an entry:
-        List<Map<IndexEntry, Revision>> thisLevel = new ArrayList<>();
-
-        IndexEntry e = moduleBranches.keySet().iterator().next();
-
-        for (Revision b : moduleBranches.remove(e)) {
-            Map<IndexEntry, Revision> result = new HashMap<>();
-
-            result.put(e, b);
-            thisLevel.add(result);
-        }
-
-        List<Map<IndexEntry, Revision>> children = createCombinations(moduleBranches);
-        if (children.isEmpty()) return thisLevel;
-    
-        // Merge the two together
         List<Map<IndexEntry, Revision>> result = new ArrayList<>();
-
-        for (Map<IndexEntry, Revision> thisLevelEntry : thisLevel) {
-      
-            for (Map<IndexEntry, Revision> childLevelEntry : children) {
-                HashMap<IndexEntry, Revision> r = new HashMap<>();
-                r.putAll(thisLevelEntry);
-                r.putAll(childLevelEntry);
-                result.add(r);
-            }
-      
-        }
-
         return result;
     }
 }

--- a/src/main/java/hudson/plugins/git/SubmoduleConfig.java
+++ b/src/main/java/hudson/plugins/git/SubmoduleConfig.java
@@ -11,25 +11,29 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.regex.Pattern;
 
+/**
+ * Deprecated data class used in a submodule configuration experiment.
+ * Deprecated as inaccessible in git plugin 4.6.0.  Class retained for
+ * binary compatibility.
+ *
+ * @deprecated
+ */
+@Deprecated
 public class SubmoduleConfig implements java.io.Serializable {
     private static final long serialVersionUID = 1L;
-    String   submoduleName;
-    String[] branches;
+    private static final String[] EMPTY_ARRAY = new String[0];
+    String   submoduleName = null;
+    String[] branches = EMPTY_ARRAY;
 
     public SubmoduleConfig() {
         this(null, Collections.emptySet());
     }
 
     public SubmoduleConfig(String submoduleName, String[] branches) {
-        this(submoduleName, branches != null ? Arrays.asList(branches) : Collections.emptySet());
     }
 
     @DataBoundConstructor
     public SubmoduleConfig(String submoduleName, Collection<String> branches) {
-        this.submoduleName = submoduleName;
-        if (CollectionUtils.isNotEmpty(branches)) {
-            this.branches = branches.toArray(new String[0]);
-        }
     }
 
     @Whitelisted
@@ -38,44 +42,24 @@ public class SubmoduleConfig implements java.io.Serializable {
     }
 
     public void setSubmoduleName(String submoduleName) {
-        this.submoduleName = submoduleName;
     }
 
     public String[] getBranches() {
-        /* findbugs correctly complains that returning branches exposes the
-         * internal representation of the class to callers.  Returning a copy
-         * of the array does not expose internal representation, at the possible
-         * expense of some additional memory.
-         */
-        return Arrays.copyOf(branches, branches.length);
+        return EMPTY_ARRAY;
     }
 
     public void setBranches(String[] branches) {
-        /* findbugs correctly complains that assign to branches exposes the
-         * internal representation of the class to callers.  Assigning a copy
-         * of the array does not expose internal representation, at the possible
-         * expense of some additional memory.
-         */
-        this.branches = Arrays.copyOf(branches, branches.length);
     }
 
     public boolean revisionMatchesInterest(Revision r) {
-        for (Branch br : r.getBranches()) {
-            if (branchMatchesInterest(br)) return true;
-        }
         return false;
     }
 
     public boolean branchMatchesInterest(Branch br) {
-        for (String regex : branches) {
-            if (!Pattern.matches(regex, br.getName())) {
-                return false;
-            }
-        }
-        return true;
+        return false;
     }
 
     public String getBranchesString() {
-        return Joiner.on(',').join(branches);
+        return "";
     }
 }

--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -165,22 +165,6 @@ public class SubmoduleOption extends GitSCMExtension {
             // logic to kick in properly.
             throw new IOException("Could not perform submodule update", e);
         }
-
-        if (scm.isDoGenerateSubmoduleConfigurations()) {
-            /*
-                Kohsuke Note:
-
-                I could be wrong, but this feels like a totally wrong place to do this.
-                AFAICT, SubmoduleCombinator runs a lot of git-checkout and git-commit to
-                create new commits and branches. At the end of this, the working tree is
-                significantly altered, and HEAD no longer points to 'revToBuild'.
-
-                Custom BuildChooser is probably the right place to do this kind of stuff,
-                or maybe we can add a separate callback for GitSCMExtension.
-             */
-            SubmoduleCombinator combinator = new SubmoduleCombinator(git, listener, scm.getSubmoduleCfg());
-            combinator.createSubmoduleCombinations();
-        }
     }
 
     @Override

--- a/src/main/java/jenkins/plugins/git/GitSCMBuilder.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMBuilder.java
@@ -522,7 +522,6 @@ public class GitSCMBuilder<B extends GitSCMBuilder<B>> extends SCMBuilder<B, Git
         return new GitSCM(
                 asRemoteConfigs(),
                 Collections.singletonList(new BranchSpec(head().getName())),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 browser(), gitTool(),
                 extensions);
     }

--- a/src/main/java/jenkins/plugins/git/GitStep.java
+++ b/src/main/java/jenkins/plugins/git/GitStep.java
@@ -84,7 +84,7 @@ public final class GitStep extends SCMStep {
 
     @Override
     public SCM createSCM() {
-        return new GitSCM(GitSCM.createRepoList(url, credentialsId), Collections.singletonList(new BranchSpec("*/" + branch)), false, Collections.<SubmoduleConfig>emptyList(), null, null, Collections.<GitSCMExtension>singletonList(new LocalBranch(branch)));
+        return new GitSCM(GitSCM.createRepoList(url, credentialsId), Collections.singletonList(new BranchSpec("*/" + branch)), null, null, Collections.<GitSCMExtension>singletonList(new LocalBranch(branch)));
     }
 
     @Extension

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-doGenerateSubmoduleConfigurations.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-doGenerateSubmoduleConfigurations.html
@@ -1,8 +1,5 @@
 <p>
-  Deprecated facility that was intended to test combinations of git submodule versions.
-  Will be <strong>removed</strong> in a future git plugin release.
-</p>
-<p>
-  When set to <code>true</code>, invokes <em>untested code</em> that attempts to permute submodule combinations.
-  <strong>Future behavior will ignore the user provided value</strong> and will assume <code>false</code> always.
+  Removed facility that was intended to test combinations of git submodule versions.
+  Removed in git plugin 4.6.0.
+  Ignores the user provided value and always uses <code>false</code> as its value.
 </p>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-submoduleCfg.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-submoduleCfg.html
@@ -1,4 +1,5 @@
 <p>
-  Deprecated facility that was intended to test combinations of git submodule versions.
-  Will be <strong>removed</strong> in a future git plugin release.
+  Removed facility that was intended to test combinations of git submodule versions.
+  Removed in git plugin 4.6.0.
+  Ignores the user provided value(s) and always uses empty values.
 </p>

--- a/src/main/resources/hudson/plugins/git/SubmoduleConfig/help-branches.html
+++ b/src/main/resources/hudson/plugins/git/SubmoduleConfig/help-branches.html
@@ -1,4 +1,3 @@
 <p>
-  Deprecated argument to a facility that was intended to test combinations of git submodule versions.
-  Will be <strong>removed</strong> in a future git plugin release.
+  <strong>Removed</strong> in git plugin 4.6.0.
 </p>

--- a/src/main/resources/hudson/plugins/git/SubmoduleConfig/help-submoduleName.html
+++ b/src/main/resources/hudson/plugins/git/SubmoduleConfig/help-submoduleName.html
@@ -1,4 +1,3 @@
 <p>
-  Deprecated argument to a facility that was intended to test combinations of git submodule versions.
-  Will be <strong>removed</strong> in a future git plugin release.
+  <strong>Removed</strong> in git plugin 4.6.0.
 </p>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/config.groovy
@@ -30,33 +30,3 @@ f.optionalBlock(title:_("Shallow clone"), field:"shallow", inline: true) {
         f.number(clazz:"number", min:1, step:1)
     }
 }
-
-/*
-  This needs more thought
-
-  <f:entry>
-    <f:checkbox title="Autogenerate submodule configurations" name="git.generate" checked="${scm.doGenerate}"/>
-    <label class="attach-previous">Generate submodule configurations</label>
-
-    <f:repeatable var="smcfg" name="smcfg" varStatus="cfgStatus" items="${scm.submoduleCfg}" noAddButton="false">
-           <table width="100%">
-           <f:entry title="Name of submodule">
-             <f:textbox name="git.submodule.name" value="${smcfg.submoduleName}" />
-           </f:entry>
-
-           <f:entry title="Matching Branches">
-            <f:textbox name="git.submodule.match" value="${smcfg.branchesString}" />
-           </f:entry>
-
-
-           <f:entry>
-            <div align="right">
-                <input type="button" value="Delete" class="repeatable-delete" style="margin-left: 1em;" />
-            </div>
-          </f:entry>
-          </table>
-
-        </f:repeatable>
-
-  </f:entry>
-*/

--- a/src/test/java/hudson/plugins/git/AbstractGitProject.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitProject.java
@@ -72,8 +72,8 @@ public class AbstractGitProject extends AbstractGitRepository {
 
     protected FreeStyleProject setupProject(List<BranchSpec> branches, boolean authorOrCommitter) throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
-        GitSCM scm = new GitSCM(remoteConfigs(), branches, false,
-                Collections.<SubmoduleConfig>emptyList(), null, null,
+        GitSCM scm = new GitSCM(remoteConfigs(), branches,
+                null, null,
                 Collections.<GitSCMExtension>singletonList(new DisableRemotePoll()));
         project.setScm(scm);
         project.getBuildersList().add(new CaptureEnvironmentBuilder());
@@ -145,7 +145,6 @@ public class AbstractGitProject extends AbstractGitRepository {
         GitSCM scm = new GitSCM(
                 remoteConfigs(),
                 branches,
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         scm.getExtensions().add(new DisableRemotePoll()); // don't work on a file:// repository
@@ -183,7 +182,6 @@ public class AbstractGitProject extends AbstractGitRepository {
         GitSCM scm = new GitSCM(
                 repos,
                 branchSpecs,
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, JGitTool.MAGIC_EXENAME,
                 Collections.<GitSCMExtension>emptyList());
         if (disableRemotePoll) {

--- a/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
@@ -187,7 +187,6 @@ public abstract class AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(credential),
                 branches,
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         if (credential != null) {
@@ -224,7 +223,6 @@ public abstract class AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                     repos,
                     branchSpecs,
-                    false, Collections.<SubmoduleConfig>emptyList(),
                     null, JGitTool.MAGIC_EXENAME,
                     Collections.<GitSCMExtension>emptyList());
         if(disableRemotePoll) scm.getExtensions().add(new DisableRemotePoll());

--- a/src/test/java/hudson/plugins/git/GitPublisherTest.java
+++ b/src/test/java/hudson/plugins/git/GitPublisherTest.java
@@ -148,7 +148,6 @@ public class GitPublisherTest extends AbstractGitProject {
         GitSCM scm = new GitSCM(
                 remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
@@ -198,7 +197,6 @@ public class GitPublisherTest extends AbstractGitProject {
         mp.setAxes(new AxisList(new Axis("VAR","a","b")));
         mp.setScm(new GitSCM(repoList,
                 Collections.singletonList(new BranchSpec("")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, tool.getName(), Collections.<GitSCMExtension>emptyList()));
         mp.getPublishersList().add(new GitPublisher(
                 Collections.singletonList(new TagToPush("origin","foo","message",true, false)),
@@ -242,7 +240,6 @@ public class GitPublisherTest extends AbstractGitProject {
         GitSCM scm = new GitSCM(
                 remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
@@ -279,7 +276,6 @@ public class GitPublisherTest extends AbstractGitProject {
         GitSCM scm = new GitSCM(
                 remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, MergeCommand.GitPluginFastForwardMode.FF)));
@@ -364,7 +360,6 @@ public class GitPublisherTest extends AbstractGitProject {
         GitSCM scm = new GitSCM(
                 remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, MergeCommand.GitPluginFastForwardMode.NO_FF)));
@@ -453,7 +448,6 @@ public class GitPublisherTest extends AbstractGitProject {
         GitSCM scm = new GitSCM(
                 remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, MergeCommand.GitPluginFastForwardMode.FF_ONLY)));
@@ -549,7 +543,6 @@ public class GitPublisherTest extends AbstractGitProject {
         GitSCM scm = new GitSCM(
                 remoteRepositories,
                 Collections.singletonList(new BranchSpec("origin/master")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(scm);
@@ -589,7 +582,6 @@ public class GitPublisherTest extends AbstractGitProject {
         GitSCM scm = new GitSCM(
                 remoteConfigs(),
                 Collections.singletonList(new BranchSpec("master")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(scm);
@@ -684,7 +676,6 @@ public class GitPublisherTest extends AbstractGitProject {
         GitSCM scm = new GitSCM(
                 remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null, new ArrayList<>());
         scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
         scm.getExtensions().add(new LocalBranch("integration"));
@@ -719,7 +710,6 @@ public class GitPublisherTest extends AbstractGitProject {
         GitSCM scm = new GitSCM(
                 remoteConfigs(),
                 Collections.singletonList(new BranchSpec("master")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(scm);
@@ -803,7 +793,6 @@ public class GitPublisherTest extends AbstractGitProject {
         GitSCM scm = new GitSCM(
                 remoteConfigs(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null, scmExtensions);
         project.setScm(scm);
 

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1823,7 +1823,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         project.setScm(new GitSCM(
                 ((GitSCM)project.getScm()).getUserRemoteConfigs(),
                 Collections.singletonList(new BranchSpec("master")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 // configure GitSCM with the DisableRemotePoll extension to ensure that polling use the workspace
                 Collections.singletonList(new DisableRemotePoll())));
@@ -1859,7 +1858,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         project.setScm(new GitSCM(
                 remotes,
                 Collections.singletonList(new BranchSpec("master")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList()));
 
@@ -1900,7 +1898,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         project.setScm(new GitSCM(
                 remotes,
                 Collections.singletonList(new BranchSpec(branchName)),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList()));
 
@@ -1931,7 +1928,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitSCM gitSCM = new GitSCM(
                 remotes,
                 Collections.singletonList(new BranchSpec("origin/master")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(gitSCM);
@@ -1976,7 +1972,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", "default", MergeCommand.GitPluginFastForwardMode.FF)));
@@ -2017,7 +2012,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", "default", MergeCommand.GitPluginFastForwardMode.FF)));
@@ -2053,7 +2047,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
@@ -2093,7 +2086,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(scm);
@@ -2132,7 +2124,6 @@ public class GitSCMTest extends AbstractGitTestCase {
     	GitSCM scm = new GitSCM(
     			createRemoteRepositories(),
     			Collections.singletonList(new BranchSpec("master")),
-    			false, Collections.<SubmoduleConfig>emptyList(),
     			null, null,
     			Collections.<GitSCMExtension>emptyList());
     	project.setScm(scm);
@@ -2165,7 +2156,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
@@ -2207,7 +2197,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
                 Collections.singletonList(new BranchSpec("*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
@@ -2287,7 +2276,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitRepositoryBrowser browser = new GithubWeb(url);
         GitSCM scm = new GitSCM(createRepoList(url),
                                 Collections.singletonList(new BranchSpec("")),
-                                false, Collections.<SubmoduleConfig>emptyList(),
                                 browser, null, null);
         p.setScm(scm);
         rule.configRoundtrip(p);
@@ -2306,7 +2294,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitRepositoryBrowser browser = new GithubWeb(url);
         GitSCM scm = new GitSCM(createRepoList(url),
                 Collections.singletonList(new BranchSpec("*/master")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 browser, null, null);
         p.setScm(scm);
 
@@ -2647,7 +2634,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
                 Collections.singletonList(new BranchSpec("${MY_BRANCH}")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(scm);
@@ -2669,7 +2655,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
                 Collections.singletonList(new BranchSpec("**")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 extensions);
         project.setScm(scm);
@@ -2711,7 +2696,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
                 Collections.singletonList(new BranchSpec("${MY_BRANCH}")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(scm);
@@ -2809,7 +2793,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
                 Collections.singletonList(new BranchSpec("${MY_BRANCH}")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(scm);

--- a/src/test/java/hudson/plugins/git/GitSCMUnitTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMUnitTest.java
@@ -56,18 +56,21 @@ public class GitSCMUnitTest {
     }
 
     @Test
+    @Deprecated
     public void testGetSubmoduleCfg() {
         Collection<SubmoduleConfig> emptySubmoduleConfigList = new ArrayList<>();
         assertThat(gitSCM.getSubmoduleCfg(), is(emptySubmoduleConfigList));
     }
 
     @Test
+    @Deprecated
     public void testSetSubmoduleCfg() {
+        Collection<SubmoduleConfig> emptySubmoduleConfigList = new ArrayList<>();
         Collection<SubmoduleConfig> submoduleConfigList = new ArrayList<>();
         SubmoduleConfig config = new SubmoduleConfig();
         submoduleConfigList.add(config);
         gitSCM.setSubmoduleCfg(submoduleConfigList);
-        assertThat(gitSCM.getSubmoduleCfg(), is(submoduleConfigList));
+        assertThat(gitSCM.getSubmoduleCfg(), is(emptySubmoduleConfigList));
     }
 
     @Test
@@ -219,7 +222,6 @@ public class GitSCMUnitTest {
         /* Force single-branch use case */
         GitSCM bigGitSCM = new GitSCM(createRepoList(repoURL, null),
                 Collections.singletonList(new BranchSpec("master")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null, Collections.<GitSCMExtension>emptyList());
         assertFalse(bigGitSCM.requiresWorkspaceForPolling());
     }
@@ -229,7 +231,6 @@ public class GitSCMUnitTest {
         /* Force single-branch use case */
         GitSCM bigGitSCM = new GitSCM(createRepoList(repoURL, null),
                 Collections.singletonList(new BranchSpec("origin/master")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null, Collections.<GitSCMExtension>emptyList());
         assertFalse(bigGitSCM.requiresWorkspaceForPolling());
     }
@@ -239,7 +240,6 @@ public class GitSCMUnitTest {
         /* Force single-branch use case */
         GitSCM bigGitSCM = new GitSCM(createRepoList(repoURL, null),
                 Collections.singletonList(new BranchSpec("*/master")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null, Collections.<GitSCMExtension>emptyList());
         assertFalse(bigGitSCM.requiresWorkspaceForPolling());
     }
@@ -249,7 +249,6 @@ public class GitSCMUnitTest {
         /* Force single-branch use case */
         GitSCM bigGitSCM = new GitSCM(createRepoList(repoURL, null),
                 Collections.singletonList(new BranchSpec("master*")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null, Collections.<GitSCMExtension>emptyList());
         assertTrue(bigGitSCM.requiresWorkspaceForPolling());
     }
@@ -262,7 +261,6 @@ public class GitSCMUnitTest {
         branches.add(new BranchSpec("origin/master"));
         GitSCM bigGitSCM = new GitSCM(createRepoList(repoURL, null),
                 branches,
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null, Collections.<GitSCMExtension>emptyList());
         assertTrue(bigGitSCM.requiresWorkspaceForPolling());
     }
@@ -274,7 +272,6 @@ public class GitSCMUnitTest {
         env.put("A", "");
         GitSCM bigGitSCM = new GitSCM(createRepoList(repoURL, null),
                 Collections.singletonList(new BranchSpec("${A}")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null, Collections.<GitSCMExtension>emptyList());
         assertFalse(bigGitSCM.requiresWorkspaceForPolling(env));
     }
@@ -285,17 +282,18 @@ public class GitSCMUnitTest {
     }
 
     @Test
+    @Deprecated
     public void testIsDoGenerateSubmoduleConfigurations() {
         assertFalse(gitSCM.isDoGenerateSubmoduleConfigurations());
     }
 
     @Test
+    @Deprecated
     public void testIsDoGenerateSubmoduleConfigurationsTrue() {
         GitSCM bigGitSCM = new GitSCM(createRepoList(repoURL, null),
                 Collections.singletonList(new BranchSpec("master")),
-                true, Collections.<SubmoduleConfig>emptyList(),
                 null, null, Collections.<GitSCMExtension>emptyList());
-        assertTrue(bigGitSCM.isDoGenerateSubmoduleConfigurations());
+        assertFalse(bigGitSCM.isDoGenerateSubmoduleConfigurations());
     }
 
     @Test
@@ -325,5 +323,19 @@ public class GitSCMUnitTest {
         PreBuildMergeOptions mergeOptions = gitSCM.getMergeOptions();
         assertThat(mergeOptions.getRemoteBranchName(), is(expectedMergeOptions.getRemoteBranchName()));
         assertThat(mergeOptions.getMergeTarget(), is(expectedMergeOptions.getMergeTarget()));
+    }
+
+    @Test
+    @Deprecated
+    public void testGetDoGenerateSubmoduleConfigurations() {
+        assertFalse(gitSCM.getDoGenerateSubmoduleConfigurations());
+    }
+
+    @Test
+    @Deprecated
+    public void testSetDoGenerateSubmoduleConfigurations() {
+        gitSCM.setDoGenerateSubmoduleConfigurations(true);
+        /* Confirms the passed value `true` is ignored */
+        assertFalse(gitSCM.getDoGenerateSubmoduleConfigurations());
     }
 }

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -406,7 +406,6 @@ public class GitStatusTest extends AbstractGitProject {
         GitSCM git = new GitSCM(
                 Collections.singletonList(new UserRemoteConfig(url, null, null, null)),
                 Collections.singletonList(new BranchSpec(branchString)),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(git);
@@ -460,7 +459,6 @@ public class GitStatusTest extends AbstractGitProject {
         GitSCM git = new GitSCM(
                 Collections.singletonList(new UserRemoteConfig(repoURL, null, null, null)),
                 Collections.singletonList(new BranchSpec(branch)),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>emptyList());
         project.setScm(git);

--- a/src/test/java/hudson/plugins/git/GitTagActionTest.java
+++ b/src/test/java/hudson/plugins/git/GitTagActionTest.java
@@ -121,7 +121,6 @@ public class GitTagActionTest {
         GitSCM scm = new GitSCM(
                 remotes,
                 Collections.singletonList(new BranchSpec("origin/master")),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null,
                 chooseGitImplementation(), // Both git implementations should work, choose randomly
                 Collections.<GitSCMExtension>emptyList());

--- a/src/test/java/hudson/plugins/git/SubmoduleCombinatorTest.java
+++ b/src/test/java/hudson/plugins/git/SubmoduleCombinatorTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
 
+@Deprecated
 public class SubmoduleCombinatorTest {
 
     private SubmoduleCombinator combinator = null;
@@ -44,7 +45,8 @@ public class SubmoduleCombinatorTest {
         Map<IndexEntry, Revision> item = new HashMap<>();
         List<IndexEntry> entries = new ArrayList<>();
         assertTrue(entries.add(new IndexEntry("mode", "type", "object", "file")));
-        assertEquals(-1, combinator.difference(item, entries));
+        /* Deprecated - no differences even when differences exist */
+        assertEquals(0, combinator.difference(item, entries));
     }
 
     @Test
@@ -71,6 +73,7 @@ public class SubmoduleCombinatorTest {
         Revision revision = new Revision(sha2);
         IndexEntry indexEntry2 = new IndexEntry("mode-2", "type-2", sha2.getName(), fileName);
         assertNull("items[indexEntry2] had existing value", items.put(indexEntry2, revision));
-        assertEquals("entries and items[entries] wrong diff count", 1, combinator.difference(items, entries));
+        /* Deprecated - no differences even when differences exist */
+        assertEquals("entries and items[entries] wrong diff count", 0, combinator.difference(items, entries));
     }
 }

--- a/src/test/java/hudson/plugins/git/SubmoduleConfigTest.java
+++ b/src/test/java/hudson/plugins/git/SubmoduleConfigTest.java
@@ -32,8 +32,8 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
+@Deprecated
 public class SubmoduleConfigTest {
 
     private SubmoduleConfig config = new SubmoduleConfig();
@@ -89,15 +89,15 @@ public class SubmoduleConfigTest {
     public void testSetSubmoduleName() {
         String name = "name-of-submodule";
         config.setSubmoduleName(name);
-        assertThat(config.getSubmoduleName(), is(name));
+        assertThat(config.getSubmoduleName(), is(nullValue()));
         name = "another-submodule";
         config.setSubmoduleName(name);
-        assertThat(config.getSubmoduleName(), is(name));
+        assertThat(config.getSubmoduleName(), is(nullValue()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testGetBranches() {
-        config.getBranches();
+        assertThat(config.getBranches(), is(arrayWithSize(0)));
     }
 
     public void testGetBranchesFromArray() {
@@ -111,36 +111,36 @@ public class SubmoduleConfigTest {
     @Test
     public void testSetBranches() {
         config.setBranches(branchNames);
-        assertThat(config.getBranches(), is(branchNames));
+        assertThat(config.getBranches(), is(arrayWithSize(0)));
         String[] newBranchNames = Arrays.copyOf(branchNames, branchNames.length);
         newBranchNames[0] = "new-master";
         config.setBranches(newBranchNames);
-        assertThat(config.getBranches(), is(newBranchNames));
+        assertThat(config.getBranches(), is(arrayWithSize(0)));
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testGetBranchesStringNPE() {
-        config.getBranchesString();
+    @Test
+    public void testGetBranchesStringEmpty() {
+        assertThat(config.getBranchesString(), is(""));
     }
 
     @Test
     public void testGetBranchesString() {
         config.setBranches(branchNames);
-        assertThat(config.getBranchesString(), is("master,comma,chameleon,develop"));
+        assertThat(config.getBranchesString(), is(""));
     }
 
     @Test
     public void testGetBranchesStringFromList() {
-        assertThat(configWithBranchList.getBranchesString(), is("master,masterAlias,develop"));
+        assertThat(configWithBranchList.getBranchesString(), is(""));
         configWithBranchList.setBranches(branchNames);
-        assertThat(configWithBranchList.getBranchesString(), is("master,comma,chameleon,develop"));
+        assertThat(configWithBranchList.getBranchesString(), is(""));
     }
 
     @Test
     public void testGetBranchesStringFromArray() {
-        assertThat(configWithBranchArray.getBranchesString(), is("master,comma,chameleon,develop"));
+        assertThat(configWithBranchArray.getBranchesString(), is(""));
         configWithBranchArray.setBranches(branchNames);
-        assertThat(configWithBranchArray.getBranchesString(), is("master,comma,chameleon,develop"));
+        assertThat(configWithBranchArray.getBranchesString(), is(""));
     }
 
     @Test
@@ -157,39 +157,39 @@ public class SubmoduleConfigTest {
         assertFalse(configWithBranchArray.revisionMatchesInterest(emptyRevision));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testRevisionMatchesInterestNPE() {
-        config.revisionMatchesInterest(multipleBranchesRevision);
+        assertFalse(config.revisionMatchesInterest(multipleBranchesRevision));
     }
 
     @Test
     public void testRevisionMatchesInterestMasterOnly() {
         String[] masterOnly = {"master"};
         config.setBranches(masterOnly);
-        assertTrue(config.revisionMatchesInterest(multipleBranchesRevision));
+        assertFalse(config.revisionMatchesInterest(multipleBranchesRevision));
 
         assertFalse(configWithBranchList.revisionMatchesInterest(multipleBranchesRevision));
         configWithBranchList.setBranches(masterOnly);
-        assertTrue(configWithBranchList.revisionMatchesInterest(multipleBranchesRevision));
+        assertFalse(configWithBranchList.revisionMatchesInterest(multipleBranchesRevision));
 
         assertFalse(configWithBranchArray.revisionMatchesInterest(multipleBranchesRevision));
         configWithBranchArray.setBranches(masterOnly);
-        assertTrue(configWithBranchArray.revisionMatchesInterest(multipleBranchesRevision));
+        assertFalse(configWithBranchArray.revisionMatchesInterest(multipleBranchesRevision));
     }
 
     @Test
     public void testRevisionMatchesInterestAlias() {
         String[] aliasName = {"masterAlias"};
         config.setBranches(aliasName);
-        assertTrue(config.revisionMatchesInterest(multipleBranchesRevision));
+        assertFalse(config.revisionMatchesInterest(multipleBranchesRevision));
 
         assertFalse(configWithBranchList.revisionMatchesInterest(multipleBranchesRevision));
         configWithBranchList.setBranches(aliasName);
-        assertTrue(configWithBranchList.revisionMatchesInterest(multipleBranchesRevision));
+        assertFalse(configWithBranchList.revisionMatchesInterest(multipleBranchesRevision));
 
         assertFalse(configWithBranchArray.revisionMatchesInterest(multipleBranchesRevision));
         configWithBranchArray.setBranches(aliasName);
-        assertTrue(configWithBranchArray.revisionMatchesInterest(multipleBranchesRevision));
+        assertFalse(configWithBranchArray.revisionMatchesInterest(multipleBranchesRevision));
     }
 
     @Test
@@ -205,7 +205,7 @@ public class SubmoduleConfigTest {
     public void testBranchMatchesInterest() {
         String[] masterOnly = {"master"};
         config.setBranches(masterOnly);
-        assertTrue(config.branchMatchesInterest(masterBranch));
+        assertFalse(config.branchMatchesInterest(masterBranch));
         assertFalse(config.branchMatchesInterest(masterAliasBranch));
         assertFalse(config.branchMatchesInterest(developBranch));
 
@@ -213,7 +213,7 @@ public class SubmoduleConfigTest {
         assertFalse(configWithBranchList.branchMatchesInterest(masterAliasBranch));
         assertFalse(configWithBranchList.branchMatchesInterest(developBranch));
         configWithBranchList.setBranches(masterOnly);
-        assertTrue(configWithBranchList.branchMatchesInterest(masterBranch));
+        assertFalse(configWithBranchList.branchMatchesInterest(masterBranch));
         assertFalse(configWithBranchList.branchMatchesInterest(masterAliasBranch));
         assertFalse(configWithBranchList.branchMatchesInterest(developBranch));
     }
@@ -222,7 +222,7 @@ public class SubmoduleConfigTest {
     public void testBranchMatchesInterestWithRegex() {
         String[] masterOnlyRegex = {"m.st.r"};
         config.setBranches(masterOnlyRegex);
-        assertTrue(config.branchMatchesInterest(masterBranch));
+        assertFalse(config.branchMatchesInterest(masterBranch));
         assertFalse(config.branchMatchesInterest(masterAliasBranch));
         assertFalse(config.branchMatchesInterest(developBranch));
     }

--- a/src/test/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowserTest.java
+++ b/src/test/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowserTest.java
@@ -32,7 +32,6 @@ public class TFS2013GitRepositoryBrowserTest {
         GitSCM scm = new GitSCM(
                 Collections.singletonList(new UserRemoteConfig(repoUrl, null, null, null)),
                 new ArrayList<>(),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, JGitTool.MAGIC_EXENAME,
                 Collections.<GitSCMExtension>emptyList());
         

--- a/src/test/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowserXSSTest.java
+++ b/src/test/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowserXSSTest.java
@@ -29,7 +29,6 @@ public class TFS2013GitRepositoryBrowserXSSTest {
         GitSCM scm = new GitSCM(
                 Collections.singletonList(new UserRemoteConfig("http://tfs/tfs/project/_git/repo", null, null, null)),
                 new ArrayList<>(),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, JGitTool.MAGIC_EXENAME,
                 Collections.<GitSCMExtension>emptyList());
         scm.setBrowser(new TFS2013GitRepositoryBrowser("<img src=x onerror=alert(232)>"));

--- a/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
@@ -71,7 +71,6 @@ public abstract class GitSCMExtensionTest {
 		GitSCM scm = new GitSCM(
 				repo.remoteConfigs(),
 				branches,
-				false, Collections.<SubmoduleConfig>emptyList(),
 				null, null,
 				Collections.<GitSCMExtension>emptyList());
 		scm.getExtensions().add(extension);

--- a/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java
@@ -23,18 +23,10 @@ public class GitJCasCCompatibilityTest extends RoundTripAbstractTest {
         assertThat(retriever, CoreMatchers.instanceOf(SCMRetriever.class));
         SCM scm =  ((SCMRetriever) retriever).getScm();
         assertThat(scm, CoreMatchers.instanceOf(GitSCM.class));
-
-        Collection<SubmoduleConfig> submodulesConfig = ((GitSCM) scm).getSubmoduleCfg();
-
-        assertThat(submodulesConfig.size(), is(2));
-        assertTrue(submodulesConfig.stream().anyMatch(m -> m.getSubmoduleName().equals("submodule-1")));
-        assertTrue(submodulesConfig.stream().anyMatch(m -> m.getSubmoduleName().equals("submodule-2")));
-        assertTrue(submodulesConfig.stream().anyMatch(m -> m.getBranchesString().equals("mybranch-1,mybranch-2")));
-        assertTrue(submodulesConfig.stream().anyMatch(m -> m.getBranchesString().equals("mybranch-3,mybranch-4")));
     }
 
     @Override
     protected String stringInLogExpected() {
-        return "Setting class hudson.plugins.git.SubmoduleConfig.branches = [mybranch-3, mybranch-4]";
+        return "Setting class hudson.plugins.git.GitSCM.extensions = [cleanCheckout, gitLFSPull, {checkoutOption={}}, {userIdentity={}}, {preBuildMerge={}}]";
     }
 }

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -183,7 +183,7 @@ public class GitSCMFileSystemTest {
         sampleRepo.git("checkout", "-b", "bug/JENKINS-42817");
         sampleRepo.write("file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
-        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(), new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), Collections.singletonList(new BranchSpec("*/bug/JENKINS-42817")), false, Collections.<SubmoduleConfig>emptyList(), null, null, Collections.<GitSCMExtension>emptyList()));
+        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(), new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), Collections.singletonList(new BranchSpec("*/bug/JENKINS-42817")), null, null, Collections.<GitSCMExtension>emptyList()));
         assertThat(fs, notNullValue());
         SCMFile root = fs.getRoot();
         assertThat(root, notNullValue());
@@ -213,8 +213,6 @@ public class GitSCMFileSystemTest {
         SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(),
                                             new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null),
                                                        Collections.singletonList(new BranchSpec("*")), // JENKINS-57587 issue here
-                                                       false,
-                                                       Collections.<SubmoduleConfig>emptyList(),
                                                        null, null,
                                                        Collections.<GitSCMExtension>emptyList()));
         assertThat("Wildcard branch name '*' resolved to a specific checkout unexpectedly", fs, is(nullValue()));
@@ -398,7 +396,7 @@ public class GitSCMFileSystemTest {
         sampleRepo.write("dir/subdir/file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
         sampleRepo.git("tag", "v1.0");
-        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(), new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), Collections.singletonList(new BranchSpec("refs/tags/v1.0")), false, Collections.<SubmoduleConfig>emptyList(), null, null, Collections.<GitSCMExtension>emptyList()));
+        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(), new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), Collections.singletonList(new BranchSpec("refs/tags/v1.0")), null, null, Collections.<GitSCMExtension>emptyList()));
         assertThat(fs, notNullValue());
         assertThat(fs.getRoot(), notNullValue());
         Iterable<SCMFile> children = fs.getRoot().children();

--- a/src/test/java/jenkins/plugins/git/GitSCMTelescopeTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMTelescopeTest.java
@@ -146,14 +146,11 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
         List<BranchSpec> branchSpecList = new ArrayList<>();
         branchSpecList.add(masterBranchSpec);
         boolean doGenerateSubmoduleConfigurations = false;
-        Collection<SubmoduleConfig> submoduleCfg = new ArrayList<>();
         GitRepositoryBrowser browser = new GitWeb(repoUrl);
         String gitTool = "Default";
         List<GitSCMExtension> extensions = null;
         GitSCM singleBranchSource = new GitSCM(remoteConfigList,
                 branchSpecList,
-                doGenerateSubmoduleConfigurations,
-                submoduleCfg,
                 browser,
                 gitTool,
                 extensions);

--- a/src/test/java/org/jenkinsci/plugins/gittagmessage/GitTagMessageExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gittagmessage/GitTagMessageExtensionTest.java
@@ -33,7 +33,6 @@ public class GitTagMessageExtensionTest extends AbstractGitTagMessageExtensionTe
         GitSCM scm = new GitSCM(
                 Collections.singletonList(remote),
                 Collections.singletonList(new BranchSpec(branchSpec)),
-                false, Collections.<SubmoduleConfig>emptyList(),
                 null, null,
                 Collections.<GitSCMExtension>singletonList(extension));
 


### PR DESCRIPTION
## [JENKINS-62052](https://issues.jenkins-ci.org/browse/JENKINS-62052) - Remove submodule configurator to improve pipeline snippets

Remove `doGenerateSubmoduleConfigurations` and `submoduleCfg` from pipeline syntax.

An experiment was added many years ago to allow git submodule combinations to be computed by the git plugin.  It is unavailable for Freestyle and other classic job types because no user interface was available to access it.

The experiment was made visible to Pipeline users through the Pipeline Syntax snippet generator.  The snippet generator detected the globally visible symbols and their use in a data bound constructor and presented them to the user as required arguments with default values.

No user interface or online help was available to guide the user on the allowed values for `doGenerateSubmoduleConfigurations`  or `submoduleCfg`.  No bug reports have been received on any use of either of those arguments.  Even if bug reports had been received, they would have been politely refused because I'm not willing to spend time on that experiment from long ago.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Breaking bug fix - remove undocumented options from Pipeline Syntax

## Further comments

Use a data bound setter to ignore the doGenerateSubmoduleConfigurations value instead of passing it as an argument of the data bound constructor.  Retain the constructor signature for compatbility but simplify the data bound constructor.

There has been no user interface to support submodule combination generation and no testing to support submodule combination generation for many, many releases.

The submoduleCfg argument alters doGenerateSubmoduleConfigurations.  Since doGenerateSubmoduleConfigurations has been removed, the submoduleCfg argument can also be removed from the default pipeline syntax.

It might have been possible for a Pipeline definition to enable doGenerateSubmoduleConfigurations, but it has not been documented or described in anything other than the source code.

Existing pipelines will be processed as though submodule configuration was disabled (the default).  User provided values for doGenerateSubmoduleConfigurations and submoduleCfg will be ignored.

## Pipeline Syntax Comparison

Before the change, the Pipeline syntax generator suggested:

```
checkout([$class: 'GitSCM',
        branches: [[name: '*/master']],
        doGenerateSubmoduleConfigurations: false, 
        extensions: [], 
        gitTool: 'Default', 
        submoduleCfg: [], 
        userRemoteConfigs: [[url: 'https://github.com/jenkinsci/git-plugin']]])
```

After the change, the Pipeline syntax generator suggests:

```
checkout([$class: 'GitSCM', 
        branches: [[name: '*/master']], 
        extensions: [], 
        gitTool: 'Default', 
        userRemoteConfigs: [[url: 'https://github.com/jenkinsci/git-plugin']]])
```

Still many more changes are needed to improve Pipeline syntax snippet suggestions, but this is a good beginning.