### PR TITLE
Remove submodule config debris from two tests

### DIFF
--- a/src/test/java/hudson/plugins/git/extensions/impl/PruneStaleTagPipelineTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/PruneStaleTagPipelineTest.java
@@ -83,9 +83,7 @@ public class PruneStaleTagPipelineTest {
                 + "  node {\n"
                 + "    checkout([$class: 'GitSCM',"
                 + "             branches: [[name: '*/master']],"
-                + "             doGenerateSubmoduleConfigurations: false,"
                 + "             extensions: [pruneTags(true)],"
-                + "             submoduleCfg: [],"
                 + "             userRemoteConfigs: [[url: '" + remoteURL + "']]"
                 + "    ])"
                 + "  }\n", true));

--- a/src/test/java/jenkins/plugins/git/GitSCMTelescopeTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMTelescopeTest.java
@@ -145,7 +145,6 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
         BranchSpec masterBranchSpec = new BranchSpec("master");
         List<BranchSpec> branchSpecList = new ArrayList<>();
         branchSpecList.add(masterBranchSpec);
-        boolean doGenerateSubmoduleConfigurations = false;
         GitRepositoryBrowser browser = new GitWeb(repoUrl);
         String gitTool = "Default";
         List<GitSCMExtension> extensions = null;


### PR DESCRIPTION
## Remove submodule config debris from two tests

The tests do not need the submodule config settings and are not attempting to verify anything related to submodule config behavior.  Remove the "noise" from those unused settings.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Test improvement
