### PR TITLE
[JENKINS-64902] Stop checking rev exclusions on first answer

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -2037,7 +2037,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
             revShow.add("commit "); // sentinel value
 
-            int start=0, idx=0;
+            int idx=0;
             for (String line : revShow) {
                 if (line.startsWith("commit ") && idx!=0) {
                     boolean showEntireCommitSummary = GitChangeSet.isShowEntireCommitSummaryInChanges() || !(git instanceof CliGitAPIImpl);
@@ -2046,18 +2046,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                     Boolean excludeThisCommit=null;
                     for (GitSCMExtension ext : extensions) {
                         excludeThisCommit = ext.isRevExcluded(this, git, change, listener, buildData);
-                        if (excludeThisCommit!=null)
-                            break;
+                        if(excludeThisCommit!=null)
+                            return excludeThisCommit;
                     }
-                    if (excludeThisCommit==null || !excludeThisCommit)
-                        return false;    // this sequence of commits have one commit that we want to build
-                    start = idx;
                 }
-
                 idx++;
             }
-
-            assert start==revShow.size()-1;
 
             // every commit got excluded
             return true;

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -2033,12 +2033,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 }
             } else {
                 revShow  = git.showRevision(r.getSha1());
-            }
+           }
 
             revShow.add("commit "); // sentinel value
 
-            int start=0 ,idx=0;
-            Boolean excludeThisRev=false;
+            int start=0, idx=0;
+            boolean excludeThisRev=false;
             for (String line : revShow) {
                 if (line.startsWith("commit ") && idx!=0) {
                     boolean showEntireCommitSummary = GitChangeSet.isShowEntireCommitSummaryInChanges() || !(git instanceof CliGitAPIImpl);
@@ -2047,14 +2047,19 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                     Boolean excludeThisCommit=null;
                     for (GitSCMExtension ext : extensions) {
                         excludeThisCommit = ext.isRevExcluded(this, git, change, listener, buildData);
-                        if(excludeThisCommit!=null || excludeThisCommit)
-                            excludeThisRev=true;
+                        if (excludeThisCommit==null)
+                            continue;
+                        if (excludeThisCommit)
+                            excludeThisRev = true;
                             break;
                     }
                     start = idx;
                 }
+
                 idx++;
             }
+
+            assert start==revShow.size()-1;
 
             // every commit got excluded
             return excludeThisRev;

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -2038,6 +2038,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             revShow.add("commit "); // sentinel value
 
             int start=0 ,idx=0;
+            Boolean excludeThisRev=false;
             for (String line : revShow) {
                 if (line.startsWith("commit ") && idx!=0) {
                     boolean showEntireCommitSummary = GitChangeSet.isShowEntireCommitSummaryInChanges() || !(git instanceof CliGitAPIImpl);
@@ -2046,8 +2047,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                     Boolean excludeThisCommit=null;
                     for (GitSCMExtension ext : extensions) {
                         excludeThisCommit = ext.isRevExcluded(this, git, change, listener, buildData);
-                        if(excludeThisCommit!=null)
-                            return excludeThisCommit;
+                        if(excludeThisCommit!=null && excludeThisCommit)
+                            excludeThisRev=true;
+                            break;
                     }
                     start = idx;
                 }
@@ -2055,7 +2057,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
 
             // every commit got excluded
-            return true;
+            return excludeThisRev;
         } catch (GitException e) {
             e.printStackTrace(listener.error("Failed to determine if we want to exclude " + r.getSha1String()));
             return false;   // for historical reason this is not considered a fatal error.

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -2037,7 +2037,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
             revShow.add("commit "); // sentinel value
 
-            int idx=0;
+            int start=0 ,idx=0;
             for (String line : revShow) {
                 if (line.startsWith("commit ") && idx!=0) {
                     boolean showEntireCommitSummary = GitChangeSet.isShowEntireCommitSummaryInChanges() || !(git instanceof CliGitAPIImpl);
@@ -2049,6 +2049,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                         if(excludeThisCommit!=null)
                             return excludeThisCommit;
                     }
+                    start = idx;
                 }
                 idx++;
             }

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -2047,7 +2047,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                     Boolean excludeThisCommit=null;
                     for (GitSCMExtension ext : extensions) {
                         excludeThisCommit = ext.isRevExcluded(this, git, change, listener, buildData);
-                        if(excludeThisCommit!=null && excludeThisCommit)
+                        if(excludeThisCommit!=null || excludeThisCommit)
                             excludeThisRev=true;
                             break;
                     }

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -2033,7 +2033,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 }
             } else {
                 revShow  = git.showRevision(r.getSha1());
-           }
+            }
 
             revShow.add("commit "); // sentinel value
 
@@ -2049,8 +2049,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                         excludeThisCommit = ext.isRevExcluded(this, git, change, listener, buildData);
                         if (excludeThisCommit==null)
                             continue;
-                        if (excludeThisCommit)
-                            excludeThisRev = true;
+                        else
+                            excludeThisRev = excludeThisCommit;
                             break;
                     }
                     start = idx;


### PR DESCRIPTION
## [JENKINS-64902](https://issues.jenkins.io/browse/JENKINS-64902) - Stop checking rev exclusions on first answer

there is a logic bug in handling the method isRevExcluded of the GitSCM extension

from the code description, the first extensions that either returns true or false should "win", and no further extensions should checked. only if a extensions return null, other extensions should be checked.

this is not what is happening, if a extension returns true, also the other extensions will be checked. and since the default for the isRevExcluded method is "null", also other extensions will be checked.

this basically leads to builds that should not have been triggered!

FYI: i am not a java dev, and writing tests for this is way out of my capabilities


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

this will most likely also fix [JENKINS-36195](https://issues.jenkins.io/browse/JENKINS-36195) and  [JENKINS-38508](https://issues.jenkins.io/browse/JENKINS-38508)