### PR TITLE
GIT CEILING DIRECTORIES

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -148,6 +148,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     public static final String GIT_COMMIT = "GIT_COMMIT";
     public static final String GIT_PREVIOUS_COMMIT = "GIT_PREVIOUS_COMMIT";
     public static final String GIT_PREVIOUS_SUCCESSFUL_COMMIT = "GIT_PREVIOUS_SUCCESSFUL_COMMIT";
+    public static final String GIT_CEILING_DIRECTORIES = "GIT_CEILING_DIRECTORIES";
 
     /**
      * All the configured extensions attached to this.
@@ -1324,6 +1325,13 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         environment.put(GIT_COMMIT, revToBuild.revision.getSha1String());
+        if (launcher.isUnix()) {
+            String homeValue = environment.get("HOME");
+            environment.put(GIT_CEILING_DIRECTORIES, homeValue + "/jobs");
+        } else {
+            String homeValue = environment.get("HOMEPATH");
+            environment.put(GIT_CEILING_DIRECTORIES, homeValue + "\\jobs");
+        }
         Branch localBranch = Iterables.getFirst(revToBuild.revision.getBranches(),null);
         String localBranchName = getParamLocalBranch(build, listener);
         if (localBranch != null && localBranch.getName() != null) { // null for a detached HEAD


### PR DESCRIPTION
## [JENKINS-38699](https://issues.jenkins.io/browse/JENKINS-38699) - 
Setting GIT_CEILING_DIRECTORIES environment variable on git scm checkout.

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes


- [ ] Dependency or infrastructure update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments


