### PR TITLE
[JENKINS-53346] Return correct map from additional checkout scm calls

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -79,6 +79,7 @@ import java.io.Serializable;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
 import java.text.MessageFormat;
+import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1974,7 +1975,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         BuildData buildData = null;
         while (build != null) {
             List<BuildData> buildDataList = build.getActions(BuildData.class);
-            for (BuildData bd : buildDataList) {
+            // We need to get the latest recorded build data. It may happens that the build has more than one
+            // checkout of the same repo
+            List<BuildData> buildDataListReverted = reversedView(buildDataList); 
+            for (BuildData bd : buildDataListReverted) {
                 if (bd != null && isRelevantBuildData(bd)) {
                     buildData = bd;
                     break;
@@ -1987,6 +1991,26 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         return buildData;
+    }
+
+    /**
+     * Gets a reversed view of an unmodifiable list without using increasing space or time. 
+     * @param list The list to revert.
+     * @param <T> The type of the elements of the list.
+     * @return The list <i>reverted</i>.
+     */
+    private <T> List<T> reversedView(final List<T> list) {
+        return new AbstractList<T>() {
+            @Override
+            public T get(int index) {
+                return list.get(list.size() - 1 - index);
+            }
+            
+            @Override
+            public int size() {
+                return list.size();
+            }
+        };
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1975,11 +1975,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         BuildData buildData = null;
         while (build != null) {
             List<BuildData> buildDataList = build.getActions(BuildData.class);
-            // We need to get the latest recorded build data. It may happens that the build has more than one
-            // checkout of the same repo
-            // Not used yet to let the test fail and then we see how it works 
-            // List<BuildData> buildDataListReverted = reversedView(buildDataList); 
-            List<BuildData> buildDataListReverted = buildDataList;
+            // We need to get the latest recorded build data. It may happen
+            // that the build has more than one checkout of the same repo.
+            List<BuildData> buildDataListReverted = reversedView(buildDataList);
             for (BuildData bd : buildDataListReverted) {
                 if (bd != null && isRelevantBuildData(bd)) {
                     buildData = bd;
@@ -1996,7 +1994,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     }
 
     /**
-     * Gets a reversed view of an unmodifiable list without using increasing space or time. 
+     * Gets a reversed view of an unmodifiable list without using increasing space or time.
      * @param list The list to revert.
      * @param <T> The type of the elements of the list.
      * @return The list <i>reverted</i>.
@@ -2007,7 +2005,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             public T get(int index) {
                 return list.get(list.size() - 1 - index);
             }
-            
+
             @Override
             public int size() {
                 return list.size();

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1977,7 +1977,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             List<BuildData> buildDataList = build.getActions(BuildData.class);
             // We need to get the latest recorded build data. It may happens that the build has more than one
             // checkout of the same repo
-            List<BuildData> buildDataListReverted = reversedView(buildDataList); 
+            // Not used yet to let the test fail and then we see how it works 
+            // List<BuildData> buildDataListReverted = reversedView(buildDataList); 
+            List<BuildData> buildDataListReverted = buildDataList;
             for (BuildData bd : buildDataListReverted) {
                 if (bd != null && isRelevantBuildData(bd)) {
                     buildData = bd;

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -2371,12 +2371,12 @@ public class GitSCMTest extends AbstractGitTestCase {
         
         String log = b.getLog();
         // The getLineStratingBy is to ease reading the test failure, to avoid Hamcrest shows all the log
-        assertThat(getLineStartingBy(log, "checkout1:"), containsString("checkout1: [GIT_BRANCH:git-1.1, GIT_COMMIT:82db9509c068f60c41d7a4572c0114cc6d23cd0d, GIT_URL:https://github.com/jenkinsci/git-plugin.git]"));
-        assertThat(getLineStartingBy(log, "checkout2:"), containsString("checkout2: [GIT_BRANCH:git-2.0.2, GIT_COMMIT:377a0fdbfbf07f70a3e9a566d749b2a185909c33, GIT_URL:https://github.com/jenkinsci/git-plugin.git]"));
-        assertThat(getLineStartingBy(log, "checkout3:"), containsString("checkout3: [GIT_BRANCH:git-3.0.0, GIT_COMMIT:858dee578b79ac6683419faa57a281ccb9d347aa, GIT_URL:https://github.com/jenkinsci/git-plugin.git]"));
+        assertThat(getLineStartsWith(log, "checkout1:"), containsString("checkout1: [GIT_BRANCH:git-1.1, GIT_COMMIT:82db9509c068f60c41d7a4572c0114cc6d23cd0d, GIT_URL:https://github.com/jenkinsci/git-plugin.git]"));
+        assertThat(getLineStartsWith(log, "checkout2:"), containsString("checkout2: [GIT_BRANCH:git-2.0.2, GIT_COMMIT:377a0fdbfbf07f70a3e9a566d749b2a185909c33, GIT_URL:https://github.com/jenkinsci/git-plugin.git]"));
+        assertThat(getLineStartsWith(log, "checkout3:"), containsString("checkout3: [GIT_BRANCH:git-3.0.0, GIT_COMMIT:858dee578b79ac6683419faa57a281ccb9d347aa, GIT_URL:https://github.com/jenkinsci/git-plugin.git]"));
     }
 
-    private String getLineStartingBy(String text, String startOfLine) {
+    private String getLineStartsWith(String text, String startOfLine) {
         try (Scanner scanner = new Scanner(text)) {
             while(scanner.hasNextLine()) {
                 String line = scanner.nextLine();

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -63,6 +63,9 @@ import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.jenkinsci.plugins.gitclient.*;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -2347,6 +2350,44 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertEquals(browser.getRepoUrl(), "https://github.com/jenkinsci/model-ant-project.git/");
     }
 
+    /**
+     * Test a pipeline getting the value from several checkout steps gets the latest data everytime.
+     * @throws Exception If anything wrong happens
+     */
+    @Issue("JENKINS-53346")
+    @Test
+    public void testCheckoutReturnsLatestValues() throws Exception {
+        WorkflowJob p = rule.jenkins.createProject(WorkflowJob.class, "pipeline-checkout-3-tags");
+        p.setDefinition(new CpsFlowDefinition(
+            "node {\n" +
+            "    def checkout1 = checkout([$class: 'GitSCM', branches: [[name: 'git-1.1']], extensions: [], userRemoteConfigs: [[url: 'https://github.com/jenkinsci/git-plugin.git']]])\n" +
+            "    echo \"checkout1: ${checkout1}\"\n" +
+            "    def checkout2 = checkout([$class: 'GitSCM', branches: [[name: 'git-2.0.2']], extensions: [], userRemoteConfigs: [[url: 'https://github.com/jenkinsci/git-plugin.git']]])\n" +
+            "    echo \"checkout2: ${checkout2}\"\n" +
+            "    def checkout3 = checkout([$class: 'GitSCM', branches: [[name: 'git-3.0.0']], extensions: [], userRemoteConfigs: [[url: 'https://github.com/jenkinsci/git-plugin.git']]])\n" +
+            "    echo \"checkout3: ${checkout3}\"\n" +
+            "}", true));
+        WorkflowRun b = rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        
+        String log = b.getLog();
+        // The getLineStratingBy is to ease reading the test failure, to avoid Hamcrest shows all the log
+        assertThat(getLineStartingBy(log, "checkout1:"), containsString("checkout1: [GIT_BRANCH:git-1.1, GIT_COMMIT:82db9509c068f60c41d7a4572c0114cc6d23cd0d, GIT_URL:https://github.com/jenkinsci/git-plugin.git]"));
+        assertThat(getLineStartingBy(log, "checkout2:"), containsString("checkout2: [GIT_BRANCH:git-2.0.2, GIT_COMMIT:377a0fdbfbf07f70a3e9a566d749b2a185909c33, GIT_URL:https://github.com/jenkinsci/git-plugin.git]"));
+        assertThat(getLineStartingBy(log, "checkout3:"), containsString("checkout3: [GIT_BRANCH:git-3.0.0, GIT_COMMIT:858dee578b79ac6683419faa57a281ccb9d347aa, GIT_URL:https://github.com/jenkinsci/git-plugin.git]"));
+    }
+
+    private String getLineStartingBy(String text, String startOfLine) {
+        try (Scanner scanner = new Scanner(text)) {
+            while(scanner.hasNextLine()) {
+                String line = scanner.nextLine();
+                if (line.startsWith(startOfLine)) {
+                    return line;
+                }
+            }
+        }
+        return "";
+    }
+    
     @Test
     public void testPleaseDontContinueAnyway() throws Exception {
         // create an empty repository with some commits


### PR DESCRIPTION
## [JENKINS-53346](https://issues.jenkins-ci.org/browse/JENKINS-53346) - Fix GitSCM checkout returns same values on second different call

Basically it's reverting the order of the build data that every build has to be sure we return the latest one. When a pipeline runs two or more `checkouts` against the same repo the return values are from the first checkout, not the current=latest? one.

Not sure whether it's the right approach or not as it's my first contribution to the git plugin. All tests are passing in my machine but two of them, but I don't see any relation with the changes and the tests are playing with timeouts so they may be flackies. I want to see what the CI tells us.
 
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
