### PR TITLE
[JENKINS-64712] Fix unexpected scrolling of config UI

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -29,13 +29,5 @@
     <f:entry field="addGitTagAction">
       <f:checkbox title="${%Add git tag action to jobs}" name="addGitTagAction" checked="${descriptor.addGitTagAction}"/>
     </f:entry>
-    <!--
-    <f:entry title="${%Default git client implementation}" field="defaultClientType">
-        <select>
-            <f:option value="JGIT" selected="${descriptor.defaultClientType == 'JGIT'}">${%JGit}</f:option>
-            <f:option value="GITCLI" selected="${descriptor.defaultClientType == 'GITCLI'}">${%command line Git}</f:option>
-        </select>
-    </f:entry>
-    -->
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -8,11 +8,12 @@
     <f:entry title="${%Global Config user.email Value}" field="globalConfigEmail">
       <f:textbox />
     </f:entry>
-    <f:optionalBlock title="${%Create new accounts based on author/committer's email}" field="createAccountBasedOnEmail" checked="${descriptor.createAccountBasedOnEmail}" inline="true">
-      <f:entry field="useExistingAccountWithSameEmail">
-        <f:checkbox title="${%Use existing account with same email if found}" name="useExistingAccountWithSameEmail" checked="${descriptor.useExistingAccountWithSameEmail}" />
-      </f:entry>
-    </f:optionalBlock>
+    <f:entry field="createAccountBasedOnEmail">
+      <f:checkbox title="${%Create new accounts based on author/committer's email}" name="createAccountBasedOnEmail" checked="${descriptor.createAccountBasedOnEmail}"/>
+    </f:entry>
+    <f:entry field="useExistingAccountWithSameEmail">
+      <f:checkbox title="${%Use existing account with same email if found}" name="useExistingAccountWithSameEmail" checked="${descriptor.useExistingAccountWithSameEmail}"/>
+    </f:entry>
     <f:entry field="showEntireCommitSummaryInChanges">
       <f:checkbox title="${%Show the entire commit summary in changes}" name="showEntireCommitSummaryInChanges" checked="${descriptor.showEntireCommitSummaryInChanges}"/>
     </f:entry>


### PR DESCRIPTION
## [JENKINS-64712](https://issues.jenkins-ci.org/browse/JENKINS-64712) - Fix unexpected scrolling of nested checkbox

The nesting of one checkbox beneath another checkbox appears to be purely a presentation convenience to only show the `useExistingAccountWithSameEmail` if the `useExistingAccountWithSameEmail` checkbox was enabled.  Since the GitTool data model has the `useExistingAccountWithSameEmail` and the `useExistingAccountWithSameEmail` fields at the same level, this simplifies the user experience by displaying them both at the time.

Tested interactively with Jenkins 2.263.4, Jenkins 2.277.1-rc, and Jenkins 2.281.  Behaves as expected in all cases.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

Existing values are loaded as expected on startup.

Values are persisted to the GitTool.xml configuration file when the configuration is applied or saved.

Hints in other communities suggest that the unexpected scrolling is caused by specific CSS markup, but I can't find that specific markup in my search of the generated page.  Rather than fight with CSS markup, it is easier to move the nested checkbox to the top level.

Would love to have review and verification by @MRamonLeon
