### PR TITLE
Add more pipeline help

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,7 @@ Prior release notes are recorded in the git plugin repository link:CHANGELOG.ado
 == Pipelines
 
 The git plugin provides an SCM implementation to be used with the Pipeline SCM link:https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/[`checkout` step].
-The link:https://www.jenkins.io/doc/book/pipeline/getting-started/#snippet-generator["Pipeline Syntax" snippet generator] guides the user to select checkout options.
+The link:https://www.jenkins.io/redirect/pipeline-snippet-generator["Pipeline Syntax" snippet generator] guides the user to select checkout options.
 
 The link:https://youtu.be/ai1kf4ihZUo[90 second video clip] below introduces the Pipeline Syntax snippet generator and shows how it is used to generate steps for the Jenkins Pipeline.
 

--- a/README.adoc
+++ b/README.adoc
@@ -830,6 +830,8 @@ If this option is selected, the git commit's "Author" value is used instead.
 [#tagging-extensions]
 === Tagging Extensions
 
+Tagging extensions allow the plugin to apply tags in the current workspace.
+
 [#create-a-tag-for-every-build]
 ==== Create a tag for every build
 

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-branches.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-branches.html
@@ -1,0 +1,5 @@
+<div>
+  List of branches to build.
+  Jenkins jobs are most effective when each job builds only a single branch.
+  When a single job builds multiple branches, the changelog comparisons between branches often show no changes or incorrect changes.
+</div>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-browser.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-browser.html
@@ -1,0 +1,3 @@
+<div>
+  Defines the repository browser that displays changes detected by the git plugin.
+</div>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-extensions.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-extensions.html
@@ -1,0 +1,29 @@
+<div>
+  <p>
+  Extensions add new behavior or modify existing plugin behavior for different uses.
+  Extensions help users more precisely tune plugin behavior to meet their needs.
+  </p>
+  <p>
+  Extensions include:
+    <ul>
+      <li>
+        <strong>Clone extensions</strong> modify the git operations that retrieve remote changes into the agent workspace.
+        The extensions can adjust the amount of history retrieved, how long the retrieval is allowed to run, and other retrieval details.
+      </li>
+        <strong>Checkout extensions</strong> modify the git operations that place files in the workspace from the git repository on the agent.
+        The extensions can adjust the maximum duration of the checkout operation, the use and behavior of git submodules, the location of the workspace on the disc, and more.
+      <li>
+        <strong>Changelog extensions</strong> adapt the source code difference calculations for different cases.
+      </li>
+        <strong>Tagging extensions</strong> allow the plugin to apply tags in the current workspace.
+      <li>
+        <strong>Build inititation extensions</strong> control the conditions that start a build.
+        They can ignore notifications of a change or force a deeper evaluation of the commits when polling.
+      </li>
+      <li>
+        <strong>Merge extensions</strong> can optionally merge changes from other branches into the current branch of the agent workspace.
+        They control the source branch for the merge and the options applied to the merge.
+      </li>
+    </ul>
+  </p>
+</div>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-extensions.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-extensions.html
@@ -10,12 +10,16 @@
         <strong>Clone extensions</strong> modify the git operations that retrieve remote changes into the agent workspace.
         The extensions can adjust the amount of history retrieved, how long the retrieval is allowed to run, and other retrieval details.
       </li>
+      <li>
         <strong>Checkout extensions</strong> modify the git operations that place files in the workspace from the git repository on the agent.
         The extensions can adjust the maximum duration of the checkout operation, the use and behavior of git submodules, the location of the workspace on the disc, and more.
+      </li>
       <li>
         <strong>Changelog extensions</strong> adapt the source code difference calculations for different cases.
       </li>
+      <li>
         <strong>Tagging extensions</strong> allow the plugin to apply tags in the current workspace.
+      </li>
       <li>
         <strong>Build inititation extensions</strong> control the conditions that start a build.
         They can ignore notifications of a change or force a deeper evaluation of the commits when polling.

--- a/src/main/resources/hudson/plugins/git/GitSCM/help.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help.html
@@ -1,0 +1,12 @@
+<div>
+  <p>
+  The <a href="https://plugins.jenkins.io/git/">git plugin</a> provides fundamental git operations for Jenkins projects.
+  It can poll, fetch, checkout, and merge contents of git repositories.
+  </p>
+
+  <p>
+  The git plugin provides an SCM implementation to be used with the Pipeline SCM <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step"><code>checkout</code></a> step.
+  The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator"><strong>"Pipeline Syntax" snippet generator</strong></a> guides the user to select git plugin checkout options and provides online help for each of the options.
+  </p>
+
+</div>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help.html
@@ -3,7 +3,7 @@
     Git step. It performs a clone from the specified repository.
     </p>
     <p>
-    Use the <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> to generate a sample pipeline script for the git step.
+    Use the <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Snippet Generator</a> to generate a sample pipeline script for the git step.
     More advanced checkout operations require the <code>checkout</code> step rather than the <code>git</code> step.
     Examples of the <code>git</code> step include:
     <ul>
@@ -30,7 +30,7 @@ checkout([$class: 'GitSCM', branches: [[name: '*/master']],
     <strong>NOTE:</strong> The <code>checkout</code> step is the <strong>preferred SCM checkout method</strong>.
     It provides significantly more functionality than the <code>git</code> step.
     </p>
-    <p>Use the <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> to generate a sample pipeline script for the checkout step.
+    <p>Use the <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Snippet Generator</a> to generate a sample pipeline script for the checkout step.
     </p>
     <p>
     The <code>checkout</code> step can be used in many cases where the <code>git</code> step cannot be used.
@@ -57,7 +57,7 @@ checkout([$class: 'GitSCM', branches: [[name: '*/master']],
     <strong><a id="git-step-with-defaults">Example: Git step with defaults</a></strong>
     <p>
     Checkout from the git plugin source repository using https protocol, no credentials, and the master branch.
-    </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
+    </p><p>The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
 git 'https://github.com/jenkinsci/git-plugin'
 </pre>
@@ -78,7 +78,7 @@ git 'https://github.com/jenkinsci/git-plugin'
     <p>
     Remote branch names, SHA-1 hashes, and tag names <strong>are supported</strong> by the general purpose <code>checkout</code> step.
     </p>
-    <p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
+    <p>The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
 git branch: 'stable-2.204',
     url: 'https://github.com/jenkinsci/jenkins.git'
@@ -90,7 +90,7 @@ git branch: 'stable-2.204',
     Checkout from the git client plugin source repository using ssh protocol, private key credentials, and the master branch.
     The credential must be a private key credential if the remote git repository is accessed with the ssh protocol.
     The credential must be a username / password credential if the remote git repository is accessed with http or https protocol.
-    </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
+    </p><p>The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
 git credentialsId: 'my-private-key-credential-id',
     url: 'git@github.com:jenkinsci/git-client-plugin.git'
@@ -103,7 +103,7 @@ git credentialsId: 'my-private-key-credential-id',
     If changelog is <code>false</code>, then the changelog will not be computed for this job.
     If changelog is <code>true</code> or is not set, then the changelog will be computed.
     See the <a href="https://github.com/jenkinsci/workflow-scm-step-plugin/blob/master/README.md#changelogs">workflow scm step documentation</a> for more changelog details.
-    </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
+    </p><p>The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
 git changelog: false,
     url: 'https://github.com/jenkinsci/credentials-plugin.git'
@@ -116,7 +116,7 @@ git changelog: false,
     If poll is <code>false</code>, then the remote repository will not be polled for changes.
     If poll is <code>true</code> or is not set, then the remote repository will be polled for changes.
     See the <a href="https://github.com/jenkinsci/workflow-scm-step-plugin/blob/master/README.md#polling">workflow scm step documentation</a> for more polling details.
-    </p><p>The <a href="https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator">Pipeline Snippet Generator</a> generates this example:
+    </p><p>The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
 git poll: false,
     url: 'git://github.com/jenkinsci/platformlabeler-plugin.git'

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -72,7 +72,8 @@ public class AssemblaWebDoCheckURLTest {
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(null, url), is(FormValidation.ok()));
     }
 
-    @Test
+    // Temporarily disabled while Assembla is down for maintenance
+    // @Test
     public void testPathLevelChecksOnRepoUrlUnableToConnect() throws Exception {
         // Syntax issue related specific to Assembla
         String url = "https://app.assembla.com/space/git-plugin/git/source/";

--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -72,8 +72,7 @@ public class AssemblaWebDoCheckURLTest {
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(null, url), is(FormValidation.ok()));
     }
 
-    // Temporarily disabled while Assembla is down for maintenance
-    // @Test
+    @Test
     public void testPathLevelChecksOnRepoUrlUnableToConnect() throws Exception {
         // Syntax issue related specific to Assembla
         String url = "https://app.assembla.com/space/git-plugin/git/source/";


### PR DESCRIPTION
## Add more pipeline help

Improve the pipeline help with intro text for the `checkout scm` step and for other segments of the `checkout scm` step.

- Use snippet-generator redirect
- Provide intro text for scm step
- Add heading text to tagging docs
- Add browser intro help
- Add intro help for extensions

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Documentation
