### PR TITLE
Require Jenkins 2.249.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,12 @@
   <inceptionYear>2007</inceptionYear>
 
   <properties>
-    <revision>4.6.1</revision>
+    <revision>4.7.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.222.4</jenkins.version> <!-- credentials requires 2.222.4 or higher -->
+    <jenkins.version>2.249.1</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
@@ -280,7 +280,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.222.x</artifactId>
+        <artifactId>bom-2.249.x</artifactId>
         <version>25</version>
         <scope>import</scope>
         <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,6 @@
         </exclusion>
       </exclusions>
       <optional>true</optional>
-      <version>4.2.1</version>
     </dependency>
     <!-- JCasC compatibility -->
     <dependency>


### PR DESCRIPTION
## Require Jenkins 2.249.1 as minimum version

Jenkins 2.249.1 is a recommended version and will soon be two major LTS versions behind the current 2.277.1.

- Require Jenkins 2.249.1 minimum version
- Rely on the spotbugs annotation version from parent

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
