### PR TITLE
[JENKINS-64406] Expand environment variables when performing lightweight-checkout

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -257,16 +257,17 @@ public class GitSCMFileSystem extends SCMFileSystem {
         @Override
         public boolean supports(SCM source) {
             TaskListener listener = new LogTaskListener(LOGGER, Level.FINE);
-            if (source instanceof GitSCM) {
+            if (source instanceof GitSCM
+                    && ((GitSCM) source).getUserRemoteConfigs().size() == 1
+                    && ((GitSCM) source).getBranches().size() == 1
+            ) {
                 try {
                     Node n = (Node) Jenkins.get();
                     String branchName = ((GitSCM) source).getBranches().get(0).getName();
                     EnvVars env = new EnvVars(EnvVars.masterEnvVars);
                     env.putAllNonNull((Objects.requireNonNull(n.toComputer())).buildEnvironment(listener));
                     ((GitSCM) source).getBranches().get(0).setName(env.expand(branchName)); // JENKINS-64406
-                    return ((GitSCM) source).getUserRemoteConfigs().size() == 1
-                            && ((GitSCM) source).getBranches().size() == 1
-                            && !((GitSCM) source).getBranches().get(0).getName().equals("*") // JENKINS-57587
+                    return !((GitSCM) source).getBranches().get(0).getName().equals("*") // JENKINS-57587
                             && (
                             ((GitSCM) source).getBranches().get(0).getName().matches(
                                     "^((\\Q" + Constants.R_HEADS + "\\E.*)|([^/]+)|(\\*/[^/*]+(/[^/*]+)*))$"


### PR DESCRIPTION
 [JENKINS-64406](https://issues.jenkins-ci.org/browse/JENKINS-64406) - Expand environment variable to perform lightweight-checkout for Pipeline script from SCM using single branch

When performing a lightweight-checkout for `Pipeline script from SCM` using a global environment variable with a single branch, would lead to an error as the  environment variable support was not provided in the `supports(SCM source)` method of `GitSCMFileSystem` class. This PR focuses on providing environment variable support for a single branch build only. For multiple branches a full-checkout is performed and seems more rational for now.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

 Although the  environment variable support could also be provided in `build(Item owner, SCM scm, jenkins.scm.api.SCMRevision rev)` method as well but then the branch name has to be checked against the issue JENKINS-57587 again and other match cases, defeating the purpose of supports `(SCM source)` method.