### PR TITLE
[JENKINS-38699] Only check for git repo in current workspace dir

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.7.0</version>
+      <version>3.7.1-rc2780.420cdde29962</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>3.7.1-rc2780.420cdde29962</version>
+      <version>3.7.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -789,7 +789,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         GitClient git = createClient(listener, environment, project, node, workingDirectory);
 
-        if (git.hasGitRepo()) {
+        if (git.hasGitRepo(false)) {
             // Repo is there - do a fetch
             listener.getLogger().println("Fetching changes from the remote Git repositories");
 
@@ -1205,7 +1205,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         List<RemoteConfig> repos = getParamExpandedRepos(build, listener);
         if (repos.isEmpty())    return; // defensive check even though this is an invalid configuration
 
-        if (git.hasGitRepo()) {
+        if (git.hasGitRepo(false)) {
             // It's an update
             if (repos.size() == 1)
                 log.println("Fetching changes from the remote Git repository");

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -348,7 +348,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             }
             GitClient client = git.getClient();
             client.addDefaultCredentials(getCredentials());
-            if (!client.hasGitRepo()) {
+            if (!client.hasGitRepo(false)) {
                 listener.getLogger().println("Creating git repository in " + cacheDir);
                 client.init();
             }

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -329,7 +329,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     CredentialsProvider.track(owner, credential);
                 }
 
-                if (!client.hasGitRepo()) {
+                if (!client.hasGitRepo(false)) {
                     listener.getLogger().println("Creating git repository in " + cacheDir);
                     client.init();
                 }
@@ -391,7 +391,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 }
                 GitClient client = git.getClient();
                 client.addDefaultCredentials(gitSCMSource.getCredentials());
-                if (!client.hasGitRepo()) {
+                if (!client.hasGitRepo(false)) {
                     listener.getLogger().println("Creating git repository in " + cacheDir);
                     client.init();
                 }

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -102,7 +102,7 @@ public class GitToolChooser {
             if (cacheDir != null) {
                 Git git = Git.with(TaskListener.NULL, new EnvVars(EnvVars.masterEnvVars)).in(cacheDir).using("git");
                 GitClient client = git.getClient();
-                if (client.hasGitRepo()) {
+                if (client.hasGitRepo(false)) {
                     long clientRepoSize = FileUtils.sizeOfDirectory(cacheDir) / 1024; // Conversion from Bytes to Kilo Bytes
                     if (clientRepoSize > sizeOfRepo) {
                         if (sizeOfRepo > 0) {


### PR DESCRIPTION
## [JENKINS-38699](https://issues.jenkins-ci.org/browse/JENKINS-38699) - Only check for git repo in current workspace dir

Do not allow command line git operations to extend beyond the workspace.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

The CliGit implementation of hasGitRepo() has the strange and surprising behavior that if a workspace contains a directory named ".git" and that directory is not a git repository (for example, an empty directory), then command line git will search upwards in the file system tree to find a git repository and will perform its operations on the repository it finds.  That is the right behavior for a user running command line git.  It allows them to change to different directories and have the same experience with command line git.  JGit has a different behavior.  It does not search upwards for a repository.


It is a dangerous behavior when deciding to run `git clean` or other destructive operations in a Jenkins agent workspace.  If the agent workspace is damaged, then the git commands search upwards, outside the agent workspace.  This change causes the git plugin to only search in the workspace, not any of the parent directories of the workspace.

The new method `hasGitRepo(boolean checkParentDirectories)` allows the existing CliGit implementation and the existing JGit implementation of `hasGitRepo()` to continue as they are, while the git plugin uses the new API to not check parent directories in any case.

Special thanks to @arpoch for patient work understanding the problem, proposing a solution to the problem, and providing tests that show the problem.
