### PR TITLE
[JENKINS-38676] Add repository to git build data summary

### DIFF
--- a/src/main/resources/hudson/plugins/git/util/BuildData/index.jelly
+++ b/src/main/resources/hudson/plugins/git/util/BuildData/index.jelly
@@ -8,8 +8,18 @@
 	<l:main-panel>
 	<h1>${%Git Build Data}</h1>
 
-	<strong>${%Revision}:</strong> ${it.lastBuild.SHA1.name()}
-        <j:if test="${!empty(it.scmName)}"> from <strong>SCM:</strong> ${it.scmName}</j:if>
+	<strong>${%Revision}</strong>: ${it.lastBuild.SHA1.name()}
+	<j:if test="${!empty(it.scmName)}"><br/><strong>${%SCM}</strong>: ${it.scmName}</j:if>
+	<j:if test="${!empty(it.remoteUrls)}">
+		<j:forEach var="remoteUrl" items="${it.remoteUrls}">
+			<j:if test="${remoteUrl.startsWith('http')}">
+				<br/><strong>${%Repository}</strong>: <a href="${remoteUrl}">${remoteUrl}</a>
+			</j:if>
+			<j:if test="${!remoteUrl.startsWith('http')}">
+				<br/><strong>${%Repository}</strong>: ${remoteUrl}
+			</j:if>
+		</j:forEach>
+	</j:if>
 	<ul>
 	<j:forEach var="branch" items="${it.lastBuild.revision.branches}">
 	<li>${branch.name}</li>

--- a/src/main/resources/hudson/plugins/git/util/BuildData/summary.jelly
+++ b/src/main/resources/hudson/plugins/git/util/BuildData/summary.jelly
@@ -5,7 +5,17 @@
 	<t:summary icon="/plugin/git/icons/git-48x48.png">
 
 	<strong>${%Revision}</strong>: ${it.lastBuiltRevision.sha1.name()}
-        <j:if test="${!empty(it.scmName)}"> from <strong>SCM:</strong> ${it.scmName}</j:if>
+	<j:if test="${!empty(it.scmName)}"><br/><strong>${%SCM}</strong>: ${it.scmName}</j:if>
+	<j:if test="${!empty(it.remoteUrls)}">
+		<j:forEach var="remoteUrl" items="${it.remoteUrls}">
+			<j:if test="${remoteUrl.startsWith('http')}">
+				<br/><strong>${%Repository}</strong>: <a href="${remoteUrl}">${remoteUrl}</a>
+			</j:if>
+			<j:if test="${!remoteUrl.startsWith('http')}">
+				<br/><strong>${%Repository}</strong>: ${remoteUrl}
+			</j:if>
+		</j:forEach>
+	</j:if>
         <ul>
         <j:forEach var="branch" items="${it.lastBuiltRevision.branches}">
           <j:if test="${branch!=''}">


### PR DESCRIPTION
## [JENKINS-38676](https://issues.jenkins-ci.org/browse/JENKINS-38676) - Add repository to git build data summary

More and more jobs are including multiple repositories for things like Pipeline shared libraries and multiple repository builds.  Display the repository immediately below the revision as part of the git build data summary and the git build data details.  If the repository starts with 'http', then it will be displayed as a hyperlink.  There is a risk that the hyperlink cannot be resolved by a web browser, but that risk seems reasonable.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
