### PR TITLE
[JENKINS-65398] Terminology update

### DIFF
--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -186,7 +186,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
                 // set by variable, can't validate
                 return FormValidation.ok();
 
-            // get git executable on master
+            // get git executable on controller
             EnvVars environment;
             Jenkins jenkins = Jenkins.get();
             if (item instanceof Job) {

--- a/src/main/java/hudson/plugins/git/util/BuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooser.java
@@ -52,7 +52,7 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
      * Get a list of revisions that are candidates to be built.
      *
      * <p>
-     * This method is invoked on the node where the workspace exists, which may not be the master.
+     * This method is invoked on the node where the workspace exists, which may not be the controller.
      *
      * @param isPollCall true if this method is called from pollChanges.
      * @param singleBranch contains the name of a single branch to be built
@@ -272,7 +272,7 @@ public abstract class BuildChooser implements ExtensionPoint, Describable<BuildC
      *
      * @param git client to execute git commands on working tree
      * @param listener build log
-     * @param context back-channel to master so implementation can interact with Jenkins model
+     * @param context back-channel to controller so implementation can interact with Jenkins model
      * @throws IOException on input or output error
      * @throws InterruptedException when interrupted
      */

--- a/src/main/java/hudson/plugins/git/util/BuildChooserContext.java
+++ b/src/main/java/hudson/plugins/git/util/BuildChooserContext.java
@@ -10,11 +10,11 @@ import java.io.IOException;
 import java.io.Serializable;
 
 /**
- * Provides access to the model object on the master for {@link BuildChooser}.
+ * Provides access to the model object on the controller for {@link BuildChooser}.
  *
  * <p>
  * {@link BuildChooser} runs on a node that has the workspace, which means it can run on an agent.
- * This interface provides access for {@link BuildChooser} to send a closure to the master and execute code there.
+ * This interface provides access for {@link BuildChooser} to send a closure to the controller and execute code there.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -49,7 +49,7 @@ public class GitUtils implements Serializable {
      * Resolves Git Tool by name.
      * @param gitTool Tool name. If {@code null}, default tool will be used (if exists)
      * @param builtOn Node for which the tool should be resolved
-     *                Can be {@link Jenkins#getInstance()} when running on master
+     *                Can be {@link Jenkins#getInstance()} when running on controller
      * @param env Additional environment variables
      * @param listener Event listener
      * @return Tool installation or {@code null} if it cannot be resolved

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CheckoutOption/help-timeout.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CheckoutOption/help-timeout.html
@@ -2,5 +2,5 @@
   Specify a timeout (in minutes) for checkout.<br/>
   This option overrides the default timeout of 10 minutes. <br/>
   You can change the global git timeout via the property org.jenkinsci.plugins.gitclient.Git.timeOut (see <a href="https://issues.jenkins.io/browse/JENKINS-11286" target="_blank" rel="noopener noreferrer">JENKINS-11286</a>).
-  Note that property should be set on both master and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" target="_blank" rel="noopener noreferrer">JENKINS-22547</a>).
+  Note that property should be set on both controller and agent to have effect (see <a href="https://issues.jenkins.io/browse/JENKINS-22547" target="_blank" rel="noopener noreferrer">JENKINS-22547</a>).
 </div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-reference.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-reference.html
@@ -1,4 +1,4 @@
 <div>
   Specify a folder containing a repository that will be used by Git as a reference during clone operations.<br/>
-  This option will be ignored if the folder is not available on the master or agent where the clone is being executed.
+  This option will be ignored if the folder is not available on the controller or agent where the clone is being executed.
 </div>


### PR DESCRIPTION
## [JENKINS-65398](https://issues.jenkins.io/browse/JENKINS-65398) - Terminology update

The changes introduce terminology updates to replace `master` by `controller` and remaining `slave` by `agent`.
This is lead by [JENKINS-65398](https://issues.jenkins.io/browse/JENKINS-65398).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Documentation update
