### PR TITLE
Exclude dep checks on caffeine 3.0.0+

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,3 +68,7 @@ updates:
   - dependency-name: org.jenkins-ci.plugins:promoted-builds
     versions:
     - ">= 3.5.a, < 3.6"
+  - dependency-name: com.github.ben-manes.caffeine:caffeine
+    # caffeine 3.0.0 and later requires JDK 11
+    versions:
+    - ">= 3.0.0"


### PR DESCRIPTION
## Exclude dep checks on caffeine 3.0.0+

The caffeine 3.0.0 library requires JDK 11. Can't require JDK 11.

See #1081 for the dependabot request that generated this change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
