### PR TITLE
JENKINS-65798 use stream provided by jgit directly

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMFile.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFile.java
@@ -27,7 +27,6 @@ package jenkins.plugins.git;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -172,7 +171,7 @@ public class GitSCMFile extends SCMFile {
                     }
                     ObjectId objectId = tw.getObjectId(0);
                     ObjectLoader loader = repository.open(objectId);
-                    return new ByteArrayInputStream(loader.getBytes());
+                    return loader.openStream();
                 }
             }
         });


### PR DESCRIPTION
## [JENKINS-65798](https://issues.jenkins.io/browse/JENKINS-65798) - reduce memory churn

Forward the stream provided by jgit when using GitSCMFile::content instead of creating a byte[]. Base class SCMFile::contentAsBytes already provides this if really required.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

