### PR TITLE
Make GitChangeSet serializable (for use in Jenkins Pipeline CPS methods)

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -15,6 +15,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.io.IOException;
+import java.io.Serializable;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -40,7 +41,7 @@ import java.time.format.DateTimeParseException;
  * Represents a change set.
  * @author Nigel Magnay
  */
-public class GitChangeSet extends ChangeLogSet.Entry {
+public class GitChangeSet extends ChangeLogSet.Entry implements Serializable {
 
     private static final String PREFIX_AUTHOR = "author ";
     private static final String PREFIX_COMMITTER = "committer ";
@@ -588,7 +589,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
     }
 
     @ExportedBean(defaultVisibility=999)
-    public static class Path implements AffectedFile {
+    public static class Path implements AffectedFile, Serializable {
 
         private String src;
         private String dst;


### PR DESCRIPTION
Please let me know if there is any reason why this change doesn't make sense! I would have opened a GH 'issue' first for discussion, but it seems that Issues are not enabled on this repository...

Commit message:

"Jenkins requires that objects manipulated in Jenkins Pipeline Groovy methods which are not marked @NoCPS must be serializable. It seems that there is no particular reason why GitChangeSet should not be serializable, so mark it as such."

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
