### PR TITLE
Remove outdated calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,12 +123,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <exclusions>
-        <exclusion> <!-- script-security plugin depends on error_prone_annotations:2.3.4, others 2.4.0 -->
-          <groupId>com.google.errorprone</groupId>
-          <artifactId>error_prone_annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -152,12 +146,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion> <!-- junit plugin depends on error_prone_annotations:2.3.4, others 2.4.0 -->
-          <groupId>com.google.errorprone</groupId>
-          <artifactId>error_prone_annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -241,12 +229,6 @@
       <artifactId>xmlunit-matchers</artifactId>
       <version>2.8.2</version>
       <scope>test</scope>
-      <exclusions> <!-- Rely on version from junit plugin 1.43 -->
-        <exclusion>
-          <groupId>jakarta.activation</groupId>
-          <artifactId>jakarta.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1626,20 +1626,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         @NonNull
-        // TODO: Add @Override when Jenkins core baseline is 2.222+
+        @Override
         public Permission getRequiredGlobalConfigPagePermission() {
-            return getJenkinsManageOrAdmin();
-        }
-
-        // TODO: remove when Jenkins core baseline is 2.222+
-        Permission getJenkinsManageOrAdmin() {
-            Permission manage;
-            try { // Manage is available starting from Jenkins 2.222 (https://jenkins.io/changelog/#v2.222). See JEP-223 for more info
-                manage = (Permission) ReflectionUtils.getPublicProperty(Jenkins.get(), "MANAGE");
-            } catch (IllegalArgumentException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-                manage = Jenkins.ADMINISTER;
-            }
-            return manage;
+            return Jenkins.MANAGE;
         }
 
         public boolean isShowEntireCommitSummaryInChanges() {

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -53,7 +53,7 @@ public class GitUtils implements Serializable {
      * @param env Additional environment variables
      * @param listener Event listener
      * @return Tool installation or {@code null} if it cannot be resolved
-     * @since TODO
+     * @since 4.0.0
      */
     @CheckForNull
     public static GitTool resolveGitTool(@CheckForNull String gitTool,
@@ -88,14 +88,14 @@ public class GitUtils implements Serializable {
      * @param gitTool Tool name. If {@code null}, default tool will be used (if exists)
      * @param listener Event listener
      * @return Tool installation or {@code null} if it cannot be resolved
-     * @since TODO
+     * @since 4.0.0
      */
     @CheckForNull
     public static GitTool resolveGitTool(@CheckForNull String gitTool, @NonNull TaskListener listener) {
         return resolveGitTool(gitTool, null, null, listener);
     }
 
-    public static Node workspaceToNode(FilePath workspace) { // TODO https://trello.com/c/doFFMdUm/46-filepath-getcomputer
+    public static Node workspaceToNode(FilePath workspace) {
         Jenkins j = Jenkins.get();
         if (workspace != null && workspace.isRemote()) {
             for (Computer c : j.getComputers()) {


### PR DESCRIPTION
## Remove outdated code

- Remove permissions code for Jenkins core before 2.222
- Document release version for two API's
- Remove unused exclusions from pom file

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
