### PR TITLE
Remove caffeine dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,13 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <dependency>
+        <!-- Resolve Java 11 upper bounds error, remove when no longer needed -->
+        <groupId>jakarta.activation</groupId>
+        <artifactId>jakarta.activation-api</artifactId>
+        <version>1.2.2</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -274,24 +274,6 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      <dependency><!-- If caffeine is needed, use version 2.9.1.
-                       Resolves an upper bounds dependency message.
-                       Does not include caffeine in the hpi file. -->
-        <groupId>com.github.ben-manes.caffeine</groupId>
-        <artifactId>caffeine</artifactId>
-        <version>2.9.1</version>
-        <exclusions>
-          <!--  do not bring in the annotations -->
-          <exclusion>
-            <groupId>org.checkerframework</groupId>
-            <artifactId>checker-qual</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Remove caffeine dependency

Improve dependencies by removing an unnused dependency on caffeine.  It was added pending a release of the script-security plugin.  That release is now available and its version is included in the plugin BOM.

Add jakarata activation api dependency to resolve a Java 11 upper bound dependency error.  Error does not appear on Java 8, only Java 11.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
