### PR TITLE
Escape example URL

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1266,7 +1266,7 @@ The issue can be especially challenging when a job retains a very large number o
 
 Multiple attempts to resolve the core issue without breaking compatibility have been unsuccessful.
 A workaround is provided below that will remove the git build data from the build records.
-The workaround is a system groovy script that needs to be run from the Jenkins Administrator's Script Console (as in `https://jenkins.example.com/script` ).
+The workaround is a system groovy script that needs to be run from the Jenkins Administrator's Script Console (as in https\://jenkins.example.com/script ).
 Administrator permission is required to run system groovy scripts.
 
 This script removes the static list of BuildsByBranch that is stored for each build by the Git Plugin.

--- a/README.adoc
+++ b/README.adoc
@@ -1266,7 +1266,7 @@ The issue can be especially challenging when a job retains a very large number o
 
 Multiple attempts to resolve the core issue without breaking compatibility have been unsuccessful.
 A workaround is provided below that will remove the git build data from the build records.
-The workaround is a system groovy script that needs to be run from the Jenkins Administrator's Script Console (as in https\://jenkins.example.com/script ).
+The workaround is a system groovy script that needs to be run from the Jenkins Administrator's Script Console (as in \\https://jenkins.example.com/script ).
 Administrator permission is required to run system groovy scripts.
 
 This script removes the static list of BuildsByBranch that is stored for each build by the Git Plugin.

--- a/README.adoc
+++ b/README.adoc
@@ -1266,7 +1266,7 @@ The issue can be especially challenging when a job retains a very large number o
 
 Multiple attempts to resolve the core issue without breaking compatibility have been unsuccessful.
 A workaround is provided below that will remove the git build data from the build records.
-The workaround is a system groovy script that needs to be run from the Jenkins Administrator's Script Console (as in \https://jenkins.example.com/script ).
+The workaround is a system groovy script that needs to be run from the Jenkins Administrator's Script Console (as in `https://jenkins.example.com/script` ).
 Administrator permission is required to run system groovy scripts.
 
 This script removes the static list of BuildsByBranch that is stored for each build by the Git Plugin.


### PR DESCRIPTION
## Escape the example URL

Technique described in asciidoctor manual does not work for GitHub asciidoc renderer.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Documentation
