### PR TITLE
[JENKINS-66149] Warn against checkout to subdir extension in Pipeline

### DIFF
--- a/src/main/resources/hudson/plugins/git/extensions/impl/RelativeTargetDirectory/help-relativeTargetDir.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/RelativeTargetDirectory/help-relativeTargetDir.html
@@ -2,4 +2,11 @@
   Specify a local directory (relative to <a href="ws" target="_blank" rel="noopener noreferrer">the workspace root</a>)
   where the Git repository will be checked out. If left empty, the workspace root itself
   will be used.
+  <p>
+  This extension should <strong>not</strong> be used in Jenkins Pipeline (either declarative or scripted).
+  Jenkins Pipeline already provides standard techniques for checkout to a subdirectory.
+  Use <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#ws-allocate-workspace" target="_blank" rel="noopener noreferrer">ws</a> and
+  <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#dir-change-current-directory" target="_blank" rel="noopener noreferrer">dir</a>
+  in Jenkins Pipeline rather than this extension.
+  </p>
 </div>


### PR DESCRIPTION
## [JENKINS-66149](https://issues.jenkins.io/browse/JENKINS-66149) Warn Pipeline users to not use checkout to subdirectory

Include text from the documentation in the online help so that Pipeline users may see that they should not use the 'checkout to subdirectory' extension with Pipeline.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
