### PR TITLE
[JENKINS-66212] Fix getLastBuild null pointer exception

### DIFF
--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -177,10 +177,11 @@ public class BuildData implements Action, Serializable, Cloneable {
                 ObjectId lastBuildRevisionSha1 = lastBuild.revision.getSha1();
                 if (lastBuildRevisionSha1 != null) {
                     if (lastBuildRevisionSha1.equals(sha1)) {
-                        LOGGER.log(Level.FINEST, "lastBuildRevisionSha1 matches sha1:" + sha1.getName() + ", returning lastBuild");
+                        LOGGER.log(Level.FINEST, "lastBuildRevisionSha1 matches sha1:{0}, returning lastBuild", sha1.getName());
                         return lastBuild;
                     } else {
-                        LOGGER.log(Level.FINEST, "lastBuildRevisionSha1: " + lastBuildRevisionSha1.getName() + " does not match sha1:" + sha1.getName() + ", checking lastBuild.marked");
+                        LOGGER.log(Level.FINEST, "lastBuildRevisionSha1: {0} does not match sha1:{1}, checking lastBuild.marked",
+                                new Object[]{lastBuildRevisionSha1.getName(), sha1.getName()});
                     }
                 } else {
                     LOGGER.log(Level.FINEST, "lastBuild.revision.getSha1() is null, checking lastBuild.marked");
@@ -192,10 +193,11 @@ public class BuildData implements Action, Serializable, Cloneable {
                 ObjectId lastBuildMarkedSha1 = lastBuild.marked.getSha1();
                 if (lastBuildMarkedSha1 != null) {
                     if (lastBuildMarkedSha1.equals(sha1)) {
-                        LOGGER.log(Level.FINEST, "lastBuildMarkedSha1 matches sha1:" + sha1.getName() + ", returning lastBuild");
+                        LOGGER.log(Level.FINEST, "lastBuildMarkedSha1 matches sha1:{0}, returning lastBuild", sha1.getName());
                         return lastBuild;
                     } else {
-                        LOGGER.log(Level.FINEST, "lastBuildMarkedSha1:" + lastBuildMarkedSha1.getName() + " does not match sha1:" + sha1.getName());
+                        LOGGER.log(Level.FINEST, "lastBuildMarkedSha1: {0} does not match sha1:{1}",
+                                new Object[]{lastBuildMarkedSha1.getName(), sha1.getName()});
                     }
                 } else {
                     LOGGER.log(Level.FINEST, "lastBuild.marked.getSha1() is null");

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -164,22 +164,63 @@ public class BuildData implements Action, Serializable, Cloneable {
     }
 
     public Build getLastBuild(ObjectId sha1) {
+        if (sha1 == null) {
+            LOGGER.log(Level.FINEST, "sha1 is null in getLastBuild, returning null");
+            return null;
+        }
         // fast check by first checking most recent build
-        if (lastBuild != null && (lastBuild.revision.getSha1().equals(sha1) || lastBuild.marked.getSha1().equals(sha1))) return lastBuild;
+        if (lastBuild != null) {
+            if (lastBuild.revision != null) {
+                ObjectId lastBuildRevisionSha1 = lastBuild.revision.getSha1();
+                if (lastBuildRevisionSha1 != null) {
+                    if (lastBuildRevisionSha1.equals(sha1)) {
+                        LOGGER.log(Level.FINEST, "lastBuildRevisionSha1 matches sha1:" + sha1.getName() + ", returning lastBuild");
+                        return lastBuild;
+                    } else {
+                        LOGGER.log(Level.FINEST, "lastBuildRevisionSha1: " + lastBuildRevisionSha1.getName() + " does not match sha1:" + sha1.getName() + ", checking lastBuild.marked");
+                    }
+                } else {
+                    LOGGER.log(Level.FINEST, "lastBuild.revision.getSha1() is null, checking lastBuild.marked");
+                }
+            } else {
+                LOGGER.log(Level.FINEST, "lastBuild.revision is null, checking lastBuild.marked");
+            }
+            if (lastBuild.marked != null) {
+                ObjectId lastBuildMarkedSha1 = lastBuild.marked.getSha1();
+                if (lastBuildMarkedSha1 != null) {
+                    if (lastBuildMarkedSha1.equals(sha1)) {
+                        LOGGER.log(Level.FINEST, "lastBuildMarkedSha1 matches sha1:" + sha1.getName() + ", returning lastBuild");
+                        return lastBuild;
+                    } else {
+                        LOGGER.log(Level.FINEST, "lastBuildMarkedSha1:" + lastBuildMarkedSha1.getName() + " does not match sha1:" + sha1.getName());
+                    }
+                } else {
+                    LOGGER.log(Level.FINEST, "lastBuild.marked.getSha1() is null");
+                }
+            } else {
+                LOGGER.log(Level.FINEST, "lastBuild.marked is null");
+            }
+        } else {
+            LOGGER.log(Level.FINEST, "lastBuild is null");
+        }
+
         for (Build b : buildsByBranchName.values()) {
             if (b == null || b.revision == null || b.revision.getSha1() == null) {
                 continue;
             }
             if (b.revision.getSha1().equals(sha1)) {
+                LOGGER.log(Level.FINEST, "b.lastBuildRevisionSha1 matches sha1:" + sha1.getName() + ", returning b");
                 return b;
             }
             if (b.marked == null || b.marked.getSha1() == null) {
                 continue;
             }
             if (b.marked.getSha1().equals(sha1)) {
+                LOGGER.log(Level.FINEST, "b.lastBuildMarkedSha1 matches sha1:" + sha1.getName() + ", returning b");
                 return b;
             }
         }
+        LOGGER.log(Level.FINEST, "No match found in getLastBuild for sha1:" + sha1.getName() + ", returning null");
         return null;
     }
 

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -93,16 +93,19 @@ public class BuildData implements Action, Serializable, Cloneable {
      *
      * @return build data display name
      */
+    @Override
     public String getDisplayName() {
         if (scmName != null && !scmName.isEmpty())
             return "Git Build Data:" + scmName;
         return "Git Build Data";
     }
 
+    @Override
     public String getIconFileName() {
         return jenkins.model.Jenkins.RESOURCE_PATH+"/plugin/git/icons/git-32x32.png";
     }
 
+    @Override
     public String getUrlName() {
         return index == null ? "git" : "git-"+index;
     }

--- a/src/test/java/hudson/plugins/git/util/BuildDataTest.java
+++ b/src/test/java/hudson/plugins/git/util/BuildDataTest.java
@@ -92,11 +92,88 @@ public class BuildDataTest {
     }
 
     @Test
+    public void testGetLastBuildSingleBranch() {
+        String branchName = "origin/master";
+        Collection<Branch> branches = new ArrayList<>();
+        Branch branch = new Branch(branchName, sha1);
+        branches.add(branch);
+        Revision revision = new Revision(sha1, branches);
+        Build build = new Build(revision, 13, Result.FAILURE);
+        data.saveBuild(build);
+        assertThat(data.getLastBuild(sha1), is(build));
+
+        ObjectId newSha1 = ObjectId.fromString("31a987bc9fc0b08d1ad297cac8584d5871a21581");
+        Revision newRevision = new Revision(newSha1, branches);
+        Revision marked = revision;
+        Build newBuild = new Build(marked, newRevision, 17, Result.SUCCESS);
+        data.saveBuild(newBuild);
+        assertThat(data.getLastBuild(newSha1), is(newBuild));
+
+        assertThat(data.getLastBuild(sha1), is(newBuild));
+
+        ObjectId unbuiltSha1 = ObjectId.fromString("da99ce34121292bc887e91fc0a9d60cf8a701662");
+        assertThat(data.getLastBuild(unbuiltSha1), is(nullValue()));
+    }
+
+    @Test
+    public void testGetLastBuildMultipleBranches() {
+
+        String branchName = "origin/master";
+        Collection<Branch> branches = new ArrayList<>();
+        Branch branch = new Branch(branchName, sha1);
+        branches.add(branch);
+        Revision revision = new Revision(sha1, branches);
+        Build build = new Build(revision, 13, Result.FAILURE);
+        data.saveBuild(build);
+        assertThat(data.getLastBuild(sha1), is(build));
+
+        ObjectId newSha1 = ObjectId.fromString("31a987bc9fc0b08d1ad297cac8584d5871a21581");
+        Branch newBranch = new Branch("origin/stable-3.x", newSha1);
+        branches.add(newBranch);
+        Revision newRevision = new Revision(newSha1, branches);
+        Revision marked = revision;
+        Build newBuild = new Build(marked, newRevision, 17, Result.SUCCESS);
+        data.saveBuild(newBuild);
+        assertThat(data.getLastBuild(newSha1), is(newBuild));
+
+        assertThat(data.getLastBuild(sha1), is(newBuild));
+
+        ObjectId unbuiltSha1 = ObjectId.fromString("da99ce34121292bc887e91fc0a9d60cf8a701662");
+        assertThat(data.getLastBuild(unbuiltSha1), is(nullValue()));
+    }
+
+    @Test
+    public void testGetLastBuildWithNullSha1() {
+        assertThat(data.getLastBuild(null), is(nullValue()));
+
+        String branchName = "origin/master";
+        Collection<Branch> branches = new ArrayList<>();
+        Branch branch = new Branch(branchName, sha1);
+        branches.add(branch);
+        Revision revision = new Revision(null, branches); // A revision with a null sha1 (unexpected)
+        Build build = new Build(revision, 29, Result.FAILURE);
+        data.saveBuild(build);
+        assertThat(data.getLastBuild(sha1), is(nullValue()));
+
+        ObjectId unbuiltSha1 = ObjectId.fromString("da99ce34121292bc887e91fc0a9d60cf8a701662");
+        assertThat(data.getLastBuild(unbuiltSha1), is(nullValue()));
+    }
+
+    @Test
     public void testSaveBuild() {
         Revision revision = new Revision(sha1);
         Build build = new Build(revision, 1, Result.SUCCESS);
         data.saveBuild(build);
         assertThat(data.getLastBuild(sha1), is(build));
+
+        Revision nullRevision = new Revision(null);
+        Build newBuild = new Build(revision, nullRevision, 2, Result.SUCCESS);
+        data.saveBuild(newBuild);
+        assertThat(data.getLastBuild(sha1), is(newBuild));
+
+        Build anotherBuild = new Build(nullRevision, revision, 3, Result.SUCCESS);
+        data.saveBuild(anotherBuild);
+        assertThat(data.getLastBuild(sha1), is(anotherBuild));
     }
 
     @Test
@@ -486,6 +563,11 @@ public class BuildDataTest {
         assertTrue(dataClone.similarTo(data2));
         data2.setScmName("scm 2");
         assertTrue(dataClone.similarTo(data2));
+    }
+
+    @Test
+    public void testHashCode() {
+        // Tested in testEquals
     }
 
     @Test


### PR DESCRIPTION
## [JENKINS-66212](https://issues.jenkins.io/browse/JENKINS-66212) - Fix getLastBuild null pointer exception

Provide diagnostic logging to identify which of the previous expected conditions are no longer valid.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
