### PR TITLE
[JENKINS-66214] Fix gitUsernamePassword capitalization

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -75,21 +75,21 @@ The variable bindings are available even if the `JGit` or `JGit with Apache HTTP
 
 .Shell example
 ```groovy
-withCredentials([GitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
   sh 'git fetch --all'
 }
 ```
 
 .Batch example
 ```groovy
-withCredentials([GitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
   bat 'git submodule update --init --recursive'
 }
 ```
 
 .Powershell example
 ```groovy
-withCredentials([GitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
   powershell 'git push'
 }
 ```

--- a/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
+++ b/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
@@ -174,7 +174,8 @@ public class GitUsernamePasswordBinding extends MultiBinding<StandardUsernamePas
         }
     }
 
-    @Symbol("GitUsernamePassword")
+    // Mistakenly defined GitUsernamePassword in first release, prefer gitUsernamePassword as symbol
+    @Symbol({"gitUsernamePassword", "GitUsernamePassword"})
     @Extension
     public static final class DescriptorImpl extends BindingDescriptor<StandardUsernamePasswordCredentials> {
 

--- a/src/main/resources/jenkins/plugins/git/GitUsernamePasswordBinding/help-credentialsId.html
+++ b/src/main/resources/jenkins/plugins/git/GitUsernamePasswordBinding/help-credentialsId.html
@@ -4,7 +4,7 @@
 <p>
 <strong>Shell example</strong>
 <pre>
-withCredentials([GitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
   sh 'git fetch --all'
 }
 </pre>
@@ -13,7 +13,7 @@ withCredentials([GitUsernamePassword(credentialsId: 'my-credentials-id', gitTool
 <p>
 <strong>Batch example</strong>
 <pre>
-withCredentials([GitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
   bat 'git submodule update --init --recursive'
 }
 </pre>
@@ -22,7 +22,7 @@ withCredentials([GitUsernamePassword(credentialsId: 'my-credentials-id', gitTool
 <p>
 <strong>Powershell example</strong>
 <pre>
-withCredentials([GitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
   powershell 'git push'
 }
 </pre>

--- a/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
+++ b/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
@@ -165,7 +165,7 @@ public class GitUsernamePasswordBindingTest {
         if (isCliGitTool()) {
             project.setDefinition(new CpsFlowDefinition(""
                     + "node {\n"
-                    + "withCredentials([GitUsernamePassword(credentialsId: '" + credentialID + "', gitToolName: '" + gitToolInstance.getName() + "')]) {"
+                    + "  withCredentials([gitUsernamePassword(credentialsId: '" + credentialID + "', gitToolName: '" + gitToolInstance.getName() + "')]) {"
                     + "    if (isUnix()) {\n"
                     + "      sh 'env | grep -E \"GIT_USERNAME|GIT_PASSWORD|GIT_TERMINAL_PROMPT\" > auth.txt'\n"
                     + "    } else {\n"
@@ -176,7 +176,7 @@ public class GitUsernamePasswordBindingTest {
         } else {
             project.setDefinition(new CpsFlowDefinition(""
                     + "node {\n"
-                    + "withCredentials([GitUsernamePassword(credentialsId: '" + credentialID + "', gitToolName: '" + gitToolInstance.getName() + "')]) {"
+                    + "  withCredentials([gitUsernamePassword(credentialsId: '" + credentialID + "', gitToolName: '" + gitToolInstance.getName() + "')]) {"
                     + "    if (isUnix()) {\n"
                     + "      sh 'env | grep -E \"GIT_USERNAME|GIT_PASSWORD|GIT_TERMINAL_PROMPT\" > auth.txt'\n"
                     + "    } else {\n"

--- a/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
+++ b/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Collection;
+import java.util.Random;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -81,6 +82,8 @@ public class GitUsernamePasswordBindingTest {
     private UsernamePasswordCredentialsImpl credentials = null;
     private GitUsernamePasswordBinding gitCredBind = null;
 
+    private final Random random = new Random();
+
     public GitUsernamePasswordBindingTest(String username, String password, GitTool gitToolInstance) {
         this.username = username;
         this.password = password;
@@ -107,24 +110,22 @@ public class GitUsernamePasswordBindingTest {
         Jenkins.get().getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(gitToolInstance);
     }
 
+    private String batchCheck(boolean includeCliCheck) {
+        return includeCliCheck
+                ? "set | findstr GIT_USERNAME > auth.txt & set | findstr GIT_PASSWORD >> auth.txt & set | findstr GCM_INTERACTIVE >> auth.txt"
+                : "set | findstr GIT_USERNAME > auth.txt & set | findstr GIT_PASSWORD >> auth.txt";
+    }
+
+    private String shellCheck() {
+        return "env | grep -E \"GIT_USERNAME|GIT_PASSWORD|GIT_TERMINAL_PROMPT\" > auth.txt";
+    }
+
     @Test
     public void test_EnvironmentVariables_FreeStyleProject() throws Exception {
         FreeStyleProject prj = r.createFreeStyleProject();
         prj.getBuildWrappersList().add(new SecretBuildWrapper(Collections.<MultiBinding<?>>
                 singletonList(new GitUsernamePasswordBinding(gitToolInstance.getName(), credentialID))));
-        if (isCliGitTool()) {
-            if (isWindows()) {
-                prj.getBuildersList().add(new BatchFile("set | findstr GIT_USERNAME > auth.txt & set | findstr GIT_PASSWORD >> auth.txt & set | findstr GCM_INTERACTIVE >> auth.txt"));
-            } else {
-                prj.getBuildersList().add(new Shell("env | grep -E \"GIT_USERNAME|GIT_PASSWORD|GIT_TERMINAL_PROMPT\" > auth.txt"));
-            }
-        } else {
-            if (isWindows()) {
-                prj.getBuildersList().add(new BatchFile("set | findstr GIT_USERNAME > auth.txt & set | findstr GIT_PASSWORD >> auth.txt"));
-            } else {
-                prj.getBuildersList().add(new Shell("env | grep -E \"GIT_USERNAME|GIT_PASSWORD|GIT_TERMINAL_PROMPT\" > auth.txt"));
-            }
-        }
+        prj.getBuildersList().add(isWindows() ? new BatchFile(batchCheck(isCliGitTool())) : new Shell(shellCheck()));
         r.configRoundtrip((Item) prj);
 
         SecretBuildWrapper wrapper = prj.getBuildWrappersList().get(SecretBuildWrapper.class);
@@ -162,29 +163,24 @@ public class GitUsernamePasswordBindingTest {
     @Test
     public void test_EnvironmentVariables_PipelineJob() throws Exception {
         WorkflowJob project = r.createProject(WorkflowJob.class);
-        if (isCliGitTool()) {
-            project.setDefinition(new CpsFlowDefinition(""
-                    + "node {\n"
-                    + "  withCredentials([gitUsernamePassword(credentialsId: '" + credentialID + "', gitToolName: '" + gitToolInstance.getName() + "')]) {"
-                    + "    if (isUnix()) {\n"
-                    + "      sh 'env | grep -E \"GIT_USERNAME|GIT_PASSWORD|GIT_TERMINAL_PROMPT\" > auth.txt'\n"
-                    + "    } else {\n"
-                    + "      bat 'set | findstr GIT_USERNAME > auth.txt & set | findstr GIT_PASSWORD >> auth.txt & set | findstr GCM_INTERACTIVE >> auth.txt'\n"
-                    + "    }\n"
-                    + "  }\n"
-                    + "}", true));
-        } else {
-            project.setDefinition(new CpsFlowDefinition(""
-                    + "node {\n"
-                    + "  withCredentials([gitUsernamePassword(credentialsId: '" + credentialID + "', gitToolName: '" + gitToolInstance.getName() + "')]) {"
-                    + "    if (isUnix()) {\n"
-                    + "      sh 'env | grep -E \"GIT_USERNAME|GIT_PASSWORD|GIT_TERMINAL_PROMPT\" > auth.txt'\n"
-                    + "    } else {\n"
-                    + "      bat 'set | findstr GIT_USERNAME > auth.txt & set | findstr GIT_PASSWORD >> auth.txt'\n"
-                    + "    }\n"
-                    + "  }\n"
-                    + "}", true));
-        }
+
+        // JENKINS-66214 - allow either gitUsernamePassword or GitUsernamePassword as keyword
+        String keyword = random.nextBoolean() ? "gitUsernamePassword" : "GitUsernamePassword";
+
+        // Use default tool if JGit or JGitApache
+        String gitToolNameArg = !isCliGitTool() ? "" : ", gitToolName: '" + gitToolInstance.getName() + "'";
+
+        String pipeline = ""
+                + "node {\n"
+                + "  withCredentials([" + keyword + "(credentialsId: '" + credentialID + "'" + gitToolNameArg + ")]) {\n"
+                + "    if (isUnix()) {\n"
+                + "      sh '" + shellCheck() + "'\n"
+                + "    } else {\n"
+                + "      bat '" + batchCheck(isCliGitTool()) + "'\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+        project.setDefinition(new CpsFlowDefinition(pipeline, true));
         WorkflowRun b = project.scheduleBuild2(0).waitForStart();
         r.waitForCompletion(b);
         r.assertBuildStatusSuccess(b);
@@ -194,7 +190,7 @@ public class GitUsernamePasswordBindingTest {
         String fileContents = r.jenkins.getWorkspaceFor(project).child("auth.txt").readToString().trim();
         assertThat(fileContents, containsString("GIT_USERNAME=" + this.username));
         assertThat(fileContents, containsString("GIT_PASSWORD=" + this.password));
-        //Assert Git specific env variables
+        // Assert Git version specific env variables
         if (isCliGitTool()) {
             if (isWindows()) {
                 assertThat(fileContents, containsString("GCM_INTERACTIVE=false"));
@@ -209,11 +205,7 @@ public class GitUsernamePasswordBindingTest {
         FreeStyleProject prj = r.createFreeStyleProject();
         prj.getBuildWrappersList().add(new SecretBuildWrapper(Collections.<MultiBinding<?>>
                 singletonList(new GitUsernamePasswordBinding(gitToolInstance.getName(), credentialID))));
-        if (isWindows()) {
-            prj.getBuildersList().add(new BatchFile("set | findstr GIT_USERNAME > auth.txt & set | findstr GIT_PASSWORD >> auth.txt"));
-        } else {
-            prj.getBuildersList().add(new Shell("env | grep GIT_USERNAME > auth.txt; env | grep GIT_PASSWORD >> auth.txt;"));
-        }
+        prj.getBuildersList().add(isWindows() ? new BatchFile(batchCheck(false)) : new Shell(shellCheck()));
         r.configRoundtrip((Item) prj);
         SecretBuildWrapper wrapper = prj.getBuildWrappersList().get(SecretBuildWrapper.class);
         assertThat(wrapper, is(notNullValue()));


### PR DESCRIPTION
## [JENKINS-66214](https://issues.jenkins.io/browse/JENKINS-66214) - Use correct capitalization for gitUsernamePassword symbol

Git plugin 4.8.0 added git credentials binding so that sh, bat, and powershell steps could perform authenticated git operations with git repositories.  Unfortunately, the keyword used GitUsernamePassword instead of following the Pipeline DSL convention of gitUsernamePassword.  This change allows both forms and prefers the gitUsernamePassword form.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
