### PR TITLE
Simplify Linux test result search

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
+++ b/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
@@ -116,13 +116,13 @@ public class GitUsernamePasswordBindingTest {
             if (isWindows()) {
                 prj.getBuildersList().add(new BatchFile("set | findstr GIT_USERNAME > auth.txt & set | findstr GIT_PASSWORD >> auth.txt & set | findstr GCM_INTERACTIVE >> auth.txt"));
             } else {
-                prj.getBuildersList().add(new Shell("env | grep GIT_USERNAME > auth.txt; env | grep GIT_PASSWORD >> auth.txt; env | grep GIT_TERMINAL_PROMPT >> auth.txt;"));
+                prj.getBuildersList().add(new Shell("env | grep -E \"GIT_USERNAME|GIT_PASSWORD|GIT_TERMINAL_PROMPT\" > auth.txt"));
             }
         } else {
             if (isWindows()) {
                 prj.getBuildersList().add(new BatchFile("set | findstr GIT_USERNAME > auth.txt & set | findstr GIT_PASSWORD >> auth.txt"));
             } else {
-                prj.getBuildersList().add(new Shell("env | grep GIT_USERNAME > auth.txt; env | grep GIT_PASSWORD >> auth.txt;"));
+                prj.getBuildersList().add(new Shell("env | grep -E \"GIT_USERNAME|GIT_PASSWORD|GIT_TERMINAL_PROMPT\" > auth.txt"));
             }
         }
         r.configRoundtrip((Item) prj);
@@ -167,7 +167,7 @@ public class GitUsernamePasswordBindingTest {
                     + "node {\n"
                     + "withCredentials([GitUsernamePassword(credentialsId: '" + credentialID + "', gitToolName: '" + gitToolInstance.getName() + "')]) {"
                     + "    if (isUnix()) {\n"
-                    + "      sh 'env | grep GIT_USERNAME > auth.txt; env | grep GIT_PASSWORD >> auth.txt; env | grep GIT_TERMINAL_PROMPT >> auth.txt;'\n"
+                    + "      sh 'env | grep -E \"GIT_USERNAME|GIT_PASSWORD|GIT_TERMINAL_PROMPT\" > auth.txt'\n"
                     + "    } else {\n"
                     + "      bat 'set | findstr GIT_USERNAME > auth.txt & set | findstr GIT_PASSWORD >> auth.txt & set | findstr GCM_INTERACTIVE >> auth.txt'\n"
                     + "    }\n"
@@ -178,7 +178,7 @@ public class GitUsernamePasswordBindingTest {
                     + "node {\n"
                     + "withCredentials([GitUsernamePassword(credentialsId: '" + credentialID + "', gitToolName: '" + gitToolInstance.getName() + "')]) {"
                     + "    if (isUnix()) {\n"
-                    + "      sh 'env | grep GIT_USERNAME > auth.txt; env | grep GIT_PASSWORD >> auth.txt;'\n"
+                    + "      sh 'env | grep -E \"GIT_USERNAME|GIT_PASSWORD|GIT_TERMINAL_PROMPT\" > auth.txt'\n"
                     + "    } else {\n"
                     + "      bat 'set | findstr GIT_USERNAME > auth.txt & set | findstr GIT_PASSWORD >> auth.txt'\n"
                     + "    }\n"


### PR DESCRIPTION
## Simplify test result search

Fixes test execution on Linux computers with command line git versions older than 2.3.  One example is CentOS 7 with its installation of command line git 1.8.3.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
