### PR TITLE
Use plugin bom for credentials binding plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
-      <version>1.25</version>
     </dependency>
     <dependency><!-- we contribute AbstractBuildParameters for Git if it's available -->
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Use plugin bom for credentials binding plugin version

No need to specify the credentials binding plugin version explicity.  We can rely on the plugin bom evaluation to provide the minimum version.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields

## Types of changes

- [x] Dependency or infrastructure update
