### PR TITLE
Narrow the withCredentials example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -75,21 +75,24 @@ The variable bindings are available even if the `JGit` or `JGit with Apache HTTP
 
 .Shell example
 ```groovy
-withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id',
+                 gitToolName: 'git-tool')]) {
   sh 'git fetch --all'
 }
 ```
 
 .Batch example
 ```groovy
-withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id',
+                 gitToolName: 'git-tool')]) {
   bat 'git submodule update --init --recursive'
 }
 ```
 
 .Powershell example
 ```groovy
-withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id',
+                 gitToolName: 'git-tool')]) {
   powershell 'git push'
 }
 ```

--- a/src/main/resources/jenkins/plugins/git/GitUsernamePasswordBinding/help-credentialsId.html
+++ b/src/main/resources/jenkins/plugins/git/GitUsernamePasswordBinding/help-credentialsId.html
@@ -4,7 +4,8 @@
 <p>
 <strong>Shell example</strong>
 <pre>
-withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id',
+                 gitToolName: 'git-tool')]) {
   sh 'git fetch --all'
 }
 </pre>
@@ -13,7 +14,8 @@ withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitTool
 <p>
 <strong>Batch example</strong>
 <pre>
-withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id',
+                 gitToolName: 'git-tool')]) {
   bat 'git submodule update --init --recursive'
 }
 </pre>
@@ -22,7 +24,8 @@ withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitTool
 <p>
 <strong>Powershell example</strong>
 <pre>
-withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id', gitToolName: 'git-tool')]) {
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id',
+                 gitToolName: 'git-tool')]) {
   powershell 'git push'
 }
 </pre>


### PR DESCRIPTION
## Make pipeline step docs easier to read

https://www.jenkins.io/doc/pipeline/steps/credentials-binding/#withcredentials-bind-credentials-to-variables will be easier to read without a horizontal scroll bar in the example text.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields

## Types of changes

- [x] Documentation
