### PR TITLE
Require POST for tool name API call

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
+++ b/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
@@ -15,6 +15,7 @@ import hudson.plugins.git.GitTool;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
 import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
@@ -185,6 +186,7 @@ public class GitUsernamePasswordBinding extends MultiBinding<StandardUsernamePas
             return Messages.GitUsernamePasswordBinding_DisplayName();
         }
 
+        @RequirePOST
         public ListBoxModel doFillGitToolNameItems() {
             ListBoxModel items = new ListBoxModel();
              List<GitTool> toolList = Jenkins.get().getDescriptorByType(GitSCM.DescriptorImpl.class).getGitTools();


### PR DESCRIPTION
## Require POST for the git tool name check call

Only used for Jenkins forms, should always be POST.  The call is not especially expensive, but there is no reason to allow a GET request in this context.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Infrastructure update
