### PR TITLE
JENKINS-25389 Allow push of tags created during the build

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1290,6 +1290,10 @@ The commits in the local workspace have been evaluated by the job.
 The most recent commits from the remote repository have not been evaluated by the job.
 Users may find that the risk of pushing an untested configuration is less than the risk of delaying the visibility of the changes which have been evaluated by the job.
 
+Include tags::
+
+  Push all tags to the selected remote (same as --tags option of git-push).
+
 [#combining-repositories]
 == Combining repositories
 

--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -318,7 +318,7 @@ public class GitPublisher extends Recorder implements Serializable {
 
                         listener.getLogger().println("Pushing HEAD to branch " + branchName + " at repo "
                                                      + targetRepo);
-                        PushCommand push = git.push().to(remoteURI).ref("HEAD:" + branchName).force(forcePush);
+                        PushCommand push = git.push().to(remoteURI).ref("HEAD:" + branchName).tags(b.includeTags).force(forcePush);
                         push.execute();
                     } catch (GitException e) {
                         e.printStackTrace(listener.error("Failed to push branch " + branchName + " to " + targetRepo));
@@ -498,6 +498,7 @@ public class GitPublisher extends Recorder implements Serializable {
     public static final class BranchToPush extends PushConfig {
         private String branchName;
         private boolean rebaseBeforePush;
+        private boolean includeTags;
 
         public String getBranchName() {
             return branchName;
@@ -516,6 +517,15 @@ public class GitPublisher extends Recorder implements Serializable {
 
         public boolean getRebaseBeforePush() {
             return rebaseBeforePush;
+        }
+
+        @DataBoundSetter
+        public void setIncludeTags(boolean includeTags){
+            this.includeTags = includeTags;
+        }
+
+        public boolean getIncludeTags(){
+            return includeTags;
         }
 
         @Extension

--- a/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
@@ -79,6 +79,9 @@
           <f:entry field="rebaseBeforePush">
             <f:checkbox title="${%Rebase before push}" />
           </f:entry>
+          <f:entry field="includeTags">
+            <f:checkbox title="${%Include tags in the push}" />
+          </f:entry>
         </local:blockWrapper>
         <div align="right">
           <input type="button" value="${%Delete Branch}" class="repeatable-delete" style="margin-left: 1em;" />


### PR DESCRIPTION
## [JENKINS-25389](https://issues.jenkins.io/browse/JENKINS-25389) - Allow push of tags created during the build

This change adds an option named `Include tags in the push` to each branch to push. When checked, the branch will be pushed with the equivalent of git-push `--tags` option.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [x] New feature (non-breaking change which adds functionality)
