### PR TITLE
[JENKINS-66296] Restore a package protected method

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1635,6 +1635,21 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             return Jenkins.MANAGE;
         }
 
+        /**
+         * Package protected method that was added for temporary use
+         * with the Manage permission until the plugin required a
+         * Jenkins core version that has Manage permission available.
+         * Unfortunately, because it is package protected, it is part
+         * of the class signature and needs to be retained for
+         * compatibility.  Method was removed in git plugin 4.8.0 and
+         * the removal seems to have exposed a bug elsewhere that is
+         * reported as https://issues.jenkins.io/browse/JENKINS-66296 ,
+         * Restoring this method seems to resolve that issue.
+         */
+        Permission getJenkinsManageOrAdmin() {
+            return Jenkins.MANAGE;
+        }
+
         public boolean isShowEntireCommitSummaryInChanges() {
             return showEntireCommitSummaryInChanges;
         }


### PR DESCRIPTION
## [JENKINS-66296](https://issues.jenkins.io/browse/JENKINS-66296) - Avoid unnecessary polling generated rebuild after upgrade

The removal of the package protected method getJenkinsManageOrAdmin seems to have caused JENKINS-66296, an unmarshalling error in the upgrade from git plugin 4.7.2 to git plugin 4.8.0.

Restoring the package protected method seems to avoid the unmarshalling and thus avoids a problem elsewhere in the code.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
