### PR TITLE
Git credentials binding unit test improvements

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
+++ b/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
@@ -139,7 +139,9 @@ public class GitUsernamePasswordBindingTest {
         }
 
         FreeStyleBuild b = r.buildAndAssertSuccess(prj);
-        r.assertLogNotContains(this.username, b);
+        if(credentials.isUsernameSecret()) {
+            r.assertLogNotContains(this.username, b);
+        }
         r.assertLogNotContains(this.password, b);
 
         //Assert Keys
@@ -147,7 +149,9 @@ public class GitUsernamePasswordBindingTest {
         assertThat(binding.variables(b), hasItem("GIT_PASSWORD"));
         //Assert setKeyBindings method
         String fileContents = b.getWorkspace().child("auth.txt").readToString().trim();
-        assertThat(fileContents, containsString("GIT_USERNAME=" + this.username));
+        if(credentials.isUsernameSecret()) {
+            assertThat(fileContents, containsString("GIT_USERNAME=" + this.username));
+        }
         assertThat(fileContents, containsString("GIT_PASSWORD=" + this.password));
         //Assert Git specific env variables
         if (isCliGitTool()) {
@@ -183,11 +187,15 @@ public class GitUsernamePasswordBindingTest {
         WorkflowRun b = project.scheduleBuild2(0).waitForStart();
         r.waitForCompletion(b);
         r.assertBuildStatusSuccess(b);
-        r.assertLogNotContains(this.username, b);
+        if(credentials.isUsernameSecret()) {
+            r.assertLogNotContains(this.username, b);
+        }
         r.assertLogNotContains(this.password, b);
         //Assert setKeyBindings method
         String fileContents = r.jenkins.getWorkspaceFor(project).child("auth.txt").readToString().trim();
-        assertThat(fileContents, containsString("GIT_USERNAME=" + this.username));
+        if(credentials.isUsernameSecret()) {
+            assertThat(fileContents, containsString("GIT_USERNAME=" + this.username));
+        }
         assertThat(fileContents, containsString("GIT_PASSWORD=" + this.password));
         // Assert Git version specific env variables
         if (isCliGitTool()) {

--- a/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
+++ b/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
@@ -92,7 +92,6 @@ public class GitUsernamePasswordBindingTest {
 
     @Before
     public void basicSetup() throws IOException {
-        Jenkins.get();
         //File init
         rootDir = tempFolder.getRoot();
         rootFilePath = new FilePath(rootDir.getAbsoluteFile());

--- a/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
+++ b/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
@@ -49,7 +49,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 @RunWith(Parameterized.class)
 public class GitUsernamePasswordBindingTest {
-    @Parameterized.Parameters(name = "User {0}: Password {1}: GitToolName {2}: GitToolInstance {3}")
+    @Parameterized.Parameters(name = "User {0}: Password {1}: GitToolInstance {2}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
                 {"randomName", "special%%_342@**", new GitTool("git", "git", null)},

--- a/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
+++ b/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
@@ -147,13 +147,13 @@ public class GitUsernamePasswordBindingTest {
         //Assert Keys
         assertThat(binding.variables(b), hasItem("GIT_USERNAME"));
         assertThat(binding.variables(b), hasItem("GIT_PASSWORD"));
-        //Assert setKeyBindings method
+        //Assert credential values
         String fileContents = b.getWorkspace().child("auth.txt").readToString().trim();
         if(credentials.isUsernameSecret()) {
             assertThat(fileContents, containsString("GIT_USERNAME=" + this.username));
         }
         assertThat(fileContents, containsString("GIT_PASSWORD=" + this.password));
-        //Assert Git specific env variables
+        //Assert Git specific env variables based on its version
         if (isCliGitTool()) {
             if (isWindows()) {
                 assertThat(fileContents, containsString("GCM_INTERACTIVE=false"));
@@ -191,13 +191,13 @@ public class GitUsernamePasswordBindingTest {
             r.assertLogNotContains(this.username, b);
         }
         r.assertLogNotContains(this.password, b);
-        //Assert setKeyBindings method
+        //Assert credential values
         String fileContents = r.jenkins.getWorkspaceFor(project).child("auth.txt").readToString().trim();
         if(credentials.isUsernameSecret()) {
             assertThat(fileContents, containsString("GIT_USERNAME=" + this.username));
         }
         assertThat(fileContents, containsString("GIT_PASSWORD=" + this.password));
-        // Assert Git version specific env variables
+        // Assert Git specific env variables based on its version
         if (isCliGitTool()) {
             if (isWindows()) {
                 assertThat(fileContents, containsString("GCM_INTERACTIVE=false"));

--- a/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
+++ b/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
@@ -208,6 +208,11 @@ public class GitUsernamePasswordBindingTest {
     }
 
     @Test
+    public void test_isCurrentNodeOSUnix(){
+        assertThat(gitCredBind.isCurrentNodeOSUnix(r.createLocalLauncher()), not(equalTo(isWindows())));
+    }
+
+    @Test
     public void test_getCliGitTool_using_FreeStyleProject() throws Exception {
         FreeStyleProject prj = r.createFreeStyleProject();
         prj.getBuildWrappersList().add(new SecretBuildWrapper(Collections.<MultiBinding<?>>


### PR DESCRIPTION
## [JENKINS-66525](https://issues.jenkins.io/browse/JENKINS-66525) - Improvements for Git Username Password binding unit tests 

This PR removes redundant code in `Git Username Password Binding` test class, making the it more understandable. New unit tests are also added.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency or infrastructure update
