### PR TITLE
Adapting `GitSCMSourceTest` and `GitToolChooserTest` to jenkinsci/jenkins#5425

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
@@ -364,7 +364,7 @@ public class GitSCMSourceTest {
             return;
         }
         TaskListener log = StreamTaskListener.fromStdout();
-        HelloToolInstaller inst = new HelloToolInstaller("master", "echo Hello", "git");
+        HelloToolInstaller inst = new HelloToolInstaller(jenkins.jenkins.getSelfLabel().getName(), "echo Hello", "git");
         GitTool t = new GitTool("myGit", null, Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
         t.getDescriptor().setInstallations(t);

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -113,7 +113,7 @@ public class GitToolChooserTest {
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
 
-        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", "updated/git");
+        TestToolInstaller inst = new TestToolInstaller(jenkins.jenkins.getSelfLabel().getName(), "echo Hello", "updated/git");
         GitTool t = new GitTool("myGit", "default/git", Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
 
@@ -148,7 +148,7 @@ public class GitToolChooserTest {
         agent.setMode(Node.Mode.NORMAL);
         agent.setLabelString("agent-windows");
 
-        TestToolInstaller inst = new TestToolInstaller("master", "echo Hello", "myGit/git");
+        TestToolInstaller inst = new TestToolInstaller(jenkins.jenkins.getSelfLabel().getName(), "echo Hello", "myGit/git");
         GitTool toolOnMaster = new GitTool("myGit", "default/git", Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
 


### PR DESCRIPTION
More breakage from jenkinsci/jenkins#5425. This gets the test to pass against both old and new cores.