### PR TITLE
[JENKINS-64803] Test case retrieve tags with folder scoped credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <version>3.7.1</version>


### PR DESCRIPTION
## [JENKINS-64803](https://issues.jenkins.io/browse/JENKINS-64803) - summarize pull request in one line

In the context of Shared Library, the fetching of tags fails because the implementation of [protected SCMRevision retrieve​(@NonNull String thingName, @NonNull TaskListener listener, @CheckForNull Item context)](https://javadoc.jenkins.io/plugin/scm-api/jenkins/scm/api/SCMSource.html#retrieve(java.lang.String,hudson.model.TaskListener,hudson.model.Item)) eventually looses the Item context. In such cases, the [credentials lookup uses getOwner()](https://github.com/jenkinsci/git-plugin/blob/git-4.8.2/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java#L1252-L1255) that in the case of a pipeline library is `null`. Therefore if the credentials provided are defined at a folder level, the lookup does not find them.

The suggested fix pass the `retrieveContext` passed from the SCM API does the `doRetrieve` methods when we have it.

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
~- [ ] I have added documentation as necessary~
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
~- [ ] Documentation in README has been updated as necessary~
~- [ ] Online help has been added and reviewed for any new or modified fields~
- [ ] I have interactively tested my changes
~- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)~

## Types of changes

~- [ ] Dependency or infrastructure update~
- [ ] Bug fix (non-breaking change which fixes an issue)
~- [ ] New feature (non-breaking change which adds functionality)~
~- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~