### PR TITLE
Remove two Assembla tests

### DIFF
--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -81,13 +81,6 @@ public class AssemblaWebDoCheckURLTest {
     }
 
     @Test
-    public void testPathLevelChecksOnRepoUrl() throws Exception {
-        // Any path related errors will not be caught except syntax issues
-        String url = "https://app.assembla.com/spaces/";
-        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url), is(FormValidation.ok()));
-    }
-
-    @Test
     public void testPathLevelChecksOnRepoUrlSupersetOfAssembla() throws Exception {
         java.util.Random random = new java.util.Random();
         String [] urls = {
@@ -102,12 +95,6 @@ public class AssemblaWebDoCheckURLTest {
         String url = urls[random.nextInt(urls.length)]; // Don't abuse a single web site with tests
         assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
                 is("Invalid URL"));
-    }
-
-    @Test
-    public void testInitialChecksOnRepoUrlWithEmptyPath() throws Exception {
-        String url = "https://www.assembla.com";
-        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url), is(FormValidation.ok()));
     }
 
     @Test


### PR DESCRIPTION
## [BOM PR 650](https://github.com/jenkinsci/bom/pull/650) - Remove two broken Assembla tests

Tests now fail due to changes in the https://www.assembla.com web site.  Not enough value in those tests to retain them.  Will reduce code coverage but also will reduce maintainence overhead and provide a small reduction in test time.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have removed tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Test
