### PR TITLE
Replace GitHub references to git:// protocol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
   </dependencyManagement>
 
   <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-userRemoteConfigs.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-userRemoteConfigs.html
@@ -8,7 +8,6 @@
     <li>ssh://user@other.host.com/~/repos/R.git (to access the repos/R.git
     repository in the user's home directory)</li>
     <li>https://github.com/github/git.git</li>
-    <li>git://github.com/github/git.git</li>
   </ul>
   <br>
   If the repository is a super-project, the

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-userRemoteConfigs_ja.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-userRemoteConfigs_ja.html
@@ -8,7 +8,6 @@
     <li>git@github.com:github/git.git (SSHプロトコルの短縮記法)</li>
     <li>ssh://user@other.host.com/~/repos/R.git (ホームディレクトリのrepos/R.gitリポジトリへのアクセス)</li>
     <li>https://github.com/github/git.git</li>
-    <li>git://github.com/github/git.git</li>
   </ul>
   <br>
   リポジトリがスーパープロジェクトの場合、サブモジュールをクローンする場所は、

--- a/src/main/resources/jenkins/plugins/git/GitStep/help.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help.html
@@ -110,16 +110,16 @@ git changelog: false,
 </pre>
     </p>
 
-    <strong><a id="git-step-with-git-and-polling">Example: Git step with git protocol and polling disabled</a></strong>
+    <strong><a id="git-step-with-git-and-polling">Example: Git step with https protocol and polling disabled</a></strong>
     <p>
-    Checkout from the Jenkins platform labeler repository using git protocol, no credentials, the master branch, and no polling for changes.
+    Checkout from the Jenkins platform labeler repository using https protocol, no credentials, the master branch, and no polling for changes.
     If poll is <code>false</code>, then the remote repository will not be polled for changes.
     If poll is <code>true</code> or is not set, then the remote repository will be polled for changes.
     See the <a href="https://github.com/jenkinsci/workflow-scm-step-plugin/blob/master/README.md#polling">workflow scm step documentation</a> for more polling details.
     </p><p>The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Syntax Snippet Generator</a> generates this example:
 <pre>
 git poll: false,
-    url: 'git://github.com/jenkinsci/platformlabeler-plugin.git'
+    url: 'https://github.com/jenkinsci/platformlabeler-plugin.git'
 </pre>
     </p>
 

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -2286,7 +2286,7 @@ public class GitSCMTest extends AbstractGitTestCase {
     @Test
     public void testConfigRoundtripExtensionsPreserved() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
-        final String url = "git://github.com/jenkinsci/git-plugin.git";
+        final String url = "https://github.com/jenkinsci/git-plugin.git";
         GitRepositoryBrowser browser = new GithubWeb(url);
         GitSCM scm = new GitSCM(createRepoList(url),
                 Collections.singletonList(new BranchSpec("*/master")),
@@ -2337,7 +2337,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         GitSCM oldGit = (GitSCM) p.getScm();
         assertEquals(Collections.emptyList(), oldGit.getExtensions().toList());
         assertEquals(0, oldGit.getSubmoduleCfg().size());
-        assertEquals("git git://github.com/jenkinsci/model-ant-project.git", oldGit.getKey());
+        assertEquals("git https://github.com/jenkinsci/model-ant-project.git", oldGit.getKey());
         assertThat(oldGit.getEffectiveBrowser(), instanceOf(GithubWeb.class));
         GithubWeb browser = (GithubWeb) oldGit.getEffectiveBrowser();
         assertEquals(browser.getRepoUrl(), "https://github.com/jenkinsci/model-ant-project.git/");

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -416,21 +416,21 @@ public class GitStatusTest extends AbstractGitProject {
     @Test
     public void testLooselyMatches() throws URISyntaxException {
         String[] equivalentRepoURLs = new String[]{
-            "https://github.com/jenkinsci/git-plugin",
-            "https://github.com/jenkinsci/git-plugin/",
-            "https://github.com/jenkinsci/git-plugin.git",
-            "https://github.com/jenkinsci/git-plugin.git/",
-            "https://someone@github.com/jenkinsci/git-plugin.git",
-            "https://someone:somepassword@github.com/jenkinsci/git-plugin/",
-            "git://github.com/jenkinsci/git-plugin",
-            "git://github.com/jenkinsci/git-plugin/",
-            "git://github.com/jenkinsci/git-plugin.git",
-            "git://github.com/jenkinsci/git-plugin.git/",
-            "ssh://git@github.com/jenkinsci/git-plugin",
-            "ssh://github.com/jenkinsci/git-plugin.git",
-            "git@github.com:jenkinsci/git-plugin/",
-            "git@github.com:jenkinsci/git-plugin.git",
-            "git@github.com:jenkinsci/git-plugin.git/"
+            "https://example.com/jenkinsci/git-plugin",
+            "https://example.com/jenkinsci/git-plugin/",
+            "https://example.com/jenkinsci/git-plugin.git",
+            "https://example.com/jenkinsci/git-plugin.git/",
+            "https://someone@example.com/jenkinsci/git-plugin.git",
+            "https://someone:somepassword@example.com/jenkinsci/git-plugin/",
+            "git://example.com/jenkinsci/git-plugin",
+            "git://example.com/jenkinsci/git-plugin/",
+            "git://example.com/jenkinsci/git-plugin.git",
+            "git://example.com/jenkinsci/git-plugin.git/",
+            "ssh://git@example.com/jenkinsci/git-plugin",
+            "ssh://example.com/jenkinsci/git-plugin.git",
+            "git@example.com:jenkinsci/git-plugin/",
+            "git@example.com:jenkinsci/git-plugin.git",
+            "git@example.com:jenkinsci/git-plugin.git/"
         };
         List<URIish> uris = new ArrayList<>();
         for (String testURL : equivalentRepoURLs) {
@@ -442,7 +442,7 @@ public class GitStatusTest extends AbstractGitProject {
          */
         URIish badURLTrailingSlashes = new URIish(equivalentRepoURLs[0] + "///");
         /* Different hostname should always fail match check */
-        URIish badURLHostname = new URIish(equivalentRepoURLs[0].replace("github.com", "bitbucket.org"));
+        URIish badURLHostname = new URIish(equivalentRepoURLs[0].replace("example.com", "bitbucket.org"));
 
         for (URIish lhs : uris) {
             assertFalse(lhs + " matches trailing slashes " + badURLTrailingSlashes, GitStatus.looselyMatches(lhs, badURLTrailingSlashes));

--- a/src/test/java/hudson/plugins/git/util/BuildDataTest.java
+++ b/src/test/java/hudson/plugins/git/util/BuildDataTest.java
@@ -299,7 +299,7 @@ public class BuildDataTest {
         assertEquals("Objects with same saved build not equal hashCodes", data2.hashCode(), data1.hashCode());
 
         // Add remote URL makes objects unequal
-        final String remoteUrl2 = "git://github.com/jenkinsci/git-plugin.git";
+        final String remoteUrl2 = "git@github.com:jenkinsci/git-plugin.git";
         data1.addRemoteUrl(remoteUrl2);
         assertFalse("Distinct objects shouldn't be equal", data.equals(data1));
         assertFalse("Distinct objects shouldn't be equal", data1.equals(data));
@@ -506,7 +506,7 @@ public class BuildDataTest {
         assertTrue("Objects with same saved build not similar (2)", dataClone.similarTo(data2));
 
         // Add remote URL makes objects dissimilar
-        final String remoteUrl = "git://github.com/jenkinsci/git-client-plugin.git";
+        final String remoteUrl = "https://github.com/jenkinsci/git-client-plugin.git";
         dataClone.addRemoteUrl(remoteUrl);
         assertFalse("Distinct objects shouldn't be similar (1)", data.similarTo(dataClone));
         assertFalse("Distinct objects shouldn't be similar (2)", dataClone.similarTo(data));

--- a/src/test/java/hudson/plugins/git/util/GitUtilsTest.java
+++ b/src/test/java/hudson/plugins/git/util/GitUtilsTest.java
@@ -319,11 +319,11 @@ public class GitUtilsTest {
     public void testFixupNames() {
         String[] names = {"origin", "origin2", null, "", null};
         String[] urls = {
-            "git://github.com/jenkinsci/git-plugin.git",
-            "git@github.com:jenkinsci/git-plugin.git",
-            "https://github.com/jenkinsci/git-plugin",
-            "https://github.com/jenkinsci/git-plugin.git",
-            "ssh://github.com/jenkinsci/git-plugin.git"
+            "git://example.com/jenkinsci/git-plugin.git",
+            "git@example.com:jenkinsci/git-plugin.git",
+            "https://example.com/jenkinsci/git-plugin",
+            "https://example.com/jenkinsci/git-plugin.git",
+            "ssh://example.com/jenkinsci/git-plugin.git"
         };
         String[] expected = {"origin", "origin2", "origin1", "origin3", "origin4"};
         String[] actual = GitUtils.fixupNames(names, urls);

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -263,7 +263,7 @@ public class GitToolChooserTest {
     public void testRemoteAlternatives() throws Exception {
         GitTool tool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
 
-        GitToolChooser nullRemoteSizeEstimator = new GitToolChooser("git://github.com/git/git.git", null, null, tool, null, TaskListener.NULL, true);
+        GitToolChooser nullRemoteSizeEstimator = new GitToolChooser("git://example.com/git/git.git", null, null, tool, null, TaskListener.NULL, true);
         assertThat(nullRemoteSizeEstimator.remoteAlternatives(null), is(empty()));
         assertThat(nullRemoteSizeEstimator.remoteAlternatives(""), is(empty()));
 
@@ -275,14 +275,14 @@ public class GitToolChooserTest {
          * a valid alias for every other alternative in the list.
          */
         String[] remoteAlternatives = {
-                "git://github.com/jenkinsci/git-plugin",
-                "git://github.com/jenkinsci/git-plugin.git",
-                "git@github.com:jenkinsci/git-plugin",
-                "git@github.com:jenkinsci/git-plugin.git",
-                "https://github.com/jenkinsci/git-plugin",
-                "https://github.com/jenkinsci/git-plugin.git",
-                "ssh://git@github.com/jenkinsci/git-plugin",
-                "ssh://git@github.com/jenkinsci/git-plugin.git",
+                "git://example.com/jenkinsci/git-plugin",
+                "git://example.com/jenkinsci/git-plugin.git",
+                "git@example.com:jenkinsci/git-plugin",
+                "git@example.com:jenkinsci/git-plugin.git",
+                "https://example.com/jenkinsci/git-plugin",
+                "https://example.com/jenkinsci/git-plugin.git",
+                "ssh://git@example.com/jenkinsci/git-plugin",
+                "ssh://git@example.com/jenkinsci/git-plugin.git",
         };
 
         for (String remote : remoteAlternatives) {
@@ -306,17 +306,17 @@ public class GitToolChooserTest {
         GitTool tool = new JGitTool(Collections.<ToolProperty<?>>emptyList());
 
         String[] remoteAlternatives = {
-                "git://github.com/jenkinsci/git-plugin",
-                "git://github.com/jenkinsci/git-plugin.git",
-                "git@github.com:jenkinsci/git-plugin",
-                "git@github.com:jenkinsci/git-plugin.git",
-                "https://github.com/jenkinsci/git-plugin",
-                "https://github.com/jenkinsci/git-plugin.git",
-                "ssh://git@github.com/jenkinsci/git-plugin",
-                "ssh://git@github.com/jenkinsci/git-plugin.git",
+                "git://example.com/jenkinsci/git-plugin",
+                "git://example.com/jenkinsci/git-plugin.git",
+                "git@example.com:jenkinsci/git-plugin",
+                "git@example.com:jenkinsci/git-plugin.git",
+                "https://example.com/jenkinsci/git-plugin",
+                "https://example.com/jenkinsci/git-plugin.git",
+                "ssh://git@example.com/jenkinsci/git-plugin",
+                "ssh://git@example.com/jenkinsci/git-plugin.git",
         };
 
-        String actualNormalizedURL = "https://github.com/jenkinsci/git-plugin.git";
+        String actualNormalizedURL = "https://example.com/jenkinsci/git-plugin.git";
 
         for (String remote : remoteAlternatives) {
             GitToolChooser sizeEstimator = new GitToolChooser(remote, null, null, tool, null, TaskListener.NULL, random.nextBoolean());

--- a/src/test/resources/hudson/plugins/git/GitSCMTest/old1.xml
+++ b/src/test/resources/hudson/plugins/git/GitSCMTest/old1.xml
@@ -6,7 +6,7 @@
       <hudson.plugins.git.UserRemoteConfig>
         <name>origin</name>
         <refspec>+refs/heads/*:refs/remotes/origin/*</refspec>
-        <url>git://github.com/jenkinsci/model-ant-project.git</url>
+        <url>https://github.com/jenkinsci/model-ant-project.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>


### PR DESCRIPTION
## Replace GitHub references to git:// protocol

GitHub is dropping support for git protocol, but other sites are not necessarily dropping that support.  Update the tests and the documentation to not reference git:// protocol support from github.com.

* Use https repo URL in the pom, not git://
* Remove git://github.com from examples
* Replace git protocol example with https
* Use https instead of git protocol in GitSCM compatibility test
* Use example.com, not github.com in URL tests
* Use valid GitHub URLs in BuildDataTest

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Documentation and Tests
