### PR TITLE
Remove test dep on xmlunit-matchers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,12 +222,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.xmlunit</groupId>
-      <artifactId>xmlunit-matchers</artifactId>
-      <version>2.8.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-tag-message</artifactId>
       <version>1.7.1</version>
@@ -271,13 +265,6 @@
         <version>950.v396cb834de1e</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <dependency>
-        <!-- Resolve Java 11 upper bounds error, remove when no longer needed -->
-        <groupId>jakarta.activation</groupId>
-        <artifactId>jakarta.activation-api</artifactId>
-        <version>2.0.1</version>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Remove xmlunit matcher test dependency

Dependency is no longer needed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
