### PR TITLE
[JENKINS-66887] Enable JDK11 in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,6 @@
 
 buildPlugin(failFast: false,
             configurations: [
-                [platform: 'linux', jdk: '8'],
                 [platform: 'linux', jdk: '11'],
-                [platform: 'windows', jdk: '11'],
+                [platform: 'windows', jdk: '8'],
             ])


### PR DESCRIPTION
## [JENKINS-66887](https://issues.jenkins.io/browse/JENKINS-66887) - Enable JDK11 in Jenkinsfile

In order to enable the support of JDK11 for Jenkins and its plugins, the Jenkinsfile of the git-plugin should be completed allowing to build and test the plugin using JDK11 as well as JDK8.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency or infrastructure update
