### PR TITLE
Remove usages of Guava in tests

### DIFF
--- a/src/test/java/hudson/plugins/git/UserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/UserRemoteConfigTest.java
@@ -3,7 +3,6 @@ package hudson.plugins.git;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
-import com.google.common.collect.Sets;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.User;
@@ -59,7 +58,7 @@ public class UserRemoteConfigTest {
             }
         });
         assertEquals("expected completions on " + project + " as " + user + " starting with " + currentCredentialsId,
-                Sets.newTreeSet(Arrays.asList(expectedCredentialsIds)), actual);
+                new TreeSet<>(Arrays.asList(expectedCredentialsIds)), actual);
     }
 
 }

--- a/src/test/java/hudson/plugins/git/util/AncestryBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/AncestryBuildChooserTest.java
@@ -10,6 +10,7 @@ import hudson.plugins.git.Revision;
 import hudson.plugins.git.extensions.impl.BuildChooserSetting;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -28,8 +29,6 @@ import java.util.Date;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.google.common.collect.Sets;
-import com.google.common.collect.Sets.SetView;
 import static org.junit.Assert.*;
 import org.junit.Before;
 
@@ -101,7 +100,8 @@ public class AncestryBuildChooserTest extends AbstractGitRepository {
     private String getLastCommitSha1(Set<String> prevBranches) throws Exception {
         Set<String> newBranches = stringifyBranches(testGitClient.getBranches());
         
-        SetView<String> difference = Sets.difference(newBranches, prevBranches);
+        Set<String> difference = new HashSet<>(newBranches);
+        difference.removeAll(prevBranches);
         
         assertEquals(1, difference.size());
         


### PR DESCRIPTION
This PR contains some trivial reduction of Guava usages in test code. In general, depending on fewer third-party libraries in favor of native Java Platform functionality eases maintenance.