### PR TITLE
Use spotbugs annotation, not javax.annotation

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
+++ b/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
@@ -25,7 +25,6 @@ import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -89,7 +88,7 @@ public class GitUsernamePasswordBinding extends MultiBinding<StandardUsernamePas
     }
 
     @Override
-    public Set<String> variables(@Nonnull Run<?, ?> build) {
+    public Set<String> variables(@NonNull Run<?, ?> build) {
         Set<String> keys = new LinkedHashSet<>();
         keys.add(GIT_USERNAME_KEY);
         keys.add(GIT_PASSWORD_KEY);


### PR DESCRIPTION
## Use spotbugs annotation, not javax

The javax annotation proposal was never completed.  The spotbugs project provides a good replacement that is widely used in the Jenkins project.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
