### PR TITLE
[JENKINS-67045] Migrate deprecated call to `Promotion#getTarget`

### DIFF
--- a/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
+++ b/src/main/java/hudson/plugins/git/GitRevisionBuildParameters.java
@@ -57,7 +57,7 @@ public class GitRevisionBuildParameters extends AbstractBuildParameters {
 		if (data == null && Jenkins.get().getPlugin("promoted-builds") != null) {
             if (build instanceof hudson.plugins.promoted_builds.Promotion) {
                 // We are running as a build promotion, so have to retrieve the git scm from target job
-                AbstractBuild<?,?> targetBuild = ((hudson.plugins.promoted_builds.Promotion) build).getTarget();
+                AbstractBuild<?,?> targetBuild = ((hudson.plugins.promoted_builds.Promotion) build).getTargetBuild();
                 if (targetBuild != null) {
                     data = targetBuild.getAction(BuildData.class);
                 }


### PR DESCRIPTION
## [JENKINS-67045](https://issues.jenkins.io/browse/JENKINS-67045) - Migrate deprecated call to `Promotion#getTarget`

This essentially re-introduces the method change that was done in #774 then reverted in #775. Nowadays, the promoted-builds dependency is way more recent.

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [X] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [ ] I have interactively tested my changes

## Types of changes

- [x] Dependency or infrastructure update
