### PR TITLE
Remove Jenkins from plugin name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <artifactId>git</artifactId>
   <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
-  <name>Jenkins Git plugin</name>
+  <name>Git plugin</name>
   <description>Integrates Jenkins with Git SCM</description>
   <url>https://github.com/jenkinsci/git-plugin/blob/master/README.adoc</url>
   <inceptionYear>2007</inceptionYear>


### PR DESCRIPTION
It shows up in the help provided by this plugin and others don't seem to do that:

![image](https://user-images.githubusercontent.com/21194782/140638278-44ef96e2-fe50-4bef-8366-6a33ddb8e6fb.png)
