### PR TITLE
Use standard Jenkins buttons for better compatibility

### DIFF
--- a/src/main/resources/hudson/plugins/git/BranchSpec/config.groovy
+++ b/src/main/resources/hudson/plugins/git/BranchSpec/config.groovy
@@ -7,8 +7,7 @@ f.entry(title:_("Branch Specifier (blank for 'any')"), field:"name") {
 }
 
 f.entry {
-    div(align:"right") {
-        input (type:"button", value:_("Add Branch"), class:"repeatable-add show-if-last")
-        input (type:"button", value:_("Delete Branch"), class:"repeatable-delete")
+    div() {
+        f.repeatableDeleteButton()
     }
 }

--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -2,11 +2,11 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:entry title="${%Repositories}" field="userRemoteConfigs" >
-        <f:repeatableProperty field="userRemoteConfigs" minimum="1" noAddButton="true"/>
+        <f:repeatableProperty field="userRemoteConfigs" minimum="1" add="${%Add Repository}"/>
     </f:entry>
 
     <f:entry title="${%Branches to build}" field="branches">
-        <f:repeatableProperty field="branches" minimum="1" noAddButton="true" />
+        <f:repeatableProperty field="branches" minimum="1" add="${%Add Branch}" />
     </f:entry>
 
     <j:if test="${descriptor.showGitToolOptions()}">

--- a/src/main/resources/hudson/plugins/git/UserRemoteConfig/config.groovy
+++ b/src/main/resources/hudson/plugins/git/UserRemoteConfig/config.groovy
@@ -27,8 +27,9 @@ f.advanced {
 }
 
 f.entry {
-    div(align:"right") {
-        input (type:"button", value:_("Add Repository"), class:"repeatable-add show-if-last")
-        input (type:"button", value:_("Delete Repository"), class:"repeatable-delete show-if-not-only")
+    div() {
+        input (type:"button", value:_("Delete"), class:"jenkins-button repeatable-delete show-if-not-only")
+        // TODO switch to repeatableDeleteButton once https://github.com/jenkinsci/jenkins/pull/5897 is merged
+        //f.repeatableDeleteButton(hideIfOnly: 'true')
     }
 }


### PR DESCRIPTION
## Use standard Jenkins buttons for better compatibility

This plugin wasn't using the standard controls from core, Kohsuke changed this many years ago to make the UI 'more compact', but generally better to be consistent.

The other source of non standard control is adding the CSS which prevents deleting the last instance in a repeatable block, I've added support for this in core and added a TODO to address it once the baseline is updated:
https://github.com/jenkinsci/jenkins/pull/5897/commits/dacf1aef8cb0a1af90f5fe8baf12485d7a5ad518

![image](https://user-images.githubusercontent.com/21194782/140738699-4858381f-7886-4361-8708-6498976312be.png)

See https://github.com/jenkinsci/jenkins/pull/5897

cc @MarkEWaite 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
