### PR TITLE
[JENKINS-67491] Do not fail build on auth exception

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -457,7 +457,12 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                 // don't mess us up.
                 String[] emailParts = csAuthorEmail.split("@");
                 if (emailParts.length > 0) {
-                    user = User.get(emailParts[0], true, Collections.emptyMap());
+                    try {
+                        user = User.get(emailParts[0], true, Collections.emptyMap());
+                    } catch (org.springframework.security.core.AuthenticationException authException) {
+                        // JENKINS-67491 - do not fail due to an authentication exception
+                        return User.getUnknown();
+                    }
                 } else {
                     return User.getUnknown();
                 }

--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -432,7 +432,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                     if (user == null) {
                         user = User.get(csAuthorEmail, true, Collections.emptyMap());
                     }
-                    if (setUserDetails) {
+                    if (user != null && setUserDetails) {
                         user.setFullName(csAuthor);
                         if (hasMailerPlugin())
                             setMail(user, csAuthorEmail);

--- a/src/test/java/hudson/plugins/git/GitChangeSetTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTest.java
@@ -104,7 +104,7 @@ public class GitChangeSetTest {
         final GitChangeSet changeset = GitChangeSetUtil.genChangeSet(random.nextBoolean(), random.nextBoolean());
         final boolean createAccountBasedOnEmail = false;
         final boolean useExistingAccountBasedOnEmail = random.nextBoolean();
-        final String csAuthor = "babbage-do-not-create-either";
+        final String csAuthor = "babbage-will-be-created";
         final String csAuthorEmail = csAuthor + "@";
         User user = changeset.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
         assertThat(user.getFullName(), is(csAuthor));

--- a/src/test/java/hudson/plugins/git/GitChangeSetTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
+import java.util.Random;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
@@ -19,6 +20,8 @@ public class GitChangeSetTest {
 
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
+
+    private final Random random = new Random();
 
     @Test
     public void testFindOrCreateUser() {
@@ -39,6 +42,119 @@ public class GitChangeSetTest {
 
         assertEquals(User.getUnknown(), committerCS.findOrCreateUser(null, email, false, useExistingAccountBasedOnEmail));
         assertEquals(User.getUnknown(), committerCS.findOrCreateUser(null, email, true, useExistingAccountBasedOnEmail));
+    }
+
+    @Test
+    public void testFindOrCreateUserNullAuthorEmail() {
+        final GitChangeSet changeset = GitChangeSetUtil.genChangeSet(random.nextBoolean(), random.nextBoolean());
+        final boolean createAccountBasedOnEmail = true;
+        final boolean useExistingAccountBasedOnEmail = random.nextBoolean();
+        final String csAuthor = "ada";
+        final String csAuthorEmail = null;
+        User user = changeset.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
+        assertThat(user, is(User.getUnknown()));
+    }
+
+    @Test
+    public void testFindOrCreateUserEmptyAuthorEmail() {
+        final GitChangeSet changeset = GitChangeSetUtil.genChangeSet(random.nextBoolean(), random.nextBoolean());
+        final boolean createAccountBasedOnEmail = true;
+        final boolean useExistingAccountBasedOnEmail = random.nextBoolean();
+        final String csAuthor = "babbage";
+        final String csAuthorEmail = "";
+        User user = changeset.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
+        assertThat(user, is(User.getUnknown()));
+    }
+
+    @Test
+    public void testFindOrCreateUserEmptyAuthorEmailDoNotCreateAccountBasedOnEmail() {
+        final GitChangeSet changeset = GitChangeSetUtil.genChangeSet(random.nextBoolean(), random.nextBoolean());
+        final boolean createAccountBasedOnEmail = false;
+        final boolean useExistingAccountBasedOnEmail = random.nextBoolean();
+        final String csAuthor = "babbage-do-not-create";
+        final String csAuthorEmail = "";
+        User user = changeset.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
+        assertThat(user, is(User.getUnknown()));
+    }
+
+    @Test
+    public void testFindOrCreateUserEmptyAuthorDoNotCreateAccountBasedOnEmail() {
+        final GitChangeSet changeset = GitChangeSetUtil.genChangeSet(random.nextBoolean(), random.nextBoolean());
+        final boolean createAccountBasedOnEmail = false;
+        final boolean useExistingAccountBasedOnEmail = random.nextBoolean();
+        final String csAuthor = "";
+        final String csAuthorEmail = "babbage-empty-author@example.com";
+        User user = changeset.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
+        assertThat(user, is(User.getUnknown()));
+    }
+
+    @Test
+    public void testFindOrCreateUserBadAuthorEmailDoNotCreateAccountBasedOnEmail() {
+        final GitChangeSet changeset = GitChangeSetUtil.genChangeSet(random.nextBoolean(), random.nextBoolean());
+        final boolean createAccountBasedOnEmail = false;
+        final boolean useExistingAccountBasedOnEmail = random.nextBoolean();
+        final String csAuthor = "babbage-do-not-create";
+        final String csAuthorEmail = "@";
+        User user = changeset.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
+        assertThat(user, is(User.getUnknown()));
+    }
+
+    @Test
+    public void testFindOrCreateUserOKAuthorEmailDoNotCreateAccountBasedOnEmail() {
+        final GitChangeSet changeset = GitChangeSetUtil.genChangeSet(random.nextBoolean(), random.nextBoolean());
+        final boolean createAccountBasedOnEmail = false;
+        final boolean useExistingAccountBasedOnEmail = random.nextBoolean();
+        final String csAuthor = "babbage-do-not-create-either";
+        final String csAuthorEmail = csAuthor + "@";
+        User user = changeset.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
+        assertThat(user.getFullName(), is(csAuthor));
+    }
+
+    @Test
+    public void testFindOrCreateUserBlankAuthorEmail() {
+        final GitChangeSet changeset = GitChangeSetUtil.genChangeSet(random.nextBoolean(), random.nextBoolean());
+        final boolean createAccountBasedOnEmail = true;
+        final boolean useExistingAccountBasedOnEmail = false;
+        final String csAuthor = "candide";
+        final String csAuthorEmail = " ";
+        User user = changeset.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
+        assertThat(user.getFullName(), is(csAuthor));
+    }
+
+    @Test
+    public void testFindOrCreateUserBlankAuthorEmailUseExistingAccountBasedOnEmail() {
+        final GitChangeSet changeset = GitChangeSetUtil.genChangeSet(random.nextBoolean(), random.nextBoolean());
+        final boolean createAccountBasedOnEmail = true;
+        final boolean useExistingAccountBasedOnEmail = true;
+        final String csAuthor = "cosimo";
+        final String csAuthorEmail = " ";
+        User user = changeset.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
+        assertThat(user.getFullName(), is(csAuthor));
+    }
+
+    @Test
+    public void testFindOrCreateUserValidAuthorEmailUseExistingAccountBasedOnEmail() {
+        final GitChangeSet changeset = GitChangeSetUtil.genChangeSet(random.nextBoolean(), random.nextBoolean());
+        final boolean createAccountBasedOnEmail = true;
+        final boolean useExistingAccountBasedOnEmail = true;
+        final String csAuthor = "dante";
+        final String csAuthorEmail = "alighieri@example.com";
+        User user = changeset.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
+        assertThat(user.getFullName(), is(csAuthor));
+    }
+
+    @Test
+    public void testFindOrCreateUserUseExistingAuthorEmailUseExistingAccountBasedOnEmail() {
+        final GitChangeSet changeset = GitChangeSetUtil.genChangeSet(random.nextBoolean(), random.nextBoolean());
+        final boolean createAccountBasedOnEmail = true;
+        final boolean useExistingAccountBasedOnEmail = true;
+        final String csAuthor = "ecco";
+        final String csAuthorEmail = "umberto@example.com";
+        User user = changeset.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
+        assertThat(user.getFullName(), is(csAuthor));
+        /* Confirm that second search returns user created by first search */
+        User existing = changeset.findOrCreateUser(csAuthor, csAuthorEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
+        assertThat(existing, is(user));
     }
 
     @Test


### PR DESCRIPTION
## [JENKINS-67491](https://issues.jenkins.io/browse/JENKINS-67491) Do not fail build on authentication exception

[JENKINS-55813](https://issues.jenkins.io/browse/JENKINS-55813) intentionally throws an exception when a user account is reported by Spring security as disabled, locked, or expired.  User lookup for the git changeset display is not critical enough to allow that exception to fail the build.

Changes include:

- Add more GitChangeSet tests
- Check for null user before dereferencing
- [JENKINS-67491](https://issues.jenkins.io/browse/JENKINS-67491)  Do not fail on users disabled by auth provider

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

Does not fix the one or two other locations in the method where `User.get()` is called.  I want to understand if this resolves the issue for the user before applying the same change more widely.

@basil I'd appreciate a review of the proposed change if you're willing to do it.