### PR TITLE
initialize the test repos without a default template

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -63,7 +63,7 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
     public void init() throws Exception {
         run(true, tmp.getRoot(), "git", "version");
         checkGlobalConfig();
-        git("init");
+        git("init", "--template="); // initialize without copying the installation defaults to ensure a vanilla repo that behaves the same everywhere
         write("file", "");
         git("add", "file");
         git("config", "user.name", "Git SampleRepoRule");


### PR DESCRIPTION
## Initialize test repos without a default template

Similar to #1151 by default git comes without any hooks, but when creating a new sample git repo with the code it would copy the system default hooks, meaning this sample repo can behave differently on different platforms.

by not using the hooks here we can avoid littering test code with "--no-verify" on commits, and can avoit hooks in other cases as well, which consume test time and / or even fail the operation due to a failing hook requirement (e.g. no JIRA reference)

when consuming this in pipeline-model-definition's ValidatorTest test locally go from failing due to timeout exception (10 minutes) to completing in 2 minutes

## Checklist

- [x] Unit tests pass locally with my changes (wait for CI!)
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update

@MarkEWaite 