### PR TITLE
Draft implementation

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1163,7 +1163,13 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         for (GitSCMExtension ext : extensions) {
             rev = ext.decorateRevisionToBuild(this,build,git,listener,marked,rev);
         }
-        Build revToBuild = new Build(marked, rev, build.getNumber(), null);
+
+        Revision revToDisplay = rev;
+        for (GitSCMExtension ext : extensions) {
+            revToDisplay = ext.decorateRevisionToDisplay(revToDisplay, marked);
+        }
+
+        Build revToBuild = new Build(marked, rev, build.getNumber(), null, revToDisplay);
         buildData.saveBuild(revToBuild);
 
         if (buildData.getBuildsByBranchName().size() >= 100) {

--- a/src/main/java/hudson/plugins/git/UserMergeOptions.java
+++ b/src/main/java/hudson/plugins/git/UserMergeOptions.java
@@ -28,6 +28,7 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
     private final String mergeTarget;
     private String mergeStrategy;
     private MergeCommand.GitPluginFastForwardMode fastForwardMode;
+    private DisplayRevision displayRevision;
 
     /**
      * @deprecated use the new constructor that allows to set the fast forward mode.
@@ -40,6 +41,11 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
         this(mergeRemote, mergeTarget, mergeStrategy, MergeCommand.GitPluginFastForwardMode.FF);
     }
 
+    public UserMergeOptions(String mergeRemote, String mergeTarget, String mergeStrategy,
+                            MergeCommand.GitPluginFastForwardMode fastForwardMode) {
+        this(mergeRemote, mergeTarget, mergeStrategy, MergeCommand.GitPluginFastForwardMode.FF, DisplayRevision.MERGED);
+    }
+
     /**
      * @param mergeRemote remote name used for merge
      * @param mergeTarget remote branch to be merged into current branch
@@ -47,11 +53,12 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
      * @param fastForwardMode fast forward mode
      */
     public UserMergeOptions(String mergeRemote, String mergeTarget, String mergeStrategy,
-            MergeCommand.GitPluginFastForwardMode fastForwardMode) {
+            MergeCommand.GitPluginFastForwardMode fastForwardMode, DisplayRevision displayRevision) {
         this.mergeRemote = mergeRemote;
         this.mergeTarget = mergeTarget;
         this.mergeStrategy = mergeStrategy;
         this.fastForwardMode = fastForwardMode;
+        this.displayRevision = displayRevision;
     }
 
     @DataBoundConstructor
@@ -124,6 +131,18 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
         this.fastForwardMode = fastForwardMode;
     }
 
+    public DisplayRevision getDisplayRevision() {
+        for (DisplayRevision revision : DisplayRevision.values())
+            if (revision.equals(displayRevision))
+                return revision;
+        return DisplayRevision.MERGED;
+    }
+
+    @DataBoundSetter
+    public void setDisplayRevision(DisplayRevision displayRevision) {
+        this.displayRevision = displayRevision;
+    }
+
     @Override
     public String toString() {
         return "UserMergeOptions{" +
@@ -131,6 +150,7 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
                 ", mergeTarget='" + mergeTarget + '\'' +
                 ", mergeStrategy='" + getMergeStrategy().name() + '\'' +
                 ", fastForwardMode='" + getFastForwardMode().name() + '\'' +
+                ", displayRevision='" + getDisplayRevision().name() + '\'' +
                 '}';
     }
 
@@ -148,12 +168,13 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
         return Objects.equals(mergeRemote, that.mergeRemote)
                 && Objects.equals(mergeTarget, that.mergeTarget)
                 && Objects.equals(mergeStrategy, that.mergeStrategy)
-                && Objects.equals(fastForwardMode, that.fastForwardMode);
+                && Objects.equals(fastForwardMode, that.fastForwardMode)
+                && Objects.equals(displayRevision, that.displayRevision);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mergeRemote, mergeTarget, mergeStrategy, fastForwardMode);
+        return Objects.hash(mergeRemote, mergeTarget, mergeStrategy, fastForwardMode, displayRevision);
     }
 
     @Extension
@@ -175,5 +196,15 @@ public class UserMergeOptions extends AbstractDescribableImpl<UserMergeOptions> 
         }
 
     }
+    public static enum DisplayRevision {
+        MERGED,
+        SOURCE_BRANCH;
 
+        private DisplayRevision() {
+        }
+
+        public String toString() {
+            return this.name().toLowerCase(Locale.ENGLISH);
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -372,4 +372,9 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
     public GitSCMExtensionDescriptor getDescriptor() {
         return (GitSCMExtensionDescriptor) super.getDescriptor();
     }
+
+    //What should be API of this method?
+    public Revision decorateRevisionToDisplay(Revision revToDisplay, Revision marked) {
+        return revToDisplay;
+    }
 }

--- a/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
@@ -129,6 +129,12 @@ public class PreBuildMerge extends GitSCMExtension {
     }
 
     @Override
+    //What should be API of this method?
+    public Revision decorateRevisionToDisplay(Revision revToDisplay, Revision marked) {
+        return options.getDisplayRevision() == UserMergeOptions.DisplayRevision.SOURCE_BRANCH ? marked : revToDisplay;
+    }
+
+    @Override
     public void decorateMergeCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, MergeCommand cmd) throws IOException, InterruptedException, GitException {
         if (options.getMergeStrategy() != null) {
             cmd.setStrategy(options.getMergeStrategy());

--- a/src/main/java/hudson/plugins/git/opt/PreBuildMergeOptions.java
+++ b/src/main/java/hudson/plugins/git/opt/PreBuildMergeOptions.java
@@ -1,7 +1,9 @@
 package hudson.plugins.git.opt;
 
+import hudson.plugins.git.UserMergeOptions;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -32,6 +34,8 @@ public class PreBuildMergeOptions implements Serializable {
     public String mergeStrategy = MergeCommand.Strategy.DEFAULT.toString();
 
     public MergeCommand.GitPluginFastForwardMode fastForwardMode = MergeCommand.GitPluginFastForwardMode.FF;
+
+    public UserMergeOptions.DisplayRevision displayRevision = UserMergeOptions.DisplayRevision.MERGED;
 
     public RemoteConfig getMergeRemote() {
         return mergeRemote;
@@ -72,6 +76,18 @@ public class PreBuildMergeOptions implements Serializable {
 
     public void setFastForwardMode(MergeCommand.GitPluginFastForwardMode fastForwardMode) {
       this.fastForwardMode = fastForwardMode;
+    }
+
+    @Exported
+    public UserMergeOptions.DisplayRevision getDisplayRevision() {
+        for (UserMergeOptions.DisplayRevision revision : UserMergeOptions.DisplayRevision.values())
+            if (revision.equals(displayRevision))
+                return revision;
+        return UserMergeOptions.DisplayRevision.MERGED;
+    }
+
+    public void setDisplayRevision(UserMergeOptions.DisplayRevision displayRevision) {
+        this.displayRevision = displayRevision;
     }
 
     @Exported

--- a/src/main/java/hudson/plugins/git/util/Build.java
+++ b/src/main/java/hudson/plugins/git/util/Build.java
@@ -48,6 +48,8 @@ public class Build implements Serializable, Cloneable {
      */
     public Revision revision;
 
+    public Revision displayRevision;
+
     public int      hudsonBuildNumber;
     public Result   hudsonBuildResult;
 
@@ -56,6 +58,15 @@ public class Build implements Serializable, Cloneable {
     public Build(Revision marked, Revision revision, int buildNumber, Result result) {
         this.marked = marked;
         this.revision = revision;
+        this.displayRevision = revision;
+        this.hudsonBuildNumber = buildNumber;
+        this.hudsonBuildResult = result;
+    }
+
+    public Build(Revision marked, Revision revision, int buildNumber, Result result, Revision displayRevision) {
+        this.marked = marked;
+        this.revision = revision;
+        this.displayRevision = displayRevision;
         this.hudsonBuildNumber = buildNumber;
         this.hudsonBuildResult = result;
     }
@@ -138,5 +149,10 @@ public class Build implements Serializable, Cloneable {
         if (marked==null) // this field was introduced later than 'revision'
             marked = revision;
         return this;
+    }
+
+    @Exported
+    public Revision getDisplayRevision() {
+        return displayRevision;
     }
 }

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -253,6 +253,16 @@ public class BuildData implements Action, Serializable, Cloneable {
         return lastBuild==null?null:lastBuild.revision;
     }
 
+    /**
+     * Gets revision of the previous build to display.
+     * @return display revision of the last build.
+     *    May be null will be returned if nothing has been checked out (e.g. due to wrong repository or branch)
+     */
+    @Exported
+    public @CheckForNull Revision getLastBuiltDisplayRevision() {
+        return lastBuild==null?null:lastBuild.getDisplayRevision();
+    }
+
     @Exported
     public Map<String,Build> getBuildsByBranchName() {
         return buildsByBranchName;

--- a/src/main/resources/hudson/plugins/git/UserMergeOptions/config.jelly
+++ b/src/main/resources/hudson/plugins/git/UserMergeOptions/config.jelly
@@ -16,4 +16,9 @@
           ${it.toString()}
       </f:enum>
   </f:entry>
+  <f:entry title="${%Revision to display}" field="displayRevision">
+        <f:enum>
+            ${it.toString()}
+        </f:enum>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/git/util/BuildData/index.jelly
+++ b/src/main/resources/hudson/plugins/git/util/BuildData/index.jelly
@@ -8,7 +8,7 @@
 	<l:main-panel>
 	<h1>${%Git Build Data}</h1>
 
-	<strong>${%Revision}</strong>: ${it.lastBuild.SHA1.name()}
+	<strong>${%Revision}</strong>: ${it.lastBuiltDisplayRevision.sha1.name()}
 	<j:if test="${!empty(it.scmName)}"><br/><strong>${%SCM}</strong>: ${it.scmName}</j:if>
 	<j:if test="${!empty(it.remoteUrls)}">
 		<j:forEach var="remoteUrl" items="${it.remoteUrls}">
@@ -21,7 +21,7 @@
 		</j:forEach>
 	</j:if>
 	<ul>
-	<j:forEach var="branch" items="${it.lastBuild.revision.branches}">
+	<j:forEach var="branch" items="${it.lastBuiltDisplayRevision.branches}">
 	<li>${branch.name}</li>
 	</j:forEach>
 	</ul>

--- a/src/main/resources/hudson/plugins/git/util/BuildData/summary.jelly
+++ b/src/main/resources/hudson/plugins/git/util/BuildData/summary.jelly
@@ -4,7 +4,7 @@
 	xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 	<t:summary icon="/plugin/git/icons/git-logo.svg">
 
-	<strong>${%Revision}</strong>: ${it.lastBuiltRevision.sha1.name()}
+	<strong>${%Revision}</strong>: ${it.lastBuiltDisplayRevision.sha1.name()}
 	<j:if test="${!empty(it.scmName)}"><br/><strong>${%SCM}</strong>: ${it.scmName}</j:if>
 	<j:if test="${!empty(it.remoteUrls)}">
 		<j:forEach var="remoteUrl" items="${it.remoteUrls}">
@@ -17,7 +17,7 @@
 		</j:forEach>
 	</j:if>
         <ul>
-        <j:forEach var="branch" items="${it.lastBuiltRevision.branches}">
+        <j:forEach var="branch" items="${it.lastBuiltDisplayRevision.branches}">
           <j:if test="${branch!=''}">
             <li>${branch.name}</li>
           </j:if>

--- a/src/test/java/hudson/plugins/git/extensions/impl/PreBuildMergeTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/PreBuildMergeTest.java
@@ -11,8 +11,16 @@ import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionTest;
 import hudson.plugins.git.util.BuildData;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -26,19 +34,99 @@ public class PreBuildMergeTest extends GitSCMExtensionTest
     private TestGitRepo repo;
 
     private String MASTER_FILE = "commitFileBase";
+    private String INTEGRATION_FILE = "branchFile";
+
+    private String initCommit;
 
     public void before() throws Exception {
         repo = new TestGitRepo("repo", tmp.newFolder(), listener);
         project = setupBasicProject(repo);
         // make an initial commit to master
-        repo.commit(MASTER_FILE, repo.johnDoe, "Initial Commit");
+        initCommit = repo.commit(MASTER_FILE, repo.johnDoe, "Initial Commit");
         // create integration branch
         repo.git.branch("integration");
     }
 
     @Test
     public void testBasicPreMerge() throws Exception {
+        // already existing test
         FreeStyleBuild firstBuild = build(project, Result.SUCCESS);
+    }
+
+    @Test
+    public void testDisplayMergedRevision() throws Exception {
+        // add some commits to source and target branch
+        repo.git.checkoutBranch("integration", initCommit);
+        String integrationCommit = repo.commit(INTEGRATION_FILE, repo.johnDoe, "Integration Commit");
+        repo.git.checkoutBranch("master", initCommit);
+        String masterCommit = repo.commit("Master2", repo.johnDoe, "Master2 Commit");
+
+        FreeStyleBuild firstBuild = build(project, Result.SUCCESS);
+
+        // git repository placed in build's workspace
+        TestGitRepo repoInWorkspace = getRepoInWorkspace(firstBuild);
+        
+        List<ObjectId> commitsInWorkspace = getCommitsOnHead(repoInWorkspace);
+
+        ObjectId mergeCommit = commitsInWorkspace.remove(0);
+
+        // verify state of workspace fit repo
+        // is it possible to verify merge commit (checking log message?)
+        assertEquals(Arrays.asList(integrationCommit, masterCommit, initCommit),
+                commitsInWorkspace.stream().map(AnyObjectId::name).collect(Collectors.toList()));
+
+        // verify revision displayed
+        assertEquals(GitSCM.class, project.getScm().getClass());
+        GitSCM gitSCM = (GitSCM)project.getScm();
+        BuildData buildData = gitSCM.getBuildData(firstBuild);
+        Revision buildRevision = buildData.getLastBuiltDisplayRevision();
+
+        assertEquals(mergeCommit, buildRevision.getSha1());
+        assertEquals(1, buildRevision.getBranches().size());
+        assertTrue(buildRevision.containsBranchName("origin/integration"));
+    }
+
+    @Test
+    public void testDisplaySourceRevision() throws Exception {
+        // change UserMergeOption
+        GitSCM gitSCM = (GitSCM)project.getScm();
+        gitSCM.getExtensions().get(PreBuildMerge.class).getOptions().setDisplayRevision(UserMergeOptions.DisplayRevision.SOURCE_BRANCH);
+
+        // add some commits to source and target branch
+        repo.git.checkoutBranch("integration", initCommit);
+        String integrationCommit = repo.commit(INTEGRATION_FILE, repo.johnDoe, "Integration Commit");
+        repo.git.checkoutBranch("master", initCommit);
+        String masterCommit = repo.commit("Master2", repo.johnDoe, "Master2 Commit");
+
+        FreeStyleBuild firstBuild = build(project, Result.SUCCESS);
+
+        // git repository placed in build's workspace
+        TestGitRepo repoInWorkspace = getRepoInWorkspace(firstBuild);
+        List<ObjectId> commitsInWorkspace = getCommitsOnHead(repoInWorkspace);
+
+        ObjectId mergeCommit = commitsInWorkspace.remove(0);
+
+        // verify state of workspace fit repo
+        // is it possible to verify merge commit (checking log message?)
+        assertEquals(Arrays.asList(integrationCommit, masterCommit, initCommit),
+                commitsInWorkspace.stream().map(AnyObjectId::name).collect(Collectors.toList()));
+        assertEquals(GitSCM.class, project.getScm().getClass());
+
+        // verify revision displayed
+        BuildData buildData = gitSCM.getBuildData(firstBuild);
+        Revision buildRevision = buildData.getLastBuiltDisplayRevision();
+
+        assertEquals(masterCommit, buildRevision.getSha1().name());
+        assertEquals(1, buildRevision.getBranches().size());
+        assertTrue(buildRevision.containsBranchName("origin/master"));
+    }
+
+    private List<ObjectId> getCommitsOnHead(TestGitRepo repoInWorkspace) throws InterruptedException {
+        return repoInWorkspace.git.revList("HEAD");
+    }
+
+    private TestGitRepo getRepoInWorkspace(FreeStyleBuild firstBuild) throws IOException, InterruptedException {
+        return new TestGitRepo("workspace", new File(firstBuild.getWorkspace().toString()), listener);
     }
 
     @Test


### PR DESCRIPTION
## [JENKINS-52926](https://issues.jenkins.io/browse/JENKINS-52926) - summarize pull request in one line

Linked issue is not completely resolved by this PR. This PR relates to [my comment](https://issues.jenkins.io/browse/JENKINS-52926?focusedCommentId=420595&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-420595) in linked ticket and should resolve a problem of displaying sha of merge commits, which makes hard to determine cloned code revision without looking into logs. 

This is a draft PR, I'll add documentation, docstrings and clean code a bit if solution is approved. I'll be grateful for any feedback - what else should be added, alternative implementations, etc.

This PR introduces new option to PreBuildMerge extension, which allows to choose revision included on Git Build Data summary page. By default, the merged revision is displayed to keep backward compatibility. The other option is to display head of a source branch. In some cases this is more useful information, for example when we want to know which revision from PR branch was build, instead of getting the randomly generated commit, which does not exist on remote.

I didn't want to break any existing behavior, so I decided to not change revision returned by `decorateRevisionToBuild` method. 

Unfortunately, this PR do not fix original problem from linked PR - there are still a few build entries. I can open a new ticket if it is required to merge this PR.


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue) ?
- [x] New feature (non-breaking change which adds functionality)

## Further comments

Other possible solutions:
* adding a method to `hudson.plugins.git.Revision` class from `git-client`, which returns a string with display version of revision. This method by default returns `getSha1String()`.  Then, creating a new class in `git-plugin`, which extends `Revision` class and overrides new method.
  Pros:
      - Probably the cleanest solution from `git-plugin` point of view. 
      - Changes are required only in `PreBuildMerge` implementation and jelly files.
      - Backward compatible
  Cons:
      - New method in Revision, which is useless from `git-client` point of view
      - Chanes required in 2 repos
    
* returning `marked` revision from `decorateRevisionToBuild` method if user set `displayRevision = source_branch`.
  Pros:
      - Only a few lines of code needed
      - Backward compatible because default behavior remains the same
      - Probably fixes problem with duplicated Git Build Data
  Cons:
      - In case of `displayRevision = source_branch`not only display value is changed, so there might be some unexpected behaviour