### PR TITLE
Revert equalsverifier 3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,12 +156,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-      <exclusions> <!-- Temporary exclusion pending mockito-core update in plugin bom-->
-        <exclusion>
-          <groupId>net.bytebuddy</groupId>
-          <artifactId>byte-buddy</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.9</version>
+      <version>3.8.3</version>
       <scope>test</scope>
     </dependency>
     <!--Credential Binding Plugin-->


### PR DESCRIPTION

## Revert equalsverifier 3.9

Do not want equalsverifier 3.9 until its pom files are available.

- Revert "Exclude byte-buddy from mockito-core"
- Revert "Bump equalsverifier from 3.8.3 to 3.9"

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
