### PR TITLE
hostname

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -96,6 +96,31 @@ withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id',
   powershell 'git push'
 }
 ```
+
+===== Docker BuildKit secret mount
+
+To securely forward credentials to `docker.build` the link:https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypesecret[`--mount=type=secret`] approach should be used. This avoids storing the credentials into the image like `ARG` or `ENV` would. When the optinal parameter `hostName` is specified, this binding also provides `GIT_CREDENTIAL_STORE` environment variable which contains path to link:https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage[git credentials store].
+
+.Docker BuildKit example
+```groovy
+# Jenkins pipeline
+withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id',
+                                     hostName: 'github.com')]) {
+  withEnv(['DOCKER_BUILDKIT=1']) {
+    docker.build '', "--secret id=git_store,src=${GIT_CREDENTIAL_STORE} ."
+  }
+}
+```
+```dockerfile
+# Dockerfile
+RUN --mount=type=secret,id=git_store \
+    git config --global credential.helper 'store --file /run/secrets/git_store' && \
+    git clone https://github.com/private/repo
+```
+The above configuration is best used with the link:https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc[GitHub App authentication] provided by link:https://plugins.jenkins.io/github-branch-source/[GitHub Branch Source plugin]. This issues scoped temporary token valid for one hour, which is then used in HTTPS Basic Auth.
+
+This removes the need for _service accounts_ configured with static SSH keys or Personal Access Tokens and the management burden associated with these.
+
 [#configuration]
 == [[GitPlugin-ProjectConfiguration]]Configuration
 

--- a/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
+++ b/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
@@ -37,17 +37,23 @@ public class GitUsernamePasswordBinding extends MultiBinding<StandardUsernamePas
     final static private String GIT_USERNAME_KEY = "GIT_USERNAME";
     final static private String GIT_PASSWORD_KEY = "GIT_PASSWORD";
     final private String gitToolName;
+    final private String hostName;
     private transient boolean unixNodeType;
 
     @DataBoundConstructor
-    public GitUsernamePasswordBinding(String gitToolName, String credentialsId) {
+    public GitUsernamePasswordBinding(String gitToolName, String credentialsId, String hostName) {
         super(credentialsId);
         this.gitToolName = gitToolName;
+        this.hostName = hostName;
         //Variables could be added if needed
     }
 
     public String getGitToolName(){
         return this.gitToolName;
+    }
+
+    public String getHostName(){
+        return this.hostName;
     }
 
     private void setUnixNodeType(boolean value) {
@@ -80,6 +86,15 @@ public class GitUsernamePasswordBinding extends MultiBinding<StandardUsernamePas
                                                   this.unixNodeType);
             FilePath gitTempFile = gitScript.write(credentials, unbindTempDir.getDirPath());
             secretValues.put("GIT_ASKPASS", gitTempFile.getRemote());
+            if (this.hostName != null) {
+                GenerateGitStore gitStore = new GenerateGitStore(
+                                                            credentials.getUsername(),
+                                                            credentials.getPassword().getPlainText(),
+                                                            this.hostName,
+                                                            credentials.getId());
+                FilePath gitStoreTempFile = gitStore.write(credentials, unbindTempDir.getDirPath());
+                secretValues.put("GIT_CREDENTIAL_STORE", gitStoreTempFile.getRemote());
+            }
             return new MultiEnvironment(secretValues, publicValues, unbindTempDir.getUnbinder());
         } else {
             taskListener.getLogger().println("JGit and JGitApache type Git tools are not supported by this binding");
@@ -164,6 +179,36 @@ public class GitUsernamePasswordBinding extends MultiBinding<StandardUsernamePas
                         + "IF %ARG:~0,8%==Password (ECHO " + this.passVariable + ")", null);
             }
             return gitEcho;
+        }
+
+        @Override
+        protected Class<StandardUsernamePasswordCredentials> type() {
+            return StandardUsernamePasswordCredentials.class;
+        }
+    }
+
+    protected static final class GenerateGitStore extends AbstractOnDiskBinding<StandardUsernamePasswordCredentials> {
+
+        private final String userVariable;
+        private final String passVariable;
+        private final String hostVariable;
+
+        protected GenerateGitStore(String gitUsername, String gitPassword,
+                                   String hostname, String credentialId) {
+            super(gitUsername + ":" + gitPassword, credentialId);
+            this.userVariable = gitUsername;
+            this.passVariable = gitPassword;
+            this.hostVariable = hostname;
+        }
+
+        @Override
+        protected FilePath write(StandardUsernamePasswordCredentials credentials, FilePath workspace)
+                throws IOException, InterruptedException {
+            FilePath gitStore;
+            gitStore = workspace.createTempFile("git_store", "");
+            gitStore.write("https://" + this.userVariable + ":" + this.passVariable + "@" + this.hostVariable + "\n", null);
+            gitStore.chmod(0500);
+            return gitStore;
         }
 
         @Override

--- a/src/main/resources/jenkins/plugins/git/GitUsernamePasswordBinding/config.jelly
+++ b/src/main/resources/jenkins/plugins/git/GitUsernamePasswordBinding/config.jelly
@@ -8,4 +8,7 @@
     <f:entry title="${%Git Tool Name}" field="gitToolName">
         <f:select />
     </f:entry>
+    <f:entry title="${%Hostname}" field="hostName">
+        <f:textbox/>
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
Extend the `GitUsernamePasswordBinding` by exporting the credentials suitable for git credential store

Describe the big picture of your changes here to explain to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, include a link to the issue.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Further comments

This extend the `GitUsernamePasswordBinding` by exporting the credentials in a file format suitable for [`git credential store`](https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage) which is in turn useful for `docker.build` step using BuildKit [secret mount](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypesecret). This is currently the best option for forwarding HTTP credentials to `docker.build` while avoiding storing these in the image. 
```groovy
# Jenkins pipeline
withCredentials([gitUsernamePassword(credentialsId: 'my-credentials-id',
                 hostName: 'github.com')]) {
  withEnv(['DOCKER_BUILDKIT=1']) {
    docker.build '', "--secret id=git_store,src=${GIT_CREDENTIAL_STORE} ."
  }
}
```
```dockerfile
# Dockerfile
RUN --mount=type=secret,id=git_store \
    git config --global credential.helper 'store --file /run/secrets/git_store' && \
    git clone https://github.com/private/repo
```
The above configuration is best used with the link:https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc[GitHub App authentication] provided by link:https://plugins.jenkins.io/github-branch-source/[GitHub Branch Source plugin]. This issues scoped temporary token valid for one hour, which is then used in HTTPS Basic Auth.