### PR TITLE
[JENKINS-54858] Init Org/Repo Name regex

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1612,6 +1612,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         private String gitExe;
         private String globalConfigName;
         private String globalConfigEmail;
+        private String globalUrlRegEx;
         private boolean createAccountBasedOnEmail;
         private boolean useExistingAccountWithSameEmail;
 //        private GitClientType defaultClientType = GitClientType.GITCLI;
@@ -1711,6 +1712,16 @@ public class GitSCM extends GitSCMBackwardCompatibility {
          */
         public String getGlobalConfigName() {
             return Util.fixEmptyAndTrim(globalConfigName);
+        }
+
+        /**
+         * Global setting for Regular Expression
+         * @return url regex
+         */
+        public String getGlobalUrlRegEx(){ return globalUrlRegEx; }
+
+        public void setGlobalUrlRegEx(String globalUrlRegEx){
+            this.globalUrlRegEx = globalUrlRegEx;
         }
 
         /**

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -285,24 +285,21 @@ public class BuildData implements Action, Serializable, Cloneable {
         return remoteUrls.contains(remoteUrl);
     }
 
-    public String getRepoName(String remoteUrl){
-        String globalRegex = new GitSCM.DescriptorImpl().getGlobalUrlRegEx();
-        System.out.println(globalRegex);
+    public String getRepoName(String remoteUrl,String globalRegex){
+//        String globalRegex = new GitSCM.DescriptorImpl().getGlobalUrlRegEx();
         if(globalRegex == null || globalRegex.isEmpty())
             return "Set up global gitRepo Regex";
         if(globalRegex.contains("?<repo>")){
             Pattern p = Pattern.compile(globalRegex);
             Matcher matcher = p.matcher(remoteUrl);
             matcher.find();
-            System.out.println(matcher.group("repo"));
             return matcher.group("repo");
         }
         return "Invalid Regex Format";
     }
 
-    public String getOrganizationName(String remoteUrl){
+    public String getOrganizationName(String remoteUrl,String globalRegex){
 
-        String globalRegex = new GitSCM.DescriptorImpl().getGlobalUrlRegEx();
         if(globalRegex == null || globalRegex.isEmpty())
             return "Set up global gitRepo Regex";
         if(globalRegex.contains("?<group>")){

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -6,16 +6,14 @@ import hudson.model.Action;
 import hudson.model.Api;
 import hudson.model.Run;
 import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.UserRemoteConfig;
 import java.io.Serializable;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.lang.reflect.Array;
+import java.util.*;
+
+import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.ObjectId;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -29,6 +27,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Captures the Git related information for a build.
  *
@@ -282,6 +283,36 @@ public class BuildData implements Action, Serializable, Cloneable {
 
     public boolean hasBeenReferenced(String remoteUrl) {
         return remoteUrls.contains(remoteUrl);
+    }
+
+    public String getRepoName(String remoteUrl){
+        String globalRegex = new GitSCM.DescriptorImpl().getGlobalUrlRegEx();
+        System.out.println(globalRegex);
+        if(globalRegex == null || globalRegex.isEmpty())
+            return "Set up global gitRepo Regex";
+        if(globalRegex.contains("?<repo>")){
+            Pattern p = Pattern.compile(globalRegex);
+            Matcher matcher = p.matcher(remoteUrl);
+            matcher.find();
+            System.out.println(matcher.group("repo"));
+            return matcher.group("repo");
+        }
+        return "Invalid Regex Format";
+    }
+
+    public String getOrganizationName(String remoteUrl){
+
+        String globalRegex = new GitSCM.DescriptorImpl().getGlobalUrlRegEx();
+        if(globalRegex == null || globalRegex.isEmpty())
+            return "Set up global gitRepo Regex";
+        if(globalRegex.contains("?<group>")){
+            Pattern p = Pattern.compile(globalRegex);
+            Matcher matcher = p.matcher(remoteUrl);
+            matcher.find();
+            return matcher.group("group");
+        }
+        return "Invalid Regex Format";
+//        return p.matcher(remoteUrl).group("group");
     }
 
     @Override

--- a/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/global.jelly
@@ -8,6 +8,9 @@
     <f:entry title="${%Global Config user.email Value}" field="globalConfigEmail">
       <f:textbox />
     </f:entry>
+    <f:entry title="${%Global Repository RegEx Url}" field="globalUrlRegEx">
+      <f:textbox/>
+    </f:entry>
     <f:entry field="createAccountBasedOnEmail">
       <f:checkbox title="${%Create new accounts based on author/committer's email}" name="createAccountBasedOnEmail" checked="${descriptor.createAccountBasedOnEmail}"/>
     </f:entry>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-globalUrlRegEx.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-globalUrlRegEx.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Help for Regex to be added here</p>
+</div>

--- a/src/main/resources/hudson/plugins/git/util/BuildData/index.jelly
+++ b/src/main/resources/hudson/plugins/git/util/BuildData/index.jelly
@@ -18,6 +18,8 @@
 			<j:if test="${!remoteUrl.startsWith('http')}">
 				<br/><strong>${%Repository}</strong>: ${remoteUrl}
 			</j:if>
+			<br/><strong>Organization Name</strong>: ${it.getOrganizationName(remoteUrl)}
+			<br/><strong>Repo Name</strong>: ${it.getRepoName(remoteUrl)}
 		</j:forEach>
 	</j:if>
 	<ul>

--- a/src/main/resources/hudson/plugins/git/util/BuildData/summary.jelly
+++ b/src/main/resources/hudson/plugins/git/util/BuildData/summary.jelly
@@ -14,6 +14,8 @@
 			<j:if test="${!remoteUrl.startsWith('http')}">
 				<br/><strong>${%Repository}</strong>: ${remoteUrl}
 			</j:if>
+			<br/><strong>Organization Name</strong>: ${it.getOrganizationName(remoteUrl)}
+			<br/><strong>Repo Name</strong>: ${it.getRepoName(remoteUrl)}
 		</j:forEach>
 	</j:if>
         <ul>

--- a/src/test/java/hudson/plugins/git/GitGetOrgRepoNameTest.java
+++ b/src/test/java/hudson/plugins/git/GitGetOrgRepoNameTest.java
@@ -2,29 +2,29 @@ package hudson.plugins.git;
 
 import hudson.plugins.git.util.BuildData;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
 
+import java.net.MalformedURLException;
 import java.util.ArrayList;
+import static org.junit.Assert.assertEquals;
 
 public class GitGetOrgRepoNameTest {
 
 	class Url {
-		String url;
+		String remoteUrl;
 		String testOrgName;
 		String testRepoName;
 
-		public Url(String url,String orgName,String repoName){
-			this.url = url;
-			this.testOrgName = orgName;
-			this.testRepoName = repoName;
+		public Url(String remoteUrl,String testOrgName,String testRepoName){
+			this.remoteUrl = remoteUrl;
+			this.testOrgName = testOrgName;
+			this.testRepoName = testRepoName;
 		}
 	}
 
 	@Test
-	public void testOrgRepoName(){
-//		GitSCM.DescriptorImpl globalConfig = new GitSCM.DescriptorImpl();
-		String globalRegex = ".*(@|\\/\\/).*?(\\/|:)(?<group>.*?)\\/(?<repo>.*)$";
-//		globalConfig.setGlobalUrlRegEx("");
+	public void testOrgRepoName() throws MalformedURLException {
+		String globalRegex = "(.*github.*?[/:](?<org>.*)/(?<repo>.*))&&&(.*gitlab.*?[/:](?<org>.*)/(?<repo>.*))&&&(.*?//(?<org>\\w+).*visualstudio.*?/(?<repo>.*))&&&(.*bitbucket.*?[/:](?<org>.*)/(?<repo>.*))" +
+				"&&&(.*assembla.*?[/:](?<repo>.*))";
 		BuildData data = new BuildData();
 
 		ArrayList<Url> urls = new ArrayList<>();
@@ -47,12 +47,19 @@ public class GitGetOrgRepoNameTest {
 		urls.add(new Url("https://bitbucket.org/markewaite/git-client-plugin.git","markewaite","git-client-plugin.git"));
 		urls.add(new Url("https://bitbucket.org/markewaite/tasks.git","markewaite","tasks.git"));
 		urls.add(new Url("https://github.com/MarkEWaite/bin.git","MarkEWaite","bin.git"));
+		urls.add(new Url("https://markwaite.visualstudio.com/_git/elisp","markwaite","_git/elisp"));
+		urls.add(new Url("https://markwaite.visualstudio.com/DefaultCollection/_git/","markwaite","DefaultCollection/_git/"));
+		urls.add(new Url("https://markwaite.visualstudio.com/DefaultCollection/elisp/_git/elisp","markwaite","DefaultCollection/elisp/_git/elisp"));
+		urls.add(new Url("https://github.com/MarkEWaite/bin.git","MarkEWaite","bin.git"));
+		urls.add(new Url("https://github.com/MarkEWaite/bin.git","MarkEWaite","bin.git"));
+
+		urls.add(new Url("https://www.assembla.com/spaces/git-plugin/git-2/",null,"spaces/git-plugin/git-2/"));
+		urls.add(new Url("https://git.assembla.com/git-plugin.bin.git",null,"git-plugin.bin.git"));
+		urls.add(new Url("git@git.assembla.com:git-plugin.bin.git",null,"git-plugin.bin.git"));
 
 		for(Url url : urls){
-			String repoName = data.getRepoName(url.url,globalRegex);
-			String orgName = data.getOrganizationName(url.url,globalRegex);
-			assertEquals(orgName,url.testOrgName);
-			assertEquals(repoName,url.testRepoName);
+			assertEquals(data.getOrganizationName(url.remoteUrl,globalRegex),url.testOrgName);
+			assertEquals(data.getRepoName(url.remoteUrl,globalRegex),url.testRepoName);
 		}
 	}
 }

--- a/src/test/java/hudson/plugins/git/GitGetOrgRepoNameTest.java
+++ b/src/test/java/hudson/plugins/git/GitGetOrgRepoNameTest.java
@@ -1,0 +1,58 @@
+package hudson.plugins.git;
+
+import hudson.plugins.git.util.BuildData;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+
+public class GitGetOrgRepoNameTest {
+
+	class Url {
+		String url;
+		String testOrgName;
+		String testRepoName;
+
+		public Url(String url,String orgName,String repoName){
+			this.url = url;
+			this.testOrgName = orgName;
+			this.testRepoName = repoName;
+		}
+	}
+
+	@Test
+	public void testOrgRepoName(){
+//		GitSCM.DescriptorImpl globalConfig = new GitSCM.DescriptorImpl();
+		String globalRegex = ".*(@|\\/\\/).*?(\\/|:)(?<group>.*?)\\/(?<repo>.*)$";
+//		globalConfig.setGlobalUrlRegEx("");
+		BuildData data = new BuildData();
+
+		ArrayList<Url> urls = new ArrayList<>();
+		urls.add(new Url("git@bitbucket.org:markewaite/tasks.git","markewaite","tasks.git"));
+		urls.add(new Url("git@bitbucket.org:markewaite/bin.git","markewaite","bin.git"));
+		urls.add(new Url("https://markewaite@bitbucket.org/markewaite/tasks.git","markewaite","tasks.git"));
+		urls.add(new Url("https://markewaite@bitbucket.org/markewaite/git-client-plugin.git","markewaite","git-client-plugin.git"));
+		urls.add(new Url("https://markewaite@bitbucket.org/markewaite/bin.git","markewaite","bin.git"));
+		urls.add(new Url("https://MarkEWaite:also-a-password@gitlab.com/MarkEWaite/tasks.git","MarkEWaite","tasks.git"));
+		urls.add(new Url("https://MarkEWaite:another-password@github.com/MarkEWaite/tasks.git","MarkEWaite","tasks.git"));
+		urls.add(new Url("https://MarkEWaite:yes-this-is-a-password@github.com/MarkEWaite/bin.git","MarkEWaite","bin.git"));
+		urls.add(new Url("https://gitlab.com/MarkEWaite/tasks.git","MarkEWaite","tasks.git"));
+		urls.add(new Url("https://gitlab.com/MarkEWaite/tasks","MarkEWaite","tasks"));
+		urls.add(new Url("https://gitlab.com/MarkEWaite/bin","MarkEWaite","bin"));
+		urls.add(new Url("https://github.com/MarkEWaite/tasks.git","MarkEWaite","tasks.git"));
+		urls.add(new Url("git@github.com:MarkEWaite/bin.git","MarkEWaite","bin.git"));
+		urls.add(new Url("git@gitlab.com:MarkEWaite/tasks.git","MarkEWaite","tasks.git"));
+		urls.add(new Url("git@github.com:MarkEWaite/tasks.git","MarkEWaite","tasks.git"));
+		urls.add(new Url("https://bitbucket.org/markewaite/bin.git","markewaite","bin.git"));
+		urls.add(new Url("https://bitbucket.org/markewaite/git-client-plugin.git","markewaite","git-client-plugin.git"));
+		urls.add(new Url("https://bitbucket.org/markewaite/tasks.git","markewaite","tasks.git"));
+		urls.add(new Url("https://github.com/MarkEWaite/bin.git","MarkEWaite","bin.git"));
+
+		for(Url url : urls){
+			String repoName = data.getRepoName(url.url,globalRegex);
+			String orgName = data.getOrganizationName(url.url,globalRegex);
+			assertEquals(orgName,url.testOrgName);
+			assertEquals(repoName,url.testRepoName);
+		}
+	}
+}

--- a/src/test/java/hudson/plugins/git/util/BuildDataTest.java
+++ b/src/test/java/hudson/plugins/git/util/BuildDataTest.java
@@ -228,19 +228,6 @@ public class BuildDataTest {
     }
 
     @Test
-    public void testGetRepoName(){
-        String regex = "^(\\w+(:\\/\\/|@))(\\w+.*(com|org)(:|\\/))(?<group>.*)\\/(?<repo>.*)\\/$";
-        String repoName = data.getRepoName(remoteUrl);
-        assertEquals("git-plugin",repoName);
-    }
-
-    @Test
-    public void testGetOrganizationName(){
-       String organizationName = data.getOrganizationName(remoteUrl);
-       assertEquals("jenkinsci",organizationName);
-    }
-
-    @Test
     public void testHasBeenReferenced() {
         assertFalse(data.hasBeenReferenced(remoteUrl));
         data.addRemoteUrl(remoteUrl);

--- a/src/test/java/hudson/plugins/git/util/BuildDataTest.java
+++ b/src/test/java/hudson/plugins/git/util/BuildDataTest.java
@@ -228,6 +228,19 @@ public class BuildDataTest {
     }
 
     @Test
+    public void testGetRepoName(){
+        String regex = "^(\\w+(:\\/\\/|@))(\\w+.*(com|org)(:|\\/))(?<group>.*)\\/(?<repo>.*)\\/$";
+        String repoName = data.getRepoName(remoteUrl);
+        assertEquals("git-plugin",repoName);
+    }
+
+    @Test
+    public void testGetOrganizationName(){
+       String organizationName = data.getOrganizationName(remoteUrl);
+       assertEquals("jenkinsci",organizationName);
+    }
+
+    @Test
     public void testHasBeenReferenced() {
         assertFalse(data.hasBeenReferenced(remoteUrl));
         data.addRemoteUrl(remoteUrl);

--- a/src/test/java/jenkins/plugins/git/GitSCMJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMJCasCCompatibilityTest.java
@@ -14,6 +14,7 @@ public class GitSCMJCasCCompatibilityTest extends RoundTripAbstractTest {
         GitSCM.DescriptorImpl gitSCM = (GitSCM.DescriptorImpl) restartableJenkinsRule.j.jenkins.getScm(GitSCM.class.getSimpleName());
         assertEquals("user_name", gitSCM.getGlobalConfigName());
         assertEquals("me@mail.com", gitSCM.getGlobalConfigEmail());
+        assertEquals("",gitSCM.getGlobalUrlRegEx());
         assertTrue("Allow second fetch setting not honored", gitSCM.isAllowSecondFetch());
         assertTrue("Show entire commit summary setting not honored", gitSCM.isShowEntireCommitSummaryInChanges());
         assertTrue("Hide credentials setting not honored", gitSCM.isHideCredentials());


### PR DESCRIPTION
## [JENKINS-54858](https://issues.jenkins.io/browse/JENKINS-54858) - Adds Organization/Project and Repository name

Added a global git config for regex which is used internally to get the project name and repo name.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have added tests that verify my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_
fixes an issue)

- [x] New feature (non-breaking change which adds functionality)
