### PR TITLE
Fix flaky `GitSCMTest#testSubmoduleFixup`

### DIFF
--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -62,7 +62,6 @@ import org.jenkinsci.plugins.gitclient.*;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1638,7 +1637,6 @@ public class GitSCMTest extends AbstractGitTestCase {
     @Test
     public void testSubmoduleFixup() throws Exception {
         /* Unreliable on Windows and not a platform specific test */
-        Assume.assumeFalse(isWindows());
         File repo = secondRepo.getRoot();
         FilePath moduleWs = new FilePath(repo);
         org.jenkinsci.plugins.gitclient.GitClient moduleRepo = Git.with(listener, new EnvVars()).in(repo).getClient();

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -62,6 +62,7 @@ import org.jenkinsci.plugins.gitclient.*;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1637,9 +1638,7 @@ public class GitSCMTest extends AbstractGitTestCase {
     @Test
     public void testSubmoduleFixup() throws Exception {
         /* Unreliable on Windows and not a platform specific test */
-        if (isWindows()) {
-            return;
-        }
+        Assume.assumeFalse(isWindows());
         File repo = secondRepo.getRoot();
         FilePath moduleWs = new FilePath(repo);
         org.jenkinsci.plugins.gitclient.GitClient moduleRepo = Git.with(listener, new EnvVars()).in(repo).getClient();
@@ -1672,6 +1671,8 @@ public class GitSCMTest extends AbstractGitTestCase {
 
         FreeStyleBuild db = d.getLastBuild();
         assertNotNull("downstream build didn't happen",db);
+
+        db = rule.waitForCompletion(db);
         rule.assertBuildStatusSuccess(db);
     }
 


### PR DESCRIPTION
The test should wait for the build to complete before actually checking
its status.

```
java.lang.AssertionError:
unexpected build status; build log was:
------
Started by upstream project "test0" build number 1
originally caused by:
 Legacy code started this job.  No cause information is available
Running as SYSTEM
Building in workspace /jenkins/workspace/builder/output-git/work/git/target/tmp/j h69583182000798596/workspace/test1
The recommended git tool is: NONE
No credentials specified
Cloning the remote Git repository
Cloning repository /jenkins/workspace/builder/output-git/work/git/target/tmp/junit3569465322501079491/junit1849114342070567213
 > git init /jenkins/workspace/builder/output-git/work/git/target/tmp/j h69583182000798596/workspace/test1 # timeout=10

------

Expected: is <SUCCESS>
     but: was null
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:964)
	at org.jvnet.hudson.test.JenkinsRule.assertBuildStatus(JenkinsRule.java:1439)
	at org.jvnet.hudson.test.JenkinsRule.assertBuildStatusSuccess(JenkinsRule.java:1468)
	at hudson.plugins.git.GitSCMTest.testSubmoduleFixup(GitSCMTest.java:1675)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:601)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```

## Fix flaky `GitSCMTest#testSubmoduleFixup`

Wait for downstream build completion before checking its status.

## Checklist

- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields

## Types of changes

- [x] Test
