### PR TITLE
Add warning about unexpected default branch name.

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -35,6 +35,12 @@ Try to maintain reasonable consistency with the existing files where feasible.
 Please don't perform wholesale reformatting of a file without discussing with the current maintainers.
 New code should follow the https://github.com/jenkinsci/scm-api-plugin/blob/master/CONTRIBUTING.md#code-style-guidelines[SCM API code style guidelines].
 
+**Beware:** when building locally, some global gitconfig settings can make tests fail. 
+Currently they expect the default branch to be called `master`.
+If the default branch has been set to another value than master, it should be temporarily disabled.
+This is done by adding **#** before `defaultBranch = main` in the `init` section 
+of the `.gitconfig` file (located in your home directory).
+
 [[pull-request-review]]
 == Reviewing Pull Requests
 


### PR DESCRIPTION
Tests can fail if the default branch name is not the traditional "master". This PR warns of this problem in the CONTRIBUTING.md and explains how to temporarily disable the setting.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] ~~I have referenced the Jira issue related to my changes in one or more commit messages~~
- [ ] ~~I have added tests that verify my changes~~
- [ ] ~~Unit tests pass locally with my changes~~
- [x] I have added documentation as necessary
- [ ] ~~No Javadoc warnings were introduced with my changes~~
- [ ] ~~No spotbugs warnings were introduced with my changes~~
- [ ] ~~Documentation in README has been updated as necessary~~
- [ ] ~~Online help has been added and reviewed for any new or modified fields~~
- [ ] ~~I have interactively tested my changes~~
- [ ] ~~Any dependent changes have been merged and published in upstream modules (like git-client-plugin)~~

## Types of changes

- Documentation


