### PR TITLE
Test with Java 17 in addition to Java 11 and Java 8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 buildPlugin(failFast: false,
             configurations: [
-                [platform: 'linux',   jdk: '11', jenkins: '2.342'],
+                [platform: 'linux',   jdk: '17', jenkins: '2.342'],
                 [platform: 'linux',   jdk: '11'],
                 [platform: 'windows', jdk:  '8'],
             ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@
 
 buildPlugin(failFast: false,
             configurations: [
-                [platform: 'linux', jdk: '11'],
-                [platform: 'windows', jdk: '8'],
+                [platform: 'linux',   jdk: '11', jenkins: '2.342'],
+                [platform: 'linux',   jdk: '11'],
+                [platform: 'windows', jdk:  '8'],
             ])

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <jenkins.version>2.289.1</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
     <revision>4.11.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jenkins.version>2.289.1</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -104,7 +104,7 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
      * the chosen revision and returning it) or manipulate the state of the working tree (such as
      * running git-clean.)
      *
-     * <h3>{@link #decorateRevisionToBuild(GitSCM, Run, GitClient, TaskListener, Revision, Revision)} vs {@link BuildChooser}</h3>
+     * <strong>{@link #decorateRevisionToBuild(GitSCM, Run, GitClient, TaskListener, Revision, Revision)} vs {@link BuildChooser}</strong>
      * <p>
      * {@link BuildChooser} and this method are similar in the sense that they both participate in the process
      * of determining what commits to build. So when a plugin wants to control the commit to be built, you have


### PR DESCRIPTION
## Test Java 17 in additional to Java 11 and Java 8

Use Java 17 in the Jenkinsfile to compile and test.

Tests are failing with a serialization error.  I need more guidance on the changes needed to fix the failing tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
