### PR TITLE
Fix minor typo in documentation.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1182,7 +1182,7 @@ The git plugin provides token macros for:
 
 GIT_REVISION:: Expands to the Git SHA1 commit ID that points to the commit that was built.
   length:: integer length of the commit ID that should be displayed.
-  `${GIT_REVISION}` might expand to `a806ba7701bcfc9f784ccb7854c26f03e045c1d2`, while `${GIT_REVISION,length=8}` would expoand to `a806ba77`.
+  `${GIT_REVISION}` might expand to `a806ba7701bcfc9f784ccb7854c26f03e045c1d2`, while `${GIT_REVISION,length=8}` would expand to `a806ba77`.
 
 GIT_BRANCH:: Expands to the name of the branch that was built.
   all:: boolean that expands to all branch names that point to the current commit when enabled.


### PR DESCRIPTION
## [JENKINS-68424](https://issues.jenkins.io/browse/JENKINS-68424)

Fixes a small typo in documentation, by changing "expoand" to "expand".

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

This is a really minor typo fix. Just noticed it when reading the docs and hope this is helpful and not annoying!