### PR TITLE
Merge back SECURITY-2478 fix into default branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>git</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>4.11.2</version>
   <packaging>hpi</packaging>
   <name>Git plugin</name>
   <description>Integrates Jenkins with Git SCM</description>
@@ -53,7 +53,7 @@
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <tag>${scmTag}</tag>
+    <tag>git-4.11.2</tag>
     <url>https://github.com/${gitHubRepo}</url>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>git</artifactId>
-  <version>4.11.2</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
   <name>Git plugin</name>
   <description>Integrates Jenkins with Git SCM</description>
@@ -53,12 +53,12 @@
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <tag>git-4.11.2</tag>
+    <tag>${scmTag}</tag>
     <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
   <properties>
-    <revision>4.11.2</revision>
+    <revision>4.11.3</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.289.1</jenkins.version>

--- a/src/test/java/hudson/plugins/git/Security2478Test.java
+++ b/src/test/java/hudson/plugins/git/Security2478Test.java
@@ -1,0 +1,77 @@
+package hudson.plugins.git;
+
+import hudson.model.Result;
+import jenkins.plugins.git.GitSampleRepoRule;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+
+import static org.junit.Assert.assertFalse;
+
+public class Security2478Test {
+
+    @Rule
+    public JenkinsRule rule = new JenkinsRule();
+
+    @Rule
+    public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+
+    @Before
+    public void setUpAllowNonRemoteCheckout() {
+        GitSCM.ALLOW_LOCAL_CHECKOUT = false;
+    }
+
+    @After
+    public void disallowNonRemoteCheckout() {
+        GitSCM.ALLOW_LOCAL_CHECKOUT = false;
+    }
+
+    @Issue("SECURITY-2478")
+    @Test
+    public void checkoutShouldNotAbortWhenLocalSourceAndRunningOnAgent() throws Exception {
+        assertFalse("Non Remote checkout should be disallowed", GitSCM.ALLOW_LOCAL_CHECKOUT);
+        rule.createOnlineSlave();
+        sampleRepo.init();
+        sampleRepo.write("file", "v1");
+        sampleRepo.git("commit", "--all", "--message=test commit");
+        WorkflowJob p = rule.jenkins.createProject(WorkflowJob.class, "pipeline");
+
+        String script = "node('slave0') {\n" +
+                "   checkout([$class: 'GitSCM', branches: [[name: '*/master']], extensions: [], userRemoteConfigs: [[url: '" + sampleRepo.fileUrl() + "', credentialsId: '']]])\n" +
+                "}";
+        p.setDefinition(new CpsFlowDefinition(script, true));
+        WorkflowRun run = rule.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
+        rule.assertLogNotContains("aborted because it references a local directory, which may be insecure. " +
+                "You can allow local checkouts anyway by setting the system property 'hudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT' to true.", run);
+    }
+
+    @Issue("SECURITY-2478")
+    @Test
+    public void checkoutShouldAbortWhenSourceIsNonRemoteAndRunningOnController() throws Exception {
+        assertFalse("Non Remote checkout should be disallowed", GitSCM.ALLOW_LOCAL_CHECKOUT);
+        WorkflowJob p = rule.jenkins.createProject(WorkflowJob.class, "pipeline");
+        String workspaceDir = rule.jenkins.getRootDir().getAbsolutePath();
+
+        String path = "file://" + workspaceDir + File.separator + "jobName@script" + File.separator + "anyhmachash";
+        String escapedPath = path.replace("\\", "\\\\"); // for windows
+        String script = "node {\n" +
+                "   checkout([$class: 'GitSCM', branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[" +
+                "url: '" + escapedPath + "'," +
+                " credentialsId: '']]])\n" +
+                "}";
+        p.setDefinition(new CpsFlowDefinition(script, true));
+        WorkflowRun run = rule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        rule.assertLogContains("Checkout of Git remote '" + path + "' " +
+                        "aborted because it references a local directory, which may be insecure. " +
+                        "You can allow local checkouts anyway by setting the system property 'hudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT' to true.", run);
+    }
+}

--- a/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
@@ -5,6 +5,7 @@ import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.TestGitRepo;
 import hudson.util.StreamTaskListener;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -36,6 +37,16 @@ public abstract class GitSCMExtensionTest {
 	public void setUp() throws Exception {
 		listener = StreamTaskListener.fromStderr();
 		before();
+	}
+
+	@Before
+	public void allowNonRemoteCheckout() {
+		GitSCM.ALLOW_LOCAL_CHECKOUT = true;
+	}
+
+	@After
+	public void disallowNonRemoteCheckout() {
+		GitSCM.ALLOW_LOCAL_CHECKOUT = false;
 	}
 
 	protected abstract void before() throws Exception;

--- a/src/test/java/hudson/plugins/git/extensions/impl/PruneStaleTagPipelineTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/PruneStaleTagPipelineTest.java
@@ -28,12 +28,14 @@ import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import hudson.plugins.git.GitSCM;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.TestCliGitAPIImpl;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -61,6 +63,16 @@ public class PruneStaleTagPipelineTest {
     @Before
     public void setup() throws Exception {
         listener = new LogTaskListener(Logger.getLogger("prune tags"), Level.FINEST);
+    }
+
+    @Before
+    public void allowNonRemoteCheckout() {
+        GitSCM.ALLOW_LOCAL_CHECKOUT = true;
+    }
+
+    @After
+    public void disallowNonRemoteCheckout() {
+        GitSCM.ALLOW_LOCAL_CHECKOUT = false;
     }
 
     @Issue("JENKINS-61869")

--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -28,6 +28,7 @@ import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import hudson.Launcher;
 import hudson.model.TaskListener;
+import hudson.plugins.git.GitSCM;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -47,6 +48,16 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
     private static boolean initialized = false;
 
     private static final Logger LOGGER = Logger.getLogger(GitSampleRepoRule.class.getName());
+
+    protected void before() throws Throwable {
+        super.before();
+        GitSCM.ALLOW_LOCAL_CHECKOUT = true;
+    }
+
+    protected void after() {
+        super.after();
+        GitSCM.ALLOW_LOCAL_CHECKOUT = false;
+    }
 
     public void git(String... cmds) throws Exception {
         run("git", cmds);

--- a/src/test/java/org/jenkinsci/plugins/gittagmessage/AbstractGitTagMessageExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gittagmessage/AbstractGitTagMessageExtensionTest.java
@@ -3,10 +3,12 @@ package org.jenkinsci.plugins.gittagmessage;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Run;
+import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.util.BuildData;
 import jenkins.model.ParameterizedJobMixIn;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +48,16 @@ public abstract class AbstractGitTagMessageExtensionTest<J extends Job<J, R> & P
         // Set up a temporary git repository for each test case
         repo = Git.with(jenkins.createTaskListener(), null).in(repoDir.getRoot()).getClient();
         repo.init();
+    }
+
+    @Before
+    public void allowNonRemoteCheckout() {
+        GitSCM.ALLOW_LOCAL_CHECKOUT = true;
+    }
+
+    @After
+    public void disallowNonRemoteCheckout() {
+        GitSCM.ALLOW_LOCAL_CHECKOUT = false;
     }
 
     @Test


### PR DESCRIPTION
https://www.jenkins.io/security/advisory/2022-05-17/#SECURITY-2478

I recommend merging this PR using merge commit, so that the release commits of 4.11.2 are on the history of the default branch.