### PR TITLE
[JENKINS-68562] Fix Git checkouts for controllers running on Windows

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -78,6 +78,7 @@ import java.io.PrintStream;
 import java.io.Serializable;
 import java.io.Writer;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.AbstractList;
@@ -104,7 +105,6 @@ import static hudson.scm.PollingResult.*;
 import hudson.Util;
 import hudson.plugins.git.extensions.impl.ScmName;
 import hudson.util.LogTaskListener;
-import java.nio.file.InvalidPathException;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1409,8 +1409,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     private static boolean isRemoteUrlValid(String remoteUrl) {
         if (remoteUrl == null) {
             return true;
-        }
-        if (remoteUrl.toLowerCase(Locale.ENGLISH).startsWith("file://")) {
+        } else if (remoteUrl.toLowerCase(Locale.ENGLISH).startsWith("file://")) {
             return false;
         }
         try {

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1394,7 +1394,8 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
     }
 
-    private void abortIfSourceIsLocal() throws AbortException {
+    /* Package protected for test access */
+    void abortIfSourceIsLocal() throws AbortException {
         for (UserRemoteConfig userRemoteConfig: getUserRemoteConfigs()) {
             String remoteUrl = userRemoteConfig.getUrl();
             if (!isRemoteUrlValid(remoteUrl)) {

--- a/src/test/java/hudson/plugins/git/GitSCMUnitTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMUnitTest.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.git;
 
+import hudson.AbortException;
 import hudson.EnvVars;
 import static hudson.plugins.git.GitSCM.createRepoList;
 import hudson.plugins.git.browser.GitRepositoryBrowser;
@@ -43,6 +44,8 @@ import org.eclipse.jgit.transport.URIish;
 import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.jvnet.hudson.test.Issue;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
@@ -337,5 +340,18 @@ public class GitSCMUnitTest {
         gitSCM.setDoGenerateSubmoduleConfigurations(true);
         /* Confirms the passed value `true` is ignored */
         assertFalse(gitSCM.getDoGenerateSubmoduleConfigurations());
+    }
+
+    @Issue("JENKINS-68562")
+    @Test
+    public void testAbortIfSourceIsLocal() {
+        GitSCM gitSCM = new GitSCM(createRepoList(repoURL, null),
+                Collections.singletonList(new BranchSpec("master")),
+                null, null, Collections.emptyList());
+        try {
+            gitSCM.abortIfSourceIsLocal();
+        } catch (AbortException e) {
+            fail("https remote URLs should always be valid");
+        }
     }
 }


### PR DESCRIPTION
## [JENKINS-68562](https://issues.jenkins.io/browse/JENKINS-68562) Fix Git checkouts for controllers running on Windows

The security fix in https://github.com/jenkinsci/git-plugin/commit/b295606e0b865c298fde27bea14f9b7535a976e6 broke all Git checkouts that use remotes with an explicit protocol on Jenkins controllers running on Windows. This PR fixes that issue by catching `InvalidPathException` in the relevant location.

I have not tested the PR (I do not have access to a Windows machine right now). I am not sure if we easily can create automated tests with non-`file` remotes that would exercise this behavior. We should be able to test it at surface level using mocks or maybe via a complex `WireMock` harness for a more thorough test.

Just filing a draft PR for now since I have not tested anything.

CC @Pldi23 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

