### PR TITLE
Retrieve full name matches over hazy short hash matches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,12 @@
       <artifactId>jenkins-test-harness</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <version>4.11.3</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,12 @@
       <version>4.11.3</version>
       <scope>compile</scope>
     </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>git</artifactId>
+          <version>4.11.3</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -922,15 +922,22 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             }
             if (rev.toLowerCase(Locale.ENGLISH).startsWith(revision.toLowerCase(Locale.ENGLISH))) {
                 shortNameMatches.add(name);
+                listener.getLogger().printf("Candidate partial match: %s revision %s%n", name, rev);
                 if (shortHashMatch == null) {
-                    listener.getLogger().printf("Candidate partial match: %s revision %s%n", name, rev);
                     shortHashMatch = rev;
                 } else {
-                    listener.getLogger().printf("Candidate partial match: %s revision %s%n", name, rev);
                     listener.getLogger().printf("Cannot resolve ambiguous short revision %s%n", revision);
-                    return null;
+                    if (fullTagMatches.isEmpty() && fullHashMatches.isEmpty() && fullHashMatch == null) {
+                        // We haven't found any matches, and we have ambiguous matches, cannot determine
+                        return null;
+                    }
                 }
             }
+        }
+        if (fullHashMatch != null) {
+            // JENKINS-62592, for predictability, if an exact match is found, that should be returned
+            //since this would have been skipped if this was a head or a tag we can just return whatever
+            return new GitRefSCMRevision(new GitRefSCMHead(fullHashMatch, fullHashMatches.iterator().next()), fullHashMatch);
         }
         if (!fullTagMatches.isEmpty()) {
             // we just want a tag so we can do a minimal fetch
@@ -940,34 +947,6 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             context.wantBranches(false);
             context.wantTags(true);
             context.withoutRefSpecs();
-        }
-        if (fullHashMatch != null) {
-            //since this would have been skipped if this was a head or a tag we can just return whatever
-            return new GitRefSCMRevision(new GitRefSCMHead(fullHashMatch, fullHashMatches.iterator().next()), fullHashMatch);
-        }
-        if (shortHashMatch != null) {
-            // woot this seems unambiguous
-            for (String name: shortNameMatches) {
-                if (name.startsWith(Constants.R_HEADS)) {
-                    listener.getLogger().printf("Selected match: %s revision %s%n", name, shortHashMatch);
-                    // WIN it's also a branch
-                    return new GitBranchSCMRevision(new GitBranchSCMHead(StringUtils.removeStart(name, Constants.R_HEADS)),
-                            shortHashMatch);
-                } else if (name.startsWith(Constants.R_TAGS)) {
-                    tagName = StringUtils.removeStart(name, Constants.R_TAGS);
-                    context.wantBranches(false);
-                    context.wantTags(true);
-                    context.withoutRefSpecs();
-                }
-            }
-            if (tagName != null) {
-                listener.getLogger().printf("Selected match: %s revision %s%n", tagName, shortHashMatch);
-            } else {
-                return new GitRefSCMRevision(new GitRefSCMHead(shortHashMatch, shortNameMatches.iterator().next()), shortHashMatch);
-            }
-        }
-        if (candidateOtherRef != null) {
-            return candidateOtherRef;
         }
         //if PruneStaleBranches it should take affect on the following retrievals
         boolean pruneRefs = context.pruneRefs();
@@ -995,6 +974,30 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                     context,
                     listener, pruneRefs, retrieveContext);
         }
+        if (shortHashMatch != null) {
+            // woot this seems unambiguous
+            for (String name: shortNameMatches) {
+                if (name.startsWith(Constants.R_HEADS)) {
+                    listener.getLogger().printf("Selected match: %s revision %s%n", name, shortHashMatch);
+                    // WIN it's also a branch
+                    return new GitBranchSCMRevision(new GitBranchSCMHead(StringUtils.removeStart(name, Constants.R_HEADS)),
+                            shortHashMatch);
+                } else if (name.startsWith(Constants.R_TAGS)) {
+                    tagName = StringUtils.removeStart(name, Constants.R_TAGS);
+                    context.wantBranches(false);
+                    context.wantTags(true);
+                    context.withoutRefSpecs();
+                }
+            }
+            if (tagName != null) {
+                listener.getLogger().printf("Selected match: %s revision %s%n", tagName, shortHashMatch);
+            } else {
+                return new GitRefSCMRevision(new GitRefSCMHead(shortHashMatch, shortNameMatches.iterator().next()), shortHashMatch);
+            }
+        }
+        if (candidateOtherRef != null) {
+            return candidateOtherRef;
+        }
         // Pokémon!... Got to catch them all
         listener.getLogger().printf("Could not find %s in remote references. "
                         + "Pulling heads to local for deep search...%n", revision);
@@ -1012,7 +1015,6 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                           //just to be safe
                                           listener.error("Could not resolve %s", revision);
                                           return null;
-
                                       }
                                       hash = objectId.name();
                                       String candidatePrefix = Constants.R_REMOTES.substring(Constants.R_REFS.length())

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -921,7 +921,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                     break;
                 }
             }
-            if (rev.toLowerCase(Locale.ENGLISH).startsWith(revision.toLowerCase(Locale.ENGLISH))) {
+            if (!revision.isEmpty() && rev.toLowerCase(Locale.ENGLISH).startsWith(revision.toLowerCase(Locale.ENGLISH))) {
                 shortNameMatches.add(name);
                 listener.getLogger().printf("Candidate partial match: %s revision %s%n", name, rev);
                 if (shortHashMatch == null) {

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -1141,6 +1141,7 @@ public class AbstractGitSCMSourceTest {
         TaskListener listener = StreamTaskListener.fromStderr();
         listener.getLogger().printf("ArrayList of first hash chars: %s", hashFirstLetter);
 
+        // Test existing functionality with additional revisions
         listener.getLogger().println("\n=== fetch('master') ===\n");
         SCMRevision rev = source.fetch("master", listener, null);
         assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
@@ -1160,6 +1161,7 @@ public class AbstractGitSCMSourceTest {
         assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(masterHash));
         assertThat(rev.getHead().getName(), is("master"));
 
+        // Test new functionality and verify that we are able to grab what we expect (full match versus hazy short hash)
         if (!devTagHash.equals(newHash)) {
             listener.getLogger().printf("%n=== fetch('%s') ===%n%n", newHash);
             rev = source.fetch(newHash, listener, null);
@@ -1183,11 +1185,15 @@ public class AbstractGitSCMSourceTest {
             assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(headHash));
 
             String ambiguousTag = hashFirstLetter.get(hashFirstLetter.size() - 1);
+            String ambiguousHash = sampleRepo.head();
+            sampleRepo.git("tag", ambiguousTag);
+            sampleRepo.write("file", "modified and ambiguous");
+            sampleRepo.git("commit", "--all", "--message=ambiguousTagCommit");
             listener.getLogger().printf("%n=== fetch(%s) ===%n%n", ambiguousTag);
             rev = source.fetch(ambiguousTag, listener, null);
             assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
-            assertThat(rev.getHead().getName(), is("dev"));
-            assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(devTagHash));
+            assertThat(rev.getHead().getName(), is(ambiguousTag));
+            assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(ambiguousHash));
         }
     }
 

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -1121,14 +1121,14 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.git("tag", "devTag");
         String devTagHash = sampleRepo.head();
         int i = 4; // In order to name new files and create new commits
-        String newHash = null;
+        String newHash = devTagHash;
         while (!hashFirstLetter.contains(devTagHash.substring(0,1))) {
             // Generate a new commit and try again
-            newHash = sampleRepo.head();
-            hashFirstLetter.add(newHash.substring(0,1));
             sampleRepo.git("tag", "devTag"+i);
             sampleRepo.write("file", "modified" + i);
             sampleRepo.git("commit", "--all", "--message=dev" + (i++));
+            newHash = sampleRepo.head();
+            hashFirstLetter.add(newHash.substring(0,1));
         }
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits(new ArrayList<>());
@@ -1160,12 +1160,25 @@ public class AbstractGitSCMSourceTest {
             rev = source.fetch(newHash, listener, null);
             assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
             assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(newHash));
-            assertThat(rev.getHead().getName(), is(newHash));
+            assertThat(rev.getHead().getName(), is("dev"));
+
+            listener.getLogger().printf("%n=== fetch('%s') short hash ===%n%n", newHash.substring(0, 6));
+            rev = source.fetch(newHash.substring(0, 6), listener, null);
+            assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
+            assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(newHash));
+            assertThat(rev.getHead().getName(), is("dev"));
 
             listener.getLogger().printf("%n=== fetch(devTag%d) ===%n%n", i - 1);
             rev = source.fetch("devTag" + (i-1), listener, null);
             assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
             assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(newHash));
+            assertThat(rev.getHead().getName(), is("devTag" + (i - 1)));
+
+            String ambiguousTag = hashFirstLetter.get(hashFirstLetter.size() - 1);
+            listener.getLogger().printf("%n=== fetch(%s) ===%n%n", ambiguousTag);
+            rev = source.fetch(ambiguousTag, listener, null);
+            assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
+            assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(devTagHash));
             assertThat(rev.getHead().getName(), is("devTag" + (i - 1)));
         }
     }

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -1105,6 +1105,33 @@ public class AbstractGitSCMSourceTest {
             sharedSampleRepo = null;
         }
     }
+
+    @Test
+    public void shouldReturnExactMatchOverRelativeMatchTest() throws Exception {
+        // TODO: The idea is that this code should now make sure that there isn't an exact match before sending something back
+        sampleRepo.init();
+        String masterHash = sampleRepo.head();
+        sampleRepo.git("checkout", "-b", "dev");
+        sampleRepo.write("file", "modified");
+        sampleRepo.git("commit", "--all", "--message=dev");
+        String v1Hash = sampleRepo.head();
+        sampleRepo.write("file", "modified2");
+        sampleRepo.git("commit", "--all", "--message=dev2");
+        String v2Hash = sampleRepo.head();
+        sampleRepo.write("file", "modified3");
+        sampleRepo.git("commit", "--all", "--message=dev3");
+        String devHash = sampleRepo.head();
+        GitSCMSource source = new GitSCMSource(sampleRepo.toString());
+        source.setTraits(Collections.singletonList(new BranchDiscoveryTrait()));
+
+        TaskListener listener = StreamTaskListener.fromStderr();
+
+        listener.getLogger().println("\n=== fetch('master') ===\n");
+        SCMRevision rev = source.fetch(masterHash, listener, null);
+        assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
+        assertThat(rev.getHead().getName(), is("master"));
+    }
+
     //Ugly but MockGitClient needs to be static and no good way to pass it on
     static GitSampleRepoRule sharedSampleRepo;
 

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -1118,29 +1118,28 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.git("commit", "--all", "--message=dev3");
         // Grab the devHash, but lets try and generate a hash that we know will cause an issue in our test
         ArrayList<String> hashFirstLetter = new ArrayList<>(Arrays.asList(masterHash.substring(0,1), v1Hash.substring(0,1), v2Hash.substring(0,1)));
-        String devHash = sampleRepo.head();
+        sampleRepo.git("tag", "devTag");
+        String devTagHash = sampleRepo.head();
         int i = 4; // In order to name new files and create new commits
         String newHash = null;
-        while (!hashFirstLetter.contains(devHash.substring(0,1))) {
+        while (!hashFirstLetter.contains(devTagHash.substring(0,1))) {
             // Generate a new commit and try again
-            sampleRepo.write("file", "modified" + i);
-            sampleRepo.git("commit", "--all", "--message=dev" + (i++));
             newHash = sampleRepo.head();
             hashFirstLetter.add(newHash.substring(0,1));
+            sampleRepo.git("tag", "devTag"+i);
+            sampleRepo.write("file", "modified" + i);
+            sampleRepo.git("commit", "--all", "--message=dev" + (i++));
         }
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits(new ArrayList<>());
 
         TaskListener listener = StreamTaskListener.fromStderr();
+        listener.getLogger().printf("ArrayList of first hash chars: %s", hashFirstLetter);
 
         listener.getLogger().println("\n=== fetch('master') ===\n");
         SCMRevision rev = source.fetch("master", listener, null);
         assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
         assertThat(((AbstractGitSCMSource.SCMRevisionImpl)rev).getHash(), is(masterHash));
-        listener.getLogger().println("\n=== fetch('dev') ===\n");
-        rev = source.fetch("dev", listener, null);
-        assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
-        assertThat(((AbstractGitSCMSource.SCMRevisionImpl)rev).getHash(), is(devHash));
         listener.getLogger().println("\n=== fetch('v1') ===\n");
         rev = source.fetch("v1", listener, null);
         assertThat(rev, instanceOf(GitTagSCMRevision.class));
@@ -1161,7 +1160,13 @@ public class AbstractGitSCMSourceTest {
             rev = source.fetch(newHash, listener, null);
             assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
             assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(newHash));
-            assertThat(rev.getHead().getName(), is("master"));
+            assertThat(rev.getHead().getName(), is(newHash));
+
+            listener.getLogger().printf("%n=== fetch(devTag%d) ===%n%n", i - 1);
+            rev = source.fetch("devTag" + (i-1), listener, null);
+            assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
+            assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(newHash));
+            assertThat(rev.getHead().getName(), is("devTag" + (i - 1)));
         }
     }
 

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -22,6 +22,7 @@ import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.impl.BuildChooserSetting;
 import hudson.plugins.git.extensions.impl.LocalBranch;
 import hudson.util.StreamTaskListener;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -202,18 +203,16 @@ public class AbstractGitSCMSourceTest {
                 long fileTimeStampFuzz = isWindows() ? 2000L : 1000L;
                 fileTimeStampFuzz = 12 * fileTimeStampFuzz / 10; // 20% grace for file system noise
                 switch (scmHead.getName()) {
-                    case "lightweight":
-                        {
-                            long timeStampDelta = afterLightweightTag - tagHead.getTimestamp();
-                            assertThat(timeStampDelta, is(both(greaterThanOrEqualTo(0L)).and(lessThanOrEqualTo(afterLightweightTag - beforeLightweightTag + fileTimeStampFuzz))));
-                            break;
-                        }
-                    case "annotated":
-                        {
-                            long timeStampDelta = afterAnnotatedTag - tagHead.getTimestamp();
-                            assertThat(timeStampDelta, is(both(greaterThanOrEqualTo(0L)).and(lessThanOrEqualTo(afterAnnotatedTag - beforeAnnotatedTag + fileTimeStampFuzz))));
-                            break;
-                        }
+                    case "lightweight": {
+                        long timeStampDelta = afterLightweightTag - tagHead.getTimestamp();
+                        assertThat(timeStampDelta, is(both(greaterThanOrEqualTo(0L)).and(lessThanOrEqualTo(afterLightweightTag - beforeLightweightTag + fileTimeStampFuzz))));
+                        break;
+                    }
+                    case "annotated": {
+                        long timeStampDelta = afterAnnotatedTag - tagHead.getTimestamp();
+                        assertThat(timeStampDelta, is(both(greaterThanOrEqualTo(0L)).and(lessThanOrEqualTo(afterAnnotatedTag - beforeAnnotatedTag + fileTimeStampFuzz))));
+                        break;
+                    }
                     default:
                         fail("Unexpected tag head '" + scmHead.getName() + "'");
                         break;
@@ -305,7 +304,7 @@ public class AbstractGitSCMSourceTest {
         assert folderStore != null;
         String fCredentialsId = "fcreds";
         StandardCredentials fCredentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL,
-            fCredentialsId, "fcreds", "user", "password");
+                fCredentialsId, "fcreds", "user", "password");
         folderStore.addCredentials(Domain.global(), fCredentials);
         folderStore.save();
         WorkflowJob p = f.createProject(WorkflowJob.class, "wjob");
@@ -361,19 +360,19 @@ public class AbstractGitSCMSourceTest {
         listener.getLogger().println("\n=== fetch('master') ===\n");
         SCMRevision rev = source.fetch("master", listener, null);
         assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
-        assertThat(((AbstractGitSCMSource.SCMRevisionImpl)rev).getHash(), is(masterHash));
+        assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(masterHash));
         listener.getLogger().println("\n=== fetch('dev') ===\n");
         rev = source.fetch("dev", listener, null);
         assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
-        assertThat(((AbstractGitSCMSource.SCMRevisionImpl)rev).getHash(), is(devHash));
+        assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(devHash));
         listener.getLogger().println("\n=== fetch('v1') ===\n");
         rev = source.fetch("v1", listener, null);
         assertThat(rev, instanceOf(GitTagSCMRevision.class));
-        assertThat(((GitTagSCMRevision)rev).getHash(), is(v1Hash));
+        assertThat(((GitTagSCMRevision) rev).getHash(), is(v1Hash));
         listener.getLogger().println("\n=== fetch('v2') ===\n");
         rev = source.fetch("v2", listener, null);
         assertThat(rev, instanceOf(GitTagSCMRevision.class));
-        assertThat(((GitTagSCMRevision)rev).getHash(), is(v2Hash));
+        assertThat(((GitTagSCMRevision) rev).getHash(), is(v2Hash));
 
         listener.getLogger().printf("%n=== fetch('%s') ===%n%n", masterHash);
         rev = source.fetch(masterHash, listener, null);
@@ -471,7 +470,7 @@ public class AbstractGitSCMSourceTest {
         source.setOwner(owner);
         TaskListener listener = StreamTaskListener.fromStderr();
         Map<String, SCMHead> headByName = new TreeMap<>();
-        for (SCMHead h: source.fetch(listener)) {
+        for (SCMHead h : source.fetch(listener)) {
             headByName.put(h.getName(), h);
         }
         if (duplicatePrimary) {
@@ -481,7 +480,7 @@ public class AbstractGitSCMSourceTest {
         }
         List<Action> actions = source.fetchActions(null, listener);
         GitRemoteHeadRefAction refAction = null;
-        for (Action a: actions) {
+        for (Action a : actions) {
             if (a instanceof GitRemoteHeadRefAction) {
                 refAction = (GitRemoteHeadRefAction) a;
                 break;
@@ -499,7 +498,7 @@ public class AbstractGitSCMSourceTest {
         }
 
         PrimaryInstanceMetadataAction primary = null;
-        for (Action a: actions) {
+        for (Action a : actions) {
             if (a instanceof PrimaryInstanceMetadataAction) {
                 primary = (PrimaryInstanceMetadataAction) a;
                 break;
@@ -526,7 +525,7 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.write("file", "v3");
         sampleRepo.git("commit", "--all", "--message=v3"); // dev
         // SCM.checkout does not permit a null build argument, unfortunately.
-        Run<?,?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
+        Run<?, ?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits(Arrays.asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait()));
         StreamTaskListener listener = StreamTaskListener.fromStderr();
@@ -564,7 +563,7 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.write("file", "v4");
         sampleRepo.git("commit", "--all", "--message=v4"); // dev
         // SCM.checkout does not permit a null build argument, unfortunately.
-        Run<?,?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
+        Run<?, ?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits(Arrays.asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait()));
         StreamTaskListener listener = StreamTaskListener.fromStderr();
@@ -591,7 +590,7 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.write("file", "v4");
         sampleRepo.git("commit", "--all", "--message=v4"); // dev
         // SCM.checkout does not permit a null build argument, unfortunately.
-        Run<?,?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
+        Run<?, ?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits(Arrays.asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait()));
         StreamTaskListener listener = StreamTaskListener.fromStderr();
@@ -620,7 +619,7 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.write("file", "v4");
         sampleRepo.git("commit", "--all", "--message=v4"); // dev
         // SCM.checkout does not permit a null build argument, unfortunately.
-        Run<?,?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
+        Run<?, ?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits(Arrays.asList(
                 new BranchDiscoveryTrait(),
@@ -655,7 +654,7 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.write("file", "v5");
         sampleRepo.git("commit", "--all", "--message=v4"); // dev
         // SCM.checkout does not permit a null build argument, unfortunately.
-        Run<?,?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
+        Run<?, ?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits(Arrays.asList(
                 new BranchDiscoveryTrait(),
@@ -685,7 +684,7 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.write("file", "v4");
         sampleRepo.git("commit", "--all", "--message=v4"); // dev
         // SCM.checkout does not permit a null build argument, unfortunately.
-        Run<?,?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
+        Run<?, ?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits(Arrays.asList(
                 new BranchDiscoveryTrait(),
@@ -715,7 +714,7 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.write("file", "v4");
         sampleRepo.git("commit", "--all", "--message=v4"); // dev
         // SCM.checkout does not permit a null build argument, unfortunately.
-        Run<?,?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
+        Run<?, ?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits(Arrays.asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait(), new DiscoverOtherRefsTrait("pull-requests/*/from")));
         StreamTaskListener listener = StreamTaskListener.fromStderr();
@@ -742,7 +741,7 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.write("file", "v4");
         sampleRepo.git("commit", "--all", "--message=v4"); // dev
         // SCM.checkout does not permit a null build argument, unfortunately.
-        Run<?,?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
+        Run<?, ?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         //new RefSpecsSCMSourceTrait("+refs/pull-requests/*/from:refs/remotes/@{remote}/pr/*")
         source.setTraits(Arrays.asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait(),
@@ -753,7 +752,8 @@ public class AbstractGitSCMSourceTest {
     }
 
     private int wsCount;
-    private String fileAt(String revision, Run<?,?> run, SCMSource source, TaskListener listener) throws Exception {
+
+    private String fileAt(String revision, Run<?, ?> run, SCMSource source, TaskListener listener) throws Exception {
         SCMRevision rev = source.fetch(revision, listener, null);
         if (rev == null) {
             return null;
@@ -783,18 +783,18 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.write("file", "v4");
         sampleRepo.git("commit", "--all", "--message=v4"); // dev
         // SCM.checkout does not permit a null build argument, unfortunately.
-        Run<?,?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
+        Run<?, ?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits(Arrays.asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait(), new DiscoverOtherRefsTrait("custom/*")));
         StreamTaskListener listener = StreamTaskListener.fromStderr();
 
         final SCMHeadObserver.Collector collector =
-        source.fetch(new SCMSourceCriteria() {
-            @Override
-            public boolean isHead(@NonNull Probe probe, @NonNull TaskListener listener) throws IOException {
-                return true;
-            }
-        }, new SCMHeadObserver.Collector(), listener);
+                source.fetch(new SCMSourceCriteria() {
+                    @Override
+                    public boolean isHead(@NonNull Probe probe, @NonNull TaskListener listener) throws IOException {
+                        return true;
+                    }
+                }, new SCMHeadObserver.Collector(), listener);
 
         final Map<SCMHead, SCMRevision> result = collector.result();
         assertThat(result.entrySet(), hasSize(4));
@@ -823,7 +823,7 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.write("file", "v4");
         sampleRepo.git("commit", "--all", "--message=v4"); // dev
         // SCM.checkout does not permit a null build argument, unfortunately.
-        Run<?,?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
+        Run<?, ?> run = r.buildAndAssertSuccess(r.createFreeStyleProject());
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits(Arrays.asList(new BranchDiscoveryTrait(), new TagDiscoveryTrait(), new DiscoverOtherRefsTrait("custom/*")));
         StreamTaskListener listener = StreamTaskListener.fromStderr();
@@ -982,7 +982,7 @@ public class AbstractGitSCMSourceTest {
 
         try {
             source.fetch("v1.2", listener, null);
-        } catch (GitException e){
+        } catch (GitException e) {
             assertFalse(e.getMessage().contains("--prune"));
             return;
         }
@@ -1000,7 +1000,7 @@ public class AbstractGitSCMSourceTest {
 
         try {
             source.fetch("v1.2", listener, null);
-        } catch (GitException e){
+        } catch (GitException e) {
             assertFalse(e.getMessage().contains("--prune"));
             return;
         }
@@ -1069,7 +1069,8 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.git("push", source.getRemote(), "v1.2");
     }
 
-    @Test @Issue("JENKINS-50394")
+    @Test
+    @Issue("JENKINS-50394")
     public void when_commits_added_during_discovery_we_do_not_crash() throws Exception {
         sampleRepo.init();
         sampleRepo.git("checkout", "-b", "dev");
@@ -1092,7 +1093,7 @@ public class AbstractGitSCMSourceTest {
                     hasProperty("name", equalTo("master")),
                     hasProperty("name", equalTo("dev"))
             ));
-        } catch(MissingObjectException me) {
+        } catch (MissingObjectException me) {
             fail("Not supposed to get MissingObjectException");
         } finally {
             System.clearProperty(Git.class.getName() + ".mockClient");
@@ -1117,20 +1118,22 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.write("file", "modified3");
         sampleRepo.git("commit", "--all", "--message=dev3");
         // Grab the devHash, but lets try and generate a hash that we know will cause an issue in our test
-        ArrayList<String> hashFirstLetter = new ArrayList<>(Arrays.asList(masterHash.substring(0,1), v1Hash.substring(0,1), v2Hash.substring(0,1)));
+        ArrayList<String> hashFirstLetter = new ArrayList<>(
+                Arrays.asList(masterHash.substring(0, 1), v1Hash.substring(0, 1), v2Hash.substring(0, 1))
+        );
         sampleRepo.git("tag", "devTag");
         String devTagHash = sampleRepo.head();
-        int i = 4; // In order to name new files and create new commits
+        int devTagIteration = 4; // In order to name new files and create new commits
         String previousNewHash = null;
         String newHash = devTagHash;
-        while (!hashFirstLetter.contains(devTagHash.substring(0,1))) {
+        while (!hashFirstLetter.contains(devTagHash.substring(0, 1))) {
             // Generate a new commit and try again
-            sampleRepo.git("tag", "devTag"+i);
-            sampleRepo.write("file", "modified" + i);
-            sampleRepo.git("commit", "--all", "--message=dev" + (i++));
+            sampleRepo.git("tag", "devTag" + devTagIteration);
+            sampleRepo.write("file", "modified" + devTagIteration);
+            sampleRepo.git("commit", "--all", "--message=dev" + (devTagIteration++));
             previousNewHash = newHash;
             newHash = sampleRepo.head();
-            hashFirstLetter.add(newHash.substring(0,1));
+            hashFirstLetter.add(newHash.substring(0, 1));
         }
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits(new ArrayList<>());
@@ -1141,15 +1144,15 @@ public class AbstractGitSCMSourceTest {
         listener.getLogger().println("\n=== fetch('master') ===\n");
         SCMRevision rev = source.fetch("master", listener, null);
         assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
-        assertThat(((AbstractGitSCMSource.SCMRevisionImpl)rev).getHash(), is(masterHash));
+        assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(masterHash));
         listener.getLogger().println("\n=== fetch('v1') ===\n");
         rev = source.fetch("v1", listener, null);
         assertThat(rev, instanceOf(GitTagSCMRevision.class));
-        assertThat(((GitTagSCMRevision)rev).getHash(), is(v1Hash));
+        assertThat(((GitTagSCMRevision) rev).getHash(), is(v1Hash));
         listener.getLogger().println("\n=== fetch('v2') ===\n");
         rev = source.fetch("v2", listener, null);
         assertThat(rev, instanceOf(GitTagSCMRevision.class));
-        assertThat(((GitTagSCMRevision)rev).getHash(), is(v2Hash));
+        assertThat(((GitTagSCMRevision) rev).getHash(), is(v2Hash));
 
         listener.getLogger().printf("%n=== fetch('%s') ===%n%n", masterHash);
         rev = source.fetch(masterHash, listener, null);
@@ -1171,8 +1174,8 @@ public class AbstractGitSCMSourceTest {
             assertThat(rev.getHead().getName(), is("dev"));
 
 
-            int lastDevTag = i == 4 ? 4 : i - 1;
-            String headHash = i == 4 ? devTagHash : previousNewHash;
+            int lastDevTag = devTagIteration == 4 ? 4 : devTagIteration - 1;
+            String headHash = devTagIteration == 4 ? devTagHash : previousNewHash;
             listener.getLogger().printf("%n=== fetch(devTag%d) ===%n%n", lastDevTag);
             rev = source.fetch("devTag" + lastDevTag, listener, null);
             assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -12,10 +12,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.Action;
-import hudson.model.Actionable;
-import hudson.model.Run;
-import hudson.model.TaskListener;
+import hudson.model.*;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.impl.IgnoreNotifyCommit;
@@ -35,11 +32,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
-import jenkins.plugins.git.traits.BranchDiscoveryTrait;
-import jenkins.plugins.git.traits.DiscoverOtherRefsTrait;
-import jenkins.plugins.git.traits.IgnoreOnPushNotificationTrait;
-import jenkins.plugins.git.traits.PruneStaleBranchTrait;
-import jenkins.plugins.git.traits.TagDiscoveryTrait;
+
+import jenkins.plugins.git.traits.*;
 
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
@@ -1106,30 +1100,69 @@ public class AbstractGitSCMSourceTest {
         }
     }
 
+    @Issue("JENKINS-62592")
     @Test
-    public void shouldReturnExactMatchOverRelativeMatchTest() throws Exception {
-        // TODO: The idea is that this code should now make sure that there isn't an exact match before sending something back
+    public void exactBranchMatchShouldSupersedePartialBranchMatch() throws Exception {
         sampleRepo.init();
         String masterHash = sampleRepo.head();
         sampleRepo.git("checkout", "-b", "dev");
         sampleRepo.write("file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
+        sampleRepo.git("tag", "v1");
         String v1Hash = sampleRepo.head();
         sampleRepo.write("file", "modified2");
         sampleRepo.git("commit", "--all", "--message=dev2");
+        sampleRepo.git("tag", "-a", "v2", "-m", "annotated");
         String v2Hash = sampleRepo.head();
         sampleRepo.write("file", "modified3");
         sampleRepo.git("commit", "--all", "--message=dev3");
+        // Grab the devHash, but lets try and generate a hash that we know will cause an issue in our test
+        ArrayList<String> hashFirstLetter = new ArrayList<>(Arrays.asList(masterHash.substring(0,1), v1Hash.substring(0,1), v2Hash.substring(0,1)));
         String devHash = sampleRepo.head();
+        int i = 4; // In order to name new files and create new commits
+        String newHash = null;
+        while (!hashFirstLetter.contains(devHash.substring(0,1))) {
+            // Generate a new commit and try again
+            sampleRepo.write("file", "modified" + i);
+            sampleRepo.git("commit", "--all", "--message=dev" + (i++));
+            newHash = sampleRepo.head();
+            hashFirstLetter.add(newHash.substring(0,1));
+        }
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
-        source.setTraits(Collections.singletonList(new BranchDiscoveryTrait()));
+        source.setTraits(new ArrayList<>());
 
         TaskListener listener = StreamTaskListener.fromStderr();
 
         listener.getLogger().println("\n=== fetch('master') ===\n");
-        SCMRevision rev = source.fetch(masterHash, listener, null);
+        SCMRevision rev = source.fetch("master", listener, null);
         assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
+        assertThat(((AbstractGitSCMSource.SCMRevisionImpl)rev).getHash(), is(masterHash));
+        listener.getLogger().println("\n=== fetch('dev') ===\n");
+        rev = source.fetch("dev", listener, null);
+        assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
+        assertThat(((AbstractGitSCMSource.SCMRevisionImpl)rev).getHash(), is(devHash));
+        listener.getLogger().println("\n=== fetch('v1') ===\n");
+        rev = source.fetch("v1", listener, null);
+        assertThat(rev, instanceOf(GitTagSCMRevision.class));
+        assertThat(((GitTagSCMRevision)rev).getHash(), is(v1Hash));
+        listener.getLogger().println("\n=== fetch('v2') ===\n");
+        rev = source.fetch("v2", listener, null);
+        assertThat(rev, instanceOf(GitTagSCMRevision.class));
+        assertThat(((GitTagSCMRevision)rev).getHash(), is(v2Hash));
+
+        listener.getLogger().printf("%n=== fetch('%s') ===%n%n", masterHash);
+        rev = source.fetch(masterHash, listener, null);
+        assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
+        assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(masterHash));
         assertThat(rev.getHead().getName(), is("master"));
+
+        if (null != newHash) {
+            listener.getLogger().printf("%n=== fetch('%s') ===%n%n", newHash);
+            rev = source.fetch(newHash, listener, null);
+            assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
+            assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(newHash));
+            assertThat(rev.getHead().getName(), is("master"));
+        }
     }
 
     //Ugly but MockGitClient needs to be static and no good way to pass it on


### PR DESCRIPTION
## [JENKINS-xxxxx](https://issues.jenkins.io/browse/JENKINS-xxxxx) - summarize pull request in one line

Describe the big picture of your changes here to explain to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, include a link to the issue.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x ] Unit tests pass locally with my changes
- [ x] I have added documentation as necessary
- [ x] No Javadoc warnings were introduced with my changes
- [ x] No spotbugs warnings were introduced with my changes
- [ x] Documentation in README has been updated as necessary
- [ x] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes (will update PR to check this when testing is complete!)
- [ x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [ ] Dependency or infrastructure update
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

Not a large change, but this issue addresses the problem arisen by the associated ticket (https://issues.jenkins.io/browse/JENKINS-62592). Commonly, we have seen due to our tagging method/branch name method that we will clash with the hazy short hash revision matching functionality within the AbstractGitSCMSource.retrieve method. 

Change can be summarized and seen in the associated test - instead of returning null when we first clash based on short hash, we store that we have noticed a collision and continue on. This way, if we find a full match, we can return what we see as the expected revision to retrieve.

Let me know if there are any comments or concerns that I am over looking and I look forward to helping in any way I can in this project! Thanks!


