### PR TITLE
Explicit default branch

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -75,10 +75,12 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         run(true, tmp.getRoot(), "git", "version");
         checkGlobalConfig();
         git("init", "--template="); // initialize without copying the installation defaults to ensure a vanilla repo that behaves the same everywhere
+        git("branch", "-m", "master");
         write("file", "");
         git("add", "file");
         git("config", "user.name", "Git SampleRepoRule");
         git("config", "user.email", "gits@mplereporule");
+        git("config", "init.defaultbranch", "master");
         git("commit", "--message=init");
     }
 


### PR DESCRIPTION
Tests fail on systems with a non-master default branch: https://github.com/jenkinsci/remote-file-plugin/issues/111

Recent Git versions support passing a default branch to `init` but would require git 2.28+.


Tests of this plugin are affected too, but need more investigation. 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_


- [x] Bug fix (non-breaking change which fixes an issue)


## Further comments

N/A