### PR TITLE
fix: Quote the username and password in credentials binding

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
+++ b/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
@@ -150,9 +150,9 @@ public class GitUsernamePasswordBinding extends MultiBinding<StandardUsernamePas
                 gitEcho = workspace.createTempFile("auth", ".sh");
                 // [#!/usr/bin/env sh] to be used if required, could have some corner cases
                 gitEcho.write("case $1 in\n"
-                        + "        Username*) echo " + this.userVariable
+                        + "        Username*) echo '" + this.userVariable + "'"
                         + "                ;;\n"
-                        + "        Password*) echo " + this.passVariable
+                        + "        Password*) echo '" + this.passVariable + "'"
                         + "                ;;\n"
                         + "        esac\n", null);
                 gitEcho.chmod(0500);


### PR DESCRIPTION
## [JENKINS-27082](https://issues.jenkins.io/browse/JENKINS-27082) - Quote the username and password in credentials binding

Fix wrong quoting in askpass.

Won't solve all cases of quoting but will avoid some common problems related to quoting.  For example, if the username or password includes a single quote, then the added quoting will fail.  For the more common cases where the username or password contains a special special character that is not a single quote, this pull request will be an improvement.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

Correct quoting in bash script.

- [ ] Dependency or infrastructure update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

