### PR TITLE
fix: Correct quoting in `GitUsernamePasswordBinding`

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
+++ b/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
@@ -131,7 +131,6 @@ public class GitUsernamePasswordBinding extends MultiBinding<StandardUsernamePas
             this.unixNodeType = unixNodeType;
         }
 
-        @Override
         protected FilePath write(FilePath workspace)
                 throws IOException, InterruptedException {
             FilePath gitEcho;

--- a/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
+++ b/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
@@ -74,7 +74,7 @@ public class GitUsernamePasswordBinding extends MultiBinding<StandardUsernamePas
             setGitEnvironmentVariables(getGitClientInstance(cliGitTool.getGitExe(), unbindTempDir.getDirPath(),
                                                             new EnvVars(), taskListener), publicValues);
             GenerateGitScript gitScript = new GenerateGitScript(this.unixNodeType);
-            FilePath gitTempFile = gitScript.write(credentials, unbindTempDir.getDirPath());
+            FilePath gitTempFile = gitScript.write(unbindTempDir.getDirPath());
             secretValues.put("GIT_ASKPASS", gitTempFile.getRemote());
             return new MultiEnvironment(secretValues, publicValues, unbindTempDir.getUnbinder());
         } else {

--- a/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
+++ b/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
@@ -269,17 +269,17 @@ public class GitUsernamePasswordBindingTest {
 
     @Test
     public void test_GenerateGitScript_write() throws IOException, InterruptedException {
-        GitUsernamePasswordBinding.GenerateGitScript tempGenScript = new GitUsernamePasswordBinding.GenerateGitScript(this.username, this.password, credentials.getId(), !isWindows());
+        GitUsernamePasswordBinding.GenerateGitScript tempGenScript = new GitUsernamePasswordBinding.GenerateGitScript(!isWindows());
         assertThat(tempGenScript.type(), is(StandardUsernamePasswordCredentials.class));
-        FilePath tempScriptFile = tempGenScript.write(credentials, rootFilePath);
+        FilePath tempScriptFile = tempGenScript.write(rootFilePath);
         if (!isWindows()) {
             assertThat(tempScriptFile.mode(), is(0500));
             assertThat("File extension not sh", FilenameUtils.getExtension(tempScriptFile.getName()), is("sh"));
         } else {
             assertThat("File extension not bat", FilenameUtils.getExtension(tempScriptFile.getName()), is("bat"));
         }
-        assertThat(tempScriptFile.readToString(), containsString(this.username));
-        assertThat(tempScriptFile.readToString(), containsString(this.password));
+        assertThat(tempScriptFile.readToString(), containsString("GIT_USERNAME"));
+        assertThat(tempScriptFile.readToString(), containsString("GIT_PASSWORD"));
     }
 
     /**

--- a/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
+++ b/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
@@ -270,7 +270,6 @@ public class GitUsernamePasswordBindingTest {
     @Test
     public void test_GenerateGitScript_write() throws IOException, InterruptedException {
         GitUsernamePasswordBinding.GenerateGitScript tempGenScript = new GitUsernamePasswordBinding.GenerateGitScript(!isWindows());
-        assertThat(tempGenScript.type(), is(StandardUsernamePasswordCredentials.class));
         FilePath tempScriptFile = tempGenScript.write(rootFilePath);
         if (!isWindows()) {
             assertThat(tempScriptFile.mode(), is(0500));


### PR DESCRIPTION
## JENKINS-27082 - Quote the username and password in credentials binding

Followup an better solution to: https://github.com/jenkinsci/git-plugin/pull/1310

Fix wrong quoting in askpass.

Won't solve all cases of quoting but will avoid some common problems related to quoting. For example, if the username or password includes a single quote, then the added quoting will fail. For the more common cases where the username or password contains a special special character that is not a single quote, this pull request will be an improvement.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

Correct quoting in bash script.

- [ ] Dependency or infrastructure update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
