### PR TITLE
[JENKINS-67981] handle any AuthenticationException

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -12,6 +12,8 @@ import jenkins.model.Jenkins;
 import org.apache.commons.lang.math.NumberUtils;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
+import org.springframework.security.core.AuthenticationException;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -395,6 +397,38 @@ public class GitChangeSet extends ChangeLogSet.Entry {
     }
 
     /**
+     * Get a user by id or full name
+     *
+     * Jenkins UserDetailsCache.loadUserByUsername() catches ExecutionException
+     * and will throw it back unless the cause is an instance of
+     * UsernameNotFoundException. It thus misses others AuthenticationException
+     * such as DisabledException (thrown by the ldap plugin when a user has
+     * been administratively disabled).
+     *
+     * This intercept the ExecutionException and throw the cause instead if
+     * it is an AuthenticationException.
+     *
+     * @param idOrFullName
+     * @return User | "unknown" User if no user was found
+     *
+     * @throws AuthenticationException The reason the user is not available if any
+     * @throws ExecutionException      Any other unhandled cases
+     */
+    private User getUser(String idOrFullName, Boolean create) {
+        try {
+            return User.get(idOrFullName, create, Collections.emptyMap());
+        } catch (AuthenticationException e) {
+            throw e;
+        } catch (UncheckedExecutionException e) {
+            if (e.getCause() instanceof AuthenticationException) {
+                throw (AuthenticationException) e.getCause();
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    /**
      * Returns user of the change set.
      *
      * @param csAuthor user name.
@@ -414,11 +448,15 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                 // Avoid exception from User.get("", false)
                 return User.getUnknown();
             }
-            user = User.get(csAuthorEmail, false, Collections.emptyMap());
+            try {
+                user = getUser(csAuthorEmail, false);
+            } catch (AuthenticationException authException) {
+                return User.getUnknown();
+            }
 
             if (user == null) {
                 try {
-                    user = User.get(csAuthorEmail, !useExistingAccountWithSameEmail, Collections.emptyMap());
+                    user = getUser(csAuthorEmail, !useExistingAccountWithSameEmail);
                     boolean setUserDetails = true;
                     if (user == null && useExistingAccountWithSameEmail && hasMailerPlugin()) {
                         for(User existingUser : User.getAll()) {
@@ -430,7 +468,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                         }
                     }
                     if (user == null) {
-                        user = User.get(csAuthorEmail, true, Collections.emptyMap());
+                        user = getUser(csAuthorEmail, true);
                     }
                     if (user != null && setUserDetails) {
                         user.setFullName(csAuthor);
@@ -438,6 +476,8 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                             setMail(user, csAuthorEmail);
                         user.save();
                     }
+                } catch (AuthenticationException authException) {
+                    return User.getUnknown();
                 } catch (IOException e) {
                     // add logging statement?
                 }
@@ -447,7 +487,11 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                 // Avoid exception from User.get("", false)
                 return User.getUnknown();
             }
-            user = User.get(csAuthor, false, Collections.emptyMap());
+            try {
+                user = getUser(csAuthor, false);
+            } catch (AuthenticationException authException) {
+                return User.getUnknown();
+            }
 
             if (user == null) {
                 if (csAuthorEmail == null || csAuthorEmail.isEmpty()) {
@@ -458,8 +502,8 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                 String[] emailParts = csAuthorEmail.split("@");
                 if (emailParts.length > 0) {
                     try {
-                        user = User.get(emailParts[0], true, Collections.emptyMap());
-                    } catch (org.springframework.security.core.AuthenticationException authException) {
+                        user = getUser(emailParts[0], true);
+                    } catch (AuthenticationException authException) {
                         // JENKINS-67491 - do not fail due to an authentication exception
                         return User.getUnknown();
                     }


### PR DESCRIPTION
## [JENKINS-67981](https://issues.jenkins.io/browse/JENKINS-67981) - handle any AuthenticationException

When processing the changelog, if a looked user is disabled in LDAP the git plugin would throw an `UncheckedExecutionException` with the cause being `DisabledException`. The unhandled exception would cause a build
failure whenever processing a commit that is determinated to be from a disabled user.

Jenkins `UserDetailsCache.loadUserByUsername()` receives an `ExecutionException` which wraps the `AuthenticationException`. The method inspects the cause, handles instances of `UsernameNotFoundException` which it throws but ignores any other `AuthenticationException`.

This introduces a `User` getter to handle any `AuthenticationException` and throws it instead of the `ExecutionException`. Callers can thus:
```java
  try {
    user = getUser("someOne");
  } catch (AuthenticationException e) {
    return User.getUnknown();
  }
  // Do something with "user"
```
I have added a test to ensure a `DisabledException` does yield an unknown user. It only test a single code path though.

This pull request supersedes #1233 on which I analyzed the `AuthenticationException` is wrapped in an `ExecutionException`. Compared to that other pull request, I introduce a getter to avoid copy pasting try/catch statements.

References:
* https://phabricator.wikimedia.org/T315897
* A first attempt was made in #1233 which this pull request supersedes

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes (though my Jenkins instance script console)
- [x] _Any dependent changes have been merged and published in upstream modules (like git-client-plugin)_

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue
