### PR TITLE
Use /bin/sh rather than /bin/bash in test

### DIFF
--- a/src/test/java/hudson/plugins/git/GitHooksTest.java
+++ b/src/test/java/hudson/plugins/git/GitHooksTest.java
@@ -168,9 +168,9 @@ public class GitHooksTest extends AbstractGitTestCase {
 
     private void createHookScriptAt(final File postCheckoutOutput, final FilePath hook) throws IOException, InterruptedException {
         final String nl = System.lineSeparator();
-        StringBuilder scriptContent = new StringBuilder("#!/bin/bash -v").append(nl);
+        StringBuilder scriptContent = new StringBuilder("#!/bin/sh -v").append(nl);
         scriptContent.append("date +%s > \"")
-                .append(postCheckoutOutput.getAbsolutePath().replace("\\", "\\\\")) //Git bash does the bash escaping so need to do more escaping
+                .append(postCheckoutOutput.getAbsolutePath().replace("\\", "\\\\")) // Git shell processes escapes, needs extra escapes
                 .append('"').append(nl);
         hook.write(scriptContent.toString(), Charset.defaultCharset().name());
         hook.chmod(0777);
@@ -229,7 +229,7 @@ public class GitHooksTest extends AbstractGitTestCase {
                 "node('" + node + "') {",
                 "  checkout([$class: 'GitSCM', branches: [[name: '*/master']], userRemoteConfigs: [[url: '" + uri + "']]])",
                 "  if (!fileExists('.git/hooks/post-checkout')) {",
-                "    writeFile file: '.git/hooks/post-checkout', text: \"#!/bin/bash\\necho h4xor3d\"",
+                "    writeFile file: '.git/hooks/post-checkout', text: \"#!/bin/sh\\necho h4xor3d\"",
                 "    if (isUnix()) {",
                 "      sh 'chmod +x .git/hooks/post-checkout'",
                 "    }",


### PR DESCRIPTION
## Use /bin/sh instead of /bin/bash in test

Fix test on Unix platforms that do not include bash by default.

## Tests performed

On FreeBSD and OpenBSD (where `/bin/bash` is not available), I run

```
$ git checkout master
$ mvn clean -Dtest=GitHooksTest test
HEAD is now at e98fea9 Jenkinsfile
fatal: cannot run .git/hooks/post-checkout: No such file or directory
```

Using this pull request, the failing test is resolved:

```
$ git checkout -b use-posix-shell -t origin/use-posix-shell
$ mvn clean -Dtest=GitHooksTest test
Test passes
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Test
