### PR TITLE
Fix tests on older CLI git versions

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -76,7 +76,12 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         run(true, tmp.getRoot(), "git", "version");
         checkGlobalConfig();
         git("init", "--template="); // initialize without copying the installation defaults to ensure a vanilla repo that behaves the same everywhere
-        git("branch", "-m", "master");
+	if (gitVersionAtLeast(2, 30)) {
+	    // Force branch name to master even if system default is not master
+	    // Fails on git 2.25, 2.20, 2.17, and 1.8
+	    // Works on git 2.30 and later
+            git("branch", "-m", "master");
+	}
         write("file", "");
         git("add", "file");
         git("config", "user.name", "Git SampleRepoRule");


### PR DESCRIPTION
## Fix tests on older versions of command line git

The `git branch -m master` fails on a repository created with command line git versions 2.25, 2.20, 2.17, and 1.8.  It works with git versions 2.30 and later.

Setting was added in July 2022 as part  of #1295 for systems that have their default branch name configured as something other than `master`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Test
