### PR TITLE
[JENKINS-69862] remove inline JS for URL validation

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitPublisher/config.jelly
@@ -21,7 +21,7 @@
           <br/>
           <f:entry field="tagName"
                    title="${%Tag to push}">
-            <f:textbox checkUrl="'descriptorByName/GitPublisher/checkTagName?value='+escape(this.value)" />
+            <f:textbox checkUrl="descriptorByName/GitPublisher/checkTagName" checkDependsOn="" />
           </f:entry>
           <f:entry field="tagMessage"
                    title="${%Tag message}">
@@ -36,7 +36,7 @@
           <f:entry field="targetRepoName"
                    title="${%Target remote name}">
             <f:textbox
-                checkUrl="'descriptorByName/GitPublisher/checkRemote?value='+escape(this.value)"/>
+                checkUrl="descriptorByName/GitPublisher/checkRemote" checkDependsOn="" />
           </f:entry>
         </div>
         <f:repeatableDeleteButton value="${%Delete Tag}" />
@@ -51,12 +51,12 @@
           <br/>
           <f:entry field="branchName"
                    title="${%Branch to push}">
-            <f:textbox checkUrl="'descriptorByName/GitPublisher/checkBranchName?value='+escape(this.value)" />
+            <f:textbox checkUrl="descriptorByName/GitPublisher/checkBranchName" checkDependsOn="" />
           </f:entry>
           <f:entry field="targetRepoName"
                    title="${%Target remote name}">
             <f:textbox
-                checkUrl="'descriptorByName/GitPublisher/checkRemote?value='+escape(this.value)" />
+                checkUrl="descriptorByName/GitPublisher/checkRemote" checkDependsOn="" />
           </f:entry>
           <f:entry field="rebaseBeforePush">
             <f:checkbox title="${%Rebase before push}" />
@@ -73,7 +73,7 @@
         <div>
           <br/>
           <f:entry title="${%Note to push}"    field="noteMsg" >
-            <f:textarea checkUrl="'descriptorByName/GitPublisher/checkNoteMsg?value='+escape(this.value)" />
+            <f:textarea checkUrl="descriptorByName/GitPublisher/checkNoteMsg" checkDependsOn="" />
           </f:entry>
           
           <f:entry field="targetRepoName" title="${%Target remote name}">


### PR DESCRIPTION
## [JENKINS-69862](https://issues.jenkins.io/browse/JENKINS-69862) - Remove inline JS for URL validation

Hello there :wave:

Hacktoberfest PR here solving [JENKINS-69862](https://issues.jenkins.io/browse/JENKINS-69862).

That PR removes the [legacy form validation](https://www.jenkins.io/doc/developer/security/csp/#legacy-javascript-checkurl-validation) using `checkUrl` and now uses the recommended approach including `checkDependsOn`, ensuring there are no CSP warnings with this part of the source code anymore.

I manually tested the source code before and after introducing the changes to ensure everything still works as expected (and it does).

Please let me know if anything is missing.

Thanks a lot for the review :heart:

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
