### PR TITLE
Rely on spotbugs from parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,19 +226,6 @@
       <version>1.7.1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <version>4.7.3</version>
-      <optional>true</optional>
-      <exclusions>
-        <!-- prevent inclusion in hpi as a transient dependency -->
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <!-- JCasC compatibility -->
     <dependency>
       <groupId>io.jenkins</groupId>
@@ -314,17 +301,6 @@
           <configLocation>google_checks.xml</configLocation>
           <failOnViolation>true</failOnViolation>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs</artifactId>
-            <version>4.7.3</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## Rely onspotbugs from parent pom

Not enough added value to keep a separate declaration of spotbugs.  Use spotbugs as defined for others and used by others.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- ~~I have interactively tested my changes~~
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Reduce maintenance overhead
