### PR TITLE
[JENKINS-69861] remove inline onclick handlers

### DIFF
--- a/src/main/resources/hudson/plugins/git/ApiTokenPropertyConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/git/ApiTokenPropertyConfiguration/config.jelly
@@ -15,7 +15,8 @@
                             <input type="hidden" class="api-token-uuid-input" name="apiTokenUuid" value="${apiToken.uuid}" />
                             <div class="api-token-list-item-row api-token-list-existing-token">
                                 <f:textbox readonly="true" value="${apiToken.name}" />
-                                <a href="#" onclick="return revokeApiToken(this)" class="yui-button api-token-revoke-button"
+                                <!-- onclick handler for that button is defined in resources.js -->
+                                <a href="#" class="yui-button api-token-revoke-button"
                                    data-confirm="${%Are you sure you want to revoke this access token?}"
                                    data-target-url="${descriptor.descriptorFullUrl}/revoke">
                                     ${%Revoke}
@@ -29,7 +30,8 @@
                                     <f:textbox clazz="api-token-name-input" name="apiTokenName" placeholder="${%Access token name}"/>
                                     <span class="new-api-token-value hidden"><!-- to be filled by JS --></span>
                                     <span class="yui-button api-token-save-button">
-                                        <button type="button" tabindex="0" data-target-url="${descriptor.descriptorFullUrl}/generate" onclick="saveApiToken(this)">
+                                        <!-- onclick handler for that button is defined in resources.js -->
+                                        <button type="button" tabindex="0" data-target-url="${descriptor.descriptorFullUrl}/generate">
                                             ${%Generate}
                                         </button>
                                     </span>
@@ -37,7 +39,8 @@
                                         <f:repeatableDeleteButton value="${%Cancel}" />
                                     </span>
                                     <l:copyButton message="${%Copied}" text="" clazz="hidden" tooltip="${%Copy to clipboard}" />
-                                    <a href="#" onclick="return revokeApiToken(this)" class="yui-button api-token-revoke-button hidden"
+                                    <!-- onclick handler for that button is defined in resources.js -->
+                                    <a href="#" class="yui-button api-token-revoke-button hidden"
                                        data-confirm="${%Are you sure you want to revoke this access token?}"
                                        data-target-url="${descriptor.descriptorFullUrl}/revoke">
                                         ${%Revoke}

--- a/src/main/resources/hudson/plugins/git/ApiTokenPropertyConfiguration/resources.js
+++ b/src/main/resources/hudson/plugins/git/ApiTokenPropertyConfiguration/resources.js
@@ -1,3 +1,16 @@
+/**
+* Registering the onclick handler on all the "Revoke" buttons for API Token.
+*/
+Behaviour.specify(".api-token-revoke-button", 'ApiTokenPropertyConfiguration', 0, function(button) {
+    // DEV MEMO:
+    // While un-inlining the onclick handler, we are trying to avoid modifying the existing source code and functions.
+    // In order to keep consistency with the existing code, we share the api-token-revoke-button with the revokeApiToken method
+    // which is then navigating the DOM in order to retrieve a the token to revoke.
+    // While this could be done setting additional data on the button itself and retrieving it without DOM navigation,
+    // this would need to be done in another contribution.
+    button.onclick = (_) => revokeApiToken(button);
+})
+
 function revokeApiToken(anchorRevoke) {
     const repeatedChunk = anchorRevoke.up('.repeated-chunk');
     const apiTokenList = repeatedChunk.up('.api-token-list');
@@ -19,6 +32,19 @@ function revokeApiToken(anchorRevoke) {
 
     return false;
 }
+
+/**
+* Registering the onclick handler on all the "Generate" buttons for API Token.
+*/
+Behaviour.specify(".api-token-save-button", 'ApiTokenPropertyConfiguration', 0, function(buttonContainer) {
+    // DEV MEMO:
+    // While un-inlining the onclick handler, we are trying to avoid modifying the existing source code and functions.
+    // In order to keep consistency with the existing code, we add our onclick handler on the button element which is contained in the
+    // api-token-save-button that we identify. While this could be refactored to directly identify the button, this would need to be done in an other
+    // contribution.
+    const button = buttonContainer.getElementsByTagName('button')[0];
+    button.onclick = (_) => saveApiToken(button);
+})
 
 function saveApiToken(button){
     if (button.hasClassName('request-pending')) {


### PR DESCRIPTION
## [JENKINS-69861](https://issues.jenkins.io/browse/JENKINS-69861) - Remove inline onclick handlers

Hello there :wave:

Here's another Hacktoberfest PR, this time solving [JENKINS-69861](https://issues.jenkins.io/browse/JENKINS-69861).

That PR removes the [inline event handlers](https://www.jenkins.io/doc/developer/security/csp/#inline-event-handlers) using inline `onclick` and now creates those `onclick` handlers from a separate javascript file (which was already included in the page). This is made to ensure there are no CSP warnings with this part of the source code anymore.

I manually tested the source code before and after introducing the changes to ensure everything still works as expected (and it does).

Here is a small clip of me testing the feature after performing the changes (which is the same behavior as before):

![csp-git-token](https://user-images.githubusercontent.com/311677/196435453-39a5eb36-39c7-4add-8c33-9ae9e97983e6.gif)

Please let me know if anything is missing.

Thanks a lot for the review :heart:

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
