### PR TITLE
Require Jenkins 2.346.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 buildPlugin(failFast: false,
             configurations: [
-                [platform: 'linux',   jdk: '17', jenkins: '2.342'],
-                [platform: 'linux',   jdk: '11'],
+                [platform: 'linux',   jdk: '17', jenkins: '2.375'],
+                [platform: 'linux',   jdk: '11', jenkins: '2.361.2'],
                 [platform: 'windows', jdk:  '8'],
             ])

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>pipeline-groovy-lib</artifactId>
-      <version>612.v84da_9c54906d</version> <!-- TODO until in BOM -->
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.346.x</artifactId>
-        <version>1643.v1cffef51df73</version>
+        <version>1654.vcb_69d035fa_20</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <revision>4.12.2</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.332.4</jenkins.version>
+    <jenkins.version>2.346.3</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <useBeta>true</useBeta>
     <linkXRef>false</linkXRef>
@@ -75,7 +75,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
+        <artifactId>bom-2.346.x</artifactId>
         <version>1643.v1cffef51df73</version>
         <type>pom</type>
         <scope>import</scope>

--- a/src/test/java/hudson/plugins/git/GitChangeSetTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.MockedStatic;
 import org.springframework.security.authentication.DisabledException;
-import org.springframework.security.core.AuthenticationException;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -19,12 +18,8 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class GitChangeSetTest {
 


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

- Remove unused imports
- Use pipeline groovy lib version from BOM
- Do not set forkCount in pom
- Require Jenkins 2.346.3 or newer

80% or more of the last several plugin releases are using Jenkins 2.346.1 or newer.  Safe to require 2.346.3.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
