### PR TITLE
[JENKINS-69911] - GitTagAction/tagForm.jelly javascript un-inlined.

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitTagAction/tagForm.jelly
+++ b/src/main/resources/hudson/plugins/git/GitTagAction/tagForm.jelly
@@ -109,13 +109,6 @@ THE SOFTWARE.
             </div>
           </div>
           <f:submit value="${%Tag}" />
-          <script>
-            <!-- update the visual feedback depending on the checkbox state -->
-            function updateRow(e,i) {
-              e.parentNode.parentNode.style.color = e.checked ? "inherit" : "grey";
-              $("name"+i).disabled = !e.checked;
-            }
-          </script>
         </f:form>
       </j:if>
     </l:main-panel>

--- a/src/main/resources/hudson/plugins/git/GitTagAction/tagForm.jelly
+++ b/src/main/resources/hudson/plugins/git/GitTagAction/tagForm.jelly
@@ -30,8 +30,6 @@ THE SOFTWARE.
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
 
-  <st:adjunct includes="hudson.plugins.git.GitTagAction.update-row" />
-
   <d:taglib uri="local">
     <d:tag name="listTags">
       <ul>
@@ -80,6 +78,9 @@ THE SOFTWARE.
               <div>${%Branch}</div>
               <div>${%Tag}</div>
             </div>
+
+            <st:adjunct includes="hudson.plugins.git.GitTagAction.update-row" />
+
             <j:forEach var="m" items="${tags.keySet()}" varStatus="loop">
               <div class="tr">
                 <div>

--- a/src/main/resources/hudson/plugins/git/GitTagAction/tagForm.jelly
+++ b/src/main/resources/hudson/plugins/git/GitTagAction/tagForm.jelly
@@ -29,6 +29,9 @@ THE SOFTWARE.
   This belongs to a build view.
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
+
+  <st:adjunct includes="hudson.plugins.git.GitTagAction.update-row" />
+
   <d:taglib uri="local">
     <d:tag name="listTags">
       <ul>
@@ -79,13 +82,17 @@ THE SOFTWARE.
             </div>
             <j:forEach var="m" items="${tags.keySet()}" varStatus="loop">
               <div class="tr">
-                <div><j:if test="${tags.size()!=1}">
-                  <input type="checkbox" name="tag${loop.index}" checked="true"
-                         id="tag${loop.index}" onchange="updateRow(this,${loop.index})" />
-                </j:if></div>
-                <div><label for="tag${loop.index}">
-                  ${m}
-                </label></div>
+                <div>
+                  <j:if test="${tags.size()!=1}">
+                    <input type="checkbox" name="tag${loop.index}" checked="true"
+                           id="tag${loop.index}" />
+                  </j:if>
+                </div>
+                <div>
+                  <label for="tag${loop.index}">
+                    ${m}
+                  </label>
+                </div>
                 <div class="td">
                   <input type="text" name="name${loop.index}"
                          value="${it.makeTagURL(m)}" style="width:100%" id="name${loop.index}" />

--- a/src/main/resources/hudson/plugins/git/GitTagAction/update-row.js
+++ b/src/main/resources/hudson/plugins/git/GitTagAction/update-row.js
@@ -1,0 +1,19 @@
+function updateRow(e, i) {
+    e.parentNode.parentNode.style.color = e.checked ? "inherit" : "grey";
+    $("name"+i).disabled = !e.checked;
+}
+
+// Adding an onclick listener to the link in UI
+// DEV MEMO:
+// We are doing it after DOM content is loaded as a good practice to ensure we are not slowing down
+// the page rendering. In that particular situation the addition of the onclick handler shouldn't
+// really impact the page performances, but rather stick with good practices.
+
+document.addEventListener('DOMContentLoaded', (event) => {
+
+    const tagCheckboxes = document.querySelectorAll("input[type=checkbox][id*=tag][name*=tag]");
+    tagCheckboxes.forEach((element, index) => {
+        element.onchange = (_) => updateRow(element, index);
+    });
+
+});

--- a/src/main/resources/hudson/plugins/git/GitTagAction/update-row.js
+++ b/src/main/resources/hudson/plugins/git/GitTagAction/update-row.js
@@ -3,7 +3,7 @@ function updateRow(e, i) {
     $("name"+i).disabled = !e.checked;
 }
 
-// Adding an onclick listener to the link in UI
+// Adding an onchange listener to the tag checkboxes in UI
 // DEV MEMO:
 // We are doing it after DOM content is loaded as a good practice to ensure we are not slowing down
 // the page rendering. In that particular situation the addition of the onclick handler shouldn't


### PR DESCRIPTION
## [JENKINS-69911](https://issues.jenkins.io/browse/JENKINS-69911) - Un-inlining GitTagAction/tagForm.jelly

I've removed the JavaScript from the `tagForm.jelly` file and moved it to a new file called `update-row.js`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

