### PR TITLE
Remove wasted space from branch spec and repository URL data entry

### DIFF
--- a/src/main/resources/hudson/plugins/git/BranchSpec/config.groovy
+++ b/src/main/resources/hudson/plugins/git/BranchSpec/config.groovy
@@ -6,8 +6,4 @@ f.entry(title:_("Branch Specifier (blank for 'any')"), field:"name") {
     f.textbox(default:"*/master")
 }
 
-f.entry {
-    div() {
-        f.repeatableDeleteButton()
-    }
-}
+f.repeatableDeleteButton()

--- a/src/main/resources/hudson/plugins/git/UserRemoteConfig/config.groovy
+++ b/src/main/resources/hudson/plugins/git/UserRemoteConfig/config.groovy
@@ -26,8 +26,4 @@ f.advanced {
     }
 }
 
-f.entry {
-    div(class: "show-if-not-only") {
-        f.repeatableDeleteButton()
-    }
-}
+f.repeatableDeleteButton()


### PR DESCRIPTION
Having the repeatableDelete button wrapped in the entry component causes unnecessary padding.

**Before**
<img width="925" alt="image" src="https://user-images.githubusercontent.com/43062514/198419771-b4cc4055-7e31-41a9-bc60-44dfd5a02b2a.png">

**After**
<img width="927" alt="image" src="https://user-images.githubusercontent.com/43062514/198420179-e6db3baf-e61b-4dcd-aa79-2689430ad852.png">

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
