### PR TITLE
Fix NPE in GitHooksTest on Windows

### DIFF
--- a/src/test/java/hudson/plugins/git/GitHooksTest.java
+++ b/src/test/java/hudson/plugins/git/GitHooksTest.java
@@ -1,7 +1,6 @@
 package hudson.plugins.git;
 
 import hudson.FilePath;
-import hudson.Functions;
 import hudson.model.Label;
 import hudson.slaves.DumbSlave;
 import hudson.tools.ToolProperty;
@@ -40,7 +39,6 @@ import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 
 public class GitHooksTest extends AbstractGitTestCase {
 
@@ -50,6 +48,10 @@ public class GitHooksTest extends AbstractGitTestCase {
     public static BuildWatcher watcher = new BuildWatcher();
     @ClassRule
     public static GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+    private static final String JENKINS_URL = System.getenv("JENKINS_URL") != null
+            ? System.getenv("JENKINS_URL")
+            : "http://localhost:8080/";
 
     @BeforeClass
     public static void setGitDefaults() throws Exception {
@@ -77,7 +79,13 @@ public class GitHooksTest extends AbstractGitTestCase {
 
     @Test
     public void testPipelineFromScm() throws Exception {
-        assumeNotJenkinsCiWindows();
+        if (isWindows() && JENKINS_URL.contains("ci.jenkins.io")) {
+            /*
+             * The test works on Windows, but for unknown reason does not work
+             * on the Windows agents of ci.jenkins.io.
+             */
+            return;
+        }
         GitHooksConfiguration.get().setAllowedOnController(true);
         GitHooksConfiguration.get().setAllowedOnAgents(true);
         final DumbSlave agent = rule.createOnlineSlave(Label.get("somewhere"));
@@ -194,7 +202,13 @@ public class GitHooksTest extends AbstractGitTestCase {
 
     @Test
     public void testPipelineCheckoutController() throws Exception {
-        assumeNotJenkinsCiWindows();
+        if (isWindows() && JENKINS_URL.contains("ci.jenkins.io")) {
+            /*
+             * The test works on Windows, but for unknown reason does not work
+             * on the Windows agents of ci.jenkins.io.
+             */
+            return;
+        }
 
         final WorkflowJob job = setupAndRunPipelineCheckout("master");
         WorkflowRun run;
@@ -219,7 +233,13 @@ public class GitHooksTest extends AbstractGitTestCase {
 
     @Test
     public void testPipelineCheckoutAgent() throws Exception {
-        assumeNotJenkinsCiWindows();
+        if (isWindows() && JENKINS_URL.contains("ci.jenkins.io")) {
+            /*
+             * The test works on Windows, but for unknown reason does not work
+             * on the Windows agents of ci.jenkins.io.
+             */
+            return;
+        }
 
         rule.createOnlineSlave(Label.get("belsebob"));
         final WorkflowJob job = setupAndRunPipelineCheckout("belsebob");
@@ -289,14 +309,8 @@ public class GitHooksTest extends AbstractGitTestCase {
         return String.join("\n", lines);
     }
 
-    /**
-     * Assume that it is not running on a ci.jenkins.io Windows agent.
-     *
-     * The tests are tested and confirmed working on Windows,
-     * but for unknown reason is not working on the Win agents on ci.jenkins.io.
-     */
-    private void assumeNotJenkinsCiWindows() {
-        final String jenkinsUrl = System.getenv("JENKINS_URL");
-        assumeFalse(Functions.isWindows() && jenkinsUrl.contains("ci.jenkins.io"));
+    /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */
+    private boolean isWindows() {
+        return java.io.File.pathSeparatorChar==';';
     }
 }

--- a/src/test/java/hudson/plugins/git/GitHooksTest.java
+++ b/src/test/java/hudson/plugins/git/GitHooksTest.java
@@ -107,15 +107,15 @@ public class GitHooksTest extends AbstractGitTestCase {
         WorkflowRun run = rule.buildAndAssertSuccess(job);
         rule.assertLogContains("Hello Pipeline", run);
 
-        final FilePath workspace = agent.getWorkspaceFor(job);
-        assertNotNull(workspace);
+        final FilePath jobWorkspace = agent.getWorkspaceFor(job);
+        assertNotNull(jobWorkspace);
         TemporaryFolder tf = new TemporaryFolder();
         tf.create();
         final File postCheckoutOutput1 = new File(tf.newFolder(), "svn-git-fun-post-checkout-1");
         final File postCheckoutOutput2 = new File(tf.newFolder(), "svn-git-fun-post-checkout-2");
 
         //Add hook on agent workspace
-        FilePath hook = workspace.child(".git/hooks/post-checkout");
+        FilePath hook = jobWorkspace.child(".git/hooks/post-checkout");
         createHookScriptAt(postCheckoutOutput1, hook);
 
         FilePath scriptWorkspace = rule.jenkins.getWorkspaceFor(job).withSuffix("@script");

--- a/src/test/java/hudson/plugins/git/GitHooksTest.java
+++ b/src/test/java/hudson/plugins/git/GitHooksTest.java
@@ -5,7 +5,6 @@ import hudson.model.Label;
 import hudson.slaves.DumbSlave;
 import hudson.tools.ToolProperty;
 import jenkins.plugins.git.CliGitCommand;
-import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.plugins.git.GitHooksConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -46,8 +45,6 @@ public class GitHooksTest extends AbstractGitTestCase {
     public LoggerRule lr = new LoggerRule();
     @ClassRule
     public static BuildWatcher watcher = new BuildWatcher();
-    @ClassRule
-    public static GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
 
     private static final String JENKINS_URL = System.getenv("JENKINS_URL") != null
             ? System.getenv("JENKINS_URL")


### PR DESCRIPTION
## Fix NPE in Windows run of GitHooksTest


Also intentionally avoids all calls to Functions.isWindows because that mthod is not used in any other location in the tests or in the production code.  It is not used because there was a time when a remote class loader issue was detected due to loading the Hudson.Functions class just to decide if a class was running on Windows.  The inline test is simple and is easy to read.

Confirmed that the GitHooksTest works in my dev env.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Test fix (non-breaking change which fixes a test issue)
