### PR TITLE
Split GitSCMTest for parallel execution on multiple cores

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotbugs.threshold>Medium</spotbugs.threshold>
-    <forkCount>0.8C</forkCount>
+    <forkCount>1C</forkCount>
   </properties>
 
   <dependencyManagement>

--- a/src/test/java/hudson/plugins/git/GitSCMSlowTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMSlowTest.java
@@ -1,0 +1,330 @@
+package hudson.plugins.git;
+
+import hudson.matrix.Axis;
+import hudson.matrix.AxisList;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.plugins.git.browser.GitRepositoryBrowser;
+import hudson.plugins.git.browser.GithubWeb;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.impl.ChangelogToBranch;
+import hudson.plugins.git.extensions.impl.LocalBranch;
+import hudson.plugins.git.extensions.impl.PreBuildMerge;
+import hudson.plugins.git.util.BuildChooserContext;
+import hudson.remoting.Channel;
+import hudson.remoting.VirtualChannel;
+import hudson.slaves.DumbSlave;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import jenkins.model.Jenkins;
+import jenkins.plugins.git.CliGitCommand;
+import jenkins.security.MasterToSlaveCallable;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * Split the slow tests out of GitSCMTest.
+ *
+ * @author Mark Waite
+ */
+public class GitSCMSlowTest extends AbstractGitTestCase {
+
+    private final Random random = new Random();
+    private boolean useChangelogToBranch = random.nextBoolean();
+
+    @BeforeClass
+    public static void setGitDefaults() throws Exception {
+        CliGitCommand gitCmd = new CliGitCommand(null);
+        gitCmd.setDefaults();
+    }
+
+    private void addChangelogToBranchExtension(GitSCM scm) {
+        if (useChangelogToBranch) {
+            /* Changelog should be no different with this enabled or disabled */
+            ChangelogToBranchOptions changelogOptions = new ChangelogToBranchOptions("origin", "master");
+            scm.getExtensions().add(new ChangelogToBranch(changelogOptions));
+        }
+        useChangelogToBranch = !useChangelogToBranch;
+    }
+
+    /*
+     * Makes sure that git browser URL is preserved across config round trip.
+     */
+    @Issue("JENKINS-22604")
+    @Test
+    public void testConfigRoundtripURLPreserved() throws Exception {
+        /* Long running test of low value on Windows
+         * Only run on non-Windows and approximately 50% of test runs
+         * On Windows, it requires 24 seconds before test finishes */
+        if (isWindows() || random.nextBoolean()) {
+            return;
+        }
+        FreeStyleProject p = createFreeStyleProject();
+        final String url = "https://github.com/jenkinsci/jenkins";
+        GitRepositoryBrowser browser = new GithubWeb(url);
+        GitSCM scm = new GitSCM(createRepoList(url),
+                Collections.singletonList(new BranchSpec("")),
+                browser, null, null);
+        p.setScm(scm);
+        rule.configRoundtrip(p);
+        rule.assertEqualDataBoundBeans(scm, p.getScm());
+        assertEquals("Wrong key", "git " + url, scm.getKey());
+    }
+
+    private List<UserRemoteConfig> createRepoList(String url) {
+        List<UserRemoteConfig> repoList = new ArrayList<>();
+        repoList.add(new UserRemoteConfig(url, null, null, null));
+        return repoList;
+    }
+
+    /*
+     * Makes sure that git extensions are preserved across config round trip.
+     */
+    @Issue("JENKINS-33695")
+    @Test
+    public void testConfigRoundtripExtensionsPreserved() throws Exception {
+        /* Long running test of low value on Windows
+         * Only run on non-Windows and approximately 50% of test runs
+         * On Windows, it requires 26 seconds before test finishes */
+        if (isWindows() || random.nextBoolean()) {
+            return;
+        }
+        FreeStyleProject p = createFreeStyleProject();
+        final String url = "https://github.com/jenkinsci/git-plugin.git";
+        GitRepositoryBrowser browser = new GithubWeb(url);
+        GitSCM scm = new GitSCM(createRepoList(url),
+                Collections.singletonList(new BranchSpec("*/master")),
+                browser, null, null);
+        p.setScm(scm);
+
+        /* Assert that no extensions are loaded initially */
+        assertEquals(Collections.emptyList(), scm.getExtensions().toList());
+
+        /* Add LocalBranch extension */
+        LocalBranch localBranchExtension = new LocalBranch("**");
+        scm.getExtensions().add(localBranchExtension);
+        assertTrue(scm.getExtensions().toList().contains(localBranchExtension));
+
+        /* Save the configuration */
+        rule.configRoundtrip(p);
+        List<GitSCMExtension> extensions = scm.getExtensions().toList();
+        assertTrue(extensions.contains(localBranchExtension));
+        assertEquals("Wrong extension count before reload", 1, extensions.size());
+
+        /* Reload configuration from disc */
+        p.doReload();
+        GitSCM reloadedGit = (GitSCM) p.getScm();
+        List<GitSCMExtension> reloadedExtensions = reloadedGit.getExtensions().toList();
+        assertEquals("Wrong extension count after reload", 1, reloadedExtensions.size());
+        LocalBranch reloadedLocalBranch = (LocalBranch) reloadedExtensions.get(0);
+        assertEquals(localBranchExtension.getLocalBranch(), reloadedLocalBranch.getLocalBranch());
+    }
+
+    /*
+     * Makes sure that the configuration form works.
+     */
+    @Test
+    public void testConfigRoundtrip() throws Exception {
+        /* Long running test of low value on Windows.
+         * Only run on non-Windows and approximately 50% of test runs
+         * On Windows, it requires 20 seconds before test finishes */
+        if (isWindows() || random.nextBoolean()) {
+            return;
+        }
+        FreeStyleProject p = createFreeStyleProject();
+        GitSCM scm = new GitSCM("https://github.com/jenkinsci/jenkins");
+        p.setScm(scm);
+        rule.configRoundtrip(p);
+        rule.assertEqualDataBoundBeans(scm, p.getScm());
+    }
+
+    @Test
+    public void testBuildChooserContext() throws Exception {
+        final FreeStyleProject p = createFreeStyleProject();
+        final FreeStyleBuild b = rule.buildAndAssertSuccess(p);
+
+        GitSCM.BuildChooserContextImpl c = new GitSCM.BuildChooserContextImpl(p, b, null);
+        c.actOnBuild(new BuildChooserContext.ContextCallable<Run<?, ?>, Object>() {
+            @Override
+            public Object invoke(Run param, VirtualChannel channel) throws IOException, InterruptedException {
+                assertSame(param, b);
+                return null;
+            }
+        });
+        c.actOnProject(new BuildChooserContext.ContextCallable<Job<?, ?>, Object>() {
+            @Override
+            public Object invoke(Job param, VirtualChannel channel) throws IOException, InterruptedException {
+                assertSame(param, p);
+                return null;
+            }
+        });
+        DumbSlave agent = rule.createOnlineSlave();
+        assertEquals(p.toString(), agent.getChannel().call(new GitSCMSlowTest.BuildChooserContextTestCallable(c)));
+    }
+
+    private static class BuildChooserContextTestCallable extends MasterToSlaveCallable<String, IOException> {
+
+        private final BuildChooserContext c;
+
+        public BuildChooserContextTestCallable(BuildChooserContext c) {
+            this.c = c;
+        }
+
+        @Override
+        public String call() throws IOException {
+            try {
+                return c.actOnProject(new BuildChooserContext.ContextCallable<Job<?, ?>, String>() {
+                    @Override
+                    public String invoke(Job<?, ?> param, VirtualChannel channel) throws IOException, InterruptedException {
+                        assertTrue(channel instanceof Channel);
+                        assertNotNull(Jenkins.getInstanceOrNull());
+                        return param.toString();
+                    }
+                });
+            } catch (InterruptedException e) {
+                throw new IOException(e);
+            }
+        }
+    }
+
+    @Test
+    public void testMergeFailedWithAgent() throws Exception {
+        FreeStyleProject project = setupSimpleProject("master");
+        project.setAssignedLabel(rule.createSlave().getSelfLabel());
+
+        GitSCM scm = new GitSCM(
+                createRemoteRepositories(),
+                Collections.singletonList(new BranchSpec("*")),
+                null, null,
+                Collections.emptyList());
+        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
+        addChangelogToBranchExtension(scm);
+        project.setScm(scm);
+
+        // create initial commit and then run the build against it:
+        commit("commitFileBase", johnDoe, "Initial Commit");
+        testRepo.git.branch("integration");
+        build(project, Result.SUCCESS, "commitFileBase");
+
+        testRepo.git.checkout(null, "topic1");
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit number 1");
+        final FreeStyleBuild build1 = build(project, Result.SUCCESS, commitFile1);
+        assertTrue(build1.getWorkspace().child(commitFile1).exists());
+
+        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+        // do what the GitPublisher would do
+        testRepo.git.deleteBranch("integration");
+        testRepo.git.checkout("topic1", "integration");
+
+        testRepo.git.checkout("master", "topic2");
+        commit(commitFile1, "other content", johnDoe, "Commit number 2");
+        assertTrue("scm polling did not detect commit2 change", project.poll(listener).hasChanges());
+        rule.buildAndAssertStatus(Result.FAILURE, project);
+        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+    }
+
+    @Test
+    public void testMergeWithAgent() throws Exception {
+        FreeStyleProject project = setupSimpleProject("master");
+        project.setAssignedLabel(rule.createSlave().getSelfLabel());
+
+        GitSCM scm = new GitSCM(
+                createRemoteRepositories(),
+                Collections.singletonList(new BranchSpec("*")),
+                null, null,
+                Collections.emptyList());
+        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
+        addChangelogToBranchExtension(scm);
+        project.setScm(scm);
+
+        // create initial commit and then run the build against it:
+        commit("commitFileBase", johnDoe, "Initial Commit");
+        testRepo.git.branch("integration");
+        build(project, Result.SUCCESS, "commitFileBase");
+
+        testRepo.git.checkout(null, "topic1");
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit number 1");
+        final FreeStyleBuild build1 = build(project, Result.SUCCESS, commitFile1);
+        assertTrue(build1.getWorkspace().child(commitFile1).exists());
+
+        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+        // do what the GitPublisher would do
+        testRepo.git.deleteBranch("integration");
+        testRepo.git.checkout("topic1", "integration");
+
+        testRepo.git.checkout("master", "topic2");
+        final String commitFile2 = "commitFile2";
+        commit(commitFile2, johnDoe, "Commit number 2");
+        assertTrue("scm polling did not detect commit2 change", project.poll(listener).hasChanges());
+        final FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile2);
+        assertTrue(build2.getWorkspace().child(commitFile2).exists());
+        rule.assertBuildStatusSuccess(build2);
+        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+    }
+
+    @Test
+    public void testMergeWithMatrixBuild() throws Exception {
+
+        //Create a matrix project and a couple of axes
+        MatrixProject project = rule.jenkins.createProject(MatrixProject.class, "xyz");
+        project.setAxes(new AxisList(new Axis("VAR", "a", "b")));
+
+        GitSCM scm = new GitSCM(
+                createRemoteRepositories(),
+                Collections.singletonList(new BranchSpec("*")),
+                null, null,
+                Collections.emptyList());
+        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
+        addChangelogToBranchExtension(scm);
+        project.setScm(scm);
+
+        // create initial commit and then run the build against it:
+        commit("commitFileBase", johnDoe, "Initial Commit");
+        testRepo.git.branch("integration");
+        build(project, Result.SUCCESS, "commitFileBase");
+
+        testRepo.git.checkout(null, "topic1");
+        final String commitFile1 = "commitFile1";
+        commit(commitFile1, johnDoe, "Commit number 1");
+        final MatrixBuild build1 = build(project, Result.SUCCESS, commitFile1);
+        assertTrue(build1.getWorkspace().child(commitFile1).exists());
+
+        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+        // do what the GitPublisher would do
+        testRepo.git.deleteBranch("integration");
+        testRepo.git.checkout("topic1", "integration");
+
+        testRepo.git.checkout("master", "topic2");
+        final String commitFile2 = "commitFile2";
+        commit(commitFile2, johnDoe, "Commit number 2");
+        assertTrue("scm polling did not detect commit2 change", project.poll(listener).hasChanges());
+        final MatrixBuild build2 = build(project, Result.SUCCESS, commitFile2);
+        assertTrue(build2.getWorkspace().child(commitFile2).exists());
+        rule.assertBuildStatusSuccess(build2);
+        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
+    }
+
+    /**
+     * inline ${@link hudson.Functions#isWindows()} to prevent a transient
+     * remote classloader issue
+     */
+    private boolean isWindows() {
+        return java.io.File.pathSeparatorChar == ';';
+    }
+}

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -13,26 +13,16 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
-import hudson.matrix.Axis;
-import hudson.matrix.AxisList;
-import hudson.matrix.MatrixBuild;
-import hudson.matrix.MatrixProject;
 import hudson.model.*;
-import hudson.plugins.git.GitSCM.BuildChooserContextImpl;
 import hudson.plugins.git.GitSCM.DescriptorImpl;
-import hudson.plugins.git.browser.GitRepositoryBrowser;
 import hudson.plugins.git.browser.GithubWeb;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.impl.*;
 import hudson.plugins.git.util.BuildChooser;
-import hudson.plugins.git.util.BuildChooserContext;
-import hudson.plugins.git.util.BuildChooserContext.ContextCallable;
 import hudson.plugins.git.util.BuildData;
 import hudson.plugins.git.util.GitUtils;
 import hudson.plugins.parameterizedtrigger.BuildTrigger;
 import hudson.plugins.parameterizedtrigger.ResultCondition;
-import hudson.remoting.Channel;
-import hudson.remoting.VirtualChannel;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.PollingResult;
 import hudson.scm.PollingResult.Change;
@@ -47,7 +37,6 @@ import hudson.util.LogTaskListener;
 import hudson.util.RingBufferLogHandler;
 import hudson.util.StreamTaskListener;
 
-import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.lib.Constants;
@@ -93,7 +82,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import org.junit.After;
 import org.junit.Before;
@@ -1670,51 +1658,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         rule.assertBuildStatusSuccess(db);
     }
 
-    @Test
-    public void testBuildChooserContext() throws Exception {
-        final FreeStyleProject p = createFreeStyleProject();
-        final FreeStyleBuild b = rule.buildAndAssertSuccess(p);
-
-        BuildChooserContextImpl c = new BuildChooserContextImpl(p, b, null);
-        c.actOnBuild(new ContextCallable<Run<?,?>, Object>() {
-            public Object invoke(Run param, VirtualChannel channel) throws IOException, InterruptedException {
-                assertSame(param,b);
-                return null;
-            }
-        });
-        c.actOnProject(new ContextCallable<Job<?,?>, Object>() {
-            public Object invoke(Job param, VirtualChannel channel) throws IOException, InterruptedException {
-                assertSame(param,p);
-                return null;
-            }
-        });
-        DumbSlave agent = rule.createOnlineSlave();
-        assertEquals(p.toString(), agent.getChannel().call(new BuildChooserContextTestCallable(c)));
-    }
-
-    private static class BuildChooserContextTestCallable extends MasterToSlaveCallable<String,IOException> {
-        private final BuildChooserContext c;
-
-        public BuildChooserContextTestCallable(BuildChooserContext c) {
-            this.c = c;
-        }
-
-        public String call() throws IOException {
-            try {
-                return c.actOnProject(new ContextCallable<Job<?,?>, String>() {
-                    public String invoke(Job<?,?> param, VirtualChannel channel) throws IOException, InterruptedException {
-                        assertTrue(channel instanceof Channel);
-                        assertNotNull(Jenkins.getInstanceOrNull());
-                        return param.toString();
-                    }
-                });
-            } catch (InterruptedException e) {
-                throw new IOException(e);
-            }
-        }
-
-    }
-
     // eg: "jane doe and john doe should be the culprits", culprits, [johnDoe, janeDoe])
     static public void assertCulprits(String assertMsg, Set<User> actual, PersonIdent[] expected)
     {
@@ -2033,46 +1976,6 @@ public class GitSCMTest extends AbstractGitTestCase {
     }
 
     @Test
-    public void testMergeWithAgent() throws Exception {
-        FreeStyleProject project = setupSimpleProject("master");
-        project.setAssignedLabel(rule.createSlave().getSelfLabel());
-
-        GitSCM scm = new GitSCM(
-                createRemoteRepositories(),
-                Collections.singletonList(new BranchSpec("*")),
-                null, null,
-                Collections.emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
-        addChangelogToBranchExtension(scm);
-        project.setScm(scm);
-
-        // create initial commit and then run the build against it:
-        commit("commitFileBase", johnDoe, "Initial Commit");
-        testRepo.git.branch("integration");
-        build(project, Result.SUCCESS, "commitFileBase");
-
-        testRepo.git.checkout(null, "topic1");
-        final String commitFile1 = "commitFile1";
-        commit(commitFile1, johnDoe, "Commit number 1");
-        final FreeStyleBuild build1 = build(project, Result.SUCCESS, commitFile1);
-        assertTrue(build1.getWorkspace().child(commitFile1).exists());
-
-        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
-        // do what the GitPublisher would do
-        testRepo.git.deleteBranch("integration");
-        testRepo.git.checkout("topic1", "integration");
-
-        testRepo.git.checkout("master", "topic2");
-        final String commitFile2 = "commitFile2";
-        commit(commitFile2, johnDoe, "Commit number 2");
-        assertTrue("scm polling did not detect commit2 change", project.poll(listener).hasChanges());
-        final FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile2);
-        assertTrue(build2.getWorkspace().child(commitFile2).exists());
-        rule.assertBuildStatusSuccess(build2);
-        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
-    }
-
-    @Test
     public void testMergeFailed() throws Exception {
         FreeStyleProject project = setupSimpleProject("master");
 
@@ -2141,87 +2044,6 @@ public class GitSCMTest extends AbstractGitTestCase {
     }
 
     @Test
-    public void testMergeFailedWithAgent() throws Exception {
-        FreeStyleProject project = setupSimpleProject("master");
-        project.setAssignedLabel(rule.createSlave().getSelfLabel());
-
-        GitSCM scm = new GitSCM(
-                createRemoteRepositories(),
-                Collections.singletonList(new BranchSpec("*")),
-                null, null,
-                Collections.emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
-        addChangelogToBranchExtension(scm);
-        project.setScm(scm);
-
-        // create initial commit and then run the build against it:
-        commit("commitFileBase", johnDoe, "Initial Commit");
-        testRepo.git.branch("integration");
-        build(project, Result.SUCCESS, "commitFileBase");
-
-        testRepo.git.checkout(null, "topic1");
-        final String commitFile1 = "commitFile1";
-        commit(commitFile1, johnDoe, "Commit number 1");
-        final FreeStyleBuild build1 = build(project, Result.SUCCESS, commitFile1);
-        assertTrue(build1.getWorkspace().child(commitFile1).exists());
-
-        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
-        // do what the GitPublisher would do
-        testRepo.git.deleteBranch("integration");
-        testRepo.git.checkout("topic1", "integration");
-
-        testRepo.git.checkout("master", "topic2");
-        commit(commitFile1, "other content", johnDoe, "Commit number 2");
-        assertTrue("scm polling did not detect commit2 change", project.poll(listener).hasChanges());
-        rule.buildAndAssertStatus(Result.FAILURE, project);
-        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
-    }
-
-
-    @Test
-    public void testMergeWithMatrixBuild() throws Exception {
-        
-        //Create a matrix project and a couple of axes
-        MatrixProject project = rule.jenkins.createProject(MatrixProject.class, "xyz");
-        project.setAxes(new AxisList(new Axis("VAR","a","b")));
-        
-        GitSCM scm = new GitSCM(
-                createRemoteRepositories(),
-                Collections.singletonList(new BranchSpec("*")),
-                null, null,
-                Collections.emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", null, null)));
-        addChangelogToBranchExtension(scm);
-        project.setScm(scm);
-
-        // create initial commit and then run the build against it:
-        commit("commitFileBase", johnDoe, "Initial Commit");
-        testRepo.git.branch("integration");
-        build(project, Result.SUCCESS, "commitFileBase");
-        
-        
-        testRepo.git.checkout(null, "topic1");
-        final String commitFile1 = "commitFile1";
-        commit(commitFile1, johnDoe, "Commit number 1");
-        final MatrixBuild build1 = build(project, Result.SUCCESS, commitFile1);
-        assertTrue(build1.getWorkspace().child(commitFile1).exists());
-
-        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
-        // do what the GitPublisher would do
-        testRepo.git.deleteBranch("integration");
-        testRepo.git.checkout("topic1", "integration");
-
-        testRepo.git.checkout("master", "topic2");
-        final String commitFile2 = "commitFile2";
-        commit(commitFile2, johnDoe, "Commit number 2");
-        assertTrue("scm polling did not detect commit2 change", project.poll(listener).hasChanges());
-        final MatrixBuild build2 = build(project, Result.SUCCESS, commitFile2);
-        assertTrue(build2.getWorkspace().child(commitFile2).exists());
-        rule.assertBuildStatusSuccess(build2);
-        assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
-    }
-
-    @Test
     public void testEnvironmentVariableExpansion() throws Exception {
         FreeStyleProject project = createFreeStyleProject();
         project.setScm(new GitSCM("${CAT}"+testRepo.gitDir.getPath()));
@@ -2248,97 +2070,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         public void buildEnvironmentFor(Run r, EnvVars envs, TaskListener listener) throws IOException, InterruptedException {
             envs.put("CAT","");
         }
-    }
-
-    private List<UserRemoteConfig> createRepoList(String url) {
-        List<UserRemoteConfig> repoList = new ArrayList<>();
-        repoList.add(new UserRemoteConfig(url, null, null, null));
-        return repoList;
-    }
-
-    /*
-     * Makes sure that git browser URL is preserved across config round trip.
-     */
-    @Issue("JENKINS-22604")
-    @Test
-    public void testConfigRoundtripURLPreserved() throws Exception {
-        /* Long running test of low value on Windows */
-        /* Only run on non-Windows and approximately 50% of test runs */
-        /* On Windows, it requires 24 seconds before test finishes */
-        if (isWindows() || random.nextBoolean()) {
-            return;
-        }
-        FreeStyleProject p = createFreeStyleProject();
-        final String url = "https://github.com/jenkinsci/jenkins";
-        GitRepositoryBrowser browser = new GithubWeb(url);
-        GitSCM scm = new GitSCM(createRepoList(url),
-                                Collections.singletonList(new BranchSpec("")),
-                                browser, null, null);
-        p.setScm(scm);
-        rule.configRoundtrip(p);
-        rule.assertEqualDataBoundBeans(scm,p.getScm());
-        assertEquals("Wrong key", "git " + url, scm.getKey());
-    }
-
-    /*
-     * Makes sure that git extensions are preserved across config round trip.
-     */
-    @Issue("JENKINS-33695")
-    @Test
-    public void testConfigRoundtripExtensionsPreserved() throws Exception {
-        /* Long running test of low value on Windows */
-        /* Only run on non-Windows and approximately 50% of test runs */
-        /* On Windows, it requires 26 seconds before test finishes */
-        if (isWindows() || random.nextBoolean()) {
-            return;
-        }
-        FreeStyleProject p = createFreeStyleProject();
-        final String url = "https://github.com/jenkinsci/git-plugin.git";
-        GitRepositoryBrowser browser = new GithubWeb(url);
-        GitSCM scm = new GitSCM(createRepoList(url),
-                Collections.singletonList(new BranchSpec("*/master")),
-                browser, null, null);
-        p.setScm(scm);
-
-        /* Assert that no extensions are loaded initially */
-        assertEquals(Collections.emptyList(), scm.getExtensions().toList());
-
-        /* Add LocalBranch extension */
-        LocalBranch localBranchExtension = new LocalBranch("**");
-        scm.getExtensions().add(localBranchExtension);
-        assertTrue(scm.getExtensions().toList().contains(localBranchExtension));
-
-        /* Save the configuration */
-        rule.configRoundtrip(p);
-        List<GitSCMExtension> extensions = scm.getExtensions().toList();
-        assertTrue(extensions.contains(localBranchExtension));
-        assertEquals("Wrong extension count before reload", 1, extensions.size());
-
-        /* Reload configuration from disc */
-        p.doReload();
-        GitSCM reloadedGit = (GitSCM) p.getScm();
-        List<GitSCMExtension> reloadedExtensions = reloadedGit.getExtensions().toList();
-        assertEquals("Wrong extension count after reload", 1, reloadedExtensions.size());
-        LocalBranch reloadedLocalBranch = (LocalBranch) reloadedExtensions.get(0);
-        assertEquals(localBranchExtension.getLocalBranch(), reloadedLocalBranch.getLocalBranch());
-    }
-
-    /*
-     * Makes sure that the configuration form works.
-     */
-    @Test
-    public void testConfigRoundtrip() throws Exception {
-        /* Long running test of low value on Windows */
-        /* Only run on non-Windows and approximately 50% of test runs */
-        /* On Windows, it requires 20 seconds before test finishes */
-        if (isWindows() || random.nextBoolean()) {
-            return;
-        }
-        FreeStyleProject p = createFreeStyleProject();
-        GitSCM scm = new GitSCM("https://github.com/jenkinsci/jenkins");
-        p.setScm(scm);
-        rule.configRoundtrip(p);
-        rule.assertEqualDataBoundBeans(scm,p.getScm());
     }
 
     /*


### PR DESCRIPTION
## Split GitSCMTest for more parallel execution

When I attempted to switch from one testing thread per core (stop using `forkCount=1C` in pom), the tests did not complete in the 60 minute allowed for plugin jobs on ci.jenkins.io, especially on Windows.  This pull request sets the forkCount to `1C` to use a process for each core available on the testing machine.  It also moves a few long running tests from GitSCMTest into a new class in hopes that will allow parallelism in more cases.  It also reduces test execution on Windows by skipping at least one low value, platform independent test on Windows.

- Test with all available cores
- Improve test parallelism by moving some slow tests

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Improve a test
