### PR TITLE
[JENKINS-70158] Fix null pointer exception in GitSCMFileSystem

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -308,7 +308,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 }
 
                 String headName;
-                if (rev != null) {
+                if (rev != null && env != null) {
                     headName = env.expand(rev.getHead().getName());
                 } else {
                     if (branchSpecExpandedName.startsWith(prefix)) {

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -462,6 +462,21 @@ public class GitSCMFileSystemTest {
         assertEquals(Constants.R_HEADS, result6.prefix);
     }
 
+    /* GitSCMFileSystem in git plugin 4.14.0 reported a null pointer
+     * exception when the rev was non-null and the env was null. */
+    @Issue("JENKINS-70158")
+    @Test
+    public void null_pointer_exception() throws Exception {
+        File gitDir = new File(".");
+        GitClient client = Git.with(TaskListener.NULL, new EnvVars()).in(gitDir).using("git").getClient();
+        ObjectId git260 = client.revParse(GIT_2_6_0_TAG);
+        AbstractGitSCMSource.SCMRevisionImpl rev260 =
+                new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git260.getName());
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("master-f"), rev260, null);
+        assertEquals("master-f", result1.headName);
+        assertEquals(Constants.R_HEADS, result1.prefix);
+    }
+
     /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */
     private boolean isWindows() {
         return java.io.File.pathSeparatorChar==';';


### PR DESCRIPTION
## [JENKINS-70158](https://issues.jenkins.io/browse/JENKINS-70158) Fix null pointer exception in GitSCMFileSystem

- Duplicate null pointer exception in a test (12fca98a911931410d70d395e5a218afb2b32d4b)
- Fix null pointer exception in GitSCMFileSystem (18463b8b8b318000f8081aa3b0ed47f8065d9180)

When rev was not null and env was null, a null pointer exception was thrown as the code tried to use the null env to expand environment variables in the rev argument.

First commit duplicates the null pointer exception in a test.  Second commit resolves the null pointer exception.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Additional comments

@MartinKosicky sorry that we missed the null pointer exception in the code review and in the test automation.  Thanks very much for your pull request and for the automated tests that you added.  Those tests made it very simple to add one more test for the null pointer exception.  That failing test then made it easy to fix the issue in the main code.  Thanks again!