### PR TITLE
Require Java 11 and Jenkins 2.361.4 or newer

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -66,8 +66,7 @@ Steps to test a pull request build are:
 
 . *Find the pull request on link:https://github.com/jenkinsci/git-plugin/pulls[GitHub]* - for example, link:https://github.com/jenkinsci/git-plugin/pull/676[pull request 676]
 . *Find the link:https://ci.jenkins.io/job/Plugins/job/git-plugin/view/change-requests/[ci.jenkins.io] artifacts for that pull request* from the link to the link:https://ci.jenkins.io/job/Plugins/job/git-plugin/job/PR-676/lastSuccessfulBuild/[artifacts in the Jenkins job] in "*Show all checks*"
-. *Download the `hpi` file* (like `git-4.0.1-rc3444.b3d767e3d46a.hpi`) to your computer
-. *Upload the `hpi` file* to Jenkins from the Jenkins Plugin Manager
+. *Copy the URL of the `hpi` file* into the "Advanced settings of the Plugin Manager
 . *Restart your Jenkins* and you're ready to test
 
 [[bug-triage]]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,15 +2,17 @@
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(
+  // Container agents start faster and are easier to administer
   useContainerAgent: true,
   // Do not stop parallel tests on first failure
   failFast: false,
   // Opt-in to the Artifact Caching Proxy, to be removed when it will be in opt-out.
   // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
   artifactCachingProxyEnabled: true,
+  // Test Java 11 with a recent LTS, Java 17 even more recent
   configurations: [
-    [platform: 'linux',   jdk: '17', jenkins: '2.375'],
-    [platform: 'linux',   jdk: '11', jenkins: '2.361.4'],
-    [platform: 'windows', jdk:  '8']
+    [platform: 'linux',   jdk: '17', jenkins: '2.383'],
+    [platform: 'linux',   jdk: '11', jenkins: '2.375.1'],
+    [platform: 'windows', jdk: '11']
   ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.51</version>
+    <version>4.53</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
   <name>Git plugin</name>
   <description>Integrates Jenkins with Git SCM</description>
-  <url>https://github.com/jenkinsci/git-plugin/blob/master/README.adoc</url>
+  <url>https://github.com/${gitHubRepo}</url>
   <inceptionYear>2007</inceptionYear>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,10 @@
   </scm>
 
   <properties>
-    <revision>4.14.4</revision>
+    <revision>5.0.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.346.3</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <!-- Jenkins.MANAGE is still in Beta -->
     <useBeta>true</useBeta>
@@ -76,7 +76,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.346.x</artifactId>
+        <artifactId>bom-2.361.x</artifactId>
         <version>1757.vf3c66da_b_7492</version>
         <type>pom</type>
         <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
   <name>Git plugin</name>
   <description>Integrates Jenkins with Git SCM</description>
-  <url>https://github.com/${gitHubRepo}</url>
+  <url>https://github.com/jenkinsci/git-plugin</url>
   <inceptionYear>2007</inceptionYear>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
+      <version>4.0.0-rc3303.656c06003c66</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,12 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.346.3</jenkins.version>
     <no-test-jar>false</no-test-jar>
+    <!-- Jenkins.MANAGE is still in Beta -->
     <useBeta>true</useBeta>
+    <!-- Do not run extra reporting for checkstyle or pmd -->
+    <!-- https://stackoverflow.com/questions/12038238/unable-to-locate-source-xref-to-link-to -->
     <linkXRef>false</linkXRef>
     <spotbugs.effort>Max</spotbugs.effort>
-    <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotbugs.threshold>Medium</spotbugs.threshold>
   </properties>
 

--- a/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/help-excludedMessage.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/help-excludedMessage.html
@@ -1,10 +1,10 @@
 <div>
     If set, and Jenkins is set to poll for changes, Jenkins will ignore any revisions committed with message matched to
-    <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Pattern</a> when determining
+    <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">Pattern</a> when determining
     if a build needs to be triggered. This can be used to exclude commits done by the build itself from triggering another build,
     assuming the build server commits the change with a distinct message.
-    <p/>Exclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Pattern</a>
-    <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#matches()">matching</a>
+    <p/>Exclusion uses <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">Pattern</a>
+    <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#matches()">matching</a>
     <p/>
   <pre>.*\[maven-release-plugin\].*</pre>
     The example above illustrates that if only revisions with "[maven-release-plugin]" message in first comment line

--- a/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/help-excludedMessage_ja.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/MessageExclusion/help-excludedMessage_ja.html
@@ -1,12 +1,12 @@
 <div>
     Jenkinsは、変更をポーリングするように設定され、ビルドするかどうか決定する時に、
-    <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">パターン</a>に合致するメッセージでコミットされた、リビジョンを無視します。
+    <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">パターン</a>に合致するメッセージでコミットされた、リビジョンを無視します。
     これは、ビルドサーバが別のメッセージで変更をコミットすると仮定して、
     ビルド自体が行ったコミットが、別のビルドを引き起こさないように使われます。
 
     <p/>
-    対象外メッセージは、<a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">パターン</a>
-    <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#matches()">マッチング</a>を使用する。
+    対象外メッセージは、<a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">パターン</a>
+    <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#matches()">マッチング</a>を使用する。
     <p/>
 
   <pre>.*\[maven-release-plugin\].*</pre>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/help-excludedRegions.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/help-excludedRegions.html
@@ -1,5 +1,5 @@
 <div>
-  Each exclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">java regular expression pattern matching</a>,
+  Each exclusion uses <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">java regular expression pattern matching</a>,
     and must be separated by a new line.
   <p/>
   <pre>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/help-excludedRegions_ja.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/help-excludedRegions_ja.html
@@ -1,5 +1,5 @@
 <div>
-  対象外範囲は、<a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Javaの正規表現のパターンマッチング</a>を使用し、
+  対象外範囲は、<a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">Javaの正規表現のパターンマッチング</a>を使用し、
   改行で区切られています。
   <p/>
   <pre>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/help-includedRegions.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/help-includedRegions.html
@@ -1,5 +1,5 @@
 <div>
-  Each inclusion uses <a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">java regular expression pattern matching</a>,
+  Each inclusion uses <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">java regular expression pattern matching</a>,
     and must be separated by a new line.
   An empty list implies that everything is included.
   <p/>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/help-includedRegions_ja.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/PathRestriction/help-includedRegions_ja.html
@@ -1,5 +1,5 @@
 <div>
-  対象範囲は、<a href="http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Javaの正規表現パターンマッチング</a>を使用し、改行で区切られています。
+  対象範囲は、<a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">Javaの正規表現パターンマッチング</a>を使用し、改行で区切られています。
   空行は、すべてを含むことを意味します。
   <p/>
   <pre>


### PR DESCRIPTION
## Require Java 11 and Jenkins 2.361.4 or newer

- Link to Java 11 javadoc, not Java 8
- CI test with Java 11 and Java 17
- Use the simpler documentation URL
- Remove unused properties, document required properties
- Require Jenkins 2.361.4 or newer
- Remove unused import
- Use git client plugin 4.0 incremental

Prepare for git plugin 5.0.0 release with requirement for Java 11 and with additional changes for the addition of Pipeline symbols to make Pipelines easier to express.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Further comments

Needs additional testing in:

- [x] Plugin compatibility tester in the Jenkins bill of materials
- [x] Interactive testing in Mark Waite's multi-platform cluster
- [x] Interactive testing by other users

Once this pull request is merged, then the [add-symbols branch](https://github.com/MarkEWaite/git-plugin/tree/add-symbols) needs to be merged (probably after a squash or a rebase to make the history less filled with debris).  The "add symbols" change is the reason for the increment of the major version from 4.x to 5.x.  

I hope that there is no incompatibility created by the "add symbols" change.  I've tested deeply and widely for compatibility in the "add symbols" change.  The test automation of the "add symbols" change attempts to verify many different scenarios continue to work after the change.  However, it is a large enough change that I believe it justifies incrementing the major version.