### PR TITLE
Reincrementalify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <tag>git-4.14.0</tag>
+    <tag>${scmTag}</tag>
     <url>https://github.com/${gitHubRepo}</url>
   </scm>
 


### PR DESCRIPTION
In https://ci.jenkins.io/job/Plugins/job/git-plugin/job/PR-1367/1/consoleFull I noticed that the SCM tag had fallen out of sync with the expected value leading to the lack of an incremental deployment:

```
18:59:54  Invalid archive retrieved from Jenkins, perhaps the plugin is not properly incrementalized?
18:59:54  Error: ZIP error: Error: Wrong commit hash in /project/scm/tag, expected 8301c44440e82281ca7cb0321e004df00d6926f8, got git-4.14.0 from https://ci.jenkins.io/job/Plugins/job/git-plugin/job/PR-1367/1/artifact/**/*8301c44440e8*/*8301c44440e8*/*zip*/archive.zip
18:59:54  Success: Status code 400 is in the accepted range: 100:599
```