### PR TITLE
Add conditional build step plugin to fix BOM tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,17 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <!-- BOM automated tests fail without conditional-buildstep plugin -->
+      <!-- TODO: Remove this dependency when parameterized trigger plugin dependency fix is released -->
+      <!-- https://github.com/jenkinsci/bom/pull/1623#issuecomment-1339989438 -->
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>conditional-buildstep</artifactId>
+      <version>1.4.2</version>
+      <optional>true</optional>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>
       <optional>true</optional>


### PR DESCRIPTION
## Add conditional build step plugin to fix BOM tests

Notes from Basil Crow are in https://github.com/jenkinsci/bom/pull/1623#issuecomment-1339989438

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Test

## Further comments

Attempting first pass as a test dependency and as optional.  If that passes the BOM tests, then that's lowest impact on the plugin, since it does not add an optional runtime dependency.

If the test dependency is not enough, then conditional build step plugin will be added as an optional dependency until the next release of parameterized trigger plugin.
