### PR TITLE
JENKINS-70331: Always honor useExistingAccountWithSameEmail

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -480,6 +480,14 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                 }
             }
         } else {
+            if (useExistingAccountWithSameEmail && hasMailerPlugin()) {
+                for(User existingUser : User.getAll()) {
+                    if (csAuthorEmail.equalsIgnoreCase(getMail(existingUser))) {
+                        return existingUser;
+                    }
+                }
+            }
+
             if (csAuthor.isEmpty()) {
                 // Avoid exception from User.get("", false)
                 return User.getUnknown();

--- a/src/test/java/hudson/plugins/git/GitChangeSetTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTest.java
@@ -196,7 +196,7 @@ public class GitChangeSetTest {
         final String existingUserId = "An existing user";
         final String existingUserFullName = "Some FullName";
         final String email = "jcommitter@nospam.com";
-        final boolean createAccountBasedOnEmail = true;
+        final boolean createAccountBasedOnEmail = random.nextBoolean();
         final boolean useExistingAccountBasedOnEmail = true;
 
         assertNull(User.get(email, false));


### PR DESCRIPTION
useExistingAccountWithSameEmail makes sense on its own, independently of how a new account may be created if required.

## [JENKINS-70331](https://issues.jenkins.io/browse/JENKINS-70331) - Always honor useExistingAccountWithSameEmail

In general, I'm not convinced about the whole separation in https://github.com/jenkinsci/git-plugin/blob/756dc6d7855cd8b80041bd79926e7dde84aa3d90/src/main/java/hudson/plugins/git/GitChangeSet.java#L443 based on createAccountBasedOnEmail. I think there are two independent things:
- Search
- Creation if not found
And "createAccountBasedOnEmail" whould only affect "Creation if not found".

By having the two big branches the "Search" gets duplicated. I'm not trying to fix this here, but I am adding to one of the branches logic that is already in the other one and should IMHO have been in both.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [ x ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ x ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ x ] I have added tests that verify my changes
- [ x ] Unit tests pass locally with my changes
- [ ? ] I have added documentation as necessary
- [ x ] No Javadoc warnings were introduced with my changes
- [ x ] No spotbugs warnings were introduced with my changes
- [ x ] I have interactively tested my changes

I don't think there is any doc change strictly required for this PR. But the docs regarding all this could, in general, be improved.

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [ ? ] Bug fix (non-breaking change which fixes an issue)
- [ ? ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I guess this could potentially break for somebody? Not exactly sure how.
