### PR TITLE
JENKINS-70331: Handle GitHub private email format

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -55,6 +55,8 @@ public class GitChangeSet extends ChangeLogSet.Entry {
             + PREFIX_COMMITTER + IDENTITY + "$");
     private static final Pattern RENAME_SPLIT = Pattern.compile("^(.*?)\t(.*)$");
 
+    private static final Pattern GITHUB_PRIVATE_EMAIL = Pattern.compile("^[0-9]+\\+(.*)@users\\.noreply\\.github\\.com$");
+
     private static final String NULL_HASH = "0000000000000000000000000000000000000000";
     private static final String ISO_8601 = "yyyy-MM-dd'T'HH:mm:ss";
     private static final String ISO_8601_WITH_TZ = "yyyy-MM-dd'T'HH:mm:ssX";
@@ -494,6 +496,15 @@ public class GitChangeSet extends ChangeLogSet.Entry {
                 if (csAuthorEmail == null || csAuthorEmail.isEmpty()) {
                     return User.getUnknown();
                 }
+
+                Matcher githubMatcher = GITHUB_PRIVATE_EMAIL.matcher(csAuthorEmail);
+                if (githubMatcher.matches()) {
+                    user = getUser(githubMatcher.group(1), false);
+                    if (user != null) {
+                        return user;
+                    }
+                }
+
                 // Ensure that malformed email addresses (in this case, just '@')
                 // don't mess us up.
                 String[] emailParts = csAuthorEmail.split("@");

--- a/src/test/java/hudson/plugins/git/GitChangeSetTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTest.java
@@ -231,4 +231,23 @@ public class GitChangeSetTest {
         user.addProperty(new Mailer.UserProperty(GitChangeSetUtil.COMMITTER_EMAIL));
         assertEquals(user, cs.getAuthor());
     }
+
+    @Test
+    public void testFindOrCreateUserUnderstandGitHubPrivateEmail() throws IOException {
+        final String existingUserId = "github_user";
+        final String githubPrivateEmail = "1234567+" + existingUserId + "@users.noreply.github.com";
+        final GitChangeSet committerCS = GitChangeSetUtil.genChangeSet(true, false);
+        final String existingUserFullName = "Some FullName";
+        final String email = "some.email@nospam.com";
+        final boolean createAccountBasedOnEmail = false;
+        final boolean useExistingAccountBasedOnEmail = false;
+
+        assertNull(User.get(existingUserId, false));
+
+        User existingUser = User.get(existingUserId, true);
+        assertThat(existingUser, is(not(nullValue())));
+
+        User user = committerCS.findOrCreateUser(GitChangeSetUtil.COMMITTER_NAME, githubPrivateEmail, createAccountBasedOnEmail, useExistingAccountBasedOnEmail);
+        assertThat(user, is(existingUser));
+    }
 }


### PR DESCRIPTION
This is specially useful for people using the github-oauth plugin.

## [JENKINS-70331](https://issues.jenkins.io/browse/JENKINS-70331) - Handle GitHub private email format

On July 18, 2017 GitHub changed the format of its private email addresses for new users (https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address). This patch should in theory be an "unbreaking change", but returning the behaviour to what users had before then. But that was half a decade ago...

In any case, this is going to be useful at least for anybody using github-oauth (and anybody using something different, but with matching user IDs).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ? ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ? ] Documentation in README has been updated as necessary
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

One of those, depending on how you look at it.
