### PR TITLE
Limit duration of longest tests

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -41,6 +41,13 @@ If the default branch has been set to another value than master, it should be te
 This is done by adding **#** before `defaultBranch = main` in the `init` section 
 of the `.gitconfig` file (located in your home directory).
 
+There are enough automated tests in the plugin that it can require more than 60 minutes to complete testing on slower hardware.
+The `buildPlugin()` Pipeline shared library limits plugin jobs to 60 minutes and fails them if they take more than 60 minutes.
+The longest running automated tests have been adapted to have an upper bound on their runtime.
+Once the runtime set in those long running tests has been reached, new tests in that test class are skipped with the message that the max time was exceeded.
+Those tests have also been adapted to execute the individuals tests in those classes in random order.
+By executing the tests in random order, it increases the chances that at least one of the parallel branches of `buildPlugin()` will execute each test in the long running test classes.
+
 [[pull-request-review]]
 == Reviewing Pull Requests
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,8 @@
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(
   useContainerAgent: true,
+  // Do not stop parallel tests on first failure
+  failFast: false,
   // Opt-in to the Artifact Caching Proxy, to be removed when it will be in opt-out.
   // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
   artifactCachingProxyEnabled: true,

--- a/src/test/java/hudson/plugins/git/GitChangeSetPluginHistoryTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetPluginHistoryTest.java
@@ -80,26 +80,13 @@ public class GitChangeSetPluginHistoryTest {
      *
      * @return ObjectId list for all changes which aren't merges
      */
-    private static List<ObjectId> getNonMergeChanges(boolean honorExclusions) throws IOException {
+    private static List<ObjectId> getNonMergeChanges() throws IOException {
         List<ObjectId> nonMergeChanges = new ArrayList<>();
         Process process = new ProcessBuilder("git", "rev-list", "--no-merges", "HEAD").start();
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
             String line;
             while ((line = reader.readLine()) != null) {
-                if (honorExclusions) {
-                    boolean ignore = false;
-                    for (String exclusion : git171exceptions) {
-                        if (line.startsWith(exclusion)) {
-                            ignore = true;
-                            break;
-                        }
-                    }
-                    if (!ignore) {
-                        nonMergeChanges.add(ObjectId.fromString(line));
-                    }
-                } else {
-                    nonMergeChanges.add(ObjectId.fromString(line));
-                }
+                nonMergeChanges.add(ObjectId.fromString(line));
             }
         }
         process.destroy();
@@ -117,8 +104,7 @@ public class GitChangeSetPluginHistoryTest {
             EnvVars envVars = new EnvVars();
             TaskListener listener = StreamTaskListener.fromStdout();
             GitClient git = Git.with(listener, envVars).in(new FilePath(new File("."))).using(implementation).getClient();
-            boolean honorExclusions = implementation.equals("git") && !sampleRepo.gitVersionAtLeast(1, 7, 10);
-            List<ObjectId> allNonMergeChanges = getNonMergeChanges(honorExclusions);
+            List<ObjectId> allNonMergeChanges = getNonMergeChanges();
             int count = allNonMergeChanges.size() / 10; /* 10% of all changes */
 
             for (boolean authorOrCommitter : choices) {

--- a/src/test/java/hudson/plugins/git/GitChangeSetTruncateTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTruncateTest.java
@@ -108,12 +108,9 @@ public class GitChangeSetTruncateTest {
 
     @Parameterized.Parameters(name = "{0} \"{1}\" --->>> \"{2}\"")
     public static Collection gitObjects() {
-        /* If CLI git is older than 1.8.3, don't test CLI git message truncation */
-        /* CLI git 1.7.1 (CentOS 6) does not support the message truncation command line flags */
         String[] bothGitImplementations = {"git", "jgit"};
-        String[] jgitImplementation = {"jgit"};
         List<Object[]> arguments = new ArrayList<>();
-        for (String implementation : versionCheckRepo.gitVersionAtLeast(1, 8, 3) ? bothGitImplementations : jgitImplementation) {
+        for (String implementation : bothGitImplementations) {
             for (TestData sample : TEST_DATA) {
                 Object[] item = {implementation, sample.testDataCommitSummary, sample.testDataTruncatedSummary};
                 arguments.add(item);

--- a/src/test/java/hudson/plugins/git/GitSCMSlowTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMSlowTest.java
@@ -361,10 +361,6 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
 
     @Test
     public void testInitSparseCheckout() throws Exception {
-        if (!sampleRepo.gitVersionAtLeast(1, 7, 10)) {
-            /* Older git versions have unexpected behaviors with sparse checkout */
-            return;
-        }
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         FreeStyleProject project = setupProject("master", Collections.singletonList(new SparseCheckoutPath("toto")));
 
@@ -383,10 +379,6 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
 
     @Test
     public void testInitSparseCheckoutBis() throws Exception {
-        if (!sampleRepo.gitVersionAtLeast(1, 7, 10)) {
-            /* Older git versions have unexpected behaviors with sparse checkout */
-            return;
-        }
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         FreeStyleProject project = setupProject("master", Collections.singletonList(new SparseCheckoutPath("titi")));
 
@@ -405,10 +397,6 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
 
     @Test
     public void testInitSparseCheckoutOverAgent() throws Exception {
-        if (!sampleRepo.gitVersionAtLeast(1, 7, 10)) {
-            /* Older git versions have unexpected behaviors with sparse checkout */
-            return;
-        }
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         FreeStyleProject project = setupProject("master", Collections.singletonList(new SparseCheckoutPath("titi")));
         project.setAssignedLabel(rule.createSlave().getSelfLabel());

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -2371,7 +2371,6 @@ public class GitSCMTest extends AbstractGitTestCase {
 
     @Test
     public void testSparseCheckoutAfterNormalCheckout() throws Exception {
-        assumeTrue("Git plugin does not support CLI git older than 1.8", sampleRepo.gitVersionAtLeast(1, 8));
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         FreeStyleProject project = setupSimpleProject("master");
 
@@ -2398,7 +2397,6 @@ public class GitSCMTest extends AbstractGitTestCase {
 
     @Test
     public void testNormalCheckoutAfterSparseCheckout() throws Exception {
-        assumeTrue("Git plugin does not support CLI git older than 1.8", sampleRepo.gitVersionAtLeast(1, 8));
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         FreeStyleProject project = setupProject("master", Collections.singletonList(new SparseCheckoutPath("titi")));
 
@@ -2603,14 +2601,6 @@ public class GitSCMTest extends AbstractGitTestCase {
         // Initial commit and build
         commit("toto/commitFile1", johnDoe, "Commit number 1");
         String brokenPath = "\\broken/path\\of/doom";
-        if (!sampleRepo.gitVersionAtLeast(1, 8)) {
-            /* Git 1.7.10.4 fails the first build unless the git-upload-pack
-             * program is available in its PATH.
-             * Later versions of git don't have that problem.
-             */
-            final String systemPath = System.getenv("PATH");
-            brokenPath = systemPath + File.pathSeparator + brokenPath;
-        }
         final StringParameterValue real_param = new StringParameterValue("MY_BRANCH", "master");
         final StringParameterValue fake_param = new StringParameterValue("PATH", brokenPath);
 

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -134,12 +134,6 @@ public class GitStatusTest extends AbstractGitProject {
 
     @WithoutJenkins
     @Test
-    public void testToString() {
-        assertEquals("URL: ", this.gitStatus.toString());
-    }
-
-    @WithoutJenkins
-    @Test
     public void testAllowNotifyCommitParametersDisabled() {
         assertFalse("SECURITY-275: ignore arbitrary notifyCommit parameters", GitStatus.ALLOW_NOTIFY_COMMIT_PARAMETERS);
     }

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -19,31 +19,40 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.util.*;
+import org.eclipse.jgit.transport.URIish;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.eclipse.jgit.transport.URIish;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import org.kohsuke.stapler.HttpResponses;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.FromDataPoints;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
+import org.junit.rules.Stopwatch;
+import org.junit.rules.TestName;
+import org.junit.runner.OrderWith;
 import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.WithoutJenkins;
 
 import javax.servlet.http.HttpServletRequest;
+import jenkins.plugins.git.RandomOrder;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
+@OrderWith(RandomOrder.class)
 @RunWith(Theories.class)
 public class GitStatusTest extends AbstractGitProject {
 
@@ -114,38 +123,55 @@ public class GitStatusTest extends AbstractGitProject {
         });
     }
 
+    @ClassRule
+    public static Stopwatch stopwatch = new Stopwatch();
+    @Rule
+    public TestName testName = new TestName();
+
+    private static final int MAX_SECONDS_FOR_THESE_TESTS = 300;
+
+    private boolean isTimeAvailable() {
+        return stopwatch.runtime(SECONDS) <= MAX_SECONDS_FOR_THESE_TESTS;
+    }
+
     @WithoutJenkins
     @Test
     public void testGetDisplayName() {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         assertEquals("Git", this.gitStatus.getDisplayName());
     }
 
     @WithoutJenkins
     @Test
     public void testGetIconFileName() {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         assertNull(this.gitStatus.getIconFileName());
     }
 
     @WithoutJenkins
     @Test
     public void testGetUrlName() {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         assertEquals("git", this.gitStatus.getUrlName());
     }
 
     @WithoutJenkins
     @Test
     public void testAllowNotifyCommitParametersDisabled() {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         assertFalse("SECURITY-275: ignore arbitrary notifyCommit parameters", GitStatus.ALLOW_NOTIFY_COMMIT_PARAMETERS);
     }
 
     @WithoutJenkins
     @Test
     public void testSafeParametersEmpty() {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         assertEquals("SECURITY-275: Safe notifyCommit parameters", "", GitStatus.SAFE_PARAMETERS);
     }
 
     @Test
     public void testDoNotifyCommitWithNoBranches() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         SCMTrigger aMasterTrigger = setupProjectWithTrigger("a", "master", false);
         SCMTrigger aTopicTrigger = setupProjectWithTrigger("a", "topic", false);
         SCMTrigger bMasterTrigger = setupProjectWithTrigger("b", "master", false);
@@ -162,6 +188,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithNoMatchingUrl() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         SCMTrigger aMasterTrigger = setupProjectWithTrigger("a", "master", false);
         SCMTrigger aTopicTrigger = setupProjectWithTrigger("a", "topic", false);
         SCMTrigger bMasterTrigger = setupProjectWithTrigger("b", "master", false);
@@ -178,6 +205,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithOneBranch() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         SCMTrigger aMasterTrigger = setupProjectWithTrigger("a", "master", false);
         SCMTrigger aTopicTrigger = setupProjectWithTrigger("a", "topic", false);
         SCMTrigger bMasterTrigger = setupProjectWithTrigger("b", "master", false);
@@ -194,6 +222,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithTwoBranches() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         SCMTrigger aMasterTrigger = setupProjectWithTrigger("a", "master", false);
         SCMTrigger aTopicTrigger = setupProjectWithTrigger("a", "topic", false);
         SCMTrigger aFeatureTrigger = setupProjectWithTrigger("a", "feature/def", false);
@@ -215,6 +244,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithNoMatchingBranches() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         SCMTrigger aMasterTrigger = setupProjectWithTrigger("a", "master", false);
         SCMTrigger aTopicTrigger = setupProjectWithTrigger("a", "topic", false);
         SCMTrigger bMasterTrigger = setupProjectWithTrigger("b", "master", false);
@@ -231,6 +261,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithSlashesInBranchNames() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         SCMTrigger aMasterTrigger = setupProjectWithTrigger("a", "master", false);
         SCMTrigger bMasterTrigger = setupProjectWithTrigger("b", "master", false);
 
@@ -245,6 +276,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithParametrizedBranch() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         SCMTrigger aMasterTrigger = setupProjectWithTrigger("a", "$BRANCH_TO_BUILD", false);
         SCMTrigger bMasterTrigger = setupProjectWithTrigger("b", "master", false);
         SCMTrigger bTopicTrigger = setupProjectWithTrigger("b", "topic", false);
@@ -259,6 +291,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithIgnoredRepository() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         SCMTrigger aMasterTrigger = setupProjectWithTrigger("a", "master", true);
 
         this.gitStatus.doNotifyCommit(requestWithNoParameter, "a", null, "", notifyCommitApiToken);
@@ -269,6 +302,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithNoScmTrigger() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         setupProject("a", "master", null);
         this.gitStatus.doNotifyCommit(requestWithNoParameter, "a", null, "", notifyCommitApiToken);
         // no expectation here, however we shouldn't have a build triggered, and no exception
@@ -278,11 +312,13 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithTwoBranchesAndAdditionalParameterAllowed() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         doNotifyCommitWithTwoBranchesAndAdditionalParameter(true, null);
     }
 
     @Test
     public void testDoNotifyCommitWithTwoBranchesAndAdditionalParameter() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         doNotifyCommitWithTwoBranchesAndAdditionalParameter(false, null);
     }
 
@@ -293,6 +329,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithTwoBranchesAndAdditionalUnsafeParameter() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         doNotifyCommitWithTwoBranchesAndAdditionalParameter(false, "does,not,include,param");
     }
 
@@ -365,6 +402,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitBranchWithRegex() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         SCMTrigger trigger = setupProjectWithTrigger("remote", ":[^/]*/awesome-feature", false);
         this.gitStatus.doNotifyCommit(requestWithNoParameter, "remote", "feature/awesome-feature", null, notifyCommitApiToken);
 
@@ -373,6 +411,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitBranchWithWildcard() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         SCMTrigger trigger = setupProjectWithTrigger("remote", "origin/feature/*", false);
         this.gitStatus.doNotifyCommit(requestWithNoParameter, "remote", "feature/awesome-feature", null, notifyCommitApiToken);
 
@@ -413,6 +452,7 @@ public class GitStatusTest extends AbstractGitProject {
     @WithoutJenkins
     @Test
     public void testLooselyMatches() throws URISyntaxException {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String[] equivalentRepoURLs = new String[]{
             "https://example.com/jenkinsci/git-plugin",
             "https://example.com/jenkinsci/git-plugin/",
@@ -484,6 +524,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommit() throws Exception { /* No parameters */
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         setupNotifyProject();
         this.gitStatus.doNotifyCommit(requestWithNoParameter, repoURL, branch, sha1, notifyCommitApiToken);
         assertEquals("URL: " + repoURL
@@ -493,21 +534,25 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithExtraParameterAllowed() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         doNotifyCommitWithExtraParameterAllowed(true, null);
     }
 
     @Test
     public void testDoNotifyCommitWithExtraParameter() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         doNotifyCommitWithExtraParameterAllowed(false, null);
     }
 
     @Test
     public void testDoNotifyCommitWithExtraSafeParameter() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         doNotifyCommitWithExtraParameterAllowed(false, "something,extra,is,here");
     }
 
     @Test
     public void testDoNotifyCommitWithExtraUnsafeParameter() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         doNotifyCommitWithExtraParameterAllowed(false, "something,is,not,here");
     }
 
@@ -538,6 +583,7 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithNullValueExtraParameter() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         setupNotifyProject();
         when(requestWithParameter.getParameterMap()).thenReturn(setupParameterMap(null));
         this.gitStatus.doNotifyCommit(requestWithParameter, repoURL, branch, sha1, notifyCommitApiToken);
@@ -548,27 +594,32 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     public void testDoNotifyCommitWithDefaultParameterAllowed() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         doNotifyCommitWithDefaultParameter(true, null);
     }
 
     @Test
     public void testDoNotifyCommitWithDefaultParameter() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         doNotifyCommitWithDefaultParameter(false, null);
     }
 
     @Test
     public void testDoNotifyCommitWithDefaultSafeParameter() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         doNotifyCommitWithDefaultParameter(false, "A,B,C,extra");
     }
 
     @Test
     public void testDoNotifyCommitWithDefaultUnsafeParameterC() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         doNotifyCommitWithDefaultParameter(false, "A,B,extra");
     }
 
     @Test
     public void testDoNotifyCommitWithDefaultUnsafeParameterExtra() throws Exception {
-        doNotifyCommitWithDefaultParameter(false, "A,B,C");
+         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+       doNotifyCommitWithDefaultParameter(false, "A,B,C");
     }
 
     private void doNotifyCommitWithDefaultParameter(final boolean allowed, String safeParameters) throws Exception {
@@ -642,6 +693,7 @@ public class GitStatusTest extends AbstractGitProject {
     @Test
     @Issue("JENKINS-46929")
     public void testDoNotifyCommitTriggeredHeadersLimited() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         SCMTrigger[] projectTriggers = new SCMTrigger[50];
         for (int i = 0; i < projectTriggers.length; i++) {
             projectTriggers[i] = setupProjectWithTrigger("a", "master", false);
@@ -667,6 +719,7 @@ public class GitStatusTest extends AbstractGitProject {
     @Test
     @Issue("SECURITY-2499")
     public void testDoNotifyCommitWithWrongSha1Content() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         setupProjectWithTrigger("a", "master", false);
 
         String content = "<img src=onerror=alert(1)>";
@@ -682,6 +735,7 @@ public class GitStatusTest extends AbstractGitProject {
     @Test
     @Issue("SECURITY-284")
     public void testDoNotifyCommitWithValidSha1AndValidApiToken() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         // when sha1 is provided build is scheduled right away instead of repo polling, so we do not check for trigger
         FreeStyleProject project = setupNotifyProject();
 
@@ -697,6 +751,7 @@ public class GitStatusTest extends AbstractGitProject {
     @Test
     @Issue("SECURITY-284")
     public void testDoNotifyCommitWithInvalidApiToken() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         setupProjectWithTrigger("a", "master", false);
         StaplerResponse res = mock(StaplerResponse.class);
 
@@ -709,6 +764,7 @@ public class GitStatusTest extends AbstractGitProject {
     @Test
     @Issue("SECURITY-284")
     public void testDoNotifyCommitWithUnauthenticatedPollingAllowed() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL = "disabled-for-polling";
         SCMTrigger trigger = setupProjectWithTrigger("a", "master", false);
 
@@ -720,6 +776,7 @@ public class GitStatusTest extends AbstractGitProject {
     @Test
     @Issue("SECURITY-284")
     public void testDoNotifyCommitWithAllowModeRandomValue() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL = "random";
         setupProjectWithTrigger("a", "master", false);
         StaplerResponse res = mock(StaplerResponse.class);
@@ -733,6 +790,7 @@ public class GitStatusTest extends AbstractGitProject {
     @Test
     @Issue("SECURITY-284")
     public void testDoNotifyCommitWithSha1AndAllowModePoll() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL = "disabled-for-polling";
         setupProjectWithTrigger("a", "master", false);
         StaplerResponse res = mock(StaplerResponse.class);
@@ -746,6 +804,7 @@ public class GitStatusTest extends AbstractGitProject {
     @Test
     @Issue("SECURITY-284")
     public void testDoNotifyCommitWithSha1AndAllowModePollWithInvalidToken() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL = "disabled-for-polling";
         setupProjectWithTrigger("a", "master", false);
         StaplerResponse res = mock(StaplerResponse.class);
@@ -759,6 +818,7 @@ public class GitStatusTest extends AbstractGitProject {
     @Test
     @Issue("SECURITY-284")
     public void testDoNotifyCommitWithAllowModeSha1() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL = "disabled";
         // when sha1 is provided build is scheduled right away instead of repo polling, so we do not check for trigger
         FreeStyleProject project = setupNotifyProject();

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -44,6 +44,7 @@ import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
@@ -61,8 +62,12 @@ import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.TestJGitAPIImpl;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Stopwatch;
+import org.junit.rules.TestName;
+import org.junit.runner.OrderWith;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.MockedStatic;
@@ -76,6 +81,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.atLeastOnce;
@@ -90,6 +96,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for {@link AbstractGitSCMSource}
  */
+@OrderWith(RandomOrder.class)
 public class AbstractGitSCMSourceTest {
 
     static final String GitBranchSCMHead_DEV_MASTER = "[GitBranchSCMHead{name='dev', ref='refs/heads/dev'}, GitBranchSCMHead{name='master', ref='refs/heads/master'}]";
@@ -102,11 +109,28 @@ public class AbstractGitSCMSourceTest {
     @Rule
     public GitSampleRepoRule sampleRepo2 = new GitSampleRepoRule();
 
+    @ClassRule
+    public static Stopwatch stopwatch = new Stopwatch();
+    @Rule
+    public TestName testName = new TestName();
+
+    private static final int MAX_SECONDS_FOR_THESE_TESTS = 210;
+
+    private boolean isTimeAvailable() {
+        String env = System.getenv("CI");
+        if (env == null || !Boolean.parseBoolean(env)) {
+            // Run all tests when not in CI environment
+            return true;
+        }
+        return stopwatch.runtime(SECONDS) <= MAX_SECONDS_FOR_THESE_TESTS;
+    }
+
     // TODO AbstractGitSCMSourceRetrieveHeadsTest *sounds* like it would be the right place, but it does not in fact retrieve any heads!
     @Issue("JENKINS-37482")
     @Test
     @Deprecated // Tests deprecated GitSCMSource constructor
     public void retrieveHeads() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.git("checkout", "-b", "dev");
         sampleRepo.write("file", "modified");
@@ -126,6 +150,7 @@ public class AbstractGitSCMSourceTest {
 
     @Test
     public void retrieveHeadsRequiresBranchDiscovery() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.git("checkout", "-b", "dev");
         sampleRepo.write("file", "modified");
@@ -148,6 +173,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-46207")
     @Test
     public void retrieveHeadsSupportsTagDiscovery_ignoreTagsWithoutTagDiscoveryTrait() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.git("checkout", "-b", "dev");
         sampleRepo.write("file", "modified");
@@ -176,6 +202,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-46207")
     @Test
     public void retrieveHeadsSupportsTagDiscovery_findTagsWithTagDiscoveryTrait() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.git("checkout", "-b", "dev");
         sampleRepo.write("file", "modified");
@@ -239,6 +266,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-46207")
     @Test
     public void retrieveHeadsSupportsTagDiscovery_onlyTagsWithoutBranchDiscoveryTrait() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.git("checkout", "-b", "dev");
         sampleRepo.write("file", "modified");
@@ -263,6 +291,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-45953")
     @Test
     public void retrieveRevisions() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.git("checkout", "-b", "dev");
         sampleRepo.write("file", "modified");
@@ -288,6 +317,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-64803")
     @Test
     public void retrieveTags_folderScopedCredentials() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.git("checkout", "-b", "dev");
         sampleRepo.write("file", "modified");
@@ -343,6 +373,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-47824")
     @Test
     public void retrieveByName() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         String masterHash = sampleRepo.head();
         sampleRepo.git("checkout", "-b", "dev");
@@ -438,12 +469,14 @@ public class AbstractGitSCMSourceTest {
     @Test
     @Deprecated
     public void retrievePrimaryHead_NotDuplicated() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         retrievePrimaryHead(false);
     }
 
     @Test
     @Deprecated
     public void retrievePrimaryHead_Duplicated() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         retrievePrimaryHead(true);
     }
 
@@ -519,6 +552,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-31155")
     @Test
     public void retrieveRevision() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=v1");
@@ -554,6 +588,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-48061")
     @Test
     public void retrieveRevision_nonHead() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=v1");
@@ -580,6 +615,7 @@ public class AbstractGitSCMSourceTest {
     @Test
     // @Ignore("At least file:// protocol doesn't allow fetching unannounced commits")
     public void retrieveRevision_nonAdvertised() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=v1");
@@ -608,6 +644,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-48061")
     @Test
     public void retrieveRevision_customRef() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=v1");
@@ -638,6 +675,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-48061")
     @Test
     public void retrieveRevision_customRef_descendant() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=v1");
@@ -673,6 +711,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-48061")
     @Test
     public void retrieveRevision_customRef_abbrev_sha1() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=v1");
@@ -703,6 +742,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-48061")
     @Test
     public void retrieveRevision_pr_refspec() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=v1");
@@ -730,6 +770,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-48061")
     @Test
     public void retrieveRevision_pr_local_refspec() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=v1");
@@ -771,6 +812,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-48061")
     @Test
     public void fetchOtherRef() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=v1");
@@ -806,6 +848,7 @@ public class AbstractGitSCMSourceTest {
     @Issue("JENKINS-48061")
     @Test
     public void fetchOtherRevisions() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=v1");
@@ -842,6 +885,7 @@ public class AbstractGitSCMSourceTest {
     @Test
     @Deprecated // Check GitSCMSource deprecated constructor
     public void pruneRemovesDeletedBranches() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
 
         /* Write a file to the master branch */
@@ -882,6 +926,7 @@ public class AbstractGitSCMSourceTest {
     @Test
     @Deprecated // Tests deprecated getExtensions() and setExtensions()
     public void testSpecificRevisionBuildChooser() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
 
         /* Write a file to the master branch */
@@ -942,6 +987,7 @@ public class AbstractGitSCMSourceTest {
     @Test
     @Deprecated // Tests deprecated GitSCMSource constructor
     public void testCustomRemoteName() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
 
         GitSCMSource source = new GitSCMSource(null, sampleRepo.toString(), "", "upstream", null, "*", "", true);
@@ -957,6 +1003,7 @@ public class AbstractGitSCMSourceTest {
     @Test
     @Deprecated // Tests deprecated GitSCMSource constructor
     public void testCustomRefSpecs() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
 
         GitSCMSource source = new GitSCMSource(null, sampleRepo.toString(), "", null, "+refs/heads/*:refs/remotes/origin/*          +refs/merge-requests/*/head:refs/remotes/origin/merge-requests/*", "*", "", true);
@@ -973,6 +1020,7 @@ public class AbstractGitSCMSourceTest {
 
     @Test
     public void refLockEncounteredIfPruneTraitNotPresentOnNotFoundRetrieval() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         TaskListener listener = StreamTaskListener.fromStderr();
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits((Collections.singletonList(new BranchDiscoveryTrait())));
@@ -985,6 +1033,7 @@ public class AbstractGitSCMSourceTest {
 
     @Test
     public void refLockEncounteredIfPruneTraitNotPresentOnTagRetrieval() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         TaskListener listener = StreamTaskListener.fromStderr();
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits((Collections.singletonList(new TagDiscoveryTrait())));
@@ -1002,6 +1051,7 @@ public class AbstractGitSCMSourceTest {
             /* Do not distract warnings system by using assumeThat to skip tests */
             return;
         }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         TaskListener listener = StreamTaskListener.fromStderr();
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits((Arrays.asList(new TagDiscoveryTrait(), new PruneStaleBranchTrait())));
@@ -1020,6 +1070,7 @@ public class AbstractGitSCMSourceTest {
             /* Do not distract warnings system by using assumeThat to skip tests */
             return;
         }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         TaskListener listener = StreamTaskListener.fromStderr();
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
         source.setTraits((Arrays.asList(new TagDiscoveryTrait(), new PruneStaleBranchTrait())));
@@ -1058,6 +1109,7 @@ public class AbstractGitSCMSourceTest {
 
     @Test @Issue("JENKINS-50394")
     public void when_commits_added_during_discovery_we_do_not_crash() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.git("checkout", "-b", "dev");
         sampleRepo.write("file", "modified");

--- a/src/test/java/jenkins/plugins/git/GitStepTest.java
+++ b/src/test/java/jenkins/plugins/git/GitStepTest.java
@@ -45,15 +45,22 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Stopwatch;
+import org.junit.rules.TestName;
+import org.junit.runner.OrderWith;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
+@OrderWith(RandomOrder.class)
 public class GitStepTest {
 
     @Rule
@@ -69,8 +76,25 @@ public class GitStepTest {
         gitCmd.setDefaults();
     }
 
+    @ClassRule
+    public static Stopwatch stopwatch = new Stopwatch();
+    @Rule
+    public TestName testName = new TestName();
+
+    private static final int MAX_SECONDS_FOR_THESE_TESTS = 200;
+
+    private boolean isTimeAvailable() {
+        String env = System.getenv("CI");
+        if (env == null || !Boolean.parseBoolean(env)) {
+            // Run all tests when not in CI environment
+            return true;
+        }
+        return stopwatch.runtime(SECONDS) <= MAX_SECONDS_FOR_THESE_TESTS;
+    }
+
     @Test
     public void roundtrip() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         GitStep step = new GitStep("git@github.com:jenkinsci/workflow-plugin.git");
         Step roundtrip = new StepConfigTester(r).configRoundTrip(step);
         r.assertEqualDataBoundBeans(step, roundtrip);
@@ -78,6 +102,7 @@ public class GitStepTest {
 
     @Test
     public void roundtrip_withcredentials() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         IdCredentials c = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, null, null, "user", "pass");
         CredentialsProvider.lookupStores(r.jenkins).iterator().next()
                 .addCredentials(Domain.global(), c);
@@ -89,6 +114,7 @@ public class GitStepTest {
 
     @Test
     public void basicCloneAndUpdate() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "demo");
         r.createOnlineSlave(Label.get("remote"));
@@ -112,6 +138,7 @@ public class GitStepTest {
 
     @Test
     public void changelogAndPolling() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "demo");
         p.addTrigger(new SCMTrigger("")); // no schedule, use notifyCommit only
@@ -148,6 +175,7 @@ public class GitStepTest {
 
     @Test
     public void multipleSCMs() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         otherRepo.init();
         otherRepo.write("otherfile", "");
@@ -212,6 +240,7 @@ public class GitStepTest {
     @Issue("JENKINS-29326")
     @Test
     public void identicalGitSCMs() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         otherRepo.init();
         otherRepo.write("firstfile", "");
@@ -246,6 +275,7 @@ public class GitStepTest {
 
     @Test
     public void commitToWorkspace() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -20,8 +20,12 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Stopwatch;
+import org.junit.rules.TestName;
+import org.junit.runner.OrderWith;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
@@ -34,15 +38,18 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.io.FileMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * The test aims to functionally validate "estimation of size" and "git implementation recommendation" from a
  * cached directory and from plugin extensions.
  */
+@OrderWith(RandomOrder.class)
 public class GitToolChooserTest {
 
     @Rule
@@ -75,6 +82,22 @@ public class GitToolChooserTest {
         GitToolChooser.clearRepositorySizeCache();
     }
 
+    @ClassRule
+    public static Stopwatch stopwatch = new Stopwatch();
+    @Rule
+    public TestName testName = new TestName();
+
+    private static final int MAX_SECONDS_FOR_THESE_TESTS = 150;
+
+    private boolean isTimeAvailable() {
+        String env = System.getenv("CI");
+        if (env == null || !Boolean.parseBoolean(env)) {
+            // Run all tests when not in CI environment
+            return true;
+        }
+        return stopwatch.runtime(SECONDS) <= MAX_SECONDS_FOR_THESE_TESTS;
+    }
+
     /*
     This test checks the GitToolChooser in a scenario where repo size>5M, user's choice is `jgit`.
     In the event of having no node-specific installations, GitToolChooser will choose to return the default installation.
@@ -82,6 +105,7 @@ public class GitToolChooserTest {
     @Issue("JENKINS-63519")
     @Test
     public void testResolveGitTool() throws IOException, InterruptedException {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://gitlab.com/rishabhBudhouliya/git-plugin.git";
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
@@ -108,6 +132,7 @@ public class GitToolChooserTest {
             /* Do not distract warnings system by using assumeThat to skip tests */
             return;
         }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://gitlab.com/rishabhBudhouliya/git-plugin.git";
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
@@ -138,6 +163,7 @@ public class GitToolChooserTest {
             /* Do not distract warnings system by using assumeThat to skip tests */
             return;
         }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://gitlab.com/rishabhBudhouliya/git-plugin.git";
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
@@ -177,6 +203,7 @@ public class GitToolChooserTest {
      */
     @Test
     public void testSizeEstimationWithNoGitCache() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         GitSCMSource instance = new GitSCMSource("https://github.com/rishabhBudhouliya/git-plugin.git");
 
@@ -207,6 +234,7 @@ public class GitToolChooserTest {
      */
     @Test
     public void testSizeEstimationWithGitCache() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
         sampleRepo.git("checkout", "-b", "dev");
         sampleRepo.write("file", "modified");
@@ -260,6 +288,7 @@ public class GitToolChooserTest {
     @Test
     @Issue("JENKINS-63539")
     public void testRemoteAlternatives() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         GitTool tool = new JGitTool(Collections.emptyList());
 
         GitToolChooser nullRemoteSizeEstimator = new GitToolChooser("git://example.com/git/git.git", null, null, tool, null, TaskListener.NULL, true);
@@ -302,6 +331,7 @@ public class GitToolChooserTest {
     /* Test conversion of any remote alternative of git repo URLs to a standard URL */
     @Test
     public void testConvertToCanonicalURL() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         GitTool tool = new JGitTool(Collections.emptyList());
 
         String[] remoteAlternatives = {
@@ -335,6 +365,7 @@ public class GitToolChooserTest {
      */
     @Test
     public void testSizeEstimationWithAPIForGit() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://gitlab.com/rishabhBudhouliya/git-plugin.git";
         sampleRepo.init();
         store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "github"));
@@ -357,6 +388,7 @@ public class GitToolChooserTest {
      */
     @Test
     public void testSizeEstimationWithAPIForJGit() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://github.com/rishabhBudhouliya/git-plugin.git";
         sampleRepo.init();
         store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "github"));
@@ -380,6 +412,7 @@ public class GitToolChooserTest {
      */
     @Test
     public void testSizeEstimationWithBitbucketAPIs() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://bitbucket.com/rishabhBudhouliya/git-plugin.git";
         sampleRepo.init();
         store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "github"));
@@ -401,6 +434,7 @@ public class GitToolChooserTest {
      */
     @Test
     public void testSizeEstimationWithException() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://bitbucket.com/rishabhBudhouliya/git-plugin.git";
         sampleRepo.init();
         store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "github"));
@@ -422,6 +456,7 @@ public class GitToolChooserTest {
      */
     @Test
     public void testSizeEstimationWithNoCredentials() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
 
         buildAProject(sampleRepo, true);
@@ -441,6 +476,7 @@ public class GitToolChooserTest {
      */
     @Test
     public void testGitToolChooserWithCustomGitTool() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://github.com/rishabhBudhouliya/git-plugin.git";
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
@@ -459,6 +495,7 @@ public class GitToolChooserTest {
 
     @Test
     public void testGitToolChooserWithBothGitAndJGit() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://github.com/rishabhBudhouliya/git-plugin.git";
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
@@ -477,6 +514,7 @@ public class GitToolChooserTest {
      */
     @Test
     public void testGitToolChooserWithAllTools() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://github.com/rishabhBudhouliya/git-plugin.git";
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
@@ -497,6 +535,7 @@ public class GitToolChooserTest {
      */
     @Test
     public void testGitToolChooserWithJGitApache() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://github.com/rishabhBudhouliya/git-plugin.git";
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
@@ -515,6 +554,7 @@ public class GitToolChooserTest {
      */
     @Test
     public void testGitToolChooserWithJGitApacheAndGit() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://github.com/rishabhBudhouliya/git-plugin.git";
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
@@ -533,6 +573,7 @@ public class GitToolChooserTest {
      */
     @Test
     public void testGitToolChooserWithDefaultTool() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://gitlab.com/rishabhBudhouliya/git-plugin.git";
         sampleRepo.init();
         store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "github"));
@@ -550,6 +591,7 @@ public class GitToolChooserTest {
 
     @Test
     public void testGitToolChooserWithOnlyJGit() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://gitlab.com/rishabhBudhouliya/git-plugin.git";
         sampleRepo.init();
         store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "github"));
@@ -572,6 +614,7 @@ public class GitToolChooserTest {
 
     @Test
     public void testGitToolChooserWithCustomGitTool_2() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://gitlab.com/rishabhBudhouliya/git-plugin.git";
         sampleRepo.init();
         store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "github"));
@@ -594,6 +637,7 @@ public class GitToolChooserTest {
 
     @Test
     public void testGitToolChooserWithAllTools_2() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         String remote = "https://gitlab.com/rishabhBudhouliya/git-plugin.git";
         sampleRepo.init();
         store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "github"));
@@ -619,6 +663,7 @@ public class GitToolChooserTest {
     @Test
     @Issue("JENKINS-63541")
     public void getCacheDirCreatesNoDirectory() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         // Generate a unique repository name and compute expected cache directory
         String remoteName = "https://github.com/jenkinsci/git-plugin-" + java.util.UUID.randomUUID() + ".git";
         String cacheEntry = AbstractGitSCMSource.getCacheEntry(remoteName);
@@ -642,6 +687,7 @@ public class GitToolChooserTest {
     @Test
     @Issue("JENKINS-63572")
     public void testSizeEstimationWithNoRemoteConfig() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         sampleRepo.init();
 
         failAProject(sampleRepo);

--- a/src/test/java/jenkins/plugins/git/RandomOrder.java
+++ b/src/test/java/jenkins/plugins/git/RandomOrder.java
@@ -1,0 +1,13 @@
+package jenkins.plugins.git;
+
+import org.junit.runner.manipulation.Ordering;
+
+import java.util.Random;
+
+public class RandomOrder implements Ordering.Factory {
+    private static final long SEED = new Random().nextLong();
+    @Override
+    public Ordering create(Ordering.Context context) {
+        return Ordering.shuffledBy(new Random(SEED));
+    }
+}


### PR DESCRIPTION
## Limit duration of longest tests

Limit test duration of the longest running tests.

Use JUnit assume to skip tests after time exceeded.  JUnit assume will flag the test skip as a warning in the Jenkins job.  That's a good thing in this case, since we want to know when tests are skipped due to excessive elapsed test time.

Run tests in random order so that parallel tests on ci.jenkins.io have a better chance of executing every test in at least one configuration.

Run all tests when not in CI so that developers see all results.  Developers are not limited by the 60 minute limit applied by `buildPlugin` and they usually have computers that are fast enough that the time limits are never reached on any of the tests.

Report duration limit in skip message.

- Do not stop parallel tests on first failure
- Remove low value GitStatusTest.testToString()
- Limit test duration of the longest running tests
- Remove test code for git before 1.8

Also removes test code for git before 1.8.  None of the supported operating systems provide command line git 1.7.  There is no reason to carry test code that checks a conditional that will never be true.

Do not stop parallel tests on first failure.  Tests on multiple configurations have good information to share even if one of the configurations fails.

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Tests
