### PR TITLE
[Draft] Create git as alternate symbol for GitSCM

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1640,7 +1640,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     }
 
     @Extension
-    @Symbol({"scmGit", "gitSCM"}) // Cannot use "git" because there is already a `git` pipeline step
+    @Symbol({"scmGit", "gitSCM", "git"}) // Cannot use "git" because there is already a `git` pipeline step
     public static final class DescriptorImpl extends SCMDescriptor<GitSCM> {
 
         private String gitExe;

--- a/src/test/java/hudson/plugins/git/CheckoutStepSnippetizerTest.java
+++ b/src/test/java/hudson/plugins/git/CheckoutStepSnippetizerTest.java
@@ -81,7 +81,7 @@ public class CheckoutStepSnippetizerTest {
                 + junkBranches
                 + junkExtensions
                 + "userRemoteConfigs: [[url: '" + url + "']])");
-        tester.assertParseStep(checkoutStep, "checkout scmGit("
+        tester.assertParseStep(checkoutStep, "checkout git("
                 + "branches: [[name: '**']], "
                 // Parses correctly with or without junkExtensions
                 + (random.nextBoolean() ? junkExtensions : "")


### PR DESCRIPTION
## [Draft] Create `git` as alternate symbol for `scmGit`

Seems to fail the test because the parser sees the occurence of `git` as a GitStep rather than a part of a checkout.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes (known failure)
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
