### PR TITLE
Reduce usage of third-party libraries

### DIFF
--- a/src/main/java/hudson/plugins/git/ApiTokenPropertyConfiguration.java
+++ b/src/main/java/hudson/plugins/git/ApiTokenPropertyConfiguration.java
@@ -10,7 +10,6 @@ import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
 import net.jcip.annotations.GuardedBy;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -107,7 +106,7 @@ public class ApiTokenPropertyConfiguration extends GlobalConfiguration implement
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         String apiTokenUuid = req.getParameter("apiTokenUuid");
-        if (StringUtils.isBlank(apiTokenUuid)) {
+        if (apiTokenUuid == null || apiTokenUuid.isBlank()) {
             return HttpResponses.errorWithoutStack(400, "API token UUID cannot be empty");
         }
 
@@ -124,7 +123,7 @@ public class ApiTokenPropertyConfiguration extends GlobalConfiguration implement
     }
 
     public boolean isValidApiToken(String plainApiToken) {
-        if (StringUtils.isBlank(plainApiToken)) {
+        if (plainApiToken == null || plainApiToken.isBlank()) {
             return false;
         }
 

--- a/src/main/java/hudson/plugins/git/BranchSpec.java
+++ b/src/main/java/hudson/plugins/git/BranchSpec.java
@@ -4,7 +4,6 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.Serializable;
@@ -237,7 +236,7 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
     }
 
     private String join(String repositoryName, String branchWithoutRefs) {
-        return StringUtils.join(Arrays.asList(repositoryName, branchWithoutRefs), "/");
+        return String.join("/", repositoryName, branchWithoutRefs);
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/GitBranchSpecifierColumn.java
+++ b/src/main/java/hudson/plugins/git/GitBranchSpecifierColumn.java
@@ -8,6 +8,7 @@ import hudson.views.ListViewColumnDescriptor;
 import java.util.ArrayList;
 import java.util.List;
 import jenkins.triggers.SCMTriggerItem;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -37,7 +38,7 @@ public class GitBranchSpecifierColumn extends ListViewColumn {
     }
 
     public String breakOutString(List<String> branches) {
-        return String.join(", ", branches);
+        return StringUtils.join(branches, ", ");
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/GitBranchSpecifierColumn.java
+++ b/src/main/java/hudson/plugins/git/GitBranchSpecifierColumn.java
@@ -8,7 +8,6 @@ import hudson.views.ListViewColumnDescriptor;
 import java.util.ArrayList;
 import java.util.List;
 import jenkins.triggers.SCMTriggerItem;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -38,7 +37,7 @@ public class GitBranchSpecifierColumn extends ListViewColumn {
     }
 
     public String breakOutString(List<String> branches) {
-        return StringUtils.join(branches, ", ");
+        return String.join(", ", branches);
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/GitChangeLogParser.java
+++ b/src/main/java/hudson/plugins/git/GitChangeLogParser.java
@@ -7,7 +7,6 @@ import org.jenkinsci.plugins.gitclient.CliGitAPIImpl;
 import org.jenkinsci.plugins.gitclient.GitClient;
 
 import org.apache.commons.io.LineIterator;
-import org.xml.sax.SAXException;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -81,7 +80,7 @@ public class GitChangeLogParser extends ChangeLogParser {
     }
 
     @Override public GitChangeSetList parse(Run build, RepositoryBrowser<?> browser, File changelogFile)
-        throws IOException, SAXException {
+        throws IOException {
         // Parse the log file into GitChangeSet items - each one is a commit
         try (Stream<String> lineStream = Files.lines(changelogFile.toPath(), StandardCharsets.UTF_8)) {
             return new GitChangeSetList(build, browser, parse(lineStream.iterator()));

--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -21,7 +21,6 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.plugins.gitclient.GitClient;
@@ -456,9 +455,11 @@ public class GitPublisher extends Recorder implements Serializable {
         }
 
         private FormValidation checkFieldNotEmpty(String value, String field) {
-            value = StringUtils.strip(value);
+            if (value != null) {
+                value = value.strip();
+            }
 
-            if (value == null || value.equals("")) {
+            if (value == null || value.isEmpty()) {
                 return FormValidation.error(Messages.GitPublisher_Check_Required(field));
             }
             return FormValidation.ok();

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -98,7 +98,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static hudson.init.InitMilestone.JOB_LOADED;
 import static hudson.init.InitMilestone.PLUGINS_STARTED;
 import hudson.plugins.git.browser.BitbucketWeb;
@@ -111,10 +110,6 @@ import hudson.util.LogTaskListener;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.apache.commons.collections.CollectionUtils.isEmpty;
-import static org.apache.commons.lang.StringUtils.isBlank;
-
 
 /**
  * Git SCM.
@@ -217,7 +212,12 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             List<GitSCMExtension> extensions) {
 
         // moved from createBranches
-        this.branches = isEmpty(branches) ? newArrayList(new BranchSpec("*/master")) : branches;
+        if (branches == null || branches.isEmpty()) {
+            this.branches = new ArrayList<>();
+            this.branches.add(new BranchSpec("*/master"));
+        } else {
+            this.branches = branches;
+        }
 
         this.userRemoteConfigs = userRemoteConfigs;
         updateFromUserData();
@@ -1832,7 +1832,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 String name = names[i];
                 name = name.replace(' ', '_');
 
-                if (isBlank(refs[i])) {
+                if (refs[i] == null || refs[i].isBlank()) {
                     refs[i] = "+refs/heads/*:refs/remotes/" + name + "/*";
                 }
 

--- a/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
+++ b/src/main/java/hudson/plugins/git/GitSCMBackwardCompatibility.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Set;
 
-import static org.apache.commons.lang.StringUtils.isNotBlank;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 /**
@@ -189,15 +188,15 @@ public abstract class GitSCMBackwardCompatibility extends SCM implements Seriali
 
     void readBackExtensionsFromLegacy() {
         try {
-            if (isNotBlank(excludedUsers)) {
+            if (excludedUsers != null && !excludedUsers.isBlank()) {
                 addIfMissing(new UserExclusion(excludedUsers));
                 excludedUsers = null;
             }
-            if (isNotBlank(excludedRegions) || isNotBlank(includedRegions)) {
+            if ((excludedRegions != null && !excludedRegions.isBlank()) || (includedRegions != null && !includedRegions.isBlank())) {
                 addIfMissing(new PathRestriction(includedRegions, excludedRegions));
                 excludedRegions = includedRegions = null;
             }
-            if (isNotBlank(relativeTargetDir)) {
+            if (relativeTargetDir != null && !relativeTargetDir.isBlank()) {
                 addIfMissing(new RelativeTargetDirectory(relativeTargetDir));
                 relativeTargetDir = null;
             }
@@ -208,7 +207,7 @@ public abstract class GitSCMBackwardCompatibility extends SCM implements Seriali
             if (disableSubmodules || recursiveSubmodules || trackingSubmodules) {
                 addIfMissing(new SubmoduleOption(disableSubmodules, recursiveSubmodules, trackingSubmodules, null, null, false));
             }
-            if (isNotBlank(gitConfigName) || isNotBlank(gitConfigEmail)) {
+            if ((gitConfigName != null && !gitConfigName.isBlank()) || (gitConfigEmail != null && !gitConfigEmail.isBlank())) {
                 addIfMissing(new UserIdentity(gitConfigName,gitConfigEmail));
                 gitConfigName = gitConfigEmail = null;
             }
@@ -236,7 +235,7 @@ public abstract class GitSCMBackwardCompatibility extends SCM implements Seriali
             if (ignoreNotifyCommit) {
                 addIfMissing(new IgnoreNotifyCommit());
             }
-            if (isNotBlank(scmName)) {
+            if (scmName != null && !scmName.isBlank()) {
                 addIfMissing(new ScmName(scmName));
             }
             if (localBranch!=null) {
@@ -245,7 +244,7 @@ public abstract class GitSCMBackwardCompatibility extends SCM implements Seriali
             if (buildChooser!=null && buildChooser.getClass()!=DefaultBuildChooser.class) {
                 addIfMissing(new BuildChooserSetting(buildChooser));
             }
-            if (isNotBlank(reference) || useShallowClone) {
+            if ((reference != null && !reference.isBlank()) || useShallowClone) {
                 addIfMissing(new CloneOption(useShallowClone, reference,null));
             }
         } catch (IOException e) {

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -35,8 +35,8 @@ import org.kohsuke.stapler.export.ExportedBean;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.regex.Pattern;
+import java.util.Objects;
 import java.util.UUID;
-import org.apache.commons.lang.StringUtils;
 
 import static hudson.Util.fixEmpty;
 import static hudson.Util.fixEmptyAndTrim;
@@ -154,7 +154,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
                                     : ACL.SYSTEM,
                             GitURIRequirementsBuilder.fromUri(url).build(),
                             GitClient.CREDENTIALS_MATCHER)) {
-                if (StringUtils.equals(value, o.value)) {
+                if (Objects.equals(value, o.value)) {
                     // TODO check if this type of credential is acceptable to the Git client or does it merit warning
                     // NOTE: we would need to actually lookup the credential to do the check, which may require
                     // fetching the actual credential instance from a remote credentials store. Perhaps this is

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -25,8 +25,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
-
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSet> {
@@ -102,7 +100,7 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
      */
     @CheckForNull
     public URL getChangeSetLink(final String commitId) throws IOException {
-        if (!StringUtils.isBlank(commitId)) {
+        if (commitId != null && !commitId.isBlank()) {
             return getChangeSetLink(new CommitChangeSet(commitId));
         }
         return null;

--- a/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
@@ -10,7 +10,6 @@ import hudson.scm.RepositoryBrowser;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
@@ -57,7 +56,7 @@ public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
     /*default*/ URL getRepoUrl(GitChangeSet changeSet) throws IOException { // default visibility for tests
         String result = getRepoUrl();
         
-        if (StringUtils.isBlank(result))
+        if (result == null || result.isBlank())
             return normalizeToEndWithSlash(getUrlFromFirstConfiguredRepository(changeSet));
 
         else if (!result.contains("/"))

--- a/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
@@ -9,7 +9,6 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.plugins.git.util.BuildData;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -61,7 +60,10 @@ public class PathRestriction extends GitSCMExtension {
     }
 
     private String[] normalize(String s) {
-        return StringUtils.isBlank(s) ? null : s.split("[\\r\\n]+");
+        if (s == null || s.isBlank()) {
+            return null;
+        }
+        return s.split("[\\r\\n]+");
     }
 
     private List<Pattern> getIncludedPatterns() {

--- a/src/main/java/hudson/plugins/git/util/AncestryBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/AncestryBuildChooser.java
@@ -8,6 +8,7 @@ import hudson.plugins.git.Revision;
 import hudson.remoting.VirtualChannel;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -140,7 +141,7 @@ public class AncestryBuildChooser extends DefaultBuildChooser {
 
             // wrap IOException so it can propagate
             } catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new UncheckedIOException(e);
             }
         }
         

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -1135,7 +1135,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                 target = target.substring(Constants.R_HEADS.length());
             }
             List<Action> result = new ArrayList<>();
-            if (StringUtils.isNotBlank(target)) {
+            if (target != null && !target.isBlank()) {
                 result.add(new GitRemoteHeadRefAction(getRemote(), target));
             }
             return result;
@@ -1158,7 +1158,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                 target = target.substring(Constants.R_HEADS.length());
             }
             List<Action> result = new ArrayList<>();
-            if (StringUtils.isNotBlank(target)) {
+            if (target != null && !target.isBlank()) {
                 result.add(new GitRemoteHeadRefAction(getRemote(), target));
             }
             return result;
@@ -1187,7 +1187,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                     target = target.substring(Constants.R_HEADS.length());
                 }
                 List<Action> result = new ArrayList<>();
-                if (StringUtils.isNotBlank(target)) {
+                if (target != null && !target.isBlank()) {
                     result.add(new GitRemoteHeadRefAction(getRemote(), target));
                 }
                 return result;

--- a/src/main/java/jenkins/plugins/git/GitHooksConfiguration.java
+++ b/src/main/java/jenkins/plugins/git/GitHooksConfiguration.java
@@ -31,7 +31,6 @@ import hudson.model.PersistentDescriptor;
 import hudson.remoting.Channel;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.jenkinsci.Symbol;
@@ -124,7 +123,7 @@ public class GitHooksConfiguration extends GlobalConfiguration implements Persis
     private static void unset(final Repository repo) throws IOException {
         final StoredConfig repoConfig = repo.getConfig();
         final String val = repoConfig.getString("core", null, "hooksPath");
-        if (!StringUtils.isEmpty(val) && !(DISABLED_NIX.equals(val) || DISABLED_WIN.equals(val))) {
+        if (val != null && !val.isEmpty() && !DISABLED_NIX.equals(val) && !DISABLED_WIN.equals(val)) {
             LOGGER.warning(() -> String.format("core.hooksPath explicitly set to %s and will be left intact on %s.", val, repo.getDirectory()));
         } else {
             repoConfig.unset("core", null, "hooksPath");

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -57,6 +57,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -91,7 +92,6 @@ import jenkins.scm.impl.form.NamedArrayList;
 import jenkins.scm.impl.trait.Discovery;
 import jenkins.scm.impl.trait.Selection;
 import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.Symbol;
@@ -179,7 +179,7 @@ public class GitSCMSource extends AbstractGitSCMSource {
         if (!DEFAULT_INCLUDES.equals(includes) || !DEFAULT_EXCLUDES.equals(excludes)) {
             traits.add(new WildcardSCMHeadFilterTrait(includes, excludes));
         }
-        if (!DEFAULT_REMOTE_NAME.equals(remoteName) && StringUtils.isNotBlank(remoteName)) {
+        if (remoteName != null && !remoteName.isBlank() && !DEFAULT_REMOTE_NAME.equals(remoteName)) {
             traits.add(new RemoteNameSCMSourceTrait(remoteName));
         }
         if (ignoreOnPushNotifications) {
@@ -231,10 +231,10 @@ public class GitSCMSource extends AbstractGitSCMSource {
                     }
                 }
             }
-            if (remoteName != null && !DEFAULT_REMOTE_NAME.equals(remoteName) && StringUtils.isNotBlank(remoteName)) {
+            if (remoteName != null && !remoteName.isBlank() && !DEFAULT_REMOTE_NAME.equals(remoteName)) {
                 traits.add(new RemoteNameSCMSourceTrait(remoteName));
             }
-            if (StringUtils.isNotBlank(gitTool)) {
+            if (gitTool != null && !gitTool.isBlank()) {
                 traits.add(new GitToolSCMSourceTrait(gitTool));
             }
             if (browser != null) {
@@ -262,7 +262,7 @@ public class GitSCMSource extends AbstractGitSCMSource {
             if (!defaults.contains(rawRefSpecs.trim())) {
                 List<String> templates = new ArrayList<>();
                 for (String rawRefSpec : rawRefSpecs.split(" ")) {
-                    if (StringUtils.isBlank(rawRefSpec)) {
+                    if (rawRefSpec == null || rawRefSpec.isBlank()) {
                         continue;
                     }
                     if (defaults.contains(rawRefSpec)) {
@@ -459,7 +459,7 @@ public class GitSCMSource extends AbstractGitSCMSource {
                             : ACL.SYSTEM,
                     URIRequirementBuilder.fromUri(remote).build(),
                     GitClient.CREDENTIALS_MATCHER)) {
-                if (StringUtils.equals(value, o.value)) {
+                if (Objects.equals(value, o.value)) {
                     // TODO check if this type of credential is acceptable to the Git client or does it merit warning
                     // NOTE: we would need to actually lookup the credential to do the check, which may require
                     // fetching the actual credential instance from a remote credentials store. Perhaps this is

--- a/src/main/java/jenkins/plugins/git/MergeWithGitSCMExtension.java
+++ b/src/main/java/jenkins/plugins/git/MergeWithGitSCMExtension.java
@@ -35,7 +35,6 @@ import hudson.plugins.git.extensions.impl.PreBuildMerge;
 import hudson.plugins.git.util.MergeRecord;
 import java.io.IOException;
 import jenkins.scm.api.SCMSource;
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.gitclient.CheckoutCommand;
@@ -94,7 +93,7 @@ public class MergeWithGitSCMExtension extends GitSCMExtension {
                                             Revision marked, Revision rev)
             throws IOException, InterruptedException, GitException {
         ObjectId baseObjectId;
-        if (StringUtils.isBlank(baseHash)) {
+        if (baseHash == null || baseHash.isBlank()) {
             try {
                 baseObjectId = git.revParse(Constants.R_REFS + baseName);
             } catch (GitException e) {

--- a/src/main/java/jenkins/plugins/git/traits/DiscoverOtherRefsTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/DiscoverOtherRefsTrait.java
@@ -49,7 +49,7 @@ public class DiscoverOtherRefsTrait extends SCMSourceTrait {
 
     @DataBoundConstructor
     public DiscoverOtherRefsTrait(String ref) {
-        if (StringUtils.isEmpty(ref)) {
+        if (ref == null || ref.isEmpty()) {
             throw new IllegalArgumentException("ref can not be empty");
         }
         this.ref = StringUtils.removeStart(StringUtils.removeStart(ref, Constants.R_REFS), "/");
@@ -76,7 +76,7 @@ public class DiscoverOtherRefsTrait extends SCMSourceTrait {
 
     @DataBoundSetter
     public void setNameMapping(String nameMapping) {
-        if (StringUtils.isEmpty(nameMapping)) {
+        if (nameMapping == null || nameMapping.isEmpty()) {
             setDefaultNameMapping();
         } else {
             this.nameMapping = nameMapping;
@@ -92,7 +92,7 @@ public class DiscoverOtherRefsTrait extends SCMSourceTrait {
                 break;
             }
         }
-        if (StringUtils.isEmpty(this.nameMapping)) {
+        if (this.nameMapping == null || this.nameMapping.isEmpty()) {
             if (ref.contains("*")) {
                 this.nameMapping = "other-@{1}";
             } else {

--- a/src/main/java/jenkins/plugins/git/traits/RefSpecsSCMSourceTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/RefSpecsSCMSourceTrait.java
@@ -44,7 +44,6 @@ import jenkins.scm.api.trait.SCMBuilder;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.transport.RefSpec;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -201,7 +200,7 @@ public class RefSpecsSCMSourceTrait extends SCMSourceTrait {
          */
         @DataBoundConstructor
         public RefSpecTemplate(@NonNull String value) {
-            this.value = StringUtils.trim(value);
+            this.value = value == null ? null : value.trim();
         }
 
         /**
@@ -230,10 +229,10 @@ public class RefSpecsSCMSourceTrait extends SCMSourceTrait {
              */
             @Restricted(NoExternalUse.class) // stapler
             public FormValidation doCheckValue(@QueryParameter String value) {
-                if (StringUtils.isBlank(value)) {
+                if (value == null || value.isBlank()) {
                     return FormValidation.error("No ref spec provided");
                 }
-                value = StringUtils.trim(value);
+                value = value.trim();
                 try {
                     String spec = value.replaceAll(AbstractGitSCMSource.REF_SPEC_REMOTE_NAME_PLACEHOLDER, "origin");
                     if (spec.contains("@{")) {

--- a/src/main/java/jenkins/plugins/git/traits/RemoteNameSCMSourceTrait.java
+++ b/src/main/java/jenkins/plugins/git/traits/RemoteNameSCMSourceTrait.java
@@ -223,7 +223,7 @@ public class RemoteNameSCMSourceTrait extends SCMSourceTrait {
         @Restricted(NoExternalUse.class) // stapler
         public FormValidation doCheckRemoteName(@QueryParameter String value) {
             value = StringUtils.trimToEmpty(value);
-            if (StringUtils.isBlank(value)) {
+            if (value == null || value.isBlank()) {
                 return FormValidation.error("You must specify a remote name");
             }
             if (AbstractGitSCMSource.DEFAULT_REMOTE_NAME.equals(value)) {


### PR DESCRIPTION
This PR reduces usage of third-party libraries as much as possible in favor of Java Platform equivalents. While there is nothing wrong with third-party libraries like Apache Commons Lang, most of its functionality is available in the Java Platform now, like `String#strip`, `String#isBlank`, `String#join`, etc.

Unlike Apache Commons Lang, the Java Platform forces you to think about null, which I personally think is a good thing. Some people might find the constant null checks tedious, but I think it is a good thing to be confronted with them. Many of them are actually unnecessary, which will be more obvious if they aren't buried in a library.

I realize that this change is quite subjective, so if the maintainer's preferences are different than my own, please close this PR. I won't be offended in any way, since I naturally expect different people to have different preferences.