### PR TITLE
Skip 2 tests if prune on fetch is enabled globally

### DIFF
--- a/src/test/java/jenkins/plugins/git/CliGitCommand.java
+++ b/src/test/java/jenkins/plugins/git/CliGitCommand.java
@@ -80,10 +80,14 @@ public class CliGitCommand {
         }
     }
 
-    public String[] run(String... arguments) throws IOException, InterruptedException {
+    public String[] run(boolean checkForErrors, String... arguments) throws IOException, InterruptedException {
         args = new ArgumentListBuilder("git");
         args.add(arguments);
-        return run(true);
+        return run(checkForErrors);
+    }
+
+    public String[] run(String... arguments) throws IOException, InterruptedException {
+        return run(true, arguments);
     }
 
     public String[] run() throws IOException, InterruptedException {
@@ -118,14 +122,9 @@ public class CliGitCommand {
         }
     }
 
-    private String[] runWithoutAssert(String... arguments) throws IOException, InterruptedException {
-        args = new ArgumentListBuilder("git");
-        args.add(arguments);
-        return run(false);
-    }
-
     private void setConfigIfEmpty(String configName, String value) throws Exception {
-        String[] cmdOutput = runWithoutAssert("config", "--global", configName);
+        boolean checkForErrors = false;
+        String[] cmdOutput = run(checkForErrors, "config", "--global", configName);
         if (cmdOutput == null || cmdOutput[0].isEmpty() || cmdOutput[0].equals("[]")) {
             /* Set config value globally */
             cmdOutput = run("config", "--global", configName, value);


### PR DESCRIPTION
## Skip 2 tests if prune on fetch is enabled globally

Command line git won't throw expected exception if it is pruning deleted references during the fetch operation.

Also extends the CliGitCommand class in the tests for easier use.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Test
