### PR TITLE
Rely on artifact caching proxy default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,13 +6,9 @@ buildPlugin(
   useContainerAgent: true,
   // Do not stop parallel tests on first failure
   failFast: false,
-  // Opt-in to the Artifact Caching Proxy, to be removed when it will be opt-out.
-  // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
-  artifactCachingProxyEnabled: true,
   // Test Java 11 with a recent LTS, Java 17 even more recent
   configurations: [
     [platform: 'linux',   jdk: '11'], // Linux first for coverage report on ci.jenkins.io
-    [platform: 'linux',   jdk: '17', jenkins: '2.375.2'],
-    [platform: 'windows', jdk: '17', jenkins: '2.387']
+    [platform: 'windows', jdk: '17', jenkins: '2.389']
   ]
 )


### PR DESCRIPTION
## Rely on artifact caching proxy default

Artifact caching proxy is now enabled by default.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
