### PR TITLE
[JENKINS-70725] Add CasC backwards compatibility test

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSCMJCasCBackwardsCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMJCasCBackwardsCompatibilityTest.java
@@ -1,0 +1,33 @@
+package jenkins.plugins.git;
+
+import hudson.plugins.git.GitSCM;
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GitSCMJCasCBackwardsCompatibilityTest extends RoundTripAbstractTest {
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+        GitSCM.DescriptorImpl gitSCM = (GitSCM.DescriptorImpl) restartableJenkinsRule.j.jenkins.getScm(GitSCM.class.getSimpleName());
+        assertTrue("Add git tag action setting not honored", gitSCM.isAddGitTagAction());
+        assertTrue("Allow second fetch setting not honored", gitSCM.isAllowSecondFetch());
+        assertTrue("Use existing account setting not honored", gitSCM.isUseExistingAccountWithSameEmail());
+        assertEquals("test@example.com", gitSCM.getGlobalConfigEmail());
+        assertEquals("test_user", gitSCM.getGlobalConfigName());
+        assertTrue("Hide credentials setting not honored", gitSCM.isHideCredentials());
+        assertTrue("Show entire commit summary setting not honored", gitSCM.isShowEntireCommitSummaryInChanges());
+        assertTrue("Create account based on email setting not honored", gitSCM.isCreateAccountBasedOnEmail());
+    }
+
+    @Override
+    protected String stringInLogExpected() {
+        return "globalConfigName = test_user";
+    }
+
+    @Override
+    protected String configResource() {
+        return "gitscm-backwards-compatibility.yaml";
+    }
+}

--- a/src/test/resources/jenkins/plugins/git/gitscm-backwards-compatibility.yaml
+++ b/src/test/resources/jenkins/plugins/git/gitscm-backwards-compatibility.yaml
@@ -1,0 +1,22 @@
+security:
+  gitHooks:
+    allowedOnAgents: true
+    allowedOnController: true
+  gitHostKeyVerificationConfiguration:
+    sshHostKeyVerificationStrategy: "acceptFirstConnectionStrategy"
+unclassified:
+  gitSCM:
+    addGitTagAction: true
+    allowSecondFetch: true
+    createAccountBasedOnEmail: true
+    disableGitToolChooser: true
+    globalConfigEmail: "test@example.com"
+    globalConfigName: "test_user"
+    hideCredentials: true
+    showEntireCommitSummaryInChanges: true
+    useExistingAccountWithSameEmail: true
+tool:
+  git:
+    installations:
+    - home: "git"
+      name: "Default"


### PR DESCRIPTION
## [JENKINS-70725](https://issues.jenkins.io/browse/JENKINS-70725) - Add CasC backwards compatibility test

WIP: this is a testcase for https://issues.jenkins.io/browse/JENKINS-70725 which sucessfully fails when I run it with:

```
mvn test -Dtest="GitSCMJCasCBackwardsCompatibilityTest"
```

with the error:

```
   8.666 [id=103]       WARNING o.e.j.s.h.ContextHandler$Context#log: Error while serving http://localhost:35887/jenkins/configuration-as-code/checkNewSource
java.lang.NullPointerException
        at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$collectProblems$0(ConfigurationAsCode.java:262)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1764)
...
  8.668 [id=103]       WARNING h.i.i.InstallUncaughtExceptionHandler#handleException: Caught unhandled exception with ID 5e5f4f53-7349-409a-8c71-e155756978cd
java.lang.NullPointerException
        at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$collectProblems$0(ConfigurationAsCode.java:262)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1764)
...
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 10.493 s <<< FAILURE! - in jenkins.plugins.git.GitSCMJCasCBackwardsCompatibilityTest
[ERROR] jenkins.plugins.git.GitSCMJCasCBackwardsCompatibilityTest.roundTripTest  Time elapsed: 10.48 s  <<< FAILURE!
java.lang.AssertionError: Failed to POST to http://localhost:35887/jenkins/configuration-as-code/checkNewSource?Jenkins-Crumb=test expected:<200> but was:<500>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
```

Still more work to do to ensure I can get the test to pass after adding the previous `@Symbol`.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [ ] Dependency or infrastructure update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
