### PR TITLE
Check the browser in a configRoundtrip

### DIFF
--- a/src/test/java/hudson/plugins/git/GitSCMSlowTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMSlowTest.java
@@ -155,10 +155,11 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
         assertTrue(scm.getExtensions().toList().contains(localBranchExtension));
 
         /* Save the configuration */
-        rule.configRoundtrip(p);
+        p = rule.configRoundtrip(p);
         List<GitSCMExtension> extensions = scm.getExtensions().toList();
         assertTrue(extensions.contains(localBranchExtension));
         assertEquals("Wrong extension count before reload", 1, extensions.size());
+        rule.assertEqualDataBoundBeans(browser, p.getScm().getBrowser());
 
         /* Reload configuration from disc */
         p.doReload();
@@ -167,6 +168,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
         assertEquals("Wrong extension count after reload", 1, reloadedExtensions.size());
         LocalBranch reloadedLocalBranch = (LocalBranch) reloadedExtensions.get(0);
         assertEquals(localBranchExtension.getLocalBranch(), reloadedLocalBranch.getLocalBranch());
+        rule.assertEqualDataBoundBeans(browser, reloadedGit.getBrowser());
     }
 
     /*


### PR DESCRIPTION
## Check the browser in a configRoundtrip

As discussed in https://github.com/jenkinsci/acceptance-test-harness/pull/1108
## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [X] I have referenced the Jira issue related to my changes in one or more commit messages
- [X] I have added tests that verify my changes
- [X] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Test
