### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitTagAction/update-row.js
+++ b/src/main/resources/hudson/plugins/git/GitTagAction/update-row.js
@@ -1,6 +1,6 @@
 function updateRow(e, i) {
     e.parentNode.parentNode.style.color = e.checked ? "inherit" : "grey";
-    $("name"+i).disabled = !e.checked;
+    document.getElementById("name"+i).disabled = !e.checked;
 }
 
 // Adding an onchange listener to the tag checkboxes in UI


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I installed this plugin on a custom build of Jenkins that had Prototype ripped out (a local project branch), went to the Security page and generated a Git plugin `notifyCommit` access token while stepping through the changed lines in the JavaScript debugger. I verified that all the changed lines were executed correctly.