### PR TITLE
Enable SCMTriggerTests

### DIFF
--- a/src/test/java/hudson/plugins/git/SCMTriggerTest.java
+++ b/src/test/java/hudson/plugins/git/SCMTriggerTest.java
@@ -208,33 +208,6 @@ public abstract class SCMTriggerTest extends AbstractGitProject
             "detached");
     }
 
-    @Issue("JENKINS-29796")
-    // @Test
-    public void testMultipleRefspecs() throws Exception {
-        final String remote = prepareRepo(namespaceRepoZip);
-        final UserRemoteConfig remoteConfig = new UserRemoteConfig(remote, "origin",
-                "+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*", null);
-        // First, build the master branch
-        String branchSpec = "refs/heads/master";
-        FreeStyleProject project = setupProject(Collections.singletonList(remoteConfig),
-                Collections.singletonList(new BranchSpec(branchSpec)),
-                //empty scmTriggerSpec, SCMTrigger triggered manually
-                "", isDisableRemotePoll(), getGitClient());
-        triggerSCMTrigger(project.getTrigger(SCMTrigger.class));
-        FreeStyleBuild build1 = waitForBuildFinished(project, 1, 60000);
-        assertNotNull("Job has not been triggered", build1);
-
-        // Now switch request a different branch
-        GitSCM scm = (GitSCM) project.getScm();
-        scm.getBranches().set(0,new BranchSpec("b_namespace3/master"));
-        TaskListener listener = StreamTaskListener.fromStderr();
-
-        // Since the new branch has an additional commit, polling should report changes. Without the fix for
-        // JENKINS-29796, this assertion fails.
-        PollingResult poll = project.poll(listener);
-        assertTrue("Expected and actual polling results disagree", poll.hasChanges());
-    }
-
     public void check(ZipFile repoZip, Properties commits, String branchSpec,
             String expected_GIT_COMMIT, String expected_GIT_BRANCH) throws Exception {
         String remote = prepareRepo(repoZip);

--- a/src/test/java/hudson/plugins/git/SCMTriggerTest.java
+++ b/src/test/java/hudson/plugins/git/SCMTriggerTest.java
@@ -1,15 +1,17 @@
 package hudson.plugins.git;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.TaskListener;
 import hudson.plugins.git.extensions.impl.EnforceGitClient;
 import hudson.scm.PollingResult;
 import hudson.triggers.SCMTrigger;
 import hudson.util.RunList;
-import hudson.model.TaskListener;
 import hudson.util.StreamTaskListener;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,20 +28,35 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-
-import static org.junit.Assert.*;
+import jenkins.plugins.git.RandomOrder;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Stopwatch;
 import org.junit.rules.TemporaryFolder;
-import org.jvnet.hudson.test.Issue;
+import org.junit.runner.OrderWith;
 
-public abstract class SCMTriggerTest extends AbstractGitProject
-{
+@OrderWith(RandomOrder.class)
+public abstract class SCMTriggerTest extends AbstractGitProject {
     private ZipFile namespaceRepoZip;
     private Properties namespaceRepoCommits;
     private ExecutorService singleThreadExecutor;
     protected boolean expectChanges = false;
+
+    @ClassRule
+    public static Stopwatch stopwatch = new Stopwatch();
+
+    private static final int MAX_SECONDS_FOR_THESE_TESTS = 1801;
+
+    private boolean isTimeAvailable() {
+        String env = System.getenv("CI");
+        if (env == null || !Boolean.parseBoolean(env)) {
+            // Run all tests when not in CI environment
+            return true;
+        }
+        return stopwatch.runtime(SECONDS) <= MAX_SECONDS_FOR_THESE_TESTS;
+    }
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -51,192 +68,317 @@ public abstract class SCMTriggerTest extends AbstractGitProject
         namespaceRepoCommits = parseLsRemote(new File("src/test/resources/namespaceBranchRepo.ls-remote"));
         singleThreadExecutor = Executors.newSingleThreadExecutor();
     }
-    
+
     protected abstract EnforceGitClient getGitClient();
-    
+
     protected abstract boolean isDisableRemotePoll();
 
     @Test
     public void testNamespaces_with_refsHeadsMaster() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            "refs/heads/master",
-            namespaceRepoCommits.getProperty("refs/heads/master"),
-            "origin/master");
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                "refs/heads/master",
+                namespaceRepoCommits.getProperty("refs/heads/master"),
+                "origin/master");
     }
 
-    // @Test
+    @Test
     public void testNamespaces_with_remotesOriginMaster() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            "remotes/origin/master", 
-            namespaceRepoCommits.getProperty("refs/heads/master"),
-            "origin/master");
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                "remotes/origin/master",
+                namespaceRepoCommits.getProperty("refs/heads/master"),
+                "origin/master");
     }
 
-    // @Test
+    @Test
     public void testNamespaces_with_refsRemotesOriginMaster() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            "refs/remotes/origin/master", 
-            namespaceRepoCommits.getProperty("refs/heads/master"),
-            "origin/master");
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                "refs/remotes/origin/master",
+                namespaceRepoCommits.getProperty("refs/heads/master"),
+                "origin/master");
     }
 
-    // @Test
+    @Test
     public void testNamespaces_with_master() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            "master",
-            namespaceRepoCommits.getProperty("refs/heads/master"),
-            "origin/master");
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                "master",
+                namespaceRepoCommits.getProperty("refs/heads/master"),
+                "origin/master");
     }
 
-    // @Test
+    @Test
     public void testNamespaces_with_namespace1Master() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            "a_tests/b_namespace1/master",
-            namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace1/master"),
-            "origin/a_tests/b_namespace1/master");
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                "a_tests/b_namespace1/master",
+                namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace1/master"),
+                "origin/a_tests/b_namespace1/master");
     }
 
-    // @Test
+    @Test
     public void testNamespaces_with_refsHeadsNamespace1Master() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            "refs/heads/a_tests/b_namespace1/master", 
-            namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace1/master"),
-            "origin/a_tests/b_namespace1/master");
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                "refs/heads/a_tests/b_namespace1/master",
+                namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace1/master"),
+                "origin/a_tests/b_namespace1/master");
     }
 
-    // @Test
+    @Test
     public void testNamespaces_with_namespace2Master() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            "a_tests/b_namespace2/master",
-            namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace2/master"),
-            "origin/a_tests/b_namespace2/master");
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                "a_tests/b_namespace2/master",
+                namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace2/master"),
+                "origin/a_tests/b_namespace2/master");
     }
 
-    // @Test
+    @Test
     public void testNamespaces_with_refsHeadsNamespace2Master() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            "refs/heads/a_tests/b_namespace2/master", 
-            namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace2/master"),
-            "origin/a_tests/b_namespace2/master");
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                "refs/heads/a_tests/b_namespace2/master",
+                namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace2/master"),
+                "origin/a_tests/b_namespace2/master");
     }
 
-    // @Test
+    @Test
     public void testNamespaces_with_namespace3_feature3_sha1() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
                 namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace3/feature3"),
                 namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace3/feature3"),
                 "detached");
     }
 
-    // @Test
+    @Test
     public void testNamespaces_with_namespace3_feature3_branchName() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
                 "a_tests/b_namespace3/feature3",
                 namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace3/feature3"),
                 "origin/a_tests/b_namespace3/feature3");
     }
 
-    // @Test
+    @Test
     public void testNamespaces_with_refsHeadsNamespace3_feature3_sha1() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
                 namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace3/feature3"),
                 namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace3/feature3"),
                 "detached");
     }
 
-    // @Test
+    @Test
     public void testNamespaces_with_refsHeadsNamespace3_feature3_branchName() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
                 "refs/heads/a_tests/b_namespace3/feature3",
                 namespaceRepoCommits.getProperty("refs/heads/a_tests/b_namespace3/feature3"),
                 "origin/a_tests/b_namespace3/feature3");
     }
 
-    // @Test
+    @Test
     public void testTags_with_TagA() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            "TagA",
-            namespaceRepoCommits.getProperty("refs/tags/TagA"),
-            "TagA"); //TODO: What do we expect!?
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                "TagA",
+                namespaceRepoCommits.getProperty("refs/tags/TagA"),
+                "TagA"); // TODO: What do we expect!?
     }
 
-    // @Test
+    @Test
     public void testTags_with_TagBAnnotated() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            "TagBAnnotated", 
-            namespaceRepoCommits.getProperty("refs/tags/TagBAnnotated^{}"),
-            "TagBAnnotated"); //TODO: What do we expect!?
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                "TagBAnnotated",
+                namespaceRepoCommits.getProperty("refs/tags/TagBAnnotated^{}"),
+                "TagBAnnotated"); // TODO: What do we expect!?
     }
 
-    // @Test
+    @Test
     public void testTags_with_refsTagsTagA() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            "refs/tags/TagA",
-            namespaceRepoCommits.getProperty("refs/tags/TagA"),
-            "refs/tags/TagA"); //TODO: What do we expect!?
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                "refs/tags/TagA",
+                namespaceRepoCommits.getProperty("refs/tags/TagA"),
+                "refs/tags/TagA"); // TODO: What do we expect!?
     }
 
-    // @Test
+    @Test
     public void testTags_with_refsTagsTagBAnnotated() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            "refs/tags/TagBAnnotated",
-            namespaceRepoCommits.getProperty("refs/tags/TagBAnnotated^{}"),
-            "refs/tags/TagBAnnotated");
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                "refs/tags/TagBAnnotated",
+                namespaceRepoCommits.getProperty("refs/tags/TagBAnnotated^{}"),
+                "refs/tags/TagBAnnotated");
     }
 
-    // @Test
+    @Test
     public void testCommitAsBranchSpec_feature4_sha1() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
                 namespaceRepoCommits.getProperty("refs/heads/b_namespace3/feature4"),
                 namespaceRepoCommits.getProperty("refs/heads/b_namespace3/feature4"),
                 "detached");
     }
 
-    // @Test
+    @Test
     public void testCommitAsBranchSpec_feature4_branchName() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
                 "refs/heads/b_namespace3/feature4",
                 namespaceRepoCommits.getProperty("refs/heads/b_namespace3/feature4"),
                 "origin/b_namespace3/feature4");
     }
 
-    // @Test
+    @Test
     public void testCommitAsBranchSpec() throws Exception {
-        check(namespaceRepoZip, namespaceRepoCommits,
-            namespaceRepoCommits.getProperty("refs/heads/b_namespace3/master"), 
-            namespaceRepoCommits.getProperty("refs/heads/b_namespace3/master"),
-            "detached");
+        if (isWindows()) { // Low value test - skip on Windows
+            return;
+        }
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        check(
+                namespaceRepoZip,
+                namespaceRepoCommits,
+                namespaceRepoCommits.getProperty("refs/heads/b_namespace3/master"),
+                namespaceRepoCommits.getProperty("refs/heads/b_namespace3/master"),
+                "detached");
     }
 
-    public void check(ZipFile repoZip, Properties commits, String branchSpec,
-            String expected_GIT_COMMIT, String expected_GIT_BRANCH) throws Exception {
+    public void check(
+            ZipFile repoZip,
+            Properties commits,
+            String branchSpec,
+            String expected_GIT_COMMIT,
+            String expected_GIT_BRANCH)
+            throws Exception {
         String remote = prepareRepo(repoZip);
 
-        FreeStyleProject project = setupProject(Collections.singletonList(new UserRemoteConfig(remote, null, null, null)),
+        FreeStyleProject project = setupProject(
+                Collections.singletonList(new UserRemoteConfig(remote, null, null, null)),
                 Collections.singletonList(new BranchSpec(branchSpec)),
-                    //empty scmTriggerSpec, SCMTrigger triggered manually
-                    "", isDisableRemotePoll(), getGitClient()); 
-        
-        //Speedup test - avoid waiting 1 minute
+                // empty scmTriggerSpec, SCMTrigger triggered manually
+                "",
+                isDisableRemotePoll(),
+                getGitClient());
+
+        // Speedup test - avoid waiting 1 minute
         triggerSCMTrigger(project.getTrigger(SCMTrigger.class));
-        
+
         FreeStyleBuild build1 = waitForBuildFinished(project, 1, 60000);
         assertNotNull("Job has not been triggered", build1);
 
         TaskListener listener = StreamTaskListener.fromStderr();
         PollingResult poll = project.poll(listener);
         assertFalse("Expected and actual polling results disagree", poll.hasChanges());
-        
-        //Speedup test - avoid waiting 1 minute
+
+        // Speedup test - avoid waiting 1 minute
         triggerSCMTrigger(project.getTrigger(SCMTrigger.class)).get(20, SECONDS);
-        
+
         FreeStyleBuild build2 = waitForBuildFinished(project, 2, 2000);
         assertNull("Found build 2 although no new changes and no multi candidate build", build2);
-        
-        assertEquals("Unexpected GIT_COMMIT", 
-                    expected_GIT_COMMIT, build1.getEnvironment(null).get("GIT_COMMIT"));
-        assertEquals("Unexpected GIT_BRANCH", 
-                    expected_GIT_BRANCH, build1.getEnvironment(null).get("GIT_BRANCH"));
+
+        assertEquals(
+                "Unexpected GIT_COMMIT",
+                expected_GIT_COMMIT,
+                build1.getEnvironment(null).get("GIT_COMMIT"));
+        assertEquals(
+                "Unexpected GIT_BRANCH",
+                expected_GIT_BRANCH,
+                build1.getEnvironment(null).get("GIT_BRANCH"));
     }
 
     private String prepareRepo(ZipFile repoZip) throws IOException {
@@ -245,9 +387,8 @@ public abstract class SCMTriggerTest extends AbstractGitProject
         return tempRemoteDir.getAbsolutePath();
     }
 
-    private Future<Void> triggerSCMTrigger(final SCMTrigger trigger)
-    {
-        if(trigger == null) return null;
+    private Future<Void> triggerSCMTrigger(final SCMTrigger trigger) {
+        if (trigger == null) return null;
         Callable<Void> callable = () -> {
             trigger.run();
             return null;
@@ -256,15 +397,14 @@ public abstract class SCMTriggerTest extends AbstractGitProject
     }
 
     private FreeStyleBuild waitForBuildFinished(FreeStyleProject project, int expectedBuildNumber, long timeout)
-                throws Exception
-    {
+            throws Exception {
         long endTime = System.currentTimeMillis() + timeout;
-        while(System.currentTimeMillis() < endTime) {
+        while (System.currentTimeMillis() < endTime) {
             RunList<FreeStyleBuild> builds = project.getBuilds();
-            for(FreeStyleBuild build : builds) {
-                if(build.getNumber() == expectedBuildNumber) {
-                    if(build.getResult() != null) return build;
-                    break; //Wait until build finished
+            for (FreeStyleBuild build : builds) {
+                if (build.getNumber() == expectedBuildNumber) {
+                    if (build.getResult() != null) return build;
+                    break; // Wait until build finished
                 }
             }
             Thread.sleep(10);
@@ -272,14 +412,13 @@ public abstract class SCMTriggerTest extends AbstractGitProject
         return null;
     }
 
-    private Properties parseLsRemote(File file) throws IOException
-    {
+    private Properties parseLsRemote(File file) throws IOException {
         Properties properties = new Properties();
         Pattern pattern = Pattern.compile("([a-f0-9]{40})\\s*(.*)");
-        for(String lineO : Files.readAllLines(file.toPath(), StandardCharsets.UTF_8)) {
+        for (String lineO : Files.readAllLines(file.toPath(), StandardCharsets.UTF_8)) {
             String line = lineO.trim();
             Matcher matcher = pattern.matcher(line);
-            if(matcher.matches()) {
+            if (matcher.matches()) {
                 properties.setProperty(matcher.group(2), matcher.group(1));
             } else {
                 System.err.println("ls-remote pattern does not match '" + line + "'");
@@ -287,16 +426,14 @@ public abstract class SCMTriggerTest extends AbstractGitProject
         }
         return properties;
     }
-    
-    private void extract(ZipFile zipFile, File outputDir) throws IOException
-    {
+
+    private void extract(ZipFile zipFile, File outputDir) throws IOException {
         Enumeration<? extends ZipEntry> entries = zipFile.entries();
         while (entries.hasMoreElements()) {
             ZipEntry entry = entries.nextElement();
-            File entryDestination = new File(outputDir,  entry.getName());
+            File entryDestination = new File(outputDir, entry.getName());
             entryDestination.getParentFile().mkdirs();
-            if (entry.isDirectory())
-                entryDestination.mkdirs();
+            if (entry.isDirectory()) entryDestination.mkdirs();
             else {
                 try (InputStream in = zipFile.getInputStream(entry)) {
                     Files.copy(in, entryDestination.toPath());
@@ -307,6 +444,6 @@ public abstract class SCMTriggerTest extends AbstractGitProject
 
     /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */
     private boolean isWindows() {
-        return File.pathSeparatorChar==';';
+        return File.pathSeparatorChar == ';';
     }
 }

--- a/src/test/java/hudson/plugins/git/SCMTriggerTest.java
+++ b/src/test/java/hudson/plugins/git/SCMTriggerTest.java
@@ -47,7 +47,7 @@ public abstract class SCMTriggerTest extends AbstractGitProject {
     @ClassRule
     public static Stopwatch stopwatch = new Stopwatch();
 
-    private static final int MAX_SECONDS_FOR_THESE_TESTS = 1801;
+    private static final int MAX_SECONDS_FOR_THESE_TESTS = 120;
 
     private boolean isTimeAvailable() {
         String env = System.getenv("CI");


### PR DESCRIPTION
## Enable SCMTriggerTests

The tests were disabled because they caused releases in 2016 to require an hour or more.  Newer hardware runs faster and time limiting options in tests may allow more of them to run without affecting the time to release the plugin.

- Remove test that was disabled in 2016
- Time limit SCMTriggerTest on Linux
- Allow up to 2 minutes for SCMTriggerTest

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Test
