### PR TITLE
Fix broken tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.64</version>
+    <version>4.63</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Fix broken tests

Attempt this revert in order to fix broken tests.  Need to understand which commit causes tests to fail for Java 17 on Windows and solve the underlying problem.  Reverting the upgrade to parent pom 4.64 is the simplest short term solution, then the real fixes will need to be applied to the tests on Windows.

This reverts commit 6df18ba4d479dfaf4ba5a79acdad8406a2c11dc8.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
