### PR TITLE
Fix JenkinsRule cleanup failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.63</version>
+    <version>4.64</version>
     <relativePath />
   </parent>
 

--- a/src/test/java/hudson/plugins/git/AbstractGitProject.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitProject.java
@@ -31,6 +31,7 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Node;
 import hudson.model.Result;
+import hudson.model.TaskListener;
 import hudson.plugins.git.extensions.impl.DisableRemotePoll;
 import hudson.plugins.git.extensions.impl.EnforceGitClient;
 import hudson.plugins.git.extensions.impl.PathRestriction;
@@ -48,10 +49,12 @@ import java.util.Collections;
 import java.util.List;
 
 import jenkins.MasterToSlaveFileCallable;
+import jenkins.plugins.git.JenkinsRuleUtil;
 import org.eclipse.jgit.lib.Repository;
 
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.JGitTool;
+import org.junit.After;
 
 import static org.junit.Assert.assertTrue;
 
@@ -73,6 +76,15 @@ public class AbstractGitProject extends AbstractGitRepository {
     @Rule
     public FlagRule<String> notifyCommitAccessControl =
             new FlagRule<>(() -> GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL, x -> GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL = x);
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(jenkins.getWebAppRoot(), listener);
+        if (jenkins.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(jenkins.jenkins.getRootDir(), listener);
+        }
+    }
 
     protected FreeStyleProject setupProject(List<BranchSpec> branches, boolean authorOrCommitter) throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();

--- a/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
@@ -47,6 +47,8 @@ import org.jenkinsci.plugins.gitclient.JGitTool;
 import org.junit.Before;
 import org.junit.Rule;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.JenkinsRuleUtil;
+import org.junit.After;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
@@ -89,6 +91,14 @@ public abstract class AbstractGitTestCase {
         workDir = testRepo.gitDir;
         workspace = testRepo.gitDirPath;
         git = testRepo.git;
+    }
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        JenkinsRuleUtil.makeFilesWritable(rule.getWebAppRoot(), listener);
+        if (rule.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(rule.jenkins.getRootDir(), listener);
+        }
     }
 
     protected String commit(final String fileName, final PersonIdent committer, final String message)

--- a/src/test/java/hudson/plugins/git/CheckoutStepSnippetizerTest.java
+++ b/src/test/java/hudson/plugins/git/CheckoutStepSnippetizerTest.java
@@ -35,7 +35,7 @@ import java.util.Random;
 import jenkins.plugins.git.JenkinsRuleUtil;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
 import org.jenkinsci.plugins.workflow.steps.scm.GenericSCMStep;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -78,8 +78,8 @@ public class CheckoutStepSnippetizerTest {
     /* Tested values common to many tests */
     private final String remoteConfig = "userRemoteConfigs: [[url: '" + url + "']]";
 
-    @After
-    public void makeFilesWritable() throws Exception {
+    @AfterClass
+    public static void makeFilesWritable() throws Exception {
         TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
         if (r.jenkins != null) {

--- a/src/test/java/hudson/plugins/git/CheckoutStepSnippetizerTest.java
+++ b/src/test/java/hudson/plugins/git/CheckoutStepSnippetizerTest.java
@@ -79,7 +79,8 @@ public class CheckoutStepSnippetizerTest {
     private final String remoteConfig = "userRemoteConfigs: [[url: '" + url + "']]";
 
     @After
-    public void makeFilesWritable(TaskListener listener) throws Exception {
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
         if (r.jenkins != null) {
             JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);

--- a/src/test/java/hudson/plugins/git/CheckoutStepSnippetizerTest.java
+++ b/src/test/java/hudson/plugins/git/CheckoutStepSnippetizerTest.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.git;
 
+import hudson.model.TaskListener;
 import hudson.plugins.git.browser.GitRepositoryBrowser;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.impl.CheckoutOption;
@@ -31,8 +32,10 @@ import hudson.plugins.git.extensions.impl.SubmoduleOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import jenkins.plugins.git.JenkinsRuleUtil;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
 import org.jenkinsci.plugins.workflow.steps.scm.GenericSCMStep;
+import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -74,6 +77,14 @@ public class CheckoutStepSnippetizerTest {
 
     /* Tested values common to many tests */
     private final String remoteConfig = "userRemoteConfigs: [[url: '" + url + "']]";
+
+    @After
+    public void makeFilesWritable(TaskListener listener) throws Exception {
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
+    }
 
     @Test
     public void checkoutSimplest() throws Exception {

--- a/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
@@ -74,7 +74,8 @@ public class CredentialsUserRemoteConfigTest {
         sampleRepo.git("commit", "-m", "Add src/sample.txt to sample repo");
     }
     @After
-    public void makeFilesWritable(TaskListener listener) throws Exception {
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
         if (r.jenkins != null) {
             JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);

--- a/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
@@ -4,6 +4,8 @@ import com.cloudbees.plugins.credentials.*;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.model.TaskListener;
+import static hudson.plugins.git.CheckoutStepSnippetizerTest.r;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -11,6 +13,7 @@ import java.util.List;
 import java.util.Random;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.JenkinsRuleUtil;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -22,6 +25,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.After;
 import static org.junit.Assert.assertTrue;
 
 public class CredentialsUserRemoteConfigTest {
@@ -68,6 +72,13 @@ public class CredentialsUserRemoteConfigTest {
         sampleRepo.write("src/sample.txt", "Contents of src/sample.txt");
         sampleRepo.git("add", "src/sample.txt");
         sampleRepo.git("commit", "-m", "Add src/sample.txt to sample repo");
+    }
+    @After
+    public void makeFilesWritable(TaskListener listener) throws Exception {
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
     }
 
     private String classPrologue() {

--- a/src/test/java/hudson/plugins/git/GitChangeSetBadArgsTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetBadArgsTest.java
@@ -1,8 +1,12 @@
 package hudson.plugins.git;
 
+import hudson.model.TaskListener;
 import java.util.ArrayList;
 
 import hudson.model.User;
+import static hudson.plugins.git.CheckoutStepSnippetizerTest.r;
+import jenkins.plugins.git.JenkinsRuleUtil;
+import org.junit.After;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -14,6 +18,14 @@ public class GitChangeSetBadArgsTest {
 
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
+
+    @After
+    public void makeFilesWritable(TaskListener listener) throws Exception {
+        JenkinsRuleUtil.makeFilesWritable(jenkins.getWebAppRoot(), listener);
+        if (jenkins.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(jenkins.jenkins.getRootDir(), listener);
+        }
+    }
 
     private GitChangeSet createChangeSet(boolean authorOrCommitter, String name, String email) {
         String dataSource = authorOrCommitter ? "Author" : "Committer";

--- a/src/test/java/hudson/plugins/git/GitChangeSetBadArgsTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetBadArgsTest.java
@@ -20,7 +20,8 @@ public class GitChangeSetBadArgsTest {
     public JenkinsRule jenkins = new JenkinsRule();
 
     @After
-    public void makeFilesWritable(TaskListener listener) throws Exception {
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(jenkins.getWebAppRoot(), listener);
         if (jenkins.jenkins != null) {
             JenkinsRuleUtil.makeFilesWritable(jenkins.jenkins.getRootDir(), listener);

--- a/src/test/java/hudson/plugins/git/GitChangeSetTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTest.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git;
 
+import hudson.model.TaskListener;
 import hudson.model.User;
 import hudson.tasks.Mailer;
 import hudson.tasks.Mailer.UserProperty;
@@ -12,9 +13,11 @@ import org.springframework.security.authentication.DisabledException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Random;
+import jenkins.plugins.git.JenkinsRuleUtil;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
+import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -27,6 +30,14 @@ public class GitChangeSetTest {
     public JenkinsRule jenkins = new JenkinsRule();
 
     private final Random random = new Random();
+
+    @After
+    public void makeFilesWritable(TaskListener listener) throws Exception {
+        JenkinsRuleUtil.makeFilesWritable(jenkins.getWebAppRoot(), listener);
+        if (jenkins.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(jenkins.jenkins.getRootDir(), listener);
+        }
+    }
 
     @Test
     public void testFindOrCreateUser() {

--- a/src/test/java/hudson/plugins/git/GitChangeSetTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTest.java
@@ -32,7 +32,8 @@ public class GitChangeSetTest {
     private final Random random = new Random();
 
     @After
-    public void makeFilesWritable(TaskListener listener) throws Exception {
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(jenkins.getWebAppRoot(), listener);
         if (jenkins.jenkins != null) {
             JenkinsRuleUtil.makeFilesWritable(jenkins.jenkins.getRootDir(), listener);

--- a/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
@@ -17,6 +17,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import org.junit.AfterClass;
 
 /**
  * Check that no crumb is required for successful calls to notifyCommit.
@@ -81,8 +82,8 @@ public class GitStatusCrumbExclusionTest {
         connectionPOST.disconnect();
     }
 
-    @After
-    public void makeFilesWritable() throws Exception {
+    @AfterClass
+    public static void makeFilesWritable() throws Exception {
         TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
         if (r.jenkins != null) {

--- a/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
@@ -1,10 +1,12 @@
 package hudson.plugins.git;
 
+import hudson.model.TaskListener;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import jenkins.plugins.git.JenkinsRuleUtil;
 
 import org.junit.After;
 import org.junit.Before;
@@ -77,6 +79,14 @@ public class GitStatusCrumbExclusionTest {
     @After
     public void disconnectFromPOST() {
         connectionPOST.disconnect();
+    }
+
+    @After
+    public void makeFilesWritable(TaskListener listener) throws Exception {
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
     }
 
     /*

--- a/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusCrumbExclusionTest.java
@@ -82,7 +82,8 @@ public class GitStatusCrumbExclusionTest {
     }
 
     @After
-    public void makeFilesWritable(TaskListener listener) throws Exception {
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
         if (r.jenkins != null) {
             JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);

--- a/src/test/java/hudson/plugins/git/GitStepSnippetizerTest.java
+++ b/src/test/java/hudson/plugins/git/GitStepSnippetizerTest.java
@@ -24,9 +24,12 @@
 package hudson.plugins.git;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.TaskListener;
 import java.util.Random;
 import jenkins.plugins.git.GitStep;
+import jenkins.plugins.git.JenkinsRuleUtil;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
+import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -47,6 +50,14 @@ public class GitStepSnippetizerTest {
 
     private final String url = "https://github.com/jenkinsci/git-plugin.git";
     private final GitStep gitStep = new GitStep(url);
+
+    @After
+    public void makeFilesWritable(TaskListener listener) throws Exception {
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
+    }
 
     /* Adding the default values to the step should not alter the output of the
      * round trip.

--- a/src/test/java/hudson/plugins/git/GitStepSnippetizerTest.java
+++ b/src/test/java/hudson/plugins/git/GitStepSnippetizerTest.java
@@ -29,7 +29,7 @@ import java.util.Random;
 import jenkins.plugins.git.GitStep;
 import jenkins.plugins.git.JenkinsRuleUtil;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -51,8 +51,8 @@ public class GitStepSnippetizerTest {
     private final String url = "https://github.com/jenkinsci/git-plugin.git";
     private final GitStep gitStep = new GitStep(url);
 
-    @After
-    public void makeFilesWritable() throws Exception {
+    @AfterClass
+    public static void makeFilesWritable() throws Exception {
         TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
         if (r.jenkins != null) {

--- a/src/test/java/hudson/plugins/git/GitStepSnippetizerTest.java
+++ b/src/test/java/hudson/plugins/git/GitStepSnippetizerTest.java
@@ -52,7 +52,8 @@ public class GitStepSnippetizerTest {
     private final GitStep gitStep = new GitStep(url);
 
     @After
-    public void makeFilesWritable(TaskListener listener) throws Exception {
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
         if (r.jenkins != null) {
             JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);

--- a/src/test/java/hudson/plugins/git/GitTagActionTest.java
+++ b/src/test/java/hudson/plugins/git/GitTagActionTest.java
@@ -37,7 +37,6 @@ import static org.junit.Assert.assertTrue;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import jenkins.plugins.git.JenkinsRuleUtil;
-import org.junit.After;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -164,8 +163,8 @@ public class GitTagActionTest {
         }
     }
 
-    @After
-    public void makeFilesWritable() throws Exception {
+    @AfterClass
+    public static void makeFilesWritable() throws Exception {
         TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
         if (r.jenkins != null) {

--- a/src/test/java/hudson/plugins/git/GitTagActionTest.java
+++ b/src/test/java/hudson/plugins/git/GitTagActionTest.java
@@ -36,6 +36,8 @@ import static org.junit.Assert.assertTrue;
 
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import jenkins.plugins.git.JenkinsRuleUtil;
+import org.junit.After;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -159,6 +161,14 @@ public class GitTagActionTest {
         /* Do not add git tag action to builds for other tests */
         if (gitSCMDescriptor != null) {
             gitSCMDescriptor.setAddGitTagAction(false);
+        }
+    }
+
+    @After
+    public void makeFilesWritable(TaskListener listener) throws Exception {
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
         }
     }
 

--- a/src/test/java/hudson/plugins/git/GitTagActionTest.java
+++ b/src/test/java/hudson/plugins/git/GitTagActionTest.java
@@ -165,7 +165,8 @@ public class GitTagActionTest {
     }
 
     @After
-    public void makeFilesWritable(TaskListener listener) throws Exception {
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
         if (r.jenkins != null) {
             JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);

--- a/src/test/java/hudson/plugins/git/Security2478Test.java
+++ b/src/test/java/hudson/plugins/git/Security2478Test.java
@@ -38,7 +38,8 @@ public class Security2478Test {
     }
 
     @After
-    public void makeFilesWritable(TaskListener listener) throws Exception {
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(rule.getWebAppRoot(), listener);
         if (rule.jenkins != null) {
             JenkinsRuleUtil.makeFilesWritable(rule.jenkins.getRootDir(), listener);

--- a/src/test/java/hudson/plugins/git/Security2478Test.java
+++ b/src/test/java/hudson/plugins/git/Security2478Test.java
@@ -1,6 +1,7 @@
 package hudson.plugins.git;
 
 import hudson.model.Result;
+import hudson.model.TaskListener;
 import jenkins.plugins.git.GitSampleRepoRule;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -13,6 +14,7 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
+import jenkins.plugins.git.JenkinsRuleUtil;
 
 import static org.junit.Assert.assertFalse;
 
@@ -33,6 +35,14 @@ public class Security2478Test {
     @After
     public void disallowNonRemoteCheckout() {
         GitSCM.ALLOW_LOCAL_CHECKOUT = false;
+    }
+
+    @After
+    public void makeFilesWritable(TaskListener listener) throws Exception {
+        JenkinsRuleUtil.makeFilesWritable(rule.getWebAppRoot(), listener);
+        if (rule.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(rule.jenkins.getRootDir(), listener);
+        }
     }
 
     @Issue("SECURITY-2478")

--- a/src/test/java/hudson/plugins/git/UserMergeOptionsTest.java
+++ b/src/test/java/hudson/plugins/git/UserMergeOptionsTest.java
@@ -59,7 +59,8 @@ public class UserMergeOptionsTest {
     }
 
     @After
-    public void makeFilesWritable(TaskListener listener) throws Exception {
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
         if (r.jenkins != null) {
             JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);

--- a/src/test/java/hudson/plugins/git/UserMergeOptionsTest.java
+++ b/src/test/java/hudson/plugins/git/UserMergeOptionsTest.java
@@ -11,7 +11,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.ClassRule;
@@ -58,8 +58,8 @@ public class UserMergeOptionsTest {
         deprecatedOptions = defineDeprecatedOptions(mergeRemote, mergeTarget, mergeStrategy);
     }
 
-    @After
-    public void makeFilesWritable() throws Exception {
+    @AfterClass
+    public static void makeFilesWritable() throws Exception {
         TaskListener listener = TaskListener.NULL;
         JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
         if (r.jenkins != null) {

--- a/src/test/java/hudson/plugins/git/UserMergeOptionsTest.java
+++ b/src/test/java/hudson/plugins/git/UserMergeOptionsTest.java
@@ -1,14 +1,17 @@
 package hudson.plugins.git;
 
+import hudson.model.TaskListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import jenkins.plugins.git.JenkinsRuleUtil;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.junit.After;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.ClassRule;
@@ -53,6 +56,14 @@ public class UserMergeOptionsTest {
                 mergeStrategy == null ? null : mergeStrategy.toString(),
                 fastForwardMode);
         deprecatedOptions = defineDeprecatedOptions(mergeRemote, mergeTarget, mergeStrategy);
+    }
+
+    @After
+    public void makeFilesWritable(TaskListener listener) throws Exception {
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
     }
 
     @Parameterized.Parameters(name = "{0}+{1}+{2}+{3}")

--- a/src/test/java/hudson/plugins/git/browser/GitLabWorkflowTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitLabWorkflowTest.java
@@ -1,9 +1,12 @@
 package hudson.plugins.git.browser;
 
+import hudson.model.TaskListener;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.JenkinsRuleUtil;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -14,6 +17,15 @@ public class GitLabWorkflowTest {
     public JenkinsRule r = new JenkinsRule();
     @Rule
     public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
+    }
 
     @Test
     public void checkoutWithVersion() throws Exception {

--- a/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
@@ -17,6 +17,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Collections;
 import java.util.List;
+import jenkins.plugins.git.JenkinsRuleUtil;
 
 /**
  * @author Kanstantsin Shautsou
@@ -50,6 +51,15 @@ public abstract class GitSCMExtensionTest {
 	public void disallowNonRemoteCheckout() {
 		GitSCM.ALLOW_LOCAL_CHECKOUT = false;
 	}
+
+        @After
+        public void makeFilesWritable() throws Exception {
+            JenkinsRuleUtil.makeFilesWritable(tmp.getRoot(), listener);
+            JenkinsRuleUtil.makeFilesWritable(j.getWebAppRoot(), listener);
+            if (j.jenkins != null) {
+                JenkinsRuleUtil.makeFilesWritable(j.jenkins.getRootDir(), listener);
+            }
+        }
 
 	protected abstract void before() throws Exception;
 

--- a/src/test/java/hudson/plugins/git/extensions/impl/CheckoutOptionWorkflowTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CheckoutOptionWorkflowTest.java
@@ -1,9 +1,12 @@
 package hudson.plugins.git.extensions.impl;
 
+import hudson.model.TaskListener;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.JenkinsRuleUtil;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -14,6 +17,15 @@ public class CheckoutOptionWorkflowTest {
     public JenkinsRule r = new JenkinsRule();
     @Rule
     public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
+    }
 
     @Test
     public void checkoutTimeout() throws Exception {

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionDepthTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionDepthTest.java
@@ -12,9 +12,11 @@ import hudson.model.TaskListener;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.BuildData;
+import jenkins.plugins.git.JenkinsRuleUtil;
 import org.jenkinsci.plugins.gitclient.CloneCommand;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -41,6 +43,14 @@ public class CloneOptionDepthTest {
     public CloneOptionDepthTest(int configuredDepth, int usedDepth) {
         this.configuredDepth = configuredDepth;
         this.usedDepth = usedDepth;
+    }
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        JenkinsRuleUtil.makeFilesWritable(j.getWebAppRoot(), listener);
+        if (j.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(j.jenkins.getRootDir(), listener);
+        }
     }
 
     @Parameterized.Parameters(name = "depth: configured={0}, used={1}")

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionDepthTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionDepthTest.java
@@ -16,7 +16,7 @@ import jenkins.plugins.git.JenkinsRuleUtil;
 import org.jenkinsci.plugins.gitclient.CloneCommand;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -45,11 +45,12 @@ public class CloneOptionDepthTest {
         this.usedDepth = usedDepth;
     }
 
-    @After
-    public void makeFilesWritable() throws Exception {
-        JenkinsRuleUtil.makeFilesWritable(j.getWebAppRoot(), listener);
+    @AfterClass
+    public static void makeFilesWritable() throws Exception {
+        TaskListener myListener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(j.getWebAppRoot(), myListener);
         if (j.jenkins != null) {
-            JenkinsRuleUtil.makeFilesWritable(j.jenkins.getRootDir(), listener);
+            JenkinsRuleUtil.makeFilesWritable(j.jenkins.getRootDir(), myListener);
         }
     }
 

--- a/src/test/java/hudson/plugins/git/extensions/impl/PruneStaleTagPipelineTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/PruneStaleTagPipelineTest.java
@@ -50,6 +50,7 @@ import hudson.Functions;
 import hudson.model.Result;
 import hudson.model.TaskListener;
 import hudson.util.LogTaskListener;
+import jenkins.plugins.git.JenkinsRuleUtil;
 
 public class PruneStaleTagPipelineTest {
 
@@ -73,6 +74,14 @@ public class PruneStaleTagPipelineTest {
     @After
     public void disallowNonRemoteCheckout() {
         GitSCM.ALLOW_LOCAL_CHECKOUT = false;
+    }
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        JenkinsRuleUtil.makeFilesWritable(j.getWebAppRoot(), listener);
+        if (j.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(j.jenkins.getRootDir(), listener);
+        }
     }
 
     @Issue("JENKINS-61869")

--- a/src/test/java/hudson/plugins/git/opt/PreBuildMergeOptionsTest.java
+++ b/src/test/java/hudson/plugins/git/opt/PreBuildMergeOptionsTest.java
@@ -25,12 +25,15 @@
 package hudson.plugins.git.opt;
 
 import hudson.model.FreeStyleProject;
+import hudson.model.TaskListener;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserMergeOptions;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.impl.PreBuildMerge;
 import java.util.Collections;
+import jenkins.plugins.git.JenkinsRuleUtil;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;
@@ -39,6 +42,15 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class PreBuildMergeOptionsTest {
 
     @Rule public JenkinsRule r = new JenkinsRule();
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
+    }
 
     @Issue("JENKINS-9843")
     @Test public void exporting() throws Exception {

--- a/src/test/java/hudson/plugins/git/security/ApiTokenPropertyConfigurationTest.java
+++ b/src/test/java/hudson/plugins/git/security/ApiTokenPropertyConfigurationTest.java
@@ -4,6 +4,7 @@ import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
+import hudson.model.TaskListener;
 import hudson.plugins.git.ApiTokenPropertyConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -15,9 +16,11 @@ import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
 import java.util.Collection;
 import java.util.Collections;
+import jenkins.plugins.git.JenkinsRuleUtil;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -33,6 +36,15 @@ public class ApiTokenPropertyConfigurationTest {
         authorizationStrategy.grant(Jenkins.ADMINISTER).everywhere().to("alice");
         authorizationStrategy.grant(Jenkins.READ).everywhere().to("bob");
         j.jenkins.setAuthorizationStrategy(authorizationStrategy);
+    }
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(j.getWebAppRoot(), listener);
+        if (j.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(j.jenkins.getRootDir(), listener);
+        }
     }
 
     @Test

--- a/src/test/java/hudson/plugins/git/util/GitUtilsJenkinsRuleTest.java
+++ b/src/test/java/hudson/plugins/git/util/GitUtilsJenkinsRuleTest.java
@@ -33,9 +33,11 @@ import hudson.plugins.git.GitTool;
 import hudson.slaves.DumbSlave;
 import hudson.util.StreamTaskListener;
 import java.util.UUID;
+import jenkins.plugins.git.JenkinsRuleUtil;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
+import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -44,6 +46,15 @@ public class GitUtilsJenkinsRuleTest {
 
     @ClassRule
     public static JenkinsRule j = new JenkinsRule();
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(j.getWebAppRoot(), listener);
+        if (j.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(j.jenkins.getRootDir(), listener);
+        }
+    }
 
     @Test
     public void testWorkspaceToNode() throws Exception {

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -75,6 +75,7 @@ import org.mockito.Mockito;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
+import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -113,6 +114,15 @@ public class AbstractGitSCMSourceTest {
     public static Stopwatch stopwatch = new Stopwatch();
     @Rule
     public TestName testName = new TestName();
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
+    }
 
     private static final int MAX_SECONDS_FOR_THESE_TESTS = 210;
 

--- a/src/test/java/jenkins/plugins/git/GitBranchSCMHeadTest.java
+++ b/src/test/java/jenkins/plugins/git/GitBranchSCMHeadTest.java
@@ -2,6 +2,7 @@ package jenkins.plugins.git;
 
 import hudson.FilePath;
 import hudson.model.Queue;
+import hudson.model.TaskListener;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
@@ -50,6 +51,14 @@ public class GitBranchSCMHeadTest {
         }
     }
 
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(j.getWebAppRoot(), listener);
+        if (j.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(j.jenkins.getRootDir(), listener);
+        }
+    }
 
     @Issue("JENKINS-48061")
     @Test

--- a/src/test/java/jenkins/plugins/git/GitHooksConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/git/GitHooksConfigurationTest.java
@@ -74,6 +74,15 @@ public class GitHooksConfigurationTest {
         });
     }
 
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(j.getWebAppRoot(), listener);
+        if (j.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(j.jenkins.getRootDir(), listener);
+        }
+    }
+
     @Test
     public void testGet() {
         assertThat(GitHooksConfiguration.get(), is(configuration));

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -65,6 +65,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.After;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -105,6 +106,15 @@ public class GitSCMFileSystemTest {
                 gitCmd.run("fetch", "--tags", "https://github.com/jenkinsci/git-plugin");
                 tagId = client.revParse(tag); /* throws if tag not available */
             }
+        }
+    }
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
         }
     }
 

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
@@ -65,6 +65,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.After;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -86,6 +87,15 @@ public class GitSCMSourceTest {
     @Before
     public void setup() {
         gitStatus = new GitStatus();
+    }
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(jenkins.getWebAppRoot(), listener);
+        if (jenkins.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(jenkins.jenkins.getRootDir(), listener);
+        }
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTraitsTest.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.git;
 
+import hudson.model.TaskListener;
 import hudson.plugins.git.browser.BitbucketWeb;
 import hudson.plugins.git.extensions.impl.AuthorInChangelog;
 import hudson.plugins.git.extensions.impl.CheckoutOption;
@@ -54,6 +55,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.After;
 
 public class GitSCMSourceTraitsTest {
     /**
@@ -64,6 +66,15 @@ public class GitSCMSourceTraitsTest {
 
     @Rule
     public TestName currentTestName = new TestName();
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
+    }
 
     private GitSCMSource load() {
         return load(currentTestName.getMethodName());

--- a/src/test/java/jenkins/plugins/git/GitStepTest.java
+++ b/src/test/java/jenkins/plugins/git/GitStepTest.java
@@ -30,6 +30,7 @@ import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.model.Label;
+import hudson.model.TaskListener;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitTagAction;
 import hudson.plugins.git.util.BuildData;
@@ -56,6 +57,7 @@ import org.junit.runner.OrderWith;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import org.junit.After;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -74,6 +76,15 @@ public class GitStepTest {
     public static void setGitDefaults() throws Exception {
         CliGitCommand gitCmd = new CliGitCommand(null);
         gitCmd.setDefaults();
+    }
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
     }
 
     @ClassRule

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -42,6 +42,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.io.FileMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
@@ -80,6 +81,15 @@ public class GitToolChooserTest {
     @Before
     public void resetRepositorySizeCache() {
         GitToolChooser.clearRepositorySizeCache();
+    }
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(jenkins.getWebAppRoot(), listener);
+        if (jenkins.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(jenkins.jenkins.getRootDir(), listener);
+        }
     }
 
     @ClassRule

--- a/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
+++ b/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
@@ -52,6 +52,7 @@ import static org.junit.Assume.assumeTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import org.junit.After;
 
 @OrderWith(RandomOrder.class)
 @RunWith(Parameterized.class)
@@ -155,6 +156,15 @@ public class GitUsernamePasswordBindingTest {
         //Setting Git Tool
         Jenkins.get().getDescriptorByType(GitTool.DescriptorImpl.class).getDefaultInstallers().clear();
         Jenkins.get().getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(gitToolInstance);
+    }
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
     }
 
     private String batchCheck(boolean includeCliCheck) {

--- a/src/test/java/jenkins/plugins/git/JenkinsRuleUtil.java
+++ b/src/test/java/jenkins/plugins/git/JenkinsRuleUtil.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 Mark Waite.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.plugins.git;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import hudson.Launcher;
+import hudson.model.TaskListener;
+import hudson.util.ArgumentListBuilder;
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+public class JenkinsRuleUtil {
+
+    public static void makeFilesWritable(File dir, TaskListener listener) throws Exception {
+        if (isWindows()) {
+            /* Make all files writable so they can be deleted */
+            System.out.println("**** dir being made writable is " + dir.getAbsolutePath());
+            Launcher launcher = new Launcher.LocalLauncher(listener);
+            ArgumentListBuilder args = new ArgumentListBuilder("attrib");
+            args.add("-R", "/s");
+            Launcher.ProcStarter p = launcher.launch().cmds(args).pwd(dir);
+            int status = p.start().joinWithTimeout(13, TimeUnit.SECONDS, listener);
+            assertThat("Windows attrib.exe -r /s failed", status, is(0));
+        }
+    }
+
+    private static boolean isWindows() {
+        return File.pathSeparatorChar == ';';
+    }
+}

--- a/src/test/java/jenkins/plugins/git/ModernScmTest.java
+++ b/src/test/java/jenkins/plugins/git/ModernScmTest.java
@@ -25,6 +25,7 @@
 package jenkins.plugins.git;
 
 import hudson.ExtensionList;
+import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,11 +35,21 @@ import org.jvnet.hudson.test.JenkinsRule;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.After;
 
 public class ModernScmTest {
 
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
+
+    @After
+    public void makeFilesWritable() throws Exception {
+        TaskListener listener = TaskListener.NULL;
+        JenkinsRuleUtil.makeFilesWritable(r.getWebAppRoot(), listener);
+        if (r.jenkins != null) {
+            JenkinsRuleUtil.makeFilesWritable(r.jenkins.getRootDir(), listener);
+        }
+    }
 
     @Test
     @Issue("JENKINS-58964")

--- a/src/test/java/org/jenkinsci/plugins/gittagmessage/GitTagMessageExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gittagmessage/GitTagMessageExtensionTest.java
@@ -34,7 +34,7 @@ public class GitTagMessageExtensionTest extends AbstractGitTagMessageExtensionTe
                 null, null,
                 Collections.singletonList(extension));
 
-        FreeStyleProject job = jenkins.createFreeStyleProject();
+        FreeStyleProject job = r.createFreeStyleProject();
         job.getBuildersList().add(createEnvEchoBuilder("tag", ENV_VAR_NAME_TAG));
         job.getBuildersList().add(createEnvEchoBuilder("msg", ENV_VAR_NAME_MESSAGE));
         job.setScm(scm);
@@ -45,8 +45,8 @@ public class GitTagMessageExtensionTest extends AbstractGitTagMessageExtensionTe
     protected void assertBuildEnvironment(FreeStyleBuild build, String expectedName, String expectedMessage)
             throws Exception {
         // In the freestyle shell step, unknown environment variables are returned as empty strings
-        jenkins.waitForMessage(String.format("tag='%s'", Util.fixNull(expectedName)), build);
-        jenkins.waitForMessage(String.format("msg='%s'", Util.fixNull(expectedMessage)), build);
+        r.waitForMessage(String.format("tag='%s'", Util.fixNull(expectedName)), build);
+        r.waitForMessage(String.format("msg='%s'", Util.fixNull(expectedMessage)), build);
     }
 
     private static Builder createEnvEchoBuilder(String key, String envVarName) {


### PR DESCRIPTION
## Fix Windows cleanup failures on read-only files

- Fix Windows cleanup failures on read-only files
- More JenkinsFile rule cleanup calls
- More JenkinsFile rule cleanup calls
- More JenkinsFile rule cleanup calls
- Fix test runtime

The most recent parent pom has improved the cleanup process but does not seem to remove files on Windows that are set to read-only.  This draft pull request tests if it is enough to make the files writeable.

If this pull request passes the tests, then a jenkins-test-harness test and fix can be added to confirm the cleanup problem is understood and resolved.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Test (and a draft that is not to be merged)
