### PR TITLE
Use consistent JenkinsRule variable name

### DIFF
--- a/src/test/java/hudson/plugins/git/AbstractGitProject.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitProject.java
@@ -68,14 +68,14 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class AbstractGitProject extends AbstractGitRepository {
 
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     @Rule
     public FlagRule<String> notifyCommitAccessControl =
             new FlagRule<>(() -> GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL, x -> GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL = x);
 
     protected FreeStyleProject setupProject(List<BranchSpec> branches, boolean authorOrCommitter) throws Exception {
-        FreeStyleProject project = jenkins.createFreeStyleProject();
+        FreeStyleProject project = r.createFreeStyleProject();
         GitSCM scm = new GitSCM(remoteConfigs(), branches,
                 null, null,
                 Collections.singletonList(new DisableRemotePoll()));
@@ -145,7 +145,7 @@ public class AbstractGitProject extends AbstractGitRepository {
             String relativeTargetDir, String excludedRegions,
             String excludedUsers, String localBranch, boolean fastRemotePoll,
             String includedRegions, List<SparseCheckoutPath> sparseCheckoutPaths) throws Exception {
-        FreeStyleProject project = jenkins.createFreeStyleProject();
+        FreeStyleProject project = r.createFreeStyleProject();
         GitSCM scm = new GitSCM(
                 remoteConfigs(),
                 branches,
@@ -182,7 +182,7 @@ public class AbstractGitProject extends AbstractGitRepository {
      */
     protected FreeStyleProject setupProject(List<UserRemoteConfig> repos, List<BranchSpec> branchSpecs,
             String scmTriggerSpec, boolean disableRemotePoll, EnforceGitClient enforceGitClient) throws Exception {
-        FreeStyleProject project = jenkins.createFreeStyleProject();
+        FreeStyleProject project = r.createFreeStyleProject();
         GitSCM scm = new GitSCM(
                 repos,
                 branchSpecs,
@@ -211,7 +211,7 @@ public class AbstractGitProject extends AbstractGitRepository {
             assertTrue(expectedNewlyCommittedFile + " file not found in workspace", build.getWorkspace().child(expectedNewlyCommittedFile).exists());
         }
         if (expectedResult != null) {
-            jenkins.assertBuildStatus(expectedResult, build);
+            r.assertBuildStatus(expectedResult, build);
         }
         return build;
     }
@@ -222,7 +222,7 @@ public class AbstractGitProject extends AbstractGitRepository {
             assertTrue(build.getWorkspace().child(parentDir).child(expectedNewlyCommittedFile).exists());
         }
         if (expectedResult != null) {
-            jenkins.assertBuildStatus(expectedResult, build);
+            r.assertBuildStatus(expectedResult, build);
         }
         return build;
     }
@@ -233,7 +233,7 @@ public class AbstractGitProject extends AbstractGitRepository {
             assertTrue(expectedNewlyCommittedFile + " file not found in workspace", build.getWorkspace().child(expectedNewlyCommittedFile).exists());
         }
         if (expectedResult != null) {
-            jenkins.assertBuildStatus(expectedResult, build);
+            r.assertBuildStatus(expectedResult, build);
         }
         return build;
     }

--- a/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
@@ -62,7 +62,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public abstract class AbstractGitTestCase {
     @Rule
-    public JenkinsRule rule = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     @Rule
     public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
@@ -116,7 +116,7 @@ public abstract class AbstractGitTestCase {
     }
 
     protected FreeStyleProject createFreeStyleProject() throws IOException {
-        return rule.createFreeStyleProject();
+        return r.createFreeStyleProject();
     }
 
     protected FreeStyleProject setupProject(String branchString, boolean authorOrCommitter) throws Exception {
@@ -249,7 +249,7 @@ public abstract class AbstractGitTestCase {
             assertTrue(expectedNewlyCommittedFile + " file not found in workspace", build.getWorkspace().child(expectedNewlyCommittedFile).exists());
         }
         if(expectedResult != null) {
-            rule.assertBuildStatus(expectedResult, build);
+            r.assertBuildStatus(expectedResult, build);
         }
         return build;
     }
@@ -260,7 +260,7 @@ public abstract class AbstractGitTestCase {
             assertTrue(build.getWorkspace().child(parentDir).child(expectedNewlyCommittedFile).exists());
         }
         if(expectedResult != null) {
-            rule.assertBuildStatus(expectedResult, build);
+            r.assertBuildStatus(expectedResult, build);
         }
         return build;
     }
@@ -271,7 +271,7 @@ public abstract class AbstractGitTestCase {
             assertTrue(expectedNewlyCommittedFile + " file not found in workspace", build.getWorkspace().child(expectedNewlyCommittedFile).exists());
         }
         if(expectedResult != null) {
-            rule.assertBuildStatus(expectedResult, build);
+            r.assertBuildStatus(expectedResult, build);
         }
         return build;
     }

--- a/src/test/java/hudson/plugins/git/GitChangeSetBadArgsTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetBadArgsTest.java
@@ -13,7 +13,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class GitChangeSetBadArgsTest {
 
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     private GitChangeSet createChangeSet(boolean authorOrCommitter, String name, String email) {
         String dataSource = authorOrCommitter ? "Author" : "Committer";

--- a/src/test/java/hudson/plugins/git/GitChangeSetTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.times;
 public class GitChangeSetTest {
 
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     private final Random random = new Random();
 

--- a/src/test/java/hudson/plugins/git/GitPublisherTest.java
+++ b/src/test/java/hudson/plugins/git/GitPublisherTest.java
@@ -99,7 +99,7 @@ public class GitPublisherTest extends AbstractGitProject {
 
         commitNewFile("a");
 
-        MatrixProject mp = jenkins.createProject(MatrixProject.class, "xyz");
+        MatrixProject mp = r.createProject(MatrixProject.class, "xyz");
         mp.setAxes(new AxisList(new Axis("VAR","a","b")));
         mp.setScm(new GitSCM(testGitDir.getAbsolutePath()));
         mp.getPublishersList().add(new GitPublisher(
@@ -127,7 +127,7 @@ public class GitPublisherTest extends AbstractGitProject {
             private Object writeReplace() { return new NullSCM(); }
         });
 
-        MatrixBuild b = jenkins.buildAndAssertSuccess(mp);
+        MatrixBuild b = r.buildAndAssertSuccess(mp);
 
         assertTrue(existsTag("foo"));
 
@@ -140,7 +140,7 @@ public class GitPublisherTest extends AbstractGitProject {
     @Test
     public void GitPublisherFreestylePushBranchWithJGit() throws Exception {
         GitTool tool = new JGitTool(Collections.emptyList());
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
 
         FreeStyleProject project = setupSimpleProject("master");
 
@@ -194,9 +194,9 @@ public class GitPublisherTest extends AbstractGitProject {
         repoList.add(new UserRemoteConfig(testGitDir.getAbsolutePath(), null, null, null));
 
         GitTool tool = new JGitTool(Collections.emptyList()); //testGitDir.getAbsolutePath()
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
 
-        MatrixProject mp = jenkins.createProject(MatrixProject.class, "xyz");
+        MatrixProject mp = r.createProject(MatrixProject.class, "xyz");
         mp.setAxes(new AxisList(new Axis("VAR","a","b")));
         mp.setScm(new GitSCM(repoList,
                 Collections.singletonList(new BranchSpec("")),
@@ -226,7 +226,7 @@ public class GitPublisherTest extends AbstractGitProject {
             private Object writeReplace() { return new NullSCM(); }
         });
 
-        MatrixBuild b = jenkins.buildAndAssertSuccess(mp);
+        MatrixBuild b = r.buildAndAssertSuccess(mp);
 
         /* I don't understand why the log reports pushing tag to repo origin but the tag is not pushed */
         assertThat(b.getLog(50),

--- a/src/test/java/hudson/plugins/git/GitSCMSlowTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMSlowTest.java
@@ -114,8 +114,8 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
                 Collections.singletonList(new BranchSpec("")),
                 browser, null, null);
         p.setScm(scm);
-        rule.configRoundtrip(p);
-        rule.assertEqualDataBoundBeans(scm, p.getScm());
+        r.configRoundtrip(p);
+        r.assertEqualDataBoundBeans(scm, p.getScm());
         assertEquals("Wrong key", "git " + url, scm.getKey());
     }
 
@@ -155,11 +155,11 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
         assertTrue(scm.getExtensions().toList().contains(localBranchExtension));
 
         /* Save the configuration */
-        p = rule.configRoundtrip(p);
+        p = r.configRoundtrip(p);
         List<GitSCMExtension> extensions = scm.getExtensions().toList();
         assertTrue(extensions.contains(localBranchExtension));
         assertEquals("Wrong extension count before reload", 1, extensions.size());
-        rule.assertEqualDataBoundBeans(browser, p.getScm().getBrowser());
+        r.assertEqualDataBoundBeans(browser, p.getScm().getBrowser());
 
         /* Reload configuration from disc */
         p.doReload();
@@ -168,7 +168,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
         assertEquals("Wrong extension count after reload", 1, reloadedExtensions.size());
         LocalBranch reloadedLocalBranch = (LocalBranch) reloadedExtensions.get(0);
         assertEquals(localBranchExtension.getLocalBranch(), reloadedLocalBranch.getLocalBranch());
-        rule.assertEqualDataBoundBeans(browser, reloadedGit.getBrowser());
+        r.assertEqualDataBoundBeans(browser, reloadedGit.getBrowser());
     }
 
     /*
@@ -186,15 +186,15 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
         FreeStyleProject p = createFreeStyleProject();
         GitSCM scm = new GitSCM("https://github.com/jenkinsci/jenkins");
         p.setScm(scm);
-        rule.configRoundtrip(p);
-        rule.assertEqualDataBoundBeans(scm, p.getScm());
+        r.configRoundtrip(p);
+        r.assertEqualDataBoundBeans(scm, p.getScm());
     }
 
     @Test
     public void testBuildChooserContext() throws Exception {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         final FreeStyleProject p = createFreeStyleProject();
-        final FreeStyleBuild b = rule.buildAndAssertSuccess(p);
+        final FreeStyleBuild b = r.buildAndAssertSuccess(p);
 
         GitSCM.BuildChooserContextImpl c = new GitSCM.BuildChooserContextImpl(p, b, null);
         c.actOnBuild(new BuildChooserContext.ContextCallable<Run<?, ?>, Object>() {
@@ -211,7 +211,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
                 return null;
             }
         });
-        DumbSlave agent = rule.createOnlineSlave();
+        DumbSlave agent = r.createOnlineSlave();
         assertEquals(p.toString(), agent.getChannel().call(new GitSCMSlowTest.BuildChooserContextTestCallable(c)));
     }
 
@@ -244,7 +244,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
     public void testMergeFailedWithAgent() throws Exception {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         FreeStyleProject project = setupSimpleProject("master");
-        project.setAssignedLabel(rule.createSlave().getSelfLabel());
+        project.setAssignedLabel(r.createSlave().getSelfLabel());
 
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
@@ -274,7 +274,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
         testRepo.git.checkout("master", "topic2");
         commit(commitFile1, "other content", johnDoe, "Commit number 2");
         assertTrue("scm polling did not detect commit2 change", project.poll(listener).hasChanges());
-        rule.buildAndAssertStatus(Result.FAILURE, project);
+        r.buildAndAssertStatus(Result.FAILURE, project);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
@@ -282,7 +282,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
     public void testMergeWithAgent() throws Exception {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         FreeStyleProject project = setupSimpleProject("master");
-        project.setAssignedLabel(rule.createSlave().getSelfLabel());
+        project.setAssignedLabel(r.createSlave().getSelfLabel());
 
         GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
@@ -315,7 +315,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
         assertTrue("scm polling did not detect commit2 change", project.poll(listener).hasChanges());
         final FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile2);
         assertTrue(build2.getWorkspace().child(commitFile2).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
@@ -323,7 +323,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
     public void testMergeWithMatrixBuild() throws Exception {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         //Create a matrix project and a couple of axes
-        MatrixProject project = rule.jenkins.createProject(MatrixProject.class, "xyz");
+        MatrixProject project = r.jenkins.createProject(MatrixProject.class, "xyz");
         project.setAxes(new AxisList(new Axis("VAR", "a", "b")));
 
         GitSCM scm = new GitSCM(
@@ -357,7 +357,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
         assertTrue("scm polling did not detect commit2 change", project.poll(listener).hasChanges());
         final MatrixBuild build2 = build(project, Result.SUCCESS, commitFile2);
         assertTrue(build2.getWorkspace().child(commitFile2).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
@@ -401,7 +401,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
     public void testInitSparseCheckoutOverAgent() throws Exception {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         FreeStyleProject project = setupProject("master", Collections.singletonList(new SparseCheckoutPath("titi")));
-        project.setAssignedLabel(rule.createSlave().getSelfLabel());
+        project.setAssignedLabel(r.createSlave().getSelfLabel());
 
         // run build first to create workspace
         final String commitFile1 = "toto/commitFile1";
@@ -421,7 +421,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
     public void testNodeEnvVarsAvailable() throws Exception {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         FreeStyleProject project = setupSimpleProject("master");
-        DumbSlave agent = rule.createSlave();
+        DumbSlave agent = r.createSlave();
         setVariables(agent, new EnvironmentVariablesNodeProperty.Entry("TESTKEY", "agent value"));
         project.setAssignedLabel(agent.getSelfLabel());
         final String commitFile1 = "commitFile1";
@@ -435,7 +435,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
     public void testBasicWithAgent() throws Exception {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         FreeStyleProject project = setupSimpleProject("master");
-        project.setAssignedLabel(rule.createSlave().getSelfLabel());
+        project.setAssignedLabel(r.createSlave().getSelfLabel());
 
         // create initial commit and then run the build against it:
         final String commitFile1 = "commitFile1";
@@ -453,7 +453,7 @@ public class GitSCMSlowTest extends AbstractGitTestCase {
         assertEquals("The build should have only one culprit", 1, culprits.size());
         assertEquals("", janeDoe.getName(), culprits.iterator().next().getFullName());
         assertTrue(build2.getWorkspace().child(commitFile2).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -154,7 +154,7 @@ public class GitSCMTest extends AbstractGitTestCase {
     @After
     public void waitForJenkinsIdle() throws Exception {
         if (cleanupIsUnreliable()) {
-            rule.waitUntilNoActivityUpTo(5001);
+            r.waitUntilNoActivityUpTo(5001);
         }
     }
 
@@ -219,8 +219,8 @@ public class GitSCMTest extends AbstractGitTestCase {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         final String USER = "user";
         final String MANAGER = "manager";
-        rule.jenkins.setSecurityRealm(rule.createDummySecurityRealm());
-        rule.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                                                    // Read access
                                                    .grant(Jenkins.READ).everywhere().to(USER)
 
@@ -250,7 +250,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         Fingerprint fingerprint = CredentialsProvider.getFingerprintOf(credential);
         assertThat("Fingerprint should not be set before job definition", fingerprint, nullValue());
 
-        JenkinsRule.WebClient wc = rule.createWebClient();
+        JenkinsRule.WebClient wc = r.createWebClient();
         HtmlPage page = wc.goTo("credentials/store/system/domain/_/credentials/" + credential.getId());
         assertThat("Have usage tracking reported", page.getElementById("usage"), notNullValue());
         assertThat("No fingerprint created until first use", page.getElementById("usage-missing"), notNullValue());
@@ -305,7 +305,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertEquals("The build should have only one culprit", 1, culprits.size());
         assertEquals("", janeDoe.getName(), culprits.iterator().next().getFullName());
         assertTrue(build2.getWorkspace().child(commitFile2).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
@@ -331,7 +331,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertEquals("The build should have only one culprit", 1, culprits.size());
         assertEquals("", janeDoe.getName(), culprits.iterator().next().getFullName());
         assertTrue(build2.getWorkspace().child(commitFile2).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
         // JENKINS-56176 token macro expansion broke when BuildData was no longer updated
         assertThat(TokenMacro.expandAll(build2, listener, "${GIT_REVISION,length=7}"), is(sha1String.substring(0, 7)));
@@ -774,7 +774,7 @@ public class GitSCMTest extends AbstractGitTestCase {
 
         assertTrue(build2.getWorkspace().child(commitFile2).exists());
         assertTrue(build2.getWorkspace().child(commitFile3).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
@@ -1118,7 +1118,7 @@ public class GitSCMTest extends AbstractGitTestCase {
 
         assertTrue(build2.getWorkspace().child(commitFile2).exists());
         assertTrue(build2.getWorkspace().child(commitFile3).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
@@ -1151,7 +1151,7 @@ public class GitSCMTest extends AbstractGitTestCase {
 
         assertTrue(build2.getWorkspace().child(commitFile2).exists());
         assertTrue(build2.getWorkspace().child(commitFile3).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
@@ -1321,7 +1321,7 @@ public class GitSCMTest extends AbstractGitTestCase {
 
         assertTrue(build2.getWorkspace().child(commitFile2).exists());
         assertTrue(build2.getWorkspace().child(commitFile3).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
 
     }
@@ -1350,7 +1350,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertEquals("", janeDoe.getName(), culprits.iterator().next().getFullName());
         assertTrue("The workspace should have a 'subdir' subdirectory, but does not.", build2.getWorkspace().child("subdir").exists());
         assertTrue("The 'subdir' subdirectory should contain commitFile2, but does not.", build2.getWorkspace().child("subdir").child(commitFile2).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
@@ -1360,9 +1360,9 @@ public class GitSCMTest extends AbstractGitTestCase {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         FreeStyleProject project = setupSimpleProject("master");
 
-        rule.jenkins.setNumExecutors(0);
+        r.jenkins.setNumExecutors(0);
 
-        project.setAssignedLabel(rule.createSlave().getSelfLabel());
+        project.setAssignedLabel(r.createSlave().getSelfLabel());
 
         // create initial commit and then run the build against it:
         final String commitFile1 = "commitFile1";
@@ -1380,7 +1380,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertEquals("The build should have only one culprit", 1, culprits.size());
         assertEquals("", janeDoe.getName(), culprits.iterator().next().getFullName());
         assertTrue(build2.getWorkspace().child(commitFile2).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
@@ -1473,19 +1473,19 @@ public class GitSCMTest extends AbstractGitTestCase {
         FreeStyleBuild build1 = build(project, Result.SUCCESS, commitFile1);
 
         assertEquals("origin/master", getEnvVars(project).get(GitSCM.GIT_BRANCH));
-        rule.waitForMessage(getEnvVars(project).get(GitSCM.GIT_BRANCH), build1);
+        r.waitForMessage(getEnvVars(project).get(GitSCM.GIT_BRANCH), build1);
 
-        rule.waitForMessage(checkoutString(project, GitSCM.GIT_COMMIT), build1);
+        r.waitForMessage(checkoutString(project, GitSCM.GIT_COMMIT), build1);
 
         final String commitFile2 = "commitFile2";
         commit(commitFile2, johnDoe, "Commit number 2");
         FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile2);
 
-        rule.assertLogNotContains(checkoutString(project, GitSCM.GIT_PREVIOUS_COMMIT), build2);
-        rule.waitForMessage(checkoutString(project, GitSCM.GIT_PREVIOUS_COMMIT), build1);
+        r.assertLogNotContains(checkoutString(project, GitSCM.GIT_PREVIOUS_COMMIT), build2);
+        r.waitForMessage(checkoutString(project, GitSCM.GIT_PREVIOUS_COMMIT), build1);
 
-        rule.assertLogNotContains(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build2);
-        rule.waitForMessage(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build1);
+        r.assertLogNotContains(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build2);
+        r.waitForMessage(checkoutString(project, GitSCM.GIT_PREVIOUS_SUCCESSFUL_COMMIT), build1);
     }
 
     @Test
@@ -1493,8 +1493,8 @@ public class GitSCMTest extends AbstractGitTestCase {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         GitSCM scm = new GitSCM(null);
 
-        DumbSlave agent = rule.createSlave();
-        GitTool.DescriptorImpl gitToolDescriptor = rule.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class);
+        DumbSlave agent = r.createSlave();
+        GitTool.DescriptorImpl gitToolDescriptor = r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class);
         GitTool installation = new GitTool("Default", "/usr/bin/git", null);
         gitToolDescriptor.setInstallations(installation);
 
@@ -1676,18 +1676,18 @@ public class GitSCMTest extends AbstractGitTestCase {
                 new GitRevisionBuildParameters())));
 
         d.setScm(new GitSCM(workDir.getPath()));
-        rule.jenkins.rebuildDependencyGraph();
+        r.jenkins.rebuildDependencyGraph();
 
 
-        FreeStyleBuild ub = rule.buildAndAssertSuccess(u);
+        FreeStyleBuild ub = r.buildAndAssertSuccess(u);
         for  (int i=0; (d.getLastBuild()==null || d.getLastBuild().isBuilding()) && i<100; i++) // wait only up to 10 sec to avoid infinite loop
             Thread.sleep(100);
 
         FreeStyleBuild db = d.getLastBuild();
         assertNotNull("downstream build didn't happen",db);
 
-        db = rule.waitForCompletion(db);
-        rule.assertBuildStatusSuccess(db);
+        db = r.waitForCompletion(db);
+        r.assertBuildStatusSuccess(db);
     }
 
     // eg: "jane doe and john doe should be the culprits", culprits, [johnDoe, janeDoe])
@@ -1779,7 +1779,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertEquals("", jeffDoe.getEmailAddress(), culprit.getId());
         assertEquals("", jeffDoe.getName(), culprit.getFullName());
 
-        rule.assertBuildStatusSuccess(build);
+        r.assertBuildStatusSuccess(build);
     }
     
     @Issue("JENKINS-59868")
@@ -1851,7 +1851,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         //... and build it...
         final FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile2);
         assertTrue(build2.getWorkspace().child(commitFile2).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
@@ -1874,7 +1874,7 @@ public class GitSCMTest extends AbstractGitTestCase {
                 Collections.emptyList()));
 
         final FreeStyleBuild build = build(project, Result.SUCCESS, commitFile1);
-        rule.assertBuildStatusSuccess(build);
+        r.assertBuildStatusSuccess(build);
     }
 
     @Issue("JENKINS-26268")
@@ -1974,7 +1974,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertTrue("scm polling did not detect commit2 change", project.poll(listener).hasChanges());
         final FreeStyleBuild build2 = build(project, Result.SUCCESS, commitFile2);
         assertTrue(build2.getWorkspace().child(commitFile2).exists());
-        rule.assertBuildStatusSuccess(build2);
+        r.assertBuildStatusSuccess(build2);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
 
@@ -2047,7 +2047,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         testRepo.git.checkout("master", "topic2");
         commit(commitFile1, "other content", johnDoe, "Commit number 2");
         assertTrue("scm polling did not detect commit2 change", project.poll(listener).hasChanges());
-        rule.buildAndAssertStatus(Result.FAILURE, project);
+        r.buildAndAssertStatus(Result.FAILURE, project);
         assertFalse("scm polling should not detect any more changes after build", project.poll(listener).hasChanges());
     }
     
@@ -2120,7 +2120,7 @@ public class GitSCMTest extends AbstractGitTestCase {
     @Test
     public void testDataCompatibility1() throws Exception {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
-        FreeStyleProject p = (FreeStyleProject) rule.jenkins.createProjectFromXML("foo", getClass().getResourceAsStream("GitSCMTest/old1.xml"));
+        FreeStyleProject p = (FreeStyleProject) r.jenkins.createProjectFromXML("foo", getClass().getResourceAsStream("GitSCMTest/old1.xml"));
         GitSCM oldGit = (GitSCM) p.getScm();
         assertEquals(Collections.emptyList(), oldGit.getExtensions().toList());
         assertEquals(0, oldGit.getSubmoduleCfg().size());
@@ -2147,7 +2147,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         }
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
 
-        WorkflowJob p = rule.jenkins.createProject(WorkflowJob.class, "pipeline-checkout-3-tags");
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "pipeline-checkout-3-tags");
         p.setDefinition(new CpsFlowDefinition(
             "node {\n" +
             "    def tokenBranch = ''\n" +
@@ -2171,7 +2171,7 @@ public class GitSCMTest extends AbstractGitTestCase {
             "    echo \"token3: ${tokenBranch}\"\n" +
             "    echo \"revision3: ${tokenRevision}\"\n" +
             "}", true));
-        WorkflowRun b = rule.buildAndAssertSuccess(p);
+        WorkflowRun b = r.buildAndAssertSuccess(p);
         
         String log = b.getLog();
         // The getLineStartsWith is to ease reading the test failure, to avoid Hamcrest shows all the log
@@ -2213,11 +2213,11 @@ public class GitSCMTest extends AbstractGitTestCase {
         FreeStyleProject p = createFreeStyleProject();
         p.setScm(new GitSCM(testRepo.gitDir.getAbsolutePath()));
 
-        rule.buildAndAssertSuccess(p);
+        r.buildAndAssertSuccess(p);
 
         // this should fail as it fails to fetch
         p.setScm(new GitSCM("http://localhost:4321/no/such/repository.git"));
-        rule.buildAndAssertStatus(Result.FAILURE, p);
+        r.buildAndAssertStatus(Result.FAILURE, p);
     }
 
     @Issue("JENKINS-19108")
@@ -2230,7 +2230,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         oldGit.getExtensions().add(new LocalBranch("master"));
         p.setScm(oldGit);
 
-        FreeStyleBuild b = rule.buildAndAssertSuccess(p);
+        FreeStyleBuild b = r.buildAndAssertSuccess(p);
         GitClient gc = Git.with(StreamTaskListener.fromStdout(),null).in(b.getWorkspace()).getClient();
         gc.withRepository((RepositoryCallback<Void>) (repo, channel) -> {
             Ref head = repo.findRef("HEAD");
@@ -2360,7 +2360,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         try {
             FileUtils.touch(lock);
             final FreeStyleBuild build2 = build(project, Result.FAILURE);
-            rule.waitForMessage("java.io.IOException: Could not checkout", build2);
+            r.waitForMessage("java.io.IOException: Could not checkout", build2);
         } finally {
             lock.delete();
         }
@@ -2507,7 +2507,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         final StringParameterValue branchParam = new StringParameterValue("MY_BRANCH", "manualbranch");
         final Action[] actions = {new ParametersAction(branchParam)};
         FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause(), actions).get();
-        rule.assertBuildStatus(Result.SUCCESS, build);
+        r.assertBuildStatus(Result.SUCCESS, build);
 
         assertFalse("No changes to git since last build", project.poll(listener).hasChanges());
 
@@ -2575,7 +2575,7 @@ public class GitSCMTest extends AbstractGitTestCase {
 		commit("commitFile1", johnDoe, "Commit number 1");
 
 		FreeStyleBuild first_build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
-        rule.assertBuildStatus(Result.SUCCESS, first_build);
+        r.assertBuildStatus(Result.SUCCESS, first_build);
 
 		first_build.getWorkspace().deleteContents();
 		PollingResult pollingResult = scm.poll(project, null, first_build.getWorkspace(), listener, null);
@@ -2607,7 +2607,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         project.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("MY_BRANCH", "master")));
 
         FreeStyleBuild first_build = project.scheduleBuild2(0, new Cause.UserIdCause(), actions).get();
-        rule.assertBuildStatus(Result.SUCCESS, first_build);
+        r.assertBuildStatus(Result.SUCCESS, first_build);
 
         Launcher launcher = workspace.createLauncher(listener);
         final EnvVars environment = GitUtils.getPollEnvironment(project, workspace, launcher, listener);
@@ -2916,8 +2916,8 @@ public class GitSCMTest extends AbstractGitTestCase {
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=test commit");
         FreeStyleProject p = setupSimpleProject("master");
-        Run<?,?> run = rule.buildAndAssertSuccess(p);
-        rule.waitForMessage("Commit message: \"test commit\"", run);
+        Run<?,?> run = r.buildAndAssertSuccess(p);
+        r.waitForMessage("Commit message: \"test commit\"", run);
     }
 
     /**
@@ -2957,7 +2957,7 @@ public class GitSCMTest extends AbstractGitTestCase {
         final int initialBuildNumber = project.getLastBuild().getNumber();
         final String commit1 = ObjectId.toString(commitId);
 
-        final String notificationPath = rule.getURL().toExternalForm()
+        final String notificationPath = r.getURL().toExternalForm()
                 + "git/notifyCommit?url=" + testRepo.gitDir.toString() + "&sha1=" + commit1;
         final URL notifyUrl = new URL(notificationPath);
         String notifyContent;
@@ -2967,10 +2967,10 @@ public class GitSCMTest extends AbstractGitTestCase {
         assertThat(notifyContent, containsString("No Git consumers using SCM API plugin for: " + testRepo.gitDir.toString()));
 
         if ((project.getLastBuild().getNumber() == initialBuildNumber)
-                && (rule.jenkins.getQueue().isEmpty())) {
+                && (r.jenkins.getQueue().isEmpty())) {
             return false;
         } else {
-            while (!rule.jenkins.getQueue().isEmpty()) {
+            while (!r.jenkins.getQueue().isEmpty()) {
                 Thread.sleep(100);
             }
             final FreeStyleBuild build = project.getLastBuild();
@@ -2983,7 +2983,7 @@ public class GitSCMTest extends AbstractGitTestCase {
 
     private void setupJGit(GitSCM git) {
         git.gitTool="jgit";
-        rule.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(new JGitTool(Collections.emptyList()));
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(new JGitTool(Collections.emptyList()));
     }
 
     /** We clean the environment, just in case the test is being run from a Jenkins job using this same plugin :). */

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -59,7 +59,7 @@ public class GitStatusTest extends AbstractGitProject {
         this.repoURL = new File(".").getAbsolutePath();
         this.branch = "**";
         this.sha1 = "7bb68ef21dc90bd4f7b08eca876203b2e049198d";
-        if (jenkins.jenkins != null) {
+        if (r.jenkins != null) {
             this.notifyCommitApiToken = ApiTokenPropertyConfiguration.get().generateApiToken("test").getString("value");
         }
     }
@@ -73,8 +73,8 @@ public class GitStatusTest extends AbstractGitProject {
     @After
     public void waitForAllJobsToComplete() throws Exception {
         // Put JenkinsRule into shutdown state, trying to reduce Windows cleanup exceptions
-        if (jenkins != null && jenkins.jenkins != null) {
-            jenkins.jenkins.doQuietDown();
+        if (r != null && r.jenkins != null) {
+            r.jenkins.doQuietDown();
         }
         // JenkinsRule cleanup throws exceptions during tearDown.
         // Reduce exceptions by a random delay from 0.5 to 0.9 seconds.
@@ -87,10 +87,10 @@ public class GitStatusTest extends AbstractGitProject {
          * build logs will not be active when the cleanup process tries to
          * delete them.
          */
-        if (!isWindows() || jenkins == null || jenkins.jenkins == null) {
+        if (!isWindows() || r == null || r.jenkins == null) {
             return;
         }
-        View allView = jenkins.jenkins.getView("All");
+        View allView = r.jenkins.getView("All");
         if (allView == null) {
             return;
         }
@@ -101,7 +101,7 @@ public class GitStatusTest extends AbstractGitProject {
         runList.forEach((Run run) -> {
             try {
                 Logger.getLogger(GitStatusTest.class.getName()).log(Level.INFO, "Waiting for {0}", run);
-                jenkins.waitForCompletion(run);
+                r.waitForCompletion(run);
             } catch (InterruptedException ex) {
                 Logger.getLogger(GitStatusTest.class.getName()).log(Level.SEVERE, "Interrupted waiting for GitStatusTest job", ex);
             }
@@ -361,7 +361,7 @@ public class GitStatusTest extends AbstractGitProject {
     }
 
     private void setupProject(String url, String branchString, SCMTrigger trigger) throws Exception {
-        FreeStyleProject project = jenkins.createFreeStyleProject();
+        FreeStyleProject project = r.createFreeStyleProject();
         GitSCM git = new GitSCM(
                 Collections.singletonList(new UserRemoteConfig(url, null, null, null)),
                 Collections.singletonList(new BranchSpec(branchString)),
@@ -413,7 +413,7 @@ public class GitStatusTest extends AbstractGitProject {
     }
 
     private FreeStyleProject setupNotifyProject() throws Exception {
-        FreeStyleProject project = jenkins.createFreeStyleProject();
+        FreeStyleProject project = r.createFreeStyleProject();
         project.setQuietPeriod(0);
         GitSCM git = new GitSCM(
                 Collections.singletonList(new UserRemoteConfig(repoURL, null, null, null)),
@@ -564,7 +564,7 @@ public class GitStatusTest extends AbstractGitProject {
 
         FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
 
-        jenkins.waitForMessage("aaa aaaccc ccc", build);
+        r.waitForMessage("aaa aaaccc ccc", build);
 
         String extraValue = "An-extra-value";
         when(requestWithParameter.getParameterMap()).thenReturn(setupParameterMap(extraValue));
@@ -648,7 +648,7 @@ public class GitStatusTest extends AbstractGitProject {
 
         this.gitStatus.doNotifyCommit(requestWithParameter, repoURL, branch, sha1, notifyCommitApiToken);
 
-        jenkins.waitUntilNoActivity();
+        r.waitUntilNoActivity();
         FreeStyleBuild lastBuild = project.getLastBuild();
 
         assertNotNull(lastBuild);
@@ -726,7 +726,7 @@ public class GitStatusTest extends AbstractGitProject {
 
         this.gitStatus.doNotifyCommit(requestWithParameter, repoURL, branch, sha1, null);
 
-        jenkins.waitUntilNoActivity();
+        r.waitUntilNoActivity();
         FreeStyleBuild lastBuild = project.getLastBuild();
 
         assertNotNull(lastBuild);

--- a/src/test/java/hudson/plugins/git/GitStatusTheoriesTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTheoriesTest.java
@@ -44,7 +44,7 @@ public class GitStatusTheoriesTest extends AbstractGitProject {
         this.repoURL = new File(".").getAbsolutePath();
         this.branch = "**";
         this.sha1 = "7bb68ef21dc90bd4f7b08eca876203b2e049198d";
-        if (jenkins.jenkins != null) {
+        if (r.jenkins != null) {
             this.notifyCommitApiToken = ApiTokenPropertyConfiguration.get().generateApiToken("test").getString("value");
         }
     }
@@ -58,8 +58,8 @@ public class GitStatusTheoriesTest extends AbstractGitProject {
     @After
     public void waitForAllJobsToComplete() throws Exception {
         // Put JenkinsRule into shutdown state, trying to reduce Windows cleanup exceptions
-        if (jenkins != null && jenkins.jenkins != null) {
-            jenkins.jenkins.doQuietDown();
+        if (r != null && r.jenkins != null) {
+            r.jenkins.doQuietDown();
         }
         // JenkinsRule cleanup throws exceptions during tearDown.
         // Reduce exceptions by a random delay from 0.5 to 0.9 seconds.
@@ -72,10 +72,10 @@ public class GitStatusTheoriesTest extends AbstractGitProject {
          * build logs will not be active when the cleanup process tries to
          * delete them.
          */
-        if (!isWindows() || jenkins == null || jenkins.jenkins == null) {
+        if (!isWindows() || r == null || r.jenkins == null) {
             return;
         }
-        View allView = jenkins.jenkins.getView("All");
+        View allView = r.jenkins.getView("All");
         if (allView == null) {
             return;
         }
@@ -86,7 +86,7 @@ public class GitStatusTheoriesTest extends AbstractGitProject {
         runList.forEach((Run run) -> {
             try {
                 Logger.getLogger(GitStatusTheoriesTest.class.getName()).log(Level.INFO, "Waiting for {0}", run);
-                jenkins.waitForCompletion(run);
+                r.waitForCompletion(run);
             } catch (InterruptedException ex) {
                 Logger.getLogger(GitStatusTheoriesTest.class.getName()).log(Level.SEVERE, "Interrupted waiting for GitStatusTheoriesTest job", ex);
             }
@@ -134,7 +134,7 @@ public class GitStatusTheoriesTest extends AbstractGitProject {
     }
 
     private void setupProject(String url, String branchString, SCMTrigger trigger) throws Exception {
-        FreeStyleProject project = jenkins.createFreeStyleProject();
+        FreeStyleProject project = r.createFreeStyleProject();
         GitSCM git = new GitSCM(
                 Collections.singletonList(new UserRemoteConfig(url, null, null, null)),
                 Collections.singletonList(new BranchSpec(branchString)),

--- a/src/test/java/hudson/plugins/git/Security2478Test.java
+++ b/src/test/java/hudson/plugins/git/Security2478Test.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertFalse;
 public class Security2478Test {
 
     @Rule
-    public JenkinsRule rule = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     @Rule
     public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
@@ -39,18 +39,18 @@ public class Security2478Test {
     @Test
     public void checkoutShouldNotAbortWhenLocalSourceAndRunningOnAgent() throws Exception {
         assertFalse("Non Remote checkout should be disallowed", GitSCM.ALLOW_LOCAL_CHECKOUT);
-        rule.createOnlineSlave();
+        r.createOnlineSlave();
         sampleRepo.init();
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=test commit");
-        WorkflowJob p = rule.jenkins.createProject(WorkflowJob.class, "pipeline");
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "pipeline");
 
         String script = "node('slave0') {\n" +
                 "   checkout([$class: 'GitSCM', branches: [[name: '*/master']], extensions: [], userRemoteConfigs: [[url: '" + sampleRepo.fileUrl() + "', credentialsId: '']]])\n" +
                 "}";
         p.setDefinition(new CpsFlowDefinition(script, true));
-        WorkflowRun run = rule.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
-        rule.assertLogNotContains("aborted because it references a local directory, which may be insecure. " +
+        WorkflowRun run = r.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
+        r.assertLogNotContains("aborted because it references a local directory, which may be insecure. " +
                 "You can allow local checkouts anyway by setting the system property 'hudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT' to true.", run);
     }
 
@@ -58,8 +58,8 @@ public class Security2478Test {
     @Test
     public void checkoutShouldAbortWhenSourceIsNonRemoteAndRunningOnController() throws Exception {
         assertFalse("Non Remote checkout should be disallowed", GitSCM.ALLOW_LOCAL_CHECKOUT);
-        WorkflowJob p = rule.jenkins.createProject(WorkflowJob.class, "pipeline");
-        String workspaceDir = rule.jenkins.getRootDir().getAbsolutePath();
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "pipeline");
+        String workspaceDir = r.jenkins.getRootDir().getAbsolutePath();
 
         String path = "file://" + workspaceDir + File.separator + "jobName@script" + File.separator + "anyhmachash";
         String escapedPath = path.replace("\\", "\\\\"); // for windows
@@ -69,8 +69,8 @@ public class Security2478Test {
                 " credentialsId: '']]])\n" +
                 "}";
         p.setDefinition(new CpsFlowDefinition(script, true));
-        WorkflowRun run = rule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
-        rule.assertLogContains("Checkout of Git remote '" + path + "' " +
+        WorkflowRun run = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        r.assertLogContains("Checkout of Git remote '" + path + "' " +
                         "aborted because it references a local directory, which may be insecure. " +
                         "You can allow local checkouts anyway by setting the system property 'hudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT' to true.", run);
     }

--- a/src/test/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowserXSSTest.java
+++ b/src/test/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowserXSSTest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class TFS2013GitRepositoryBrowserXSSTest {
 
     @Rule
-    public final JenkinsRule rule = new JenkinsRule();
+    public final JenkinsRule r = new JenkinsRule();
 
     @Test
     @Issue("SECURITY-1723")
@@ -31,11 +31,11 @@ public class TFS2013GitRepositoryBrowserXSSTest {
                 Collections.emptyList());
         scm.setBrowser(new TFS2013GitRepositoryBrowser("<img src=x onerror=alert(232)>"));
 
-        FreeStyleProject p = rule.createFreeStyleProject();
+        FreeStyleProject p = r.createFreeStyleProject();
         p.setScm(scm);
 
         AtomicBoolean xss = new AtomicBoolean(false);
-        JenkinsRule.WebClient wc = rule.createWebClient();
+        JenkinsRule.WebClient wc = r.createWebClient();
         wc.setAlertHandler((page, s) -> xss.set(true));
         HtmlPage page = wc.getPage(p, "configure");
         Assert.assertFalse(xss.get());

--- a/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/GitSCMExtensionTest.java
@@ -29,7 +29,7 @@ public abstract class GitSCMExtensionTest {
 	public static BuildWatcher buildWatcher = new BuildWatcher();
 
 	@Rule
-	public JenkinsRule j = new JenkinsRule();
+	public JenkinsRule r = new JenkinsRule();
 
 	@Rule
 	public TemporaryFolder tmp = new TemporaryFolder();
@@ -63,7 +63,7 @@ public abstract class GitSCMExtensionTest {
 	protected FreeStyleBuild build(final FreeStyleProject project, final Result expectedResult) throws Exception {
 		final FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
 		if(expectedResult != null) {
-			j.assertBuildStatus(expectedResult, build);
+			r.assertBuildStatus(expectedResult, build);
 		}
 		return build;
 	}
@@ -78,7 +78,7 @@ public abstract class GitSCMExtensionTest {
 	 */
 	protected FreeStyleProject setupBasicProject(TestGitRepo repo) throws Exception {
 		GitSCMExtension extension = getExtension();
-		FreeStyleProject project = j.createFreeStyleProject("p");
+		FreeStyleProject project = r.createFreeStyleProject("p");
 		List<BranchSpec> branches = Collections.singletonList(new BranchSpec("master"));
 		GitSCM scm = new GitSCM(
 				repo.remoteConfigs(),

--- a/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/BuildSingleRevisionOnlyTest.java
@@ -30,10 +30,10 @@ public class BuildSingleRevisionOnlyTest extends AbstractGitTestCase {
          * build logs will not be active when the cleanup process tries to
          * delete them.
          */
-        if (!isWindows() || rule == null || rule.jenkins == null) {
+        if (!isWindows() || r == null || r.jenkins == null) {
             return;
         }
-        View allView = rule.jenkins.getView("All");
+        View allView = r.jenkins.getView("All");
         if (allView == null) {
             return;
         }
@@ -44,7 +44,7 @@ public class BuildSingleRevisionOnlyTest extends AbstractGitTestCase {
         runList.forEach((Run run) -> {
             try {
                 Logger.getLogger(GitStatusTest.class.getName()).log(Level.INFO, "Waiting for {0}", run);
-                rule.waitForCompletion(run);
+                r.waitForCompletion(run);
             } catch (InterruptedException ex) {
                 Logger.getLogger(GitStatusTest.class.getName()).log(Level.SEVERE, "Interrupted waiting for GitStatusTest job", ex);
             }
@@ -77,7 +77,7 @@ public class BuildSingleRevisionOnlyTest extends AbstractGitTestCase {
 
         final FreeStyleBuild build = build(project, Result.SUCCESS, commitFile);
 
-        rule.assertBuildStatusSuccess(build);
+        r.assertBuildStatusSuccess(build);
         boolean result = build.getLog(100).contains(
                 String.format("Scheduling another build to catch up with %s", project.getName()));
         Assert.assertFalse("Single revision scheduling did not prevent a build of a different revision", result);
@@ -108,8 +108,8 @@ public class BuildSingleRevisionOnlyTest extends AbstractGitTestCase {
 
         final FreeStyleBuild build = build(project, Result.SUCCESS, commitFile);
 
-        rule.assertBuildStatusSuccess(build);
-        rule.waitForMessage(String.format("Scheduling another build to catch up with %s", project.getName()), build);
+        r.assertBuildStatusSuccess(build);
+        r.waitForMessage(String.format("Scheduling another build to catch up with %s", project.getName()), build);
 
         // Wait briefly for newly scheduled job to start.
         // Once job has started, waitForAllJobsToComplete will hold the test until job completes.

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionDepthTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionDepthTest.java
@@ -28,7 +28,7 @@ import org.mockito.Mockito;
 public class CloneOptionDepthTest {
 
     @ClassRule
-    public static JenkinsRule j = new JenkinsRule();
+    public static JenkinsRule r = new JenkinsRule();
 
     private GitSCM scm;
     private Run<?, ?> build;

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionHonorRefSpecTest.java
@@ -78,7 +78,7 @@ public class CloneOptionHonorRefSpecTest extends AbstractGitTestCase {
         ));
         project.getBuildersList().add(createEnvEchoBuilder(refSpecName));
 
-        final FreeStyleBuild b = rule.buildAndAssertSuccess(project);
+        final FreeStyleBuild b = r.buildAndAssertSuccess(project);
 
         List<String> logs = b.getLog(50);
         for (String line : logs) {

--- a/src/test/java/hudson/plugins/git/security/ApiTokenPropertyConfigurationTest.java
+++ b/src/test/java/hudson/plugins/git/security/ApiTokenPropertyConfigurationTest.java
@@ -24,20 +24,20 @@ import static org.junit.Assert.assertTrue;
 public class ApiTokenPropertyConfigurationTest {
 
     @Rule
-    public JenkinsRule j = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     @Before
     public void init() {
-        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
         MockAuthorizationStrategy authorizationStrategy = new MockAuthorizationStrategy();
         authorizationStrategy.grant(Jenkins.ADMINISTER).everywhere().to("alice");
         authorizationStrategy.grant(Jenkins.READ).everywhere().to("bob");
-        j.jenkins.setAuthorizationStrategy(authorizationStrategy);
+        r.jenkins.setAuthorizationStrategy(authorizationStrategy);
     }
 
     @Test
     public void testAdminPermissionRequiredToGenerateNewApiTokens() throws Exception {
-        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+        try (JenkinsRule.WebClient wc = r.createWebClient()) {
             wc.login("bob");
             WebRequest req = new WebRequest(
                     wc.createCrumbedUrl(ApiTokenPropertyConfiguration.get().getDescriptorUrl() + "/generate"), HttpMethod.POST);
@@ -53,7 +53,7 @@ public class ApiTokenPropertyConfigurationTest {
 
     @Test
     public void adminPermissionsRequiredToRevokeApiTokens() throws Exception {
-        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+        try (JenkinsRule.WebClient wc = r.createWebClient()) {
             wc.login("bob");
             WebRequest req = new WebRequest(wc.createCrumbedUrl(ApiTokenPropertyConfiguration.get().getDescriptorUrl() + "/revoke"), HttpMethod.POST);
             wc.setThrowExceptionOnFailingStatusCode(false);
@@ -67,7 +67,7 @@ public class ApiTokenPropertyConfigurationTest {
 
     @Test
     public void testBasicGenerationAndRevocation() throws Exception {
-        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+        try (JenkinsRule.WebClient wc = r.createWebClient()) {
             wc.login("alice");
             WebRequest generateReq = new WebRequest(
                     wc.createCrumbedUrl(ApiTokenPropertyConfiguration.get().getDescriptorUrl() + "/generate"), HttpMethod.POST);

--- a/src/test/java/hudson/plugins/git/util/GitUtilsJenkinsRuleTest.java
+++ b/src/test/java/hudson/plugins/git/util/GitUtilsJenkinsRuleTest.java
@@ -43,28 +43,28 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class GitUtilsJenkinsRuleTest {
 
     @ClassRule
-    public static JenkinsRule j = new JenkinsRule();
+    public static JenkinsRule r = new JenkinsRule();
 
     @Test
     public void testWorkspaceToNode() throws Exception {
         String labelString = "label-" + UUID.randomUUID();
         Label label = new LabelAtom(labelString);
-        DumbSlave agent = j.createOnlineSlave(label);
+        DumbSlave agent = r.createOnlineSlave(label);
         FilePath workspace = agent.getWorkspaceRoot();
         assertThat(GitUtils.workspaceToNode(workspace).getLabelString(), is(labelString));
 
         /* Check that workspace on master reports master even when agent connected */
-        assertThat(GitUtils.workspaceToNode(j.getInstance().getRootPath()), is(j.getInstance()));
+        assertThat(GitUtils.workspaceToNode(r.getInstance().getRootPath()), is(r.getInstance()));
     }
 
     @Test
     public void testWorkspaceToNodeRootPath() {
-        assertThat(GitUtils.workspaceToNode(j.getInstance().getRootPath()), is(j.getInstance()));
+        assertThat(GitUtils.workspaceToNode(r.getInstance().getRootPath()), is(r.getInstance()));
     }
 
     @Test
     public void testWorkspaceToNodeNullWorkspace() {
-        assertThat(GitUtils.workspaceToNode(null), is(j.getInstance()));
+        assertThat(GitUtils.workspaceToNode(null), is(r.getInstance()));
     }
 
     @Test
@@ -107,7 +107,7 @@ public class GitUtilsJenkinsRuleTest {
         String gitTool = "/opt/my-non-existing-git/bin/git";
         String labelString = "label-" + UUID.randomUUID();
         Label label = new LabelAtom(labelString);
-        DumbSlave agent = j.createOnlineSlave(label);
+        DumbSlave agent = r.createOnlineSlave(label);
         EnvVars env = new EnvVars();
         GitTool tool = GitUtils.resolveGitTool(gitTool, agent, env, listener);
         assertThat(tool.getGitExe(), startsWith("git"));

--- a/src/test/java/jenkins/plugins/git/GitBranchSCMHeadTest.java
+++ b/src/test/java/jenkins/plugins/git/GitBranchSCMHeadTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertNotNull;
 public class GitBranchSCMHeadTest {
 
     @Rule
-    public JenkinsRule j = new JenkinsRule() {
+    public JenkinsRule r = new JenkinsRule() {
         @Override
         public void before() throws Throwable {
             if (!isWindows() && "testMigrationNoBuildStorm".equals(this.getTestDescription().getMethodName())) {
@@ -60,7 +60,7 @@ public class GitBranchSCMHeadTest {
             /* Do not distract warnings system by using assumeThat to skip tests */
             return;
         }
-        final WorkflowMultiBranchProject job = j.jenkins.getItemByFullName("job", WorkflowMultiBranchProject.class);
+        final WorkflowMultiBranchProject job = r.jenkins.getItemByFullName("job", WorkflowMultiBranchProject.class);
         assertEquals(4, job.getItems().size());
         WorkflowJob master = job.getItem("master");
         assertEquals(1, master.getBuilds().size());
@@ -72,7 +72,7 @@ public class GitBranchSCMHeadTest {
         final Queue.Item item = job.scheduleBuild2(0);
         assertNotNull(item);
         item.getFuture().waitForStart();
-        j.waitUntilNoActivity();
+        r.waitUntilNoActivity();
 
         assertEquals(4, job.getItems().size());
         master = job.getItem("master");

--- a/src/test/java/jenkins/plugins/git/GitHooksConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/git/GitHooksConfigurationTest.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertTrue;
 public class GitHooksConfigurationTest {
 
     @Rule
-    public JenkinsRule j = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     private GitHooksConfiguration configuration;
     private GitClient client;

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
@@ -79,7 +79,7 @@ public class GitSCMSourceTest {
     public static final String REMOTE = "git@remote:test/project.git";
 
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     private GitStatus gitStatus;
 
@@ -94,12 +94,12 @@ public class GitSCMSourceTest {
         String notifyCommitApiToken = ApiTokenPropertyConfiguration.get().generateApiToken("test").getString("value");
         GitSCMSource gitSCMSource = new GitSCMSource("id", REMOTE, "", "*", "", false);
         GitSCMSourceOwner scmSourceOwner = setupGitSCMSourceOwner(gitSCMSource);
-        jenkins.getInstance().add(scmSourceOwner, "gitSourceOwner");
+        r.getInstance().add(scmSourceOwner, "gitSourceOwner");
 
         gitStatus.doNotifyCommit(mock(HttpServletRequest.class), REMOTE, "master", "", notifyCommitApiToken);
 
         SCMHeadEvent event =
-                jenkins.getInstance().getExtensionList(SCMEventListener.class).get(SCMEventListenerImpl.class)
+                r.getInstance().getExtensionList(SCMEventListener.class).get(SCMEventListenerImpl.class)
                         .waitSCMHeadEvent(1, TimeUnit.SECONDS);
         assertThat(event, notNullValue());
         assertThat((Iterable<SCMHead>) event.heads(gitSCMSource).keySet(), hasItem(is(new GitBranchSCMHead("master"))));
@@ -364,13 +364,13 @@ public class GitSCMSourceTest {
             return;
         }
         TaskListener log = StreamTaskListener.fromStdout();
-        HelloToolInstaller inst = new HelloToolInstaller(jenkins.jenkins.getSelfLabel().getName(), "echo Hello", "git");
+        HelloToolInstaller inst = new HelloToolInstaller(r.jenkins.getSelfLabel().getName(), "echo Hello", "git");
         GitTool t = new GitTool("myGit", null, Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
         t.getDescriptor().setInstallations(t);
 
         GitTool defaultTool = GitTool.getDefaultInstallation();
-        GitTool resolved = (GitTool) defaultTool.translate(jenkins.jenkins, new EnvVars(), TaskListener.NULL);
+        GitTool resolved = (GitTool) defaultTool.translate(r.jenkins, new EnvVars(), TaskListener.NULL);
         assertThat(resolved.getGitExe(), org.hamcrest.CoreMatchers.containsString("git"));
 
         GitSCMSource instance = new GitSCMSource("http://git.test/telescope.git");

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -53,7 +53,7 @@ import static org.junit.Assume.assumeTrue;
 public class GitToolChooserTest {
 
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     @Rule
     public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
@@ -112,7 +112,7 @@ public class GitToolChooserTest {
 
         GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.emptyList());
         GitTool JTool = new JGitTool(Collections.emptyList());
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, JTool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, JTool);
 
         GitToolChooser r = new GitToolChooser(remote, context, credentialsId, JTool, null, TaskListener.NULL,true);
 
@@ -137,13 +137,13 @@ public class GitToolChooserTest {
         Item context = Mockito.mock(Item.class);
         String credentialsId = null;
 
-        TestToolInstaller inst = new TestToolInstaller(jenkins.jenkins.getSelfLabel().getName(), "echo Hello", "updated/git");
+        TestToolInstaller inst = new TestToolInstaller(r.jenkins.getSelfLabel().getName(), "echo Hello", "updated/git");
         GitTool t = new GitTool("myGit", "default/git", Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
 
         GitTool tool = new GitTool("my-git", "git", Collections.emptyList());
         GitTool JTool = new JGitTool(Collections.emptyList());
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, JTool, t);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, JTool, t);
 
         GitToolChooser r = new GitToolChooser(remote, context, credentialsId, JTool, null, TaskListener.NULL,true);
 
@@ -169,11 +169,11 @@ public class GitToolChooserTest {
         String credentialsId = null;
 
         LabelAtom label = new LabelAtom("agent-windows");
-        DumbSlave agent = jenkins.createOnlineSlave(label);
+        DumbSlave agent = r.createOnlineSlave(label);
         agent.setMode(Node.Mode.NORMAL);
         agent.setLabelString("agent-windows");
 
-        TestToolInstaller inst = new TestToolInstaller(jenkins.jenkins.getSelfLabel().getName(), "echo Hello", "myGit/git");
+        TestToolInstaller inst = new TestToolInstaller(r.jenkins.getSelfLabel().getName(), "echo Hello", "myGit/git");
         GitTool toolOnMaster = new GitTool("myGit", "default/git", Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(inst))));
 
@@ -182,15 +182,15 @@ public class GitToolChooserTest {
 
         GitTool JTool = new JGitTool(Collections.emptyList());
 
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(toolOnMaster, toolOnAgent, JTool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(toolOnMaster, toolOnAgent, JTool);
         agent.getNodeProperties().add(new ToolLocationNodeProperty(new ToolLocationNodeProperty.ToolLocation(
-                jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class), toolOnMaster.getName(), toolOnMaster.getHome())));
+                r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class), toolOnMaster.getName(), toolOnMaster.getHome())));
 
         agent.getNodeProperties().add(new ToolLocationNodeProperty(new ToolLocationNodeProperty.ToolLocation(
-                jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class), toolOnAgent.getName(), toolOnAgent.getHome())));
+                r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class), toolOnAgent.getName(), toolOnAgent.getHome())));
 
         agent.getNodeProperties().add(new ToolLocationNodeProperty(new ToolLocationNodeProperty.ToolLocation(
-                jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class), JTool.getName(), null)));
+                r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class), JTool.getName(), null)));
 
         GitToolChooser r = new GitToolChooser(remote, context, credentialsId, JTool, agent, TaskListener.NULL,true);
 
@@ -212,7 +212,7 @@ public class GitToolChooserTest {
 
         buildAProject(sampleRepo, false);
 
-        List<TopLevelItem> list = jenkins.jenkins.getItems();
+        List<TopLevelItem> list = r.jenkins.getItems();
 
         //Since no installation is provided, the gitExe will be git
         GitTool rTool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.emptyList());
@@ -256,14 +256,14 @@ public class GitToolChooserTest {
         GitTool tool = new JGitTool(Collections.emptyList());
 
         // Add a JGit tool to the Jenkins instance to let the estimator find and recommend "jgit"
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
 
         store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "github"));
         store.save();
 
         buildAProject(sampleRepo, false);
 
-        List<TopLevelItem> list = jenkins.jenkins.getItems();
+        List<TopLevelItem> list = r.jenkins.getItems();
 
         GitToolChooser repoSizeEstimator = new GitToolChooser(source.getRemote(), list.get(0), "github", tool, null,TaskListener.NULL,true);
         /*
@@ -372,7 +372,7 @@ public class GitToolChooserTest {
         store.save();
         buildAProject(sampleRepo, false);
 
-        List<TopLevelItem> list = jenkins.jenkins.getItems();
+        List<TopLevelItem> list = r.jenkins.getItems();
 
         // Assuming no tool is installed and git is present in the machine
         GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.emptyList());
@@ -396,11 +396,11 @@ public class GitToolChooserTest {
 
         // With JGit, we don't ask the name and home of the tool
         GitTool tool = new JGitTool(Collections.emptyList());
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
 
 
         buildAProject(sampleRepo, false);
-        List<TopLevelItem> list = jenkins.jenkins.getItems();
+        List<TopLevelItem> list = r.jenkins.getItems();
 
         GitToolChooser sizeEstimator = new GitToolChooser(remote, list.get(0), "github", tool, null, TaskListener.NULL,true);
         assertThat(sizeEstimator.getGitTool(), containsString("jgit"));
@@ -418,7 +418,7 @@ public class GitToolChooserTest {
         store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "github"));
         store.save();
         buildAProject(sampleRepo, false);
-        List<TopLevelItem> list = jenkins.jenkins.getItems();
+        List<TopLevelItem> list = r.jenkins.getItems();
 
         // Assuming no tool is installed by user and git is present in the machine
         GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.emptyList());
@@ -440,7 +440,7 @@ public class GitToolChooserTest {
         store.addCredentials(Domain.global(), createCredential(CredentialsScope.GLOBAL, "github"));
         store.save();
         buildAProject(sampleRepo, false);
-        List<TopLevelItem> list = jenkins.jenkins.getItems();
+        List<TopLevelItem> list = r.jenkins.getItems();
 
         // Assuming no tool is installed by user and git is present in the machine
         GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.emptyList());
@@ -460,7 +460,7 @@ public class GitToolChooserTest {
         sampleRepo.init();
 
         buildAProject(sampleRepo, true);
-        List<TopLevelItem> list = jenkins.jenkins.getItems();
+        List<TopLevelItem> list = r.jenkins.getItems();
 
         // Assuming no tool is installed by user and git is present in the machine
         GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.emptyList());
@@ -483,7 +483,7 @@ public class GitToolChooserTest {
 
         // With JGit, we don't ask the name and home of the tool
         GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.emptyList());
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
 
         GitToolChooser gitToolChooser = new GitToolChooser(remote, context, credentialsId, tool, null, TaskListener.NULL,true);
 
@@ -503,7 +503,7 @@ public class GitToolChooserTest {
         // With JGit, we don't ask the name and home of the tool
         GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.emptyList());
         GitTool jgitTool = new JGitTool(Collections.emptyList());
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, jgitTool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, jgitTool);
 
         GitToolChooser gitToolChooser = new GitToolChooser(remote, context, credentialsId, tool, null, TaskListener.NULL,true);
         assertThat(gitToolChooser.getGitTool(), is("jgit"));
@@ -523,7 +523,7 @@ public class GitToolChooserTest {
         GitTool tool = new GitTool("my-git", "/usr/bin/git", Collections.emptyList());
         GitTool jgitTool = new JGitTool(Collections.emptyList());
         GitTool jGitApacheTool = new JGitApacheTool(Collections.emptyList());
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, jgitTool, jGitApacheTool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, jgitTool, jGitApacheTool);
 
         GitToolChooser gitToolChooser = new GitToolChooser(remote, context, credentialsId, tool, null, TaskListener.NULL,true);
         assertThat(gitToolChooser.getGitTool(), is("jgit"));
@@ -543,7 +543,7 @@ public class GitToolChooserTest {
         // With JGit, we don't ask the name and home of the tool
         GitTool tool = new GitTool("my-git", "/usr/bin/git", Collections.emptyList());
         GitTool jGitApacheTool = new JGitApacheTool(Collections.emptyList());
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, jGitApacheTool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, jGitApacheTool);
 
         GitToolChooser gitToolChooser = new GitToolChooser(remote, context, credentialsId, jGitApacheTool, null, TaskListener.NULL,true);
         assertThat(gitToolChooser.getGitTool(), is("jgitapache"));
@@ -561,7 +561,7 @@ public class GitToolChooserTest {
 
         // With JGit, we don't ask the name and home of the tool
         GitTool jGitApacheTool = new JGitApacheTool(Collections.emptyList());
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(jGitApacheTool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(jGitApacheTool);
 
         GitToolChooser gitToolChooser = new GitToolChooser(remote, context, credentialsId, jGitApacheTool, null, TaskListener.NULL,true);
         assertThat(gitToolChooser.getGitTool(), is("jgitapache"));
@@ -580,7 +580,7 @@ public class GitToolChooserTest {
         store.save();
         buildAProject(sampleRepo, false);
 
-        List<TopLevelItem> list = jenkins.jenkins.getItems();
+        List<TopLevelItem> list = r.jenkins.getItems();
 
         // Assuming no tool is installed and git is present in the machine
         GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.emptyList());
@@ -599,11 +599,11 @@ public class GitToolChooserTest {
 
         // With JGit, we don't ask the name and home of the tool
         GitTool jGitTool = new JGitTool(Collections.emptyList());
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(jGitTool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(jGitTool);
 
         buildAProject(sampleRepo, false);
 
-        List<TopLevelItem> list = jenkins.jenkins.getItems();
+        List<TopLevelItem> list = r.jenkins.getItems();
 
         // Assuming no tool is installed and git is present in the machine
         String gitExe = jGitTool.getGitExe();
@@ -622,11 +622,11 @@ public class GitToolChooserTest {
 
         // With JGit, we don't ask the name and home of the tool
         GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.emptyList());
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
 
         buildAProject(sampleRepo, false);
 
-        List<TopLevelItem> list = jenkins.jenkins.getItems();
+        List<TopLevelItem> list = r.jenkins.getItems();
 
         // Assuming no tool is installed and git is present in the machine
         String gitExe = tool.getGitExe();
@@ -647,11 +647,11 @@ public class GitToolChooserTest {
         GitTool tool = new GitTool("my-git", isWindows() ? "git.exe" : "git", Collections.emptyList());
         GitTool jgitTool = new JGitTool(Collections.emptyList());
         GitTool jGitApacheTool = new JGitApacheTool(Collections.emptyList());
-        jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, jgitTool, jGitApacheTool);
+        r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool, jgitTool, jGitApacheTool);
 
         buildAProject(sampleRepo, false);
 
-        List<TopLevelItem> list = jenkins.jenkins.getItems();
+        List<TopLevelItem> list = r.jenkins.getItems();
 
         // Assuming no tool is installed and git is present in the machine
         String gitExe = tool.getGitExe();
@@ -667,7 +667,7 @@ public class GitToolChooserTest {
         // Generate a unique repository name and compute expected cache directory
         String remoteName = "https://github.com/jenkinsci/git-plugin-" + java.util.UUID.randomUUID() + ".git";
         String cacheEntry = AbstractGitSCMSource.getCacheEntry(remoteName);
-        File expectedCacheDir = new File(new File(jenkins.jenkins.getRootDir(), "caches"), cacheEntry);
+        File expectedCacheDir = new File(new File(r.jenkins.getRootDir(), "caches"), cacheEntry);
 
         // Directory should not exist
         assertThat(expectedCacheDir, is(not(anExistingFileOrDirectory())));
@@ -692,7 +692,7 @@ public class GitToolChooserTest {
 
         failAProject(sampleRepo);
 
-        List<TopLevelItem> list = jenkins.jenkins.getItems();
+        List<TopLevelItem> list = r.jenkins.getItems();
 
         // Use JGit as the git tool for this NPE check
         GitTool jgitTool = new JGitTool(Collections.emptyList());
@@ -780,7 +780,7 @@ public class GitToolChooserTest {
 
 
     private void buildAProject(GitSampleRepoRule sampleRepo, boolean noCredentials) throws Exception {
-        WorkflowJob p = jenkins.jenkins.createProject(WorkflowJob.class, "p");
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
                 "node {\n"
                         + "  checkout(\n"
@@ -790,23 +790,23 @@ public class GitToolChooserTest {
                         + "  def tokenBranch = tm '${GIT_BRANCH,fullName=false}'\n"
                         + "  echo \"token macro expanded branch is ${tokenBranch}\"\n"
                         + "}", true));
-        WorkflowRun b = jenkins.buildAndAssertSuccess(p);
+        WorkflowRun b = r.buildAndAssertSuccess(p);
         if (!noCredentials) {
-            jenkins.waitForMessage("using credential github", b);
+            r.waitForMessage("using credential github", b);
         }
-        jenkins.waitForMessage("token macro expanded branch is remotes/origin/master", b); // Unexpected but current behavior
+        r.waitForMessage("token macro expanded branch is remotes/origin/master", b); // Unexpected but current behavior
     }
 
     /* Attempt to perform a checkout without defining a remote repository. Expected to fail, but should not report NPE */
     private void failAProject(GitSampleRepoRule sampleRepo) throws Exception {
-        WorkflowJob p = jenkins.jenkins.createProject(WorkflowJob.class, "intentionally-failing-job-without-remote-config");
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "intentionally-failing-job-without-remote-config");
         p.setDefinition(new CpsFlowDefinition("node {\n"
                                               + "  checkout(\n"
                                               + "    [$class: 'GitSCM']\n"
                                               + "  )\n"
                                               + "}", true));
-        WorkflowRun b = jenkins.buildAndAssertStatus(hudson.model.Result.FAILURE, p);
-        jenkins.waitForMessage("Couldn't find any revision to build", b);
+        WorkflowRun b = r.buildAndAssertStatus(hudson.model.Result.FAILURE, p);
+        r.waitForMessage("Couldn't find any revision to build", b);
     }
 
     private StandardCredentials createCredential(CredentialsScope scope, String id) {

--- a/src/test/java/jenkins/plugins/git/ModernScmTest.java
+++ b/src/test/java/jenkins/plugins/git/ModernScmTest.java
@@ -38,7 +38,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ModernScmTest {
 
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     @Test
     @Issue("JENKINS-58964")

--- a/src/test/java/jenkins/plugins/git/traits/GitSCMExtensionTraitTest.java
+++ b/src/test/java/jenkins/plugins/git/traits/GitSCMExtensionTraitTest.java
@@ -15,7 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GitSCMExtensionTraitTest {
     @ClassRule
-    public static JenkinsRule j = new JenkinsRule();
+    public static JenkinsRule r = new JenkinsRule();
 
     public List<GitSCMExtensionTraitDescriptor> descriptors() {
         List<GitSCMExtensionTraitDescriptor> list = new ArrayList<>();

--- a/src/test/java/org/jenkinsci/plugins/gittagmessage/AbstractGitTagMessageExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gittagmessage/AbstractGitTagMessageExtensionTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertNotNull;
 
 public abstract class AbstractGitTagMessageExtensionTest<J extends Job<J, R> & ParameterizedJobMixIn.ParameterizedJob<J, R>, R extends Run<J, R> & Queue.Executable> {
 
-    @Rule public final JenkinsRule jenkins = new JenkinsRule();
+    @Rule public final JenkinsRule r = new JenkinsRule();
 
     @Rule public final TemporaryFolder repoDir = new TemporaryFolder();
 
@@ -50,7 +50,7 @@ public abstract class AbstractGitTagMessageExtensionTest<J extends Job<J, R> & P
     public void setUp() throws IOException, InterruptedException, ConfigInvalidException {
         SystemReader.getInstance().getUserConfig().clear();
         // Set up a temporary git repository for each test case
-        repo = Git.with(jenkins.createTaskListener(), GitUtilsTest.getConfigNoSystemEnvsVars()).in(repoDir.getRoot()).getClient();
+        repo = Git.with(r.createTaskListener(), GitUtilsTest.getConfigNoSystemEnvsVars()).in(repoDir.getRoot()).getClient();
         repo.init();
     }
 
@@ -176,7 +176,7 @@ public abstract class AbstractGitTagMessageExtensionTest<J extends Job<J, R> & P
      * @return The build that was executed.
      */
     private R buildJobAndAssertSuccess(J job) throws Exception {
-        R build = jenkins.buildAndAssertSuccess(job);
+        R build = r.buildAndAssertSuccess(job);
         assertNotNull(build.getAction(BuildData.class));
         return build;
     }

--- a/src/test/java/org/jenkinsci/plugins/gittagmessage/GitTagMessageExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gittagmessage/GitTagMessageExtensionTest.java
@@ -34,7 +34,7 @@ public class GitTagMessageExtensionTest extends AbstractGitTagMessageExtensionTe
                 null, null,
                 Collections.singletonList(extension));
 
-        FreeStyleProject job = jenkins.createFreeStyleProject();
+        FreeStyleProject job = r.createFreeStyleProject();
         job.getBuildersList().add(createEnvEchoBuilder("tag", ENV_VAR_NAME_TAG));
         job.getBuildersList().add(createEnvEchoBuilder("msg", ENV_VAR_NAME_MESSAGE));
         job.setScm(scm);
@@ -45,8 +45,8 @@ public class GitTagMessageExtensionTest extends AbstractGitTagMessageExtensionTe
     protected void assertBuildEnvironment(FreeStyleBuild build, String expectedName, String expectedMessage)
             throws Exception {
         // In the freestyle shell step, unknown environment variables are returned as empty strings
-        jenkins.waitForMessage(String.format("tag='%s'", Util.fixNull(expectedName)), build);
-        jenkins.waitForMessage(String.format("msg='%s'", Util.fixNull(expectedMessage)), build);
+        r.waitForMessage(String.format("tag='%s'", Util.fixNull(expectedName)), build);
+        r.waitForMessage(String.format("msg='%s'", Util.fixNull(expectedMessage)), build);
     }
 
     private static Builder createEnvEchoBuilder(String key, String envVarName) {


### PR DESCRIPTION
## Use consistent variable name for JenkinsRule

Several different names are used inconsistently throughout the tests. Those naming differences make it more difficult to read the tests and more difficult to maintain.

Many 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Maintenance improvement
