### PR TITLE
Use plugin bom 2143.ve4c3c9ec790a

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,6 @@
   <properties>
     <revision>5.1.0</revision>
     <changelist>-SNAPSHOT</changelist>
-    <!-- TODO: Remove when updated to plugin bill of materials that includes this version -->
-    <configuration-as-code-plugin.version>1647.ve39ca_b_829b_42</configuration-as-code-plugin.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.387.3</jenkins.version>
     <no-test-jar>false</no-test-jar>
@@ -90,7 +88,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>
-        <version>2133.v2e6c00fe4d61</version>
+        <version>2143.ve4c3c9ec790a</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -248,13 +246,11 @@
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <optional>true</optional>
-      <version>${configuration-as-code-plugin.version}</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
       <scope>test</scope>
-      <version>${configuration-as-code-plugin.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>


### PR DESCRIPTION
## Use plugin bom 2143.ve4c3c9ec790a

Remove the temporary entries for configuration as code plugin version.

Plugin bill of materials now includes the configuration as code plugin version that uses HTMLUnit 3.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
