### PR TITLE
Increase spotbugs checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <!-- https://stackoverflow.com/questions/12038238/unable-to-locate-source-xref-to-link-to -->
     <linkXRef>false</linkXRef>
     <spotbugs.effort>Max</spotbugs.effort>
-    <spotbugs.threshold>Medium</spotbugs.threshold>
+    <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -958,10 +958,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
     }
 
-    private static CredentialsMatcher gitScanCredentialsMatcher() {
-        return CredentialsMatchers.anyOf(CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class));
-    }
-
     @NonNull
     private BuildData fixNull(BuildData bd) {
         ScmName sn = getExtensions().get(ScmName.class);

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -1136,7 +1136,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                 target = target.substring(Constants.R_HEADS.length());
             }
             List<Action> result = new ArrayList<>();
-            if (target != null && !target.isBlank()) {
+            if (!target.isBlank()) {
                 result.add(new GitRemoteHeadRefAction(getRemote(), target));
             }
             return result;
@@ -1159,7 +1159,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                 target = target.substring(Constants.R_HEADS.length());
             }
             List<Action> result = new ArrayList<>();
-            if (target != null && !target.isBlank()) {
+            if (!target.isBlank()) {
                 result.add(new GitRemoteHeadRefAction(getRemote(), target));
             }
             return result;
@@ -1188,7 +1188,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                     target = target.substring(Constants.R_HEADS.length());
                 }
                 List<Action> result = new ArrayList<>();
-                if (target != null && !target.isBlank()) {
+                if (!target.isBlank()) {
                     result.add(new GitRemoteHeadRefAction(getRemote(), target));
                 }
                 return result;

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -269,17 +269,15 @@ public class GitToolChooser {
     /** Cache the estimated repository size for variants of repository URL */
     private void assignSizeToInternalCache(String repoURL, long repoSize) {
         repoURL = convertToCanonicalURL(repoURL);
-        if (repositorySizeCache.containsKey(repoURL)) {
-            long oldSize = repositorySizeCache.get(repoURL);
-            if (oldSize < repoSize) {
-                LOGGER.log(Level.FINE, "Replacing old repo size {0} with new size {1} for repo {2}", new Object[]{oldSize, repoSize, repoURL});
-                repositorySizeCache.put(repoURL, repoSize);
-            } else if (oldSize > repoSize) {
-                LOGGER.log(Level.FINE, "Ignoring new size {1} in favor of old size {0} for repo {2}", new Object[]{oldSize, repoSize, repoURL});
-            }
-        } else {
+        Long oldSize = repositorySizeCache.put(repoURL, repoSize);
+        if (oldSize == null) {
             LOGGER.log(Level.FINE, "Caching repo size {0} for repo {1}", new Object[]{repoSize, repoURL});
-            repositorySizeCache.put(repoURL, repoSize);
+        } else if (oldSize < repoSize) {
+            LOGGER.log(Level.FINE, "Replaced old repo size {0} with new size {1} for repo {2}", new Object[]{oldSize, repoSize, repoURL});
+        } else if (oldSize > repoSize) {
+            /* Put back the larger old repo size and log a warning. This is not harmful but should be quite rare */
+            LOGGER.log(Level.WARNING, "Ignoring new repo size {1} in favor of old size {0} for repo {2}", new Object[]{oldSize, repoSize, repoURL});
+            repositorySizeCache.put(repoURL, oldSize);
         }
     }
 

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!--
+    Exclusions in this section have been triaged and determined to be
+    false positives.
+  -->
+  <Match>
+    <Bug pattern="BC_UNCONFIRMED_CAST_OF_RETURN_VALUE" />
+    <Class name="hudson.plugins.git.GitChangeSet" />
+    <Method name="getUser" />
+  </Match>
+  <Match>
+    <Bug pattern="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR" />
+    <Or>
+      <Class name="hudson.plugins.git.GitChangeSetList" />
+      <Class name="hudson.plugins.git.GitSCM" />
+    </Or>
+  </Match>
+  <Match>
+    <Bug pattern="SE_NO_SERIALVERSIONID" />
+    <Or>
+      <Class name="hudson.plugins.git.ChangelogToBranchOptions" />
+      <Class name="hudson.plugins.git.GitPublisher$BranchToPush" />
+      <Class name="hudson.plugins.git.GitPublisher$NoteToPush" />
+      <Class name="hudson.plugins.git.GitPublisher$TagToPush" />
+      <Class name="hudson.plugins.git.GitSCM$BuildChooserContextImpl" />
+      <Class name="hudson.plugins.git.UserMergeOptions" />
+      <Class name="hudson.plugins.git.UserRemoteConfig" />
+      <Class name="hudson.plugins.git.browser.TFS2013GitRepositoryBrowser" />
+      <Class name="hudson.plugins.git.extensions.impl.SparseCheckoutPath$SparseCheckoutPathToPath" />
+      <Class name="hudson.plugins.git.util.DefaultBuildChooser" />
+      <Class name="jenkins.plugins.git.AbstractGitSCMSource$SCMRevisionImpl" />
+      <Class name="jenkins.plugins.git.AbstractGitSCMSource$SpecificRevisionBuildChooser" />
+      <Class name="jenkins.plugins.git.AbstractGitSCMSource$TelescopingSCMProbe" />
+      <Class name="jenkins.plugins.git.AbstractGitSCMSource$TreeWalkingSCMProbe" />
+      <Class name="jenkins.plugins.git.GitBranchSCMHead" />
+      <Class name="jenkins.plugins.git.GitBranchSCMRevision" />
+      <Class name="jenkins.plugins.git.GitRefSCMHead" />
+      <Class name="jenkins.plugins.git.GitRefSCMRevision" />
+      <Class name="jenkins.plugins.git.GitTagSCMHead" />
+      <Class name="jenkins.plugins.git.GitTagSCMRevision" />
+    </Or>
+  </Match>
+  <Match>
+    <!-- Ignoring in all cases because per class exclusion seemed to be ignored -->
+    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
+  </Match>
+  <Match>
+    <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
+    <Class name="hudson.plugins.git.GitStatus$JenkinsAbstractProjectListener" />
+    <Method name="onNotifyCommit" />
+  </Match>
+  <Match>
+    <Bug pattern="UWF_NULL_FIELD" />
+    <Class name="hudson.plugins.git.SubmoduleConfig" />
+    <Field name="submoduleName" />
+  </Match>
+
+  <!--
+    Here lies technical debt. Exclusions in this section have not yet
+    been triaged. When working on this section, pick an exclusion to
+    triage, then:
+
+    - Add a @SuppressFBWarnings(value = "[...]", justification = "[...]")
+      annotation if it is a false positive.  Indicate the reason why
+      it is a false positive, then remove the exclusion from this
+      section.
+
+    - If it is not a false positive, fix the bug, then remove the
+      exclusion from this section.
+   -->
+  <Match>
+    <Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
+    <Class name="hudson.plugins.git.extensions.impl.PathRestriction" />
+    <Method name="normalize" />
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Increase spotbugs checks

Increases spotbugs checks by reducing the threshold to "Low".  Also resolves a few spotbugs warnings by code corrections.

- Remove uncalled static method
- Remove redundant null checks in AbstractGitSCMSource
- Fix spotbugs warning on repo cache size updates
- Increase spotbugs checks

Inspired by a NonNull annotation in #1468 that should have reported a spotbugs warning and did not.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Dependency or infrastructure update
