### PR TITLE
Fix erratic GitStatusTest

### DIFF
--- a/src/main/java/hudson/plugins/git/GitChangeSet.java
+++ b/src/main/java/hudson/plugins/git/GitChangeSet.java
@@ -590,7 +590,7 @@ public class GitChangeSet extends ChangeLogSet.Entry {
     /**
      * Gets the author name for this changeset - note that this is mainly here
      * so that we can test authorOrCommitter without needing a fully instantiated
-     * Hudson (which is needed for User.get in getAuthor()).
+     * Jenkins (which is needed for User.get in getAuthor()).
      *
      * @return author name
      */

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -696,7 +696,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     public static final Pattern GIT_REF = Pattern.compile("^(refs/[^/]+)/(.+)");
 
     private PollingResult compareRemoteRevisionWithImpl(Job<?, ?> project, Launcher launcher, FilePath workspace, final @NonNull TaskListener listener) throws IOException, InterruptedException {
-        // Poll for changes. Are there any unbuilt revisions that Hudson ought to build ?
+        // Poll for changes. Are there any unbuilt revisions that Jenkins ought to build ?
 
         listener.getLogger().println("Using strategy: " + getBuildChooser().getDisplayName());
 

--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -34,7 +34,7 @@ import org.eclipse.jgit.transport.URIish;
 import org.kohsuke.stapler.*;
 
 /**
- * Information screen for the use of Git in Hudson.
+ * Root action that requests the plugin to poll for changes in remote repositories.
  */
 @Extension
 public class GitStatus implements UnprotectedRootAction {

--- a/src/test/java/hudson/plugins/git/GitStatusSimpleTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusSimpleTest.java
@@ -2,11 +2,9 @@ package hudson.plugins.git;
 
 import static org.junit.Assert.*;
 
-import java.net.URISyntaxException;
 import org.eclipse.jgit.transport.URIish;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,7 +43,7 @@ public class GitStatusSimpleTest {
     }
 
     @Test
-    public void testLooselyMatches() throws URISyntaxException {
+    public void testLooselyMatches() throws Exception {
         String[] equivalentRepoURLs = new String[] {
             "https://example.com/jenkinsci/git-plugin",
             "https://example.com/jenkinsci/git-plugin/",

--- a/src/test/java/hudson/plugins/git/GitStatusSimpleTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusSimpleTest.java
@@ -1,0 +1,88 @@
+package hudson.plugins.git;
+
+import static org.junit.Assert.*;
+
+import java.net.URISyntaxException;
+import org.eclipse.jgit.transport.URIish;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GitStatusSimpleTest {
+
+    private GitStatus gitStatus;
+
+    @Before
+    public void setUp() throws Exception {
+        this.gitStatus = new GitStatus();
+    }
+
+    @Test
+    public void testGetDisplayName() {
+        assertEquals("Git", this.gitStatus.getDisplayName());
+    }
+
+    @Test
+    public void testGetIconFileName() {
+        assertNull(this.gitStatus.getIconFileName());
+    }
+
+    @Test
+    public void testGetUrlName() {
+        assertEquals("git", this.gitStatus.getUrlName());
+    }
+
+    @Test
+    public void testAllowNotifyCommitParametersDisabled() {
+        assertFalse("SECURITY-275: ignore arbitrary notifyCommit parameters", GitStatus.ALLOW_NOTIFY_COMMIT_PARAMETERS);
+    }
+
+    @Test
+    public void testSafeParametersEmpty() {
+        assertEquals("SECURITY-275: Safe notifyCommit parameters", "", GitStatus.SAFE_PARAMETERS);
+    }
+
+    @Test
+    public void testLooselyMatches() throws URISyntaxException {
+        String[] equivalentRepoURLs = new String[] {
+            "https://example.com/jenkinsci/git-plugin",
+            "https://example.com/jenkinsci/git-plugin/",
+            "https://example.com/jenkinsci/git-plugin.git",
+            "https://example.com/jenkinsci/git-plugin.git/",
+            "https://someone@example.com/jenkinsci/git-plugin.git",
+            "https://someone:somepassword@example.com/jenkinsci/git-plugin/",
+            "git://example.com/jenkinsci/git-plugin",
+            "git://example.com/jenkinsci/git-plugin/",
+            "git://example.com/jenkinsci/git-plugin.git",
+            "git://example.com/jenkinsci/git-plugin.git/",
+            "ssh://git@example.com/jenkinsci/git-plugin",
+            "ssh://example.com/jenkinsci/git-plugin.git",
+            "git@example.com:jenkinsci/git-plugin/",
+            "git@example.com:jenkinsci/git-plugin.git",
+            "git@example.com:jenkinsci/git-plugin.git/"
+        };
+        List<URIish> uris = new ArrayList<>();
+        for (String testURL : equivalentRepoURLs) {
+            uris.add(new URIish(testURL));
+        }
+
+        /* Extra slashes on end of URL probably should be considered equivalent,
+         * but current implementation does not consider them as loose matches
+         */
+        URIish badURLTrailingSlashes = new URIish(equivalentRepoURLs[0] + "///");
+        /* Different hostname should always fail match check */
+        URIish badURLHostname = new URIish(equivalentRepoURLs[0].replace("example.com", "bitbucket.org"));
+
+        for (URIish lhs : uris) {
+            assertFalse(
+                    lhs + " matches trailing slashes " + badURLTrailingSlashes,
+                    GitStatus.looselyMatches(lhs, badURLTrailingSlashes));
+            assertFalse(lhs + " matches bad hostname " + badURLHostname, GitStatus.looselyMatches(lhs, badURLHostname));
+            for (URIish rhs : uris) {
+                assertTrue(lhs + " and " + rhs + " didn't match", GitStatus.looselyMatches(lhs, rhs));
+            }
+        }
+    }
+}

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -72,9 +72,8 @@ public class GitStatusTest extends AbstractGitProject {
 
     @After
     public void waitForAllJobsToComplete() throws Exception {
-        // Put JenkinsRule into shutdown state, trying to reduce Windows cleanup exceptions
-        if (r != null && r.jenkins != null) {
-            r.jenkins.doQuietDown();
+        if (r == null || r.jenkins == null) {
+            return; // No jobs if not running with a JenkinsRule
         }
         // JenkinsRule cleanup throws exceptions during tearDown.
         // Reduce exceptions by a random delay from 0.5 to 0.9 seconds.
@@ -82,14 +81,12 @@ public class GitStatusTest extends AbstractGitProject {
         // for fewer exceptions and for better Windows job cleanup.
         java.util.Random random = new java.util.Random();
         Thread.sleep(500L + random.nextInt(400));
+
         /* Windows job cleanup fails to delete build logs in some of these tests.
          * Wait for the jobs to complete before exiting the test so that the
          * build logs will not be active when the cleanup process tries to
          * delete them.
          */
-        if (!isWindows() || r == null || r.jenkins == null) {
-            return;
-        }
         View allView = r.jenkins.getView("All");
         if (allView == null) {
             return;

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -86,7 +86,7 @@ public class GitStatusTest extends AbstractGitProject {
          */
         View allView = r.jenkins.getView("All");
         if (allView == null) {
-            assertTrue(false); // unexpected
+            fail("All view was not found when it should always be available");
             return;
         }
         RunList<Run> runList = allView.getBuilds();

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -91,6 +91,7 @@ public class GitStatusTest extends AbstractGitProject {
         }
         RunList<Run> runList = allView.getBuilds();
         if (runList == null) {
+            Logger.getLogger(GitStatusTest.class.getName()).log(Level.INFO, "No waiting, no entries in the runList");
             return;
         }
         runList.forEach((Run run) -> {


### PR DESCRIPTION
## Fix erratic GitStatusTest

Test already had code that waits for jobs to complete on Windows.  The improved job leak detection that was implemented in the Jenkins test harness will sometimes show the same conditions on Unix builds.  Wait for jobs to complete on Windows and on Unix.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Test
