### PR TITLE
Pass POST parameters in body rather than query string

### DIFF
--- a/src/main/resources/hudson/plugins/git/ApiTokenPropertyConfiguration/resources.js
+++ b/src/main/resources/hudson/plugins/git/ApiTokenPropertyConfiguration/resources.js
@@ -20,9 +20,12 @@ function revokeApiToken(anchorRevoke) {
     const apiTokenUuid = inputUuid.value;
 
     if (confirm(confirmMessage)) {
-        fetch(targetUrl + "?" + new URLSearchParams({apiTokenUuid: apiTokenUuid}), {
-            headers: crumb.wrap({}),
+        fetch(targetUrl, {
+            headers: crumb.wrap({
+              "Content-Type": "application/x-www-form-urlencoded",
+            }),
             method: "post",
+            body: new URLSearchParams({apiTokenUuid: apiTokenUuid}),
         }).then((rsp) => {
             if (rsp.ok) {
                 repeatedChunk.remove();
@@ -59,9 +62,12 @@ function saveApiToken(button){
     const nameInput = repeatedChunk.querySelector('.api-token-name-input');
     const apiTokenName = nameInput.value;
 
-    fetch(targetUrl + "?" + new URLSearchParams({apiTokenName: apiTokenName}), {
-        headers: crumb.wrap({}),
+    fetch(targetUrl, {
+        headers: crumb.wrap({
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
         method: "post",
+        body: new URLSearchParams({apiTokenName: apiTokenName}),
     }).then((rsp) => {
         if (rsp.ok) {
             rsp.json().then((json) => {


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/8279. There is no user-visible bug here, nor is there any security problem. But the code did not conform to best practices. This PR is a code cleanup PR to make the code conform to best practices. There is no urgent need to merge and release it.

To test this PR, I set breakpoints on the modified lines and exercised the code successfully by generating and subsequently revoking an API token.