### PR TITLE
Use plugin bom more widely

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,20 +173,8 @@
       <!-- we contribute AbstractBuildParameters for Git if it's available -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>parameterized-trigger</artifactId>
-      <version>2.43.1</version>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <!-- BOM automated tests fail without conditional-buildstep plugin -->
-      <!-- TODO: Remove this dependency when parameterized trigger plugin dependency fix is released -->
-      <!-- https://github.com/jenkinsci/bom/pull/1623#issuecomment-1339989438 -->
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>conditional-buildstep</artifactId>
-      <version>1.4.3</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
-
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>


### PR DESCRIPTION
## Use plugin bom more widely

parameterized-trigger now managed by bom

conditional-buildstep not needed as a dependency

maven plugin now mannaged by bom

Needs to be verified in the plugin bill of materials before it is merged.  Previous attempts to remove the conditional-buildstep dependency passed tests in the git plugin but failed in the bill of materials when the maven plugin was being loaded.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Tests
