### PR TITLE
Use a working git:// protocol example

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitSCM/help.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help.html
@@ -117,7 +117,7 @@ checkout changelog: false,
 
     <strong><a id="checkout-step-with-git-and-polling">Example: Checkout step with git protocol and polling disabled</a></strong>
     <p>
-    Checkout from the Jenkins platform labeler repository using git protocol, no credentials, the master branch, and no polling for changes.
+    Checkout from the command line git repository using git protocol, no credentials, the master branch, and no polling for changes.
     If poll is <code>false</code>, then the remote repository will not be polled for changes.
     If poll is <code>true</code> or is not set, then the remote repository will be polled for changes.
     See the <a href="https://github.com/jenkinsci/workflow-scm-step-plugin/blob/master/README.md#polling">workflow scm step documentation</a> for more polling details.
@@ -125,7 +125,7 @@ checkout changelog: false,
 <pre>
 checkout poll: false,
          scmGit(userRemoteConfigs: [
-                    [ url: 'git://github.com/jenkinsci/platformlabeler-plugin' ]
+                    [ url: 'git://git.kernel.org/pub/scm/git/git.git ]
                 ])
 </pre>
     </p>


### PR DESCRIPTION
## Use a working git:// protocol example in documentation

The [Sep 2021 GitHub blog post](https://github.blog/2021-09-01-improving-git-protocol-security-github/) announced the removal of the git:// protocol from GitHub.

Change the documentation to use a provider that still supports unauthenticated git:// protocol.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Documentation
