### PR TITLE
Use poll env when checking for ls-remote branches.

### DIFF
--- a/src/main/java/hudson/plugins/git/BranchSpec.java
+++ b/src/main/java/hudson/plugins/git/BranchSpec.java
@@ -138,7 +138,7 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
         return items;
     }
 
-    private String getExpandedName(EnvVars env) {
+    public String getExpandedName(EnvVars env) {
         String expandedName = env.expand(name);
         if (expandedName.length() == 0) {
             return "**";

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -44,6 +44,7 @@ import org.eclipse.jgit.util.SystemReader;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.jenkinsci.plugins.gitclient.*;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Rule;
@@ -2446,6 +2447,41 @@ public class GitSCMTest extends AbstractGitTestCase {
         build(project, Result.SUCCESS);
 
         assertFalse("No changes to git since last build, thus no new build is expected", project.poll(listener).hasChanges());
+    }
+
+    @Test
+    @Issue("JENKINS-20427")
+    public void testPolling_environmentValueInBranchSpecTriggersBuild() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        // create parameterized project with environment value in branch specification
+        WorkflowJob project = r.jenkins.createProject(WorkflowJob.class, "pipeline-remote-poll-with-param");
+        List<UserRemoteConfig> remotes = new ArrayList<>();
+        remotes.addAll(testRepo.remoteConfigs());
+        GitSCM scm = new GitSCM(
+                remotes,
+                Collections.singletonList(new BranchSpec("${MY_BRANCH}")),
+                null, null,
+                Collections.emptyList());
+        project.setDefinition(new CpsScmFlowDefinition(scm, "./Jenkinsfile"));
+        project.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("MY_BRANCH", "master")));
+
+        // commit something in order to create an initial base version in git
+        commit(
+            "Jenkinsfile",
+            "node {\n" +
+            "  echo 'Hello world!'\n" +
+            "}",
+            johnDoe,
+            "Add Jenkinsfile"
+        );
+
+        // build the project
+        Run<?,?> run = r.buildAndAssertStatus(Result.SUCCESS, project);
+
+        // commit something in order to check that polling detects the change.
+        commit("toto/commitFile2", johnDoe, "Commit number 2");
+
+        assertTrue("There are changes to git since last build, thus a new build is expected", project.poll(listener).hasChanges());
     }
 
     public void baseTestPolling_parentHead(List<GitSCMExtension> extensions) throws Exception {


### PR DESCRIPTION
The core issue is that params are not resolved until the start of the build (i.e. not valid in the Polling context).

The `git ls-remote` code-path uses and empty env when checking for branches - which means params in a branch spec don't get resolved.
I have updated the code to use the `pollEnv` variable when evaluating these params - as these .

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [ ] Dependency or infrastructure update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
