### PR TITLE
Improvement for isRevExcluded method. For matching on commit message

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
@@ -25,53 +25,75 @@ import java.util.regex.PatternSyntaxException;
  * @author Kanstantsin Shautsou
  */
 public class MessageExclusion extends GitSCMExtension {
-	/**
-	 * Java Pattern for matching messages to be ignored.
-	 */
-	private String excludedMessage;
+    /**
+     * Java Pattern for matching messages to be ignored.
+     */
+    private String excludedMessage;
 
-	private transient volatile Pattern excludedPattern;
+    private transient volatile Pattern excludedPattern;
 
-	@DataBoundConstructor
-	public MessageExclusion(String excludedMessage) { this.excludedMessage = excludedMessage; }
+    @DataBoundConstructor
+    public MessageExclusion(String excludedMessage) {
+        this.excludedMessage = excludedMessage;
+    }
 
-	@Override
-	public boolean requiresWorkspaceForPolling() { return true; }
+    @Override
+    public boolean requiresWorkspaceForPolling() {
+        return true;
+    }
 
-	public String getExcludedMessage() { return excludedMessage; }
+    public String getExcludedMessage() {
+        return excludedMessage;
+    }
 
-	@Override
-	@SuppressFBWarnings(value="NP_BOOLEAN_RETURN_NULL", justification="null used to indicate other extensions should decide")
-	@CheckForNull
-	public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener, BuildData buildData) throws IOException, InterruptedException, GitException {
-		if (excludedPattern == null){
-			excludedPattern = Pattern.compile(excludedMessage);
-		}
-		String msg = commit.getComment();
-		if (excludedPattern.matcher(msg).matches()){
-			listener.getLogger().println("Ignored commit " + commit.getId() + ": Found excluded message: " + msg);
-			return true;
-		}
+    @Override
+    @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "null used to indicate other extensions should decide")
+    @CheckForNull
+    public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener, BuildData buildData) throws IOException, InterruptedException, GitException {
+        if (excludedMessage == null || excludedMessage.trim().isEmpty()) {
+            listener.getLogger().println("Excluded message pattern is empty. No commits will be excluded based on message.");
+            return null; // No decision
+        }
 
-		return null;
-	}
+        if (excludedPattern == null) {
+            try {
+                excludedPattern = Pattern.compile(excludedMessage);
+            } catch (PatternSyntaxException ex) {
+                listener.getLogger().println("Error compiling the excluded message pattern: " + ex.getMessage());
+                return null; // Pattern is invalid, so no decision
+            }
+        }
 
-	@Extension
-        // No @Symbol annotation because message exclusion is done using a trait in Pipeline
-	public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        String msg = commit.getComment();
+        if (msg == null) {
+            listener.getLogger().println("Commit " + commit.getId() + " has a null message. It won't be excluded based on message.");
+            return null; // Commit message is null, so no decision
+        }
 
-		public FormValidation doCheckExcludedMessage(@QueryParameter String value) {
-			try {
-				Pattern.compile(value);
-			} catch (PatternSyntaxException ex){
-				return FormValidation.error(ex.getMessage());
-			}
-			return FormValidation.ok();
-		}
+        if (excludedPattern.matcher(msg).find()) {
+            listener.getLogger().println("Ignored commit " + commit.getId() + ": Found excluded message: " + msg);
+            return true; // Commit message contains the excluded pattern
+        }
 
-		@Override
-		public String getDisplayName() {
-			return "Polling ignores commits with certain messages";
-		}
-	}
+        return null; // No decision
+    }
+
+    @Extension
+    // No @Symbol annotation because message exclusion is done using a trait in Pipeline
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+
+        public FormValidation doCheckExcludedMessage(@QueryParameter String value) {
+            try {
+                Pattern.compile(value);
+            } catch (PatternSyntaxException ex) {
+                return FormValidation.error(ex.getMessage());
+            }
+            return FormValidation.ok();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Polling ignores commits with certain messages";
+        }
+    }
 }


### PR DESCRIPTION
This improved version adds more logging, handles potential null values, and uses the find() method for matching. This should make the method more robust