### PR TITLE
Use Spring security API instead of Acegi security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>1305.v5886374f499b_</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -92,11 +92,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>credentials</artifactId>
-        <version>1307.v3757c78f17c3</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials</artifactId>
-        <version>1305.v5886374f499b_</version>
+        <version>1307.v3757c78f17c3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -149,9 +149,9 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
                 return FormValidation.ok();
             }
             for (ListBoxModel.Option o : CredentialsProvider
-                    .listCredentials(StandardUsernameCredentials.class, project, project instanceof Queue.Task
-                                    ? Tasks.getAuthenticationOf((Queue.Task) project)
-                                    : ACL.SYSTEM,
+                    .listCredentialsInItem(StandardUsernameCredentials.class, project, project instanceof Queue.Task
+                                    ? Tasks.getAuthenticationOf2((Queue.Task) project)
+                                    : ACL.SYSTEM2,
                             GitURIRequirementsBuilder.fromUri(url).build(),
                             GitClient.CREDENTIALS_MATCHER)) {
                 if (Objects.equals(value, o.value)) {
@@ -259,7 +259,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
 
         private static StandardCredentials lookupCredentials(@CheckForNull Item project, String credentialId, String uri) {
             return (credentialId == null) ? null : CredentialsMatchers.firstOrNull(
-                        CredentialsProvider.lookupCredentials(StandardCredentials.class, project, ACL.SYSTEM,
+                        CredentialsProvider.lookupCredentialsInItem(StandardCredentials.class, project, ACL.SYSTEM2,
                                 GitURIRequirementsBuilder.fromUri(uri).build()),
                         CredentialsMatchers.withId(credentialId));
         }

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -1288,8 +1288,8 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         }
         return CredentialsMatchers
                 .firstOrNull(
-                        CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, context,
-                                ACL.SYSTEM, URIRequirementBuilder.fromUri(getRemote()).build()),
+                        CredentialsProvider.lookupCredentialsInItem(StandardUsernameCredentials.class, context,
+                                ACL.SYSTEM2, URIRequirementBuilder.fromUri(getRemote()).build()),
                         CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsId),
                                 GitClient.CREDENTIALS_MATCHER));
     }

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -368,10 +368,10 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 String credentialsId = config.getCredentialsId();
                 if (credentialsId != null) {
                     StandardCredentials credential = CredentialsMatchers.firstOrNull(
-                            CredentialsProvider.lookupCredentials(
+                            CredentialsProvider.lookupCredentialsInItem(
                                 StandardUsernameCredentials.class,
                                 owner,
-                                ACL.SYSTEM,
+                                ACL.SYSTEM2,
                                 URIRequirementBuilder.fromUri(remote).build()
                             ),
                             CredentialsMatchers.allOf(

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -451,12 +451,12 @@ public class GitSCMSource extends AbstractGitSCMSource {
                 return FormValidation.ok();
             }
 
-            for (ListBoxModel.Option o : CredentialsProvider.listCredentials(
+            for (ListBoxModel.Option o : CredentialsProvider.listCredentialsInItem(
                     StandardUsernameCredentials.class,
                     context,
                     context instanceof Queue.Task
-                            ? Tasks.getAuthenticationOf((Queue.Task) context)
-                            : ACL.SYSTEM,
+                            ? Tasks.getAuthenticationOf2((Queue.Task) context)
+                            : ACL.SYSTEM2,
                     URIRequirementBuilder.fromUri(remote).build(),
                     GitClient.CREDENTIALS_MATCHER)) {
                 if (Objects.equals(value, o.value)) {

--- a/src/main/java/jenkins/plugins/git/GitSCMTelescope.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMTelescope.java
@@ -195,10 +195,10 @@ public abstract class GitSCMTelescope extends SCMFileSystem.Builder {
                     String credentialsId = config.getCredentialsId();
                     if (credentialsId != null) {
                         List<StandardUsernameCredentials> urlCredentials = CredentialsProvider
-                                .lookupCredentials(StandardUsernameCredentials.class, owner,
+                                .lookupCredentialsInItem(StandardUsernameCredentials.class, owner,
                                         owner instanceof Queue.Task
-                                                ? Tasks.getAuthenticationOf((Queue.Task) owner)
-                                                : ACL.SYSTEM, URIRequirementBuilder.fromUri(remote).build());
+                                                ? Tasks.getAuthenticationOf2((Queue.Task) owner)
+                                                : ACL.SYSTEM2, URIRequirementBuilder.fromUri(remote).build());
                         credentials = CredentialsMatchers.firstOrNull(
                                 urlCredentials,
                                 CredentialsMatchers


### PR DESCRIPTION
## Use Spring security API instead of Acegi security

* [x] Downstream usage of https://github.com/jenkinsci/credentials-plugin/pull/490

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Use modern API instead of the deprecated API
