### PR TITLE
Remove `CheckoutOption.requiresWorkspaceForPolling` override

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/CheckoutOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CheckoutOption.java
@@ -41,14 +41,6 @@ public class CheckoutOption extends FakeGitSCMExtension {
      * {@inheritDoc}
      */
     @Override
-    public boolean requiresWorkspaceForPolling() {
-        return false;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void decorateCheckoutCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, CheckoutCommand cmd) throws IOException, InterruptedException, GitException {
         cmd.timeout(timeout);
     }


### PR DESCRIPTION
Did not need to override this method as it left the value at the default of `false`: https://github.com/jenkinsci/git-plugin/blob/daa95b6d0957492a2fcee458097bd99a04e06a31/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java#L43-L45