### PR TITLE
Documentation - clarify when certain env variables are being set

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1332,8 +1332,8 @@ GIT_LOCAL_BRANCH:: Name of branch being built without remote name, as in `master
 === Commit Variables
 
 GIT_COMMIT:: SHA-1 of the commit used in this build
-GIT_PREVIOUS_COMMIT:: SHA-1 of the commit used in the preceding build of this project
-GIT_PREVIOUS_SUCCESSFUL_COMMIT:: SHA-1 of the commit used in the most recent successful build of this project
+GIT_PREVIOUS_COMMIT:: SHA-1 of the commit used in the preceding build of this project. If this is the first time a particular branch is being built, this variable is not set.
+GIT_PREVIOUS_SUCCESSFUL_COMMIT:: SHA-1 of the commit used in the most recent successful build of this project. If this is the first time a particular branch is being built, this variable is not set.
 
 [#system-configuration-variables]
 === System Configuration Variables


### PR DESCRIPTION
Highlight that `GIT_PREVIOUS_SUCCESSFUL_COMMIT` and `GIT_PREVIOUS_COMMIT` are not being set during the first build for a given git branch. Might save someone else a few headscratches.
Also, this appears to be part of [the previous, now-deprecated documentation](https://wiki.jenkins.io/JENKINS/Git-Plugin.html).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Documentation in README has been updated as necessary

## Types of changes

- [x] Dependency or infrastructure update