### PR TITLE
Add global configuration as code example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -426,7 +426,31 @@ If the workspace is removed, the tag that was applied is lost.
 Tagging a workspace made sense when using centralized repositories that automatically applied the tag to the centralized repository.
 Applying a git tag in an agent workspace doesn't have many practical uses.
 
+[#configuration-as-code]
+=== Configuration as code
+
+The global settings of the git plugin can be defined with the Jenkins link:https://plugins.jenkins.io/configuration-as-code/[configuration as code plugin].
+Detailed descriptions of the individual settings are available in the link:#global-configuration[global configuration settings] section of this document.
+
+An example configuration might look like this:
+
+[,yaml]
+----
+unclassified:
+  scmGit:
+    addGitTagAction: false
+    allowSecondFetch: false
+    createAccountBasedOnEmail: false
+    disableGitToolChooser: false
+    globalConfigEmail: "jenkins-user@example.com"
+    globalConfigName: "jenkins-user"
+    hideCredentials: false
+    showEntireCommitSummaryInChanges: true
+    useExistingAccountWithSameEmail: false
+----
+
 [#security-configuration]
+
 === Security Configuration
 
 image:/images/git-security-configuration.png[Security Configuration]


### PR DESCRIPTION
## Add global configuration as code example

Configuration as code examples are available in most plugin documentation but were not included in the git plugin documentation.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Documentation
