### PR TITLE
Require Jenkins 2.401.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <revision>5.2.2</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.401.3</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <!-- Jenkins.MANAGE is still in Beta -->
     <useBeta>true</useBeta>
@@ -87,8 +87,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.401.x</artifactId>
+        <version>2641.v88e707466454</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.401.3 or newer

Git client plugin will [require 2.401.3 or newer](https://github.com/jenkinsci/git-client-plugin/pull/1078) in its next release so that it can [depend on the gson-api plugin](https://github.com/jenkinsci/git-client-plugin/pull/1077) rather than bundling the gson-api jar file as a transitive dependency for the Eclipse JGit LFS library.

The installation data indicates that most users are already prepared for this change:

* 42% of all installations of the git plugin are already running Jenkins 2.401.3 or newer
* 75% of all installations of git plugin 5.0.0 or newer are already running Jenkins 2.401.3 or newer.  The git plugin 5.0.0 release was more than 11 months ago
* 94% of the 107000 installations of git plugin 5.2.0 + 5.2.1 are running on Jenkins 2.401.3 or newer

The majority of git plugin users that are upgrading their plugin version are upgrading to releases of the plugin on Jenkins 2.401.3 or newer.

Security advisories that apply to Jenkins 2.401.2 or 2.387.3 and do not apply to Jenkins 2.401.3 include:

* https://www.jenkins.io/security/advisory/2023-07-26/
* https://www.jenkins.io/security/advisory/2023-06-14/

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Maintenance
