### PR TITLE
Use spotbugs plugin 4.8.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,13 @@
     <!-- Do not run extra reporting for checkstyle or pmd -->
     <!-- https://stackoverflow.com/questions/12038238/unable-to-locate-source-xref-to-link-to -->
     <linkXRef>false</linkXRef>
+    <!-- TODO: Remove when plugin pom is using this version or newer -->
+    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
+    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotbugs.effort>Max</spotbugs.effort>
+    <!-- TODO: Remove when plugin pom includes this omitVisitors -->
+    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
+    <spotbugs.omitVisitors>ConstructorThrow,FindReturnRef</spotbugs.omitVisitors>
     <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1641,6 +1641,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     @Symbol({"scmGit", "gitSCM"}) // Cannot use "git" because there is already a `git` pipeline step
     public static final class DescriptorImpl extends SCMDescriptor<GitSCM> {
 
+        @SuppressFBWarnings(value="UUF_UNUSED_FIELD", justification="Do not risk compatibility")
         private String gitExe;
         private String globalConfigName;
         private String globalConfigEmail;
@@ -1734,7 +1735,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
          */
         @Deprecated
         public String getGitExe() {
-            return gitExe;
+            return null;
         }
 
         /**
@@ -1805,7 +1806,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
          * @return git executable
          */
         public String getOldGitExe() {
-            return gitExe;
+            return null;
         }
 
         public static List<RemoteConfig> createRepositoryConfigurations(String[] urls,

--- a/src/main/java/hudson/plugins/git/RemoteConfigConverter.java
+++ b/src/main/java/hudson/plugins/git/RemoteConfigConverter.java
@@ -11,6 +11,7 @@ import com.thoughtworks.xstream.core.util.HierarchicalStreams;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.mapper.Mapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.transport.RemoteConfig;
 
@@ -119,6 +120,7 @@ public class RemoteConfigConverter implements Converter {
             }
         }
 
+        @SuppressFBWarnings(value="SE_PREVENT_EXT_OBJ_OVERWRITE", justification="Used during version upgrade")
         public void readExternal(ObjectInput in) throws IOException,
                 ClassNotFoundException {
             name = in.readUTF();

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -20,6 +20,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.URI;
@@ -95,8 +96,9 @@ public class AssemblaWeb extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public AssemblaWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(AssemblaWeb.class, jsonObject);
         }
 

--- a/src/main/java/hudson/plugins/git/browser/BitbucketServer.java
+++ b/src/main/java/hudson/plugins/git/browser/BitbucketServer.java
@@ -11,6 +11,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -78,8 +79,9 @@ public class BitbucketServer extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public BitbucketServer newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(BitbucketServer.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/BitbucketWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/BitbucketWeb.java
@@ -11,6 +11,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -79,8 +80,9 @@ public class BitbucketWeb extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public BitbucketWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(BitbucketWeb.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/CGit.java
+++ b/src/main/java/hudson/plugins/git/browser/CGit.java
@@ -13,6 +13,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -89,8 +90,9 @@ public class CGit extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public CGit newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(CGit.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
@@ -17,6 +17,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.URL;
@@ -76,8 +77,9 @@ public class FisheyeGitRepositoryBrowser extends GitRepositoryBrowser {
 		}
 
 		@Override
+                @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                                    justification = "Inherited javadoc commits that req is non-null")
 		public FisheyeGitRepositoryBrowser newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-			assert req != null; //see inherited javadoc
 			return req.bindJSON(FisheyeGitRepositoryBrowser.class, jsonObject);
 		}
 

--- a/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
@@ -20,6 +20,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -81,8 +82,9 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public GitBlitRepositoryBrowser newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(GitBlitRepositoryBrowser.class, jsonObject);
         }
 

--- a/src/main/java/hudson/plugins/git/browser/GitLab.java
+++ b/src/main/java/hudson/plugins/git/browser/GitLab.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.net.URL;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.servlet.ServletException;
 
 import org.kohsuke.stapler.QueryParameter;
@@ -142,8 +143,9 @@ public class GitLab extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public GitLab newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(GitLab.class, jsonObject);
         }
 

--- a/src/main/java/hudson/plugins/git/browser/GitList.java
+++ b/src/main/java/hudson/plugins/git/browser/GitList.java
@@ -13,6 +13,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -91,8 +92,9 @@ public class GitList extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public GitList newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(GitList.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/GitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GitWeb.java
@@ -13,6 +13,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -91,8 +92,9 @@ public class GitWeb extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public GitWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(GitWeb.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/GithubWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GithubWeb.java
@@ -13,6 +13,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -97,8 +98,9 @@ public class GithubWeb extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
 		public GithubWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
 			return req.bindJSON(GithubWeb.class, jsonObject);
 		}
 	}

--- a/src/main/java/hudson/plugins/git/browser/Gitiles.java
+++ b/src/main/java/hudson/plugins/git/browser/Gitiles.java
@@ -16,6 +16,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.servlet.ServletException;
 
 import net.sf.json.JSONObject;
@@ -69,8 +70,9 @@ public class Gitiles extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public Gitiles newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(Gitiles.class, jsonObject);
         }
 

--- a/src/main/java/hudson/plugins/git/browser/GitoriousWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GitoriousWeb.java
@@ -11,6 +11,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -73,8 +74,9 @@ public class GitoriousWeb extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public GitoriousWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(GitoriousWeb.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/GogsGit.java
+++ b/src/main/java/hudson/plugins/git/browser/GogsGit.java
@@ -13,6 +13,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -99,8 +100,9 @@ public class GogsGit extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public GogsGit newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(GogsGit.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/KilnGit.java
+++ b/src/main/java/hudson/plugins/git/browser/KilnGit.java
@@ -14,6 +14,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -110,8 +111,9 @@ public class KilnGit extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public KilnGit newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(KilnGit.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/Phabricator.java
+++ b/src/main/java/hudson/plugins/git/browser/Phabricator.java
@@ -11,6 +11,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -89,8 +90,9 @@ public class Phabricator extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public Phabricator newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(Phabricator.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/RedmineWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/RedmineWeb.java
@@ -12,6 +12,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -92,8 +93,9 @@ public class RedmineWeb extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public RedmineWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(RedmineWeb.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/RhodeCode.java
+++ b/src/main/java/hudson/plugins/git/browser/RhodeCode.java
@@ -13,6 +13,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -94,8 +95,9 @@ public class RhodeCode extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public RhodeCode newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(RhodeCode.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/Stash.java
+++ b/src/main/java/hudson/plugins/git/browser/Stash.java
@@ -12,6 +12,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URL;
 
@@ -94,8 +95,9 @@ public class Stash extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public Stash newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(Stash.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
@@ -19,6 +19,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -92,8 +93,9 @@ public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public TFS2013GitRepositoryBrowser newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             try {
                 req.getSubmittedForm();
             } catch (ServletException e) {

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -21,6 +21,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -88,8 +89,9 @@ public class ViewGitWeb extends GitRepositoryBrowser {
         }
 
         @Override
+        @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+                            justification = "Inherited javadoc commits that req is non-null")
         public ViewGitWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
-            assert req != null; //see inherited javadoc
             return req.bindJSON(ViewGitWeb.class, jsonObject);
         }
 

--- a/src/main/java/hudson/plugins/git/opt/PreBuildMergeOptions.java
+++ b/src/main/java/hudson/plugins/git/opt/PreBuildMergeOptions.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git.opt;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
 import org.kohsuke.stapler.export.Exported;
@@ -19,18 +20,26 @@ public class PreBuildMergeOptions implements Serializable {
     /**
      * Remote repository that contains the {@linkplain #mergeTarget ref}.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE",
+                        justification = "Preserve API compatibility")
     public RemoteConfig mergeRemote = null;
 
     /**
      * Remote ref to merge.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE",
+                        justification = "Preserve API compatibility")
     public String mergeTarget = null;
 
     /**
      * Merge strategy.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE",
+                        justification = "Preserve API compatibility")
     public String mergeStrategy = MergeCommand.Strategy.DEFAULT.toString();
 
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE",
+                        justification = "Preserve API compatibility")
     public MergeCommand.GitPluginFastForwardMode fastForwardMode = MergeCommand.GitPluginFastForwardMode.FF;
 
     public RemoteConfig getMergeRemote() {

--- a/src/main/java/hudson/plugins/git/util/Build.java
+++ b/src/main/java/hudson/plugins/git/util/Build.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Result;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
@@ -38,6 +39,8 @@ public class Build implements Serializable, Cloneable {
      * to the same value as {@link #revision}, as we want to be able to build two pull requests rooted at the same
      * commit in the base repository.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE",
+                        justification = "Preserve API compatibility")
     public Revision marked;
 
     /**

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -1,6 +1,7 @@
 package hudson.plugins.git.util;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.AbstractBuild;
 import hudson.model.Action;
 import hudson.model.Api;
@@ -47,21 +48,29 @@ public class BuildData implements Action, Serializable, Cloneable {
      * This map contains all the branches we've built in the past (including the build that this {@link BuildData}
      * is attached to)
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE",
+                        justification = "Preserve API compatibility")
     public Map<String, Build> buildsByBranchName = new HashMap<>();
 
     /**
      * The last build that we did (among the values in {@link #buildsByBranchName}.)
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE",
+                        justification = "Preserve API compatibility")
     public Build lastBuild;
 
     /**
      * The name of the SCM as given by the user.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE",
+                        justification = "Preserve API compatibility")
     public String scmName;
 
     /**
      * The URLs that have been referenced.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE",
+                        justification = "Preserve API compatibility")
     public Set<String> remoteUrls = new HashSet<>();
 
     /**


### PR DESCRIPTION
## Use spotbugs plugin 4.8.2.0

Suppress the CT_CONSTRUCTUR_THROWS warning because it is not helpful in a Jenkins context.  More details are available in https://github.com/jenkinsci/plugin-pom/pull/869#issuecomment-1860918407

Suppress public primitive spotbugs warning for existing APIs.  Preserve compatibility without allowing new additions to include public primitives.

Suppress null argument check for descriptor's newInstance.  Javadoc of the parent object states that the req argument will always be non-null, but cannot be annotated as non-null due to compatibility needs.

Suppress unused field warning in GitSCM descriptor.  Do not risk compatibility by removing the private field.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Maintenance

## Further comments

Changes to pom.xml will be removed once plugin pom includes the new settings.
