### PR TITLE
Revert "Bump org.jenkins-ci.plugins:promoted-builds (#1542)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
   # Maintain dependencies for maven
   - package-ecosystem: "maven"
     directory: "/"
+    ignore:
+      # Fails plugin bill of materials tests
+      - dependency-name: "org.jenkins-ci.plugins:promoted-builds"
+        versions: ["945.v597f5c6a_d3fd"]
     schedule:
       interval: "weekly"
     labels:

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>promoted-builds</artifactId>
-      <version>945.v597f5c6a_d3fd</version>
+      <version>3.11</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fails tests in plugin bill of materials with report that promoted builds
needs to be upgraded to a newer version.

One error message is:

Caused by: java.io.IOException: Failed to load: Git plugin (git 5.2.2-rc5199.9999da_372d5a_)
 - Update required: Jenkins promoted builds plugin (promoted-builds 3.11) to be updated to 945.v597f5c6a_d3fd or higher

Second error message is:

Caused by: java.io.IOException: Failed to load: Git plugin (git 5.2.2-rc5199.9999da_372d5a_)
 - Update required: Jenkins promoted builds plugin (promoted-builds 892.vd6219fc0a_efb) to be updated to 945.v597f5c6a_d3fd or higher

Also adds a dependabot exclusion for that release of promoted builds
plugin.

This reverts commit 4f5ecfeafaf16d1d44b699561509279d4b2cdb8a.
