### PR TITLE
disable tag.gpgsign as it could be active for some systems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>4.6.1-rc3521.3dcd9ff316b_4</version>
+      <version>4.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
+      <version>4.6.1-rc3521.3dcd9ff316b_4</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <version>4.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -146,6 +146,16 @@ public class GitPublisher extends Recorder implements Serializable {
         input = input.replaceAll("\\$BUILDDURATION", buildDuration);
         return input;
     }
+
+    protected GitClient getGitClient(
+            GitSCM gitSCM,
+            BuildListener listener,
+            EnvVars environment,
+            AbstractBuild<?, ?> build,
+            UnsupportedCommand cmd)
+            throws IOException, InterruptedException {
+        return gitSCM.createClient(listener, environment, build, build.getWorkspace(), cmd);
+    }
     
     @Override
     public boolean perform(AbstractBuild<?, ?> build,
@@ -180,7 +190,7 @@ public class GitPublisher extends Recorder implements Serializable {
 
             UnsupportedCommand cmd = new UnsupportedCommand();
             cmd.gitPublisher(true);
-            final GitClient git  = gitSCM.createClient(listener, environment, build, build.getWorkspace(), cmd);
+            final GitClient git  = getGitClient(gitSCM, listener, environment, build, cmd);
 
             URIish remoteURI;
 

--- a/src/main/java/hudson/plugins/git/GitTagAction.java
+++ b/src/main/java/hudson/plugins/git/GitTagAction.java
@@ -185,7 +185,7 @@ public class GitTagAction extends AbstractScmTagAction implements Describable<Gi
     /**
      * The thread that performs tagging operation asynchronously.
      */
-    public final class TagWorkerThread extends TaskThread {
+    public class TagWorkerThread extends TaskThread {
         private final Map<String, String> tagSet;
 
         public TagWorkerThread(Map<String, String> tagSet,String ignoredComment) {
@@ -193,14 +193,18 @@ public class GitTagAction extends AbstractScmTagAction implements Describable<Gi
             this.tagSet = tagSet;
         }
 
+        protected GitClient getGitClient(TaskListener listener, EnvVars environment, FilePath workspace)
+                throws IOException, InterruptedException {
+            return Git.with(listener, environment)
+                    .in(workspace)
+                    .getClient();
+        }
+
         @Override
         protected void perform(final TaskListener listener) throws Exception {
             final EnvVars environment = getRun().getEnvironment(listener);
             final FilePath workspace = new FilePath(new File(ws));
-            final GitClient git = Git.with(listener, environment)
-                    .in(workspace)
-                    .getClient();
-
+            final GitClient git = getGitClient(listener, environment, workspace);
 
             for (Map.Entry<String, String> entry : tagSet.entrySet()) {
                 try {

--- a/src/test/java/hudson/plugins/git/AbstractGitRepository.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitRepository.java
@@ -7,6 +7,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
+import hudson.plugins.git.util.GitUtilsTest;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.Before;
 import org.junit.Rule;
 
@@ -38,10 +40,11 @@ public abstract class AbstractGitRepository {
 
     @Before
     public void createGitRepository() throws Exception {
+        SystemReader.getInstance().getUserConfig().clear();
         TaskListener listener = StreamTaskListener.fromStderr();
         repo.init();
         testGitDir = repo.getRoot();
-        testGitClient = Git.with(listener, new EnvVars()).in(testGitDir).getClient();
+        testGitClient = Git.with(listener, GitUtilsTest.getConfigNoSystemEnvsVars()).in(testGitDir).getClient();
     }
 
     /**

--- a/src/test/java/hudson/plugins/git/GitChangeSetTruncateTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetTruncateTest.java
@@ -136,6 +136,7 @@ public class GitChangeSetTruncateTest {
         assertThat(gitCmd.run(), is(expectedResult));
         // we have to setup the repo as commitOneFile doesn't to use the env vars
         gitCmd = new CliGitCommand(gitClient, "config", "commit.gpgsign", "false");
+        gitCmd = new CliGitCommand(gitClient, "config", "tag.gpgSign", "false");
         assertThat(gitCmd.run(), is(expectedResult));
     }
 
@@ -145,6 +146,8 @@ public class GitChangeSetTruncateTest {
         /* randomize whether commit message is single line or multi-line */
         String commitMessageBody = random.nextBoolean() ? "\n\n" + "committing " + path + " with content:\n\n" + content : "";
         String commitMessage = commitSummary + commitMessageBody;
+        gitClient.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", "false");
+        gitClient.config(GitClient.ConfigLevel.LOCAL, "tag.gpgSign", "false");
         createFile(path, content);
         gitClient.add(path);
         gitClient.commit(commitMessage);

--- a/src/test/java/hudson/plugins/git/GitPublisherTest.java
+++ b/src/test/java/hudson/plugins/git/GitPublisherTest.java
@@ -747,6 +747,9 @@ public class GitPublisherTest extends AbstractGitProject {
     @Issue("JENKINS-24786")
     @Test
     public void testMergeAndPushWithCharacteristicEnvVar() throws Exception {
+        // jgit doesn't work because of missing PerBuildTag
+        //GitTool tool = new JGitTool(Collections.emptyList());
+        //r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(tool);
         FreeStyleProject project = setupSimpleProject("master");
 
         /*

--- a/src/test/java/hudson/plugins/git/GitPublisherTest.java
+++ b/src/test/java/hudson/plugins/git/GitPublisherTest.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.git;
 
+import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.matrix.Axis;
@@ -45,6 +46,7 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.util.SystemReader;
 import org.jenkinsci.plugins.gitclient.JGitTool;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
+import org.jenkinsci.plugins.gitclient.UnsupportedCommand;
 import org.jvnet.hudson.test.Issue;
 
 import java.io.File;
@@ -102,7 +104,7 @@ public class GitPublisherTest extends AbstractGitProject {
         MatrixProject mp = r.createProject(MatrixProject.class, "xyz");
         mp.setAxes(new AxisList(new Axis("VAR","a","b")));
         mp.setScm(new GitSCM(testGitDir.getAbsolutePath()));
-        mp.getPublishersList().add(new GitPublisher(
+        mp.getPublishersList().add(new TestGitPublisher(
                 Collections.singletonList(new TagToPush("origin","foo","message",true, false)),
                 Collections.emptyList(),
                 Collections.emptyList(),
@@ -157,7 +159,7 @@ public class GitPublisherTest extends AbstractGitProject {
         scm.getExtensions().add(new LocalBranch("integration"));
         project.setScm(scm);
 
-        project.getPublishersList().add(new GitPublisher(
+        project.getPublishersList().add(new TestGitPublisher(
                 Collections.emptyList(),
                 Collections.singletonList(new BranchToPush("origin", "integration")),
                 Collections.emptyList(),
@@ -201,7 +203,7 @@ public class GitPublisherTest extends AbstractGitProject {
         mp.setScm(new GitSCM(repoList,
                 Collections.singletonList(new BranchSpec("")),
                 null, tool.getName(), Collections.emptyList()));
-        mp.getPublishersList().add(new GitPublisher(
+        mp.getPublishersList().add(new TestGitPublisher(
                 Collections.singletonList(new TagToPush("origin","foo","message",true, false)),
                 Collections.emptyList(),
                 Collections.emptyList(),
@@ -249,7 +251,7 @@ public class GitPublisherTest extends AbstractGitProject {
         scm.getExtensions().add(new LocalBranch("integration"));
         project.setScm(scm);
 
-        project.getPublishersList().add(new GitPublisher(
+        project.getPublishersList().add(new TestGitPublisher(
                 Collections.emptyList(),
                 Collections.singletonList(new BranchToPush("origin", "integration")),
                 Collections.emptyList(),
@@ -285,7 +287,7 @@ public class GitPublisherTest extends AbstractGitProject {
         scm.getExtensions().add(new LocalBranch("integration"));
         project.setScm(scm);
 
-        project.getPublishersList().add(new GitPublisher(
+        project.getPublishersList().add(new TestGitPublisher(
                 Collections.emptyList(),
                 Collections.singletonList(new BranchToPush("origin", "integration")),
                 Collections.emptyList(),
@@ -369,7 +371,7 @@ public class GitPublisherTest extends AbstractGitProject {
         scm.getExtensions().add(new LocalBranch("integration"));
         project.setScm(scm);
 
-        project.getPublishersList().add(new GitPublisher(
+        project.getPublishersList().add(new TestGitPublisher(
                 Collections.emptyList(),
                 Collections.singletonList(new BranchToPush("origin", "integration")),
                 Collections.emptyList(),
@@ -457,7 +459,7 @@ public class GitPublisherTest extends AbstractGitProject {
         scm.getExtensions().add(new LocalBranch("integration"));
         project.setScm(scm);
 
-        project.getPublishersList().add(new GitPublisher(
+        project.getPublishersList().add(new TestGitPublisher(
                 Collections.emptyList(),
                 Collections.singletonList(new BranchToPush("origin", "integration")),
                 Collections.emptyList(),
@@ -554,7 +556,7 @@ public class GitPublisherTest extends AbstractGitProject {
         String tag_name = "test-tag";
         String note_content = "Test Note";
 
-        project.getPublishersList().add(new GitPublisher(
+        project.getPublishersList().add(new TestGitPublisher(
         		Collections.singletonList(new TagToPush("$TARGET_NAME", tag_name, "", false, false)),
                 Collections.singletonList(new BranchToPush("$TARGET_NAME", "$TARGET_BRANCH")),
                 Collections.singletonList(new NoteToPush("$TARGET_NAME", note_content, Constants.R_NOTES_COMMITS, false)),
@@ -584,7 +586,7 @@ public class GitPublisherTest extends AbstractGitProject {
                 Collections.emptyList());
         project.setScm(scm);
 
-        GitPublisher forcedPublisher = new GitPublisher(
+        GitPublisher forcedPublisher = new TestGitPublisher(
                 Collections.emptyList(),
                 Collections.singletonList(new BranchToPush("origin", "otherbranch")),
                 Collections.emptyList(),
@@ -631,7 +633,7 @@ public class GitPublisherTest extends AbstractGitProject {
 
         // Remove forcedPublisher, add unforcedPublisher
         project.getPublishersList().remove(forcedPublisher);
-        GitPublisher unforcedPublisher = new GitPublisher(
+        GitPublisher unforcedPublisher = new TestGitPublisher(
                 Collections.emptyList(),
                 Collections.singletonList(new BranchToPush("origin", "otherbranch")),
                 Collections.emptyList(),
@@ -680,7 +682,7 @@ public class GitPublisherTest extends AbstractGitProject {
         project.setScm(scm);
 
 
-      project.getPublishersList().add(new GitPublisher(
+      project.getPublishersList().add(new TestGitPublisher(
           Collections.emptyList(),
           Collections.singletonList(new BranchToPush("origin", "integration")),
           Collections.emptyList(),
@@ -715,7 +717,7 @@ public class GitPublisherTest extends AbstractGitProject {
         BranchToPush btp = new BranchToPush("origin", "master");
         btp.setRebaseBeforePush(true);
 
-        GitPublisher rebasedPublisher = new GitPublisher(
+        GitPublisher rebasedPublisher = new TestGitPublisher(
                 Collections.emptyList(),
                 Collections.singletonList(btp),
                 Collections.emptyList(),
@@ -802,7 +804,7 @@ public class GitPublisherTest extends AbstractGitProject {
         String tagMessageReference = envReference + " tag message";
         String noteReference = "note for " + envReference;
         String noteValue = "note for " + envValue;
-        GitPublisher publisher = new GitPublisher(
+        GitPublisher publisher = new TestGitPublisher(
                 Collections.singletonList(new TagToPush("origin", tagNameReference, tagMessageReference, false, true)),
                 Collections.singletonList(new BranchToPush("origin", envReference)),
                 Collections.singletonList(new NoteToPush("origin", noteReference, Constants.R_NOTES_COMMITS, false)),
@@ -856,6 +858,36 @@ public class GitPublisherTest extends AbstractGitProject {
 
     }
 
+    /**
+     * doing this because some system and/or users may commit/tag gpgSign activated,
+     * and we cannot answer the passphrase if needed so disabled it locally for the test
+     */
+    private static class TestGitPublisher extends GitPublisher {
+        public TestGitPublisher(
+                List<TagToPush> tagsToPush,
+                List<BranchToPush> branchesToPush,
+                List<NoteToPush> notesToPush,
+                boolean pushOnlyIfSuccess,
+                boolean pushMerge,
+                boolean forcePush) {
+            super(tagsToPush, branchesToPush, notesToPush, pushOnlyIfSuccess, pushMerge, forcePush);
+        }
+
+        @Override
+        protected GitClient getGitClient(
+                GitSCM gitSCM,
+                BuildListener listener,
+                EnvVars environment,
+                AbstractBuild<?, ?> build,
+                UnsupportedCommand cmd)
+                throws IOException, InterruptedException {
+            GitClient gitClient = super.getGitClient(gitSCM, listener, environment, build, cmd);
+            gitClient.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", "false");
+            gitClient.config(GitClient.ConfigLevel.LOCAL, "tag.gpgSign", "false");
+            return gitClient;
+        }
+    }    
+    
     private boolean existsTag(String tag) throws InterruptedException {
         return existsTagInRepo(testGitClient, tag);
     }
@@ -910,4 +942,7 @@ class LongRunningCommit extends Builder {
 
         return true;
     }
+    
+    
+    
 }

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1954,7 +1954,7 @@ public class GitSCMTest extends AbstractGitTestCase {
                 Collections.singletonList(new BranchSpec("*")),
                 null, null,
                 Collections.emptyList());
-        scm.getExtensions().add(new PreBuildMerge(new UserMergeOptions("origin", "integration", "default", MergeCommand.GitPluginFastForwardMode.FF)));
+        scm.getExtensions().add(new GitSCMSlowTest.TestPreBuildMerge(new UserMergeOptions("origin", "integration", "default", MergeCommand.GitPluginFastForwardMode.FF)));
         addChangelogToBranchExtension(scm);
         project.setScm(scm);
 

--- a/src/test/java/hudson/plugins/git/GitTagActionTest.java
+++ b/src/test/java/hudson/plugins/git/GitTagActionTest.java
@@ -1,6 +1,7 @@
 package hudson.plugins.git;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -15,6 +16,7 @@ import java.util.Random;
 import java.util.Set;
 
 import hudson.EnvVars;
+import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
@@ -24,6 +26,7 @@ import hudson.plugins.git.GitSCM.DescriptorImpl;
 import hudson.plugins.git.extensions.impl.LocalBranch;
 
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.util.SystemReader;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 
@@ -43,6 +46,9 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import javax.servlet.ServletException;
 
 /**
  * Test git tag action. Low value test that was created as part of
@@ -240,7 +246,7 @@ public class GitTagActionTest {
         if (NO_BRANCHES.equals(message)) {
             tagRevision.setBranches(null);
         }
-        tagAction = new GitTagAction(tagRun, workspace, tagRevision);
+        tagAction = new TestGitTagAction(tagRun, workspace, tagRevision);
 
         /* Schedule tag creation if message is not null */
         if (message != null) {
@@ -253,6 +259,45 @@ public class GitTagActionTest {
         }
         return tagAction;
     }
+
+    /**
+     * doing this because some system and/or users may commit/tag gpgSign activated,
+     * and we cannot answer the passphrase if needed so disabled it locally for the test
+     */
+    private static class TestGitTagAction extends GitTagAction {
+        public TestGitTagAction(Run build, FilePath workspace, Revision revision) {
+            super(build, workspace, revision);
+        }
+
+        @Override
+        void scheduleTagCreation(Map<String, String> newTags, String comment) throws IOException, ServletException {
+            new TestTagWorkerThread(newTags, comment).start();
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends Descriptor<GitTagAction> {
+            @Override
+            public String getDisplayName() {
+                return "Tag";
+            }
+        }
+
+        private class TestTagWorkerThread extends GitTagAction.TagWorkerThread {
+            public TestTagWorkerThread(Map<String, String> tagSet, String ignoredComment) {
+                super(tagSet, ignoredComment);
+            }
+
+            @Override
+            protected GitClient getGitClient(TaskListener listener, EnvVars environment, FilePath workspace) throws IOException, InterruptedException {
+                GitClient gitClient = super.getGitClient(listener, environment, workspace);
+                gitClient.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", "false");
+                gitClient.config(GitClient.ConfigLevel.LOCAL, "tag.gpgSign", "false");
+                return gitClient;
+            }
+        }
+
+    }
+
 
     private static Set<String> getMatchingTagNames() throws Exception {
         Set<GitObject> tags = workspaceGitClient.getTags();

--- a/src/test/java/hudson/plugins/git/TestGitRepo.java
+++ b/src/test/java/hudson/plugins/git/TestGitRepo.java
@@ -53,6 +53,8 @@ public class TestGitRepo {
 
         // finally: initialize the repo
 		git.init();
+        git.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", "false");
+        git.config(GitClient.ConfigLevel.LOCAL, "tag.gpgSign", "false");
 	}
 	
     /**

--- a/src/test/java/hudson/plugins/git/extensions/impl/PruneStaleTagTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/PruneStaleTagTest.java
@@ -85,7 +85,8 @@ public class PruneStaleTagTest {
 
         // clone remote repository to workspace
         GitClient localClient =  cloneRepository(remoteRepo);
-
+        localClient.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", "false");
+        localClient.config(GitClient.ConfigLevel.LOCAL, "tag.gpgSign", "false");
         GitSCM scm = new GitSCM(localClient.getRemoteUrl("origin"));
         PruneStaleTag extension = new PruneStaleTag(true);
 
@@ -227,7 +228,8 @@ public class PruneStaleTagTest {
     private GitClient initRepository(File workspace) throws Exception {
         GitClient remoteClient = newGitClient(workspace);
         remoteClient.init();
-
+        remoteClient.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", "false");
+        remoteClient.config(GitClient.ConfigLevel.LOCAL, "tag.gpgSign", "false");
         FileUtils.touch(new File(workspace, "test"));
         remoteClient.add("test");
 

--- a/src/test/java/hudson/plugins/git/util/GitUtilsTest.java
+++ b/src/test/java/hudson/plugins/git/util/GitUtilsTest.java
@@ -106,6 +106,7 @@ public class GitUtilsTest {
         originRepo.init();
         originRepo.git("config", "user.name", "Author User Name");
         originRepo.git("config", "user.email", "author.user.name@mail.example.com");
+
         originRepo.git("tag", PRIOR_TAG_NAME_1);
         originRepo.git("tag", "-a", PRIOR_TAG_NAME_2, "-m", "Annotated tag " + PRIOR_TAG_NAME_2);
         priorHeadId = ObjectId.fromString(originRepo.head());

--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -88,6 +88,7 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         git("config", "user.email", "gits@mplereporule");
         git("config", "init.defaultbranch", "master");
         git("config", "commit.gpgsign", "false");
+        git("config", "tag.gpgsign", "false");
         git("commit", "--message=init");
     }
 

--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -88,7 +88,7 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         git("config", "user.email", "gits@mplereporule");
         git("config", "init.defaultbranch", "master");
         git("config", "commit.gpgsign", "false");
-        git("config", "tag.gpgsign", "false");
+        git("config", "tag.gpgSign", "false");
         git("commit", "--message=init");
     }
 

--- a/src/test/java/jenkins/plugins/git/GitStepTest.java
+++ b/src/test/java/jenkins/plugins/git/GitStepTest.java
@@ -283,6 +283,8 @@ public class GitStepTest {
             "node {\n" +
             "  git url: $/" + sampleRepo + "/$\n" +
             "  writeFile file: 'file', text: 'edited by build'\n" +
+            "  rungit 'config --local commit.gpgsign false'\n" +
+            "  rungit 'config --local tag.gpgSign false'\n" +
             "  rungit 'commit --all --message=edits'\n" +
             "  rungit 'show master'\n" +
             "}", true));


### PR DESCRIPTION
Some test cases related to `tag` git command can fail in case of the following `~/.gitconfig` configuration
```
[tag]
       gpgSign = true
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [x] Dependency or infrastructure update
