### PR TITLE
[JENKINS-72044] Fix withCredentials directory separators on Windows

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
+++ b/src/main/java/jenkins/plugins/git/GitUsernamePasswordBinding.java
@@ -193,7 +193,8 @@ public class GitUsernamePasswordBinding extends MultiBinding<StandardUsernamePas
             if (filename.contains("\"")) {
                 filename = filename.replace("\"", "^\"");
             }
-            return "\"" + filename + "\"";
+            /* Ensure backslashes since cmd doesn't work with slashes as path separators */
+            return "\"" + filename.replace("/", "\\") + "\"";
         }
     }
 


### PR DESCRIPTION
cmd.exe doesn't work with '/' as path separator.

## [JENKINS-72044](https://issues.jenkins.io/browse/JENKINS-72044) - Fix withCredentials directory separators on Windows

With #1443 the `GIT_ASKPASS` script was changed. Unfortunately the `.bat` script contains `/` instead of `\` on Windows. While `/` generally works as path separator on Windows, it does not work with `cmd.exe`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

This is a small change that fixes a bug introduced in `5.2.0` making the `gitUsernamePassword` binding unuseable on windows agents.