### PR TITLE
Require Jenkins 2.414.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.78</version>
+    <version>4.79</version>
     <relativePath />
   </parent>
 
@@ -72,7 +72,7 @@
     <revision>5.2.2</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.401.3</jenkins.version>
+    <jenkins.version>2.414.3</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <!-- Jenkins.MANAGE is still in Beta -->
     <useBeta>true</useBeta>
@@ -87,8 +87,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.401.x</artifactId>
-        <version>2745.vc7b_fe4c876fa_</version>
+        <artifactId>bom-2.414.x</artifactId>
+        <version>2857.v01a_0144eb_20b_</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.414.3 or newer

Jenkins 2.414.3 is a suggested choice for minimum Jenkins version in the Jenkins documentation and avoids moving the version too rapidly.

Also updates to Jenkins plugin parent pom 4.79 and to the latest release of the plugin bill of materials that matches Jenkins 2.414.3.

### Testing done

Confirmed that automated tests pass with Java 21 on Linux.  Rely on ci.jenkins.io to test Windows with Java 17.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
