### PR TITLE
Removed unnecessary checking from migrate method

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitBranchSCMHead.java
+++ b/src/main/java/jenkins/plugins/git/GitBranchSCMHead.java
@@ -68,17 +68,13 @@ public class GitBranchSCMHead extends SCMHead implements GitSCMHeadMixin {
 
         @Override
         public SCMRevision migrate(@NonNull GitSCMSource source, @NonNull AbstractGitSCMSource.SCMRevisionImpl revision) {
-            if (revision.getHead().getClass() == SCMHead.class) {
-                SCMHead revisionHead = revision.getHead();
-                SCMHead branchHead = migrate(source, revisionHead);
-                if (branchHead != null) {
-                    GitBranchSCMHead gitBranchHead = (GitBranchSCMHead) branchHead;
-                    String revisionHash = revision.getHash();
-                    return new GitBranchSCMRevision(gitBranchHead, revisionHash);
-                }
+            SCMHead revisionHead = revision.getHead();
+            if (revisionHead instanceof GitBranchSCMHead) {
+                GitBranchSCMHead gitBranchHead = (GitBranchSCMHead) revisionHead;
+                String revisionHash = revision.getHash();
+                return new GitBranchSCMRevision(gitBranchHead, revisionHash);
             }
             return null;
         }
-
     }
 }


### PR DESCRIPTION
## [JENKINS-xxxxx](https://issues.jenkins.io/browse/JENKINS-xxxxx) - summarize pull request in one line

Describe the big picture of your changes here to explain to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, include a link to the issue.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes



- [ ] Dependency or infrastructure update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


In migrate method for SCMRevision, unnecessary class checking revision.getHead().getClass() == SCMHead.class is removed. Instead, we can directly check if revisionHead instanceof GitBranchSCMHead. Since we're specifically dealing with GitBranchSCMHead, IMO it's more efficient and clearer to use instanceof for this check.