### PR TITLE
[JENKINS-70897] Add support for personal access token authentication

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -279,7 +279,7 @@ Refer to the link:https://git-scm.com/book/en/v2/Git-Internals-The-Refspec[git r
 
 The git plugin supports username / password credentials and private key credentials provided by the
 https://plugins.jenkins.io/credentials[Jenkins credentials plugin].
-It does not support other credential types like secret text, secret file, or certificates.
+It does not support other credential types like secret file or certificates.
 Select credentials from the job definition drop down menu or enter their identifiers in Pipeline job definitions.
 
 When the remote repository is accessed with the **HTTP or HTTPS protocols**, the plugin requires a **username / password credential**.


### PR DESCRIPTION
## [JENKINS-70897](https://issues.jenkins.io/browse/JENKINS-70897) - summarize pull request in one line

On Bitbucket Datacenter/Cloud and Azure it is required to use personal access tokens instead of username/password authentication. 

Resolves jenkinsci/bitbucket-branch-source-plugin#716
Requires jenkinsci/git-client-plugin/pull/1104

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code. If a checkbox or line does not apply to this pull request, delete it. We prefer all checkboxes to be checked before a pull request is merged_

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [ ] Dependency or infrastructure update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
