### PR TITLE
[JENKINS-72993] Provide a JUnit 5 extension for GitSampleRepoRule

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -50,12 +50,14 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
 
     private static final Logger LOGGER = Logger.getLogger(GitSampleRepoRule.class.getName());
 
-    protected void before() throws Throwable {
+    @Override
+    public void before() throws Throwable {
         super.before();
         GitSCM.ALLOW_LOCAL_CHECKOUT = true;
     }
 
-    protected void after() {
+    @Override
+    public void after() {
         super.after();
         GitSCM.ALLOW_LOCAL_CHECKOUT = false;
     }

--- a/src/test/java/jenkins/plugins/git/junit/jupiter/GitSampleRepoExtension.java
+++ b/src/test/java/jenkins/plugins/git/junit/jupiter/GitSampleRepoExtension.java
@@ -1,0 +1,45 @@
+package jenkins.plugins.git.junit.jupiter;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import jenkins.plugins.git.GitSampleRepoRule;
+
+/**
+ * A Junit5 extension to use {@link GitSampleRepoRule} with Junit5
+ * See {@link WithGitSampleRepo} for details
+ */
+public class GitSampleRepoExtension implements ParameterResolver, AfterEachCallback {
+
+    private static final String KEY = "git-sample-repo";
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(GitSampleRepoExtension.class);
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        var rule = context.getStore(NAMESPACE).remove(KEY, GitSampleRepoRule.class);
+        if (rule != null) {
+            rule.after();
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return parameterContext.getParameter().getType().equals(GitSampleRepoRule.class);
+    }
+
+    @Override
+    public GitSampleRepoRule resolveParameter(ParameterContext parameterContext, ExtensionContext context) {
+        var rule = context.getStore(NAMESPACE).getOrComputeIfAbsent(KEY, key -> new GitSampleRepoRule(), GitSampleRepoRule.class);
+        if (rule != null) {
+            try {
+                rule.before();
+            } catch (Throwable t) {
+                throw new ParameterResolutionException(t.getMessage(), t);
+            }
+        }
+        return rule;
+    }
+}

--- a/src/test/java/jenkins/plugins/git/junit/jupiter/GitSampleRepoExtensionClassTest.java
+++ b/src/test/java/jenkins/plugins/git/junit/jupiter/GitSampleRepoExtensionClassTest.java
@@ -1,0 +1,20 @@
+package jenkins.plugins.git.junit.jupiter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import jenkins.plugins.git.GitSampleRepoRule;
+
+@WithGitSampleRepo
+class GitSampleRepoExtensionClassTest {
+
+    @Test
+    void gitSampleRepoIsInjected(GitSampleRepoRule rule) throws Exception {
+        Assertions.assertNotNull(rule);
+        // somehow testing initialization
+        var root = rule.getRoot();
+        Assertions.assertNotNull(root);
+        rule.init();
+        Assertions.assertNotNull(rule.head());
+    }
+}

--- a/src/test/java/jenkins/plugins/git/junit/jupiter/GitSampleRepoExtensionMethodTest.java
+++ b/src/test/java/jenkins/plugins/git/junit/jupiter/GitSampleRepoExtensionMethodTest.java
@@ -1,0 +1,20 @@
+package jenkins.plugins.git.junit.jupiter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import jenkins.plugins.git.GitSampleRepoRule;
+
+class GitSampleRepoExtensionMethodTest {
+
+    @WithGitSampleRepo
+    @Test
+    void gitSampleRepoIsInjected(GitSampleRepoRule rule) throws Exception {
+        Assertions.assertNotNull(rule);
+        // somehow testing initialization
+        var root = rule.getRoot();
+        Assertions.assertNotNull(root);
+        rule.init();
+        Assertions.assertNotNull(rule.head());
+    }
+}

--- a/src/test/java/jenkins/plugins/git/junit/jupiter/WithGitSampleRepo.java
+++ b/src/test/java/jenkins/plugins/git/junit/jupiter/WithGitSampleRepo.java
@@ -1,0 +1,62 @@
+package jenkins.plugins.git.junit.jupiter;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jenkins.plugins.git.GitSampleRepoRule;
+
+/**
+ * A meta annotation for the {@link GitSampleRepoExtension} to use {@link GitSampleRepoRule} with Junit5.
+ * Two possible usages:
+ * <p>
+ * 1. Class annotation: each method of the class can have the rule injected as a parameter:
+ *
+ * <blockquote>
+ * <pre>
+ * &#64;WithGitSampleRepo
+ * class ClassLevelAnnotationTest {
+ *
+ *     &#64;Test
+ *     void usingRule(GitSampleRepoRule rule) {
+ *         // ...
+ *     }
+ *
+ *     &#64;Test
+ *     void notUsingRule() {
+ *         // ...
+ *     }
+ * }
+ * </pre>
+ * </blockquote>
+ * <p>
+ * 2. Method annotation: only the annotated method can have the rule injected as a parameter:
+ *
+ * <blockquote>
+ * <pre>
+ * class MethodLevelAnnotationTest {
+ *
+ *     &#64;WithGitSampleRepo
+ *     &#64;Test
+ *     void usingRule(GitSampleRepoRule rule) {
+ *         // ...
+ *     }
+ *
+ *     &#64;Test
+ *     void notUsingRule() {
+ *         // ...
+ *     }
+ * }
+ * </pre>
+ * </blockquote>
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith(GitSampleRepoExtension.class)
+public @interface WithGitSampleRepo {
+}


### PR DESCRIPTION
## [JENKINS-72993](https://issues.jenkins.io/browse/JENKINS-72993) - Provide a JUnit 5 extension for GitSampleRepoRule

Adding a rule making the `GitSampleRepoRule` usable from a Junit5 extension, a bit like what was done with `WithJenkins` and `WithJenkinsConfiguredWithCode` (though this extension is simpler).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] New feature (non-breaking change which adds functionality) -> *developper feature*
