### PR TITLE
Fix JavaDoc Typo

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -620,7 +620,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
      * If the configuration is such that we are tracking just one branch of one repository
      * return that branch specifier (in the form of something like "origin/master" or a SHA1-hash
      *
-     * Otherwise return [@code null}.
+     * Otherwise return {@code null}.
      */
     @CheckForNull
     private String getSingleBranch(EnvVars env) {


### PR DESCRIPTION
(skipping the template because the change is so trivial)