### PR TITLE
Do not assume `HttpResponse` is a functional interface

### DIFF
--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -12,6 +12,7 @@ import hudson.scm.SCM;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.triggers.SCMTrigger;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.util.*;
@@ -177,7 +178,9 @@ public class GitStatus implements UnprotectedRootAction {
             contributors.addAll(listener.onNotifyCommit(origin, uri, sha1, buildParameters, branchesArray));
         }
 
-        return (StaplerRequest req, StaplerResponse rsp, Object node) -> {
+        return new HttpResponse() {
+          @Override
+          public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException {
             rsp.setStatus(SC_OK);
             rsp.setContentType("text/plain");
             for (int i = 0; i < contributors.size(); i++) {
@@ -192,6 +195,7 @@ public class GitStatus implements UnprotectedRootAction {
             for (ResponseContributor c : contributors) {
                 c.writeBody(req, rsp, w);
             }
+          }
         };
     }
 


### PR DESCRIPTION
It is right now, but it won't be in the future when a second compatibility method is added to it for EE 9.

### Testing done

Passed in EE 8 and EE 9.