### PR TITLE
Remove two tests that depend on assembla.com

### DIFF
--- a/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
+++ b/src/test/java/hudson/plugins/git/browser/AssemblaWebDoCheckURLTest.java
@@ -61,20 +61,6 @@ public class AssemblaWebDoCheckURLTest {
     }
 
     @Test
-    public void testPathLevelChecksOnRepoUrlValidURLNullProject() throws Exception {
-        String url = "https://app.assembla.com/space/git-plugin/git/source";
-        assertThat(assemblaWebDescriptor.doCheckRepoUrl(null, url), is(FormValidation.ok()));
-    }
-
-    @Test
-    public void testPathLevelChecksOnRepoUrlUnableToConnect() throws Exception {
-        // Syntax issue related specific to Assembla
-        String url = "https://app.assembla.com/space/git-plugin/git/source/";
-        assertThat(assemblaWebDescriptor.doCheckRepoUrl(project, url).getLocalizedMessage(),
-                is("Exception reading from Assembla URL " + url + " : ERROR: Unable to connect " + url));
-    }
-
-    @Test
     public void testPathLevelChecksOnRepoUrlSupersetOfAssembla() throws Exception {
         java.util.Random random = new java.util.Random();
         String [] urls = {


### PR DESCRIPTION
## Remove two tests that depend on assembla.com

Returned HTTP 524 is a recent test

Test is not valuable enough to waste time diagnosing it

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce?

- [x] Test
