### PR TITLE
Remove outdated test conditionals

### DIFF
--- a/src/test/java/hudson/plugins/git/GitHooksTest.java
+++ b/src/test/java/hudson/plugins/git/GitHooksTest.java
@@ -146,11 +146,6 @@ public class GitHooksTest extends AbstractGitTestCase {
         GitHooksConfiguration.get().setAllowedOnAgents(false);
         run = r.buildAndAssertSuccess(job);
         r.assertLogContains("Hello Pipeline", run);
-        if (!sampleRepo.gitVersionAtLeast(2, 0)) {
-            // Git 1.8 does not output hook text in this case
-            // Not important enough to research the difference
-            return;
-        }
         assertFalse(postCheckoutOutput1.exists());
         assertFalse(postCheckoutOutput2.exists());
 
@@ -213,20 +208,12 @@ public class GitHooksTest extends AbstractGitTestCase {
         commit("Commit3", janeDoe, "Commit number 3");
         GitHooksConfiguration.get().setAllowedOnController(true);
         run = r.buildAndAssertSuccess(job);
-        if (sampleRepo.gitVersionAtLeast(2, 0)) {
-            // Git 1.8 does not output hook text in this case
-            // Not important enough to research the difference
-            r.assertLogContains("h4xor3d", run);
-        }
+        r.assertLogContains("h4xor3d", run);
         GitHooksConfiguration.get().setAllowedOnController(false);
         GitHooksConfiguration.get().setAllowedOnAgents(true);
         commit("Commit4", janeDoe, "Commit number 4");
         run = r.buildAndAssertSuccess(job);
-        if (sampleRepo.gitVersionAtLeast(2, 0)) {
-            // Git 1.8 does not output hook text in this case
-            // Not important enough to research the difference
-            r.assertLogNotContains("h4xor3d", run);
-        }
+        r.assertLogNotContains("h4xor3d", run);
     }
 
     @Test
@@ -245,20 +232,12 @@ public class GitHooksTest extends AbstractGitTestCase {
         commit("Commit3", janeDoe, "Commit number 3");
         GitHooksConfiguration.get().setAllowedOnAgents(true);
         run = r.buildAndAssertSuccess(job);
-        if (sampleRepo.gitVersionAtLeast(2, 0)) {
-            // Git 1.8 does not output hook text in this case
-            // Not important enough to research the difference
-            r.assertLogContains("h4xor3d", run);
-        }
+        r.assertLogContains("h4xor3d", run);
         GitHooksConfiguration.get().setAllowedOnAgents(false);
         GitHooksConfiguration.get().setAllowedOnController(true);
         commit("Commit4", janeDoe, "Commit number 4");
         run = r.buildAndAssertSuccess(job);
-        if (sampleRepo.gitVersionAtLeast(2, 0)) {
-            // Git 1.8 does not output hook text in this case
-            // Not important enough to research the difference
-            r.assertLogNotContains("h4xor3d", run);
-        }
+        r.assertLogNotContains("h4xor3d", run);
     }
 
     private WorkflowJob setupAndRunPipelineCheckout(String node) throws Exception {
@@ -289,11 +268,7 @@ public class GitHooksTest extends AbstractGitTestCase {
         final String commitFile2 = "commitFile2";
         commit(commitFile2, janeDoe, "Commit number 2");
         run = r.buildAndAssertSuccess(job);
-        if (sampleRepo.gitVersionAtLeast(2, 0)) {
-            // Git 1.8 does not output hook text in this case
-            // Not important enough to research the difference
-            r.assertLogNotContains("h4xor3d", run);
-        }
+        r.assertLogNotContains("h4xor3d", run);
         return job;
     }
 

--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -80,7 +80,7 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         git("init", "--template="); // initialize without copying the installation defaults to ensure a vanilla repo that behaves the same everywhere
 	if (gitVersionAtLeast(2, 30)) {
 	    // Force branch name to master even if system default is not master
-	    // Fails on git 2.25, 2.20, 2.17, and 1.8
+	    // Fails on git 2.25, 2.20, and 2.17
 	    // Works on git 2.30 and later
             git("branch", "-m", "master");
 	}


### PR DESCRIPTION
## Remove outdated test conditionals

Git plugin is no longer tested or supported on operating systems with a command line git version older than 2.20 (Debian 10).  This removes outdated tests.  It does not prevent the plugin from running with older versions, but removes test clutter from older versions.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce?

- [x] Tests
