### PR TITLE
Use modern syntax in git step online help

### DIFF
--- a/src/main/resources/jenkins/plugins/git/GitStep/help.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help.html
@@ -19,8 +19,8 @@
     <p>
     The <code>git</code> step is a simplified shorthand for a subset of the more powerful <code>checkout</code> step:
 <pre>
-checkout([$class: 'GitSCM', branches: [[name: '*/master']],
-    userRemoteConfigs: [[url: 'https://git-server/user/repository.git']]])
+checkout scmGit(branches: [[name: 'main]],
+    userRemoteConfigs: [[url: 'https://git-server/user/repository.git']])
 </pre>
     </p>
 

--- a/src/main/resources/jenkins/plugins/git/GitStep/help_ja.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help_ja.html
@@ -3,9 +3,11 @@
     Gitステップです。 指定したリポジトリからクローンを実行します。
     </p>
     <p>
-        このステップは、一般的なSCMのステップである<code>
-checkout([$class: 'GitSCM', branches: [[name: '*/master']],
-     userRemoteConfigs: [[url: 'https://git-server/user/repository.git']]])</code>
+        このステップは、一般的なSCMのステップである
+<pre>
+checkout scmGit(branches: [[name: 'main]],
+    userRemoteConfigs: [[url: 'https://git-server/user/repository.git']])
+</pre>
     　　の短縮形です。　
 </p>
 </div>


### PR DESCRIPTION
## Use modern syntax in git step online help

The "$class: 'GitSCM'" syntax has not been needed for many releases.

Found while reviewing the online help for the [`git` step](https://www.jenkins.io/doc/pipeline/steps/git/) in the Pipeline steps reference.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce?

- [x] Documentation
