### PR TITLE
Change the default branch name

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitStep.java
+++ b/src/main/java/jenkins/plugins/git/GitStep.java
@@ -50,7 +50,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 public final class GitStep extends SCMStep {
 
     private final String url;
-    private String branch = "master";
+    private String branch = "main";
     private String credentialsId;
 
     @DataBoundConstructor


### PR DESCRIPTION
Most branches created in recent history use `main` to denote the primary branch. This value is used in the snippet generator, so important to have correct IMHO

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply. Delete the items in the list that do *not* apply_

- [ ] Dependency or infrastructure update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
