### PR TITLE
Use correct getters for note fields

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -332,15 +332,15 @@ public class GitPublisher extends Recorder implements Serializable {
                      
             if (isPushNotes()) {
                 for (final NoteToPush b : notesToPush) {
-                    if (b.getnoteMsg() == null)
+                    if (b.getNoteMsg() == null)
                         throw new AbortException("No note to push defined");
 
                     b.setEmptyTargetRepoToOrigin();
-                    String noteMsgTmp = environment.expand(b.getnoteMsg());
+                    String noteMsgTmp = environment.expand(b.getNoteMsg());
                     final String noteMsg = replaceAdditionalEnvironmentalVariables(noteMsgTmp, build);
-                    final String noteNamespace = environment.expand(b.getnoteNamespace());
+                    final String noteNamespace = environment.expand(b.getNoteNamespace());
                     final String targetRepo = environment.expand(b.getTargetRepoName());
-                    final boolean noteReplace = b.getnoteReplace();
+                    final boolean noteReplace = b.getNoteReplace();
                     
                     try {
                     	// Lookup repository with unexpanded name as GitSCM stores them unexpanded
@@ -579,15 +579,15 @@ public class GitPublisher extends Recorder implements Serializable {
         private String noteNamespace;
         private boolean noteReplace;
 
-        public String getnoteMsg() {
+        public String getNoteMsg() {
             return noteMsg;
         }
         
-        public String getnoteNamespace() {
+        public String getNoteNamespace() {
         	return noteNamespace;
         }
         
-        public boolean getnoteReplace() {
+        public boolean getNoteReplace() {
         	return noteReplace;
         }
 

--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -579,16 +579,31 @@ public class GitPublisher extends Recorder implements Serializable {
         private String noteNamespace;
         private boolean noteReplace;
 
-        public String getNoteMsg() {
+        @Deprecated
+        public String getnoteMsg() {
             return noteMsg;
         }
         
-        public String getNoteNamespace() {
+        @Deprecated
+        public String getnoteNamespace() {
         	return noteNamespace;
         }
         
-        public boolean getNoteReplace() {
+        @Deprecated
+        public boolean getnoteReplace() {
         	return noteReplace;
+        }
+
+        public String getNoteMsg() {
+            return noteMsg;
+        }
+
+        public String getNoteNamespace() {
+            return noteNamespace;
+        }
+
+        public boolean getNoteReplace() {
+            return noteReplace;
         }
 
         @DataBoundConstructor


### PR DESCRIPTION
## Use correct getters on NoteToPush

This PR corrects the getters used on the NoteToPush internal class of the GitPublisher class.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

n/a
