### PR TITLE
[JENKINS-73506] Reject fetch requests that use credentials with HTTP in FIPS mode

### DIFF
--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -101,6 +101,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMTrait;
 import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
 import jenkins.scm.impl.trait.WildcardSCMSourceFilterTrait;
+import jenkins.security.FIPS140;
 import jenkins.util.SystemProperties;
 import net.jcip.annotations.GuardedBy;
 import org.apache.commons.lang.StringUtils;
@@ -351,6 +352,17 @@ public abstract class AbstractGitSCMSource extends SCMSource {
         return doRetrieve(retriever, context, listener, prune, getOwner(), delayFetch);
     }
 
+    /**
+     * Returns false if a non-TLS protocol is used when FIPS mode is enabled.
+     * @param credentialsId any credentials (can be {@code null})
+     * @param remoteUrl the git remote url
+     * @return {@code false} if using any credentials with a non TLS protocol with FIPS mode activated
+     * @see FIPS140#useCompliantAlgorithms()
+     */
+    public static boolean isFIPSCompliantTLS(String credentialsId, String remoteUrl) {
+        return !FIPS140.useCompliantAlgorithms() || !StringUtils.isNotEmpty(credentialsId) || (!StringUtils.startsWith(remoteUrl, "http:") && !StringUtils.startsWith(remoteUrl, "git:"));
+    }
+
     @NonNull
     private <T, C extends GitSCMSourceContext<C, R>, R extends GitSCMSourceRequest> T doRetrieve(Retriever<T> retriever,
                                                                                                  @NonNull C context,
@@ -359,6 +371,12 @@ public abstract class AbstractGitSCMSource extends SCMSource {
                                                                                                  @CheckForNull Item retrieveContext,
                                                                                                  boolean delayFetch)
             throws IOException, InterruptedException {
+        if (!isFIPSCompliantTLS(this.getCredentialsId(), this.getRemote())) {
+            listener.fatalError(Messages.git_fips_url_notsecured());
+            LOGGER.log(Level.SEVERE, Messages.git_fips_url_notsecured());
+            throw new IllegalArgumentException(Messages.git_fips_url_notsecured());
+        }
+
         String cacheEntry = getCacheEntry();
         Lock cacheLock = getCacheLock(cacheEntry);
         cacheLock.lock();

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -360,7 +360,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
      * @see FIPS140#useCompliantAlgorithms()
      */
     public static boolean isFIPSCompliantTLS(String credentialsId, String remoteUrl) {
-        return !FIPS140.useCompliantAlgorithms() || !StringUtils.isNotEmpty(credentialsId) || (!StringUtils.startsWith(remoteUrl, "http:") && !StringUtils.startsWith(remoteUrl, "git:"));
+        return !FIPS140.useCompliantAlgorithms() || StringUtils.isEmpty(credentialsId) || (!StringUtils.startsWith(remoteUrl, "http:") && !StringUtils.startsWith(remoteUrl, "git:"));
     }
 
     @NonNull

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -164,6 +164,9 @@ public class GitSCMSource extends AbstractGitSCMSource {
 
     @DataBoundSetter
     public void setCredentialsId(@CheckForNull String credentialsId) {
+        if (!isFIPSCompliantTLS(credentialsId, this.remote)) {
+            LOGGER.log(Level.SEVERE, Messages.git_fips_url_notsecured());
+        }
         this.credentialsId = credentialsId;
     }
 
@@ -407,17 +410,6 @@ public class GitSCMSource extends AbstractGitSCMSource {
     @Override
     public List<SCMSourceTrait> getTraits() {
         return traits;
-    }
-
-    /**
-     * Returns false if a non-TLS protocol is used when FIPS mode is enabled.
-     * @param credentialsId any credentials (can be {@code null})
-     * @param remoteUrl the git remote url
-     * @return {@code false} if using any credentials with a non TLS protocol with FIPS mode activated
-     * @see FIPS140#useCompliantAlgorithms()
-     */
-    public static boolean isFIPSCompliantTLS(String credentialsId, String remoteUrl) {
-        return !FIPS140.useCompliantAlgorithms() || !StringUtils.isNotEmpty(credentialsId) || (!StringUtils.startsWith(remoteUrl, "http:") && !StringUtils.startsWith(remoteUrl, "git:"));
     }
 
     @Symbol("git")

--- a/src/main/resources/jenkins/plugins/git/Messages.properties
+++ b/src/main/resources/jenkins/plugins/git/Messages.properties
@@ -27,4 +27,4 @@ within.Repository=Within Repository
 additional=Additional
 GitUsernamePasswordBinding.DisplayName=Git Username and Password
 
-git.fips.url.notsecured=Invalid configuration will not fetch any remote. FIPS requires to use git URL with TLS.
+git.fips.url.notsecured=Invalid configuration will not fetch any remote. FIPS requires a secure channel for git fetch with credentials.

--- a/src/main/resources/jenkins/plugins/git/Messages.properties
+++ b/src/main/resources/jenkins/plugins/git/Messages.properties
@@ -26,3 +26,5 @@ GitStep.git=Git
 within.Repository=Within Repository
 additional=Additional
 GitUsernamePasswordBinding.DisplayName=Git Username and Password
+
+git.fips.url.notsecured=Invalid configuration will not fetch any remote. FIPS requires to use git URL with TLS.

--- a/src/test/java/jenkins/plugins/git/FIPSModeSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/FIPSModeSCMSourceTest.java
@@ -1,0 +1,58 @@
+package jenkins.plugins.git;
+
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
+import hudson.util.StreamTaskListener;
+import jenkins.security.FIPS140;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.FlagRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+import java.io.IOException;
+import java.util.logging.Level;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class FIPSModeSCMSourceTest {
+
+    @ClassRule
+    public static final FlagRule<String> FIPS_FLAG =
+            FlagRule.systemProperty(FIPS140.class.getName() + ".COMPLIANCE", "true");
+
+    @Rule
+    public JenkinsRule rule = new JenkinsRule();
+
+    @Rule
+    public LoggerRule logger = new LoggerRule();
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void remotesAreNotFetchedTest() throws IOException, InterruptedException {
+        GitSCMSource source = new GitSCMSource("http://insecure-repo");
+        // Credentials are null, so we should have no FIPS error
+        logger.record(AbstractGitSCMSource.class, Level.SEVERE);
+        logger.capture(10);
+        TaskListener listener = StreamTaskListener.fromStderr();
+        assertThrows("expected exception as repo doesn't exist", GitException.class, () ->source.fetch(listener));
+        assertThat("We should no see the error in the logs", logger.getMessages().size(), is(0));
+
+        // Using creds we should be getting an exception
+        Throwable exception = assertThrows("We're not saving creds", IllegalArgumentException.class, () -> source.setCredentialsId("cred-id"));
+        assertThat(exception.getMessage(), containsString("FIPS requires a secure channel"));
+        assertThat("credentials are not saved", source.getCredentialsId(), nullValue());
+
+        // Using old constructor (restricted since 3.4.0) to simulate credentials are being set with unsecure connection
+        // This would be equivalent to a user manually adding credentials to config.xml
+        GitSCMSource anotherSource = new GitSCMSource("fake", "http://insecure", "credentialsId", "", "", true);
+        exception = assertThrows("fetch was interrupted so no credential was leaked", IllegalArgumentException.class, () -> anotherSource.fetch(listener));
+        assertThat("We should have a severe log indicating the error", logger.getMessages().size(), is(1));
+        assertThat("Exception indicates problem", exception.getMessage(), containsString("FIPS requires a secure channel"));
+    }
+}


### PR DESCRIPTION
## [JENKINS-73506](https://issues.jenkins.io/browse/JENKINS-73506) - Checks for FIPS compliance in AbstractSCMSource

This is a follow-up of https://github.com/jenkinsci/git-plugin/pull/1611

That PR left a case without covering: SCMSources could be configured with invalid values and, when fetched (e.g. multibranch pipelines) credentials could be leaked.

`IllegalArgumentException` throwing has no effect here (other than the logs), as MBPs handle that, so failures would be transparent to the user, also credentials could come from other sources (e.g. `GIT_PASSWORD`). Form validation is still in place and wasn't modified.

Therefore, in this case we are interrupting fetch operation, so we can be sure credentials are not leaked. 

When trying to fetch a remote with credentials and an insecure URL we will 
* Log as SEVERE
* Interrupt the fetch operation
* Add the same log message to the `TaskListener` so it's show in the UI.

Added a unit test checking fetch is interrupted.

Also tested manually and checked fetching is interrupted as expected
```
Started by user unknown or anonymous
[Wed Jul 31 17:55:15 CEST 2024] Starting branch indexing...
 > git --version # timeout=10
 > git --version # 'git version 2.38.1'
using GIT_ASKPASS to set credentials 
 > git ls-remote --symref -- http://github.com/XXX/YYY # timeout=10
ERROR: Invalid configuration will not fetch any remote. FIPS requires to use git URL with TLS.
ERROR: [Wed Jul 31 17:55:18 CEST 2024] Could not fetch branches from source d3e00ee6-4048-472e-8931-391280660dc6
[Wed Jul 31 17:55:18 CEST 2024] Finished branch indexing. Indexing took 2.6 sec
Aborted
Finished: ABORTED
```
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary
- [x] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce?

- [x] New feature (non-breaking change which adds functionality)
