### PR TITLE
Adapt git browsers for Jetty 12 EE 9 transition

### DIFF
--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -116,7 +116,7 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                 return FormValidation.error(Messages.invalidUrl());
             }
             return new URLCheck() {
-                protected FormValidation check() throws IOException, ServletException {
+                protected FormValidation check() throws IOException {
                     String v = cleanUrl;
                     if (!v.endsWith("/")) {
                         v += '/';
@@ -129,7 +129,12 @@ public class AssemblaWeb extends GitRepositoryBrowser {
                             return FormValidation.error("This is a valid URL but it does not look like Assembla");
                         }
                     } catch (IOException e) {
-                        return FormValidation.error("Exception reading from Assembla URL " + cleanUrl + " : " + handleIOException(v, e));
+                        String prefix = "Exception reading from Assembla URL " + cleanUrl + " : ";
+                        if (e.getMessage().equals(v)) {
+                            return FormValidation.error(prefix + "Unable to connect " + v, e);
+                        } else {
+                            return FormValidation.error(prefix + "ERROR: " + e.getMessage(), e);
+                        }
                     }
                 }
             }.check();

--- a/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
@@ -108,7 +108,7 @@ public class FisheyeGitRepositoryBrowser extends GitRepositoryBrowser {
 			final String finalValue = value;
 			return new URLCheck() {
 				@Override
-				protected FormValidation check() throws IOException, ServletException {
+				protected FormValidation check() throws IOException {
 					try {
 						if (findText(open(new URL(finalValue)), "FishEye")) {
 							return FormValidation.ok();
@@ -116,7 +116,11 @@ public class FisheyeGitRepositoryBrowser extends GitRepositoryBrowser {
 							return FormValidation.error("This is a valid URL but it doesn't look like FishEye");
 						}
 					} catch (IOException e) {
-						return handleIOException(finalValue, e);
+						if (e.getMessage().equals(finalValue)) {
+							return FormValidation.error("Unable to connect " + finalValue, e);
+						} else {
+							return FormValidation.error(e.getMessage(), e);
+						}
 					}
 				}
 			}.check();

--- a/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
@@ -102,7 +102,7 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
                 return FormValidation.error(Messages.invalidUrl());
             }
             return new URLCheck() {
-                protected FormValidation check() throws IOException, ServletException {
+                protected FormValidation check() throws IOException {
                     String v = cleanUrl;
                     if (!v.endsWith("/")) {
                         v += '/';
@@ -115,7 +115,11 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
                             return FormValidation.error("This is a valid URL but it doesn't look like Gitblit");
                         }
                     } catch (IOException e) {
-                        return handleIOException(v, e);
+                        if (e.getMessage().equals(v)) {
+                            return FormValidation.error("Unable to connect " + v, e);
+                        } else {
+                            return FormValidation.error(e.getMessage(), e);
+                        }
                     }
                 }
             }.check();

--- a/src/main/java/hudson/plugins/git/browser/Gitiles.java
+++ b/src/main/java/hudson/plugins/git/browser/Gitiles.java
@@ -88,7 +88,7 @@ public class Gitiles extends GitRepositoryBrowser {
                 return FormValidation.error(Messages.invalidUrl());
             }
             return new URLCheck() {
-                protected FormValidation check() throws IOException, ServletException {
+                protected FormValidation check() throws IOException {
                     String v = cleanUrl;
                     if (!v.endsWith("/"))
                         v += '/';
@@ -101,7 +101,11 @@ public class Gitiles extends GitRepositoryBrowser {
                             return FormValidation.error("This is a valid URL but it doesn't look like Gitiles");
                         }
                     } catch (IOException e) {
-                        return handleIOException(v, e);
+                        if (e.getMessage().equals(v)) {
+                            return FormValidation.error("Unable to connect " + v, e);
+                        } else {
+                            return FormValidation.error(e.getMessage(), e);
+                        }
                     }
                 }
             }.check();

--- a/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
@@ -140,7 +140,7 @@ public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
             final String finalValue = value;
             return new FormValidation.URLCheck() {
                 @Override
-                protected FormValidation check() throws IOException, ServletException {
+                protected FormValidation check() throws IOException {
                     try {
                         if (findText(open(new URL(finalValue)), "icrosoft")) {
                             return FormValidation.ok();
@@ -148,7 +148,11 @@ public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
                             return FormValidation.error("This is a valid URL but it doesn't look like a Microsoft server");
                         }
                     } catch (IOException e) {
-                        return handleIOException(finalValue, e);
+                        if (e.getMessage().equals(finalValue)) {
+                            return FormValidation.error("Unable to connect " + finalValue, e);
+                        } else {
+                            return FormValidation.error(e.getMessage(), e);
+                        }
                     }
                 }
             }.check();

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -107,7 +107,7 @@ public class ViewGitWeb extends GitRepositoryBrowser {
                 return FormValidation.error(Messages.invalidUrl());
             }
             return new URLCheck() {
-                protected FormValidation check() throws IOException, ServletException {
+                protected FormValidation check() throws IOException {
                     String v = cleanUrl;
                     if (!v.endsWith("/"))
                         v += '/';
@@ -119,7 +119,11 @@ public class ViewGitWeb extends GitRepositoryBrowser {
                             return FormValidation.error("This is a valid URL but it doesn't look like ViewGit");
                         }
                     } catch (IOException e) {
-                        return handleIOException(v, e);
+                        if (e.getMessage().equals(v)) {
+                            return FormValidation.error("Unable to connect " + v, e);
+                        } else {
+                            return FormValidation.error(e.getMessage(), e);
+                        }
                     }
                 }
             }.check();


### PR DESCRIPTION
## Adapt git browsers for Jetty 12 EE 9 transition

No need to throw ServletException when checking for URL validity.  IOException is sufficient and avoids including Jakarta EE in the method signature.

### Testing done

* Confirmed that AssemblaWeb still reports the expected message when an invalid URL is provided and that it reports no message when a valid URL is provided.  Confirmed that Assembla has changed URLs and broken the browsing links that previously worked. Separate bug report
* Confirmed that GitBlit browsing works as expected by installing a GitBlit server. https://hub.docker.com/r/gitblit/gitblit
* Confirmed that ViewGit browser provides change links as expected.  Confirmed that the ViewGit URL check logic no longer works on the site used as an example.  Now reports that https://repo.or.cz/ does not look like a ViewGit site. Separate bug report

Did not check Gitiles because the Gitiles source repository is archived on GitHub at https://github.com/google/gitiles .  No further development is expected.

Did not check TFS2013 because I have no idea where to find a Team Foundation Server 2013 installation.

Did not check Fisheye because I could not find a Fisheye server on the public internet.

Resolves one of the changes needed for Jetty 12 EE 9.  More changes are noted in:

* https://github.com/jenkinsci/git-plugin/pull/1589

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
