### PR TITLE
Remove mock object test replaced in earlier commit

### DIFF
--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -593,19 +593,6 @@ public class GitStatusTest extends AbstractGitProject {
 
     @Test
     @Issue("SECURITY-284")
-    public void testDoNotifyCommitWithSha1AndAllowModePoll() throws Exception {
-        GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL = "disabled-for-polling";
-        setupProjectWithTrigger("a", "master", false);
-        StaplerResponse res = mock(StaplerResponse.class);
-
-        HttpResponse httpResponse = this.gitStatus.doNotifyCommit(requestWithNoParameter, "a", "master", sha1, null);
-        httpResponse.generateResponse(null, res, null);
-
-        Mockito.verify(res).sendError(401, "An access token is required when using the sha1 parameter. Please refer to Git plugin documentation (https://plugins.jenkins.io/git/#plugin-content-push-notification-from-repository) for details.");
-    }
-
-    @Test
-    @Issue("SECURITY-284")
     public void testDoNotifyCommitWithAllowModeSha1() throws Exception {
         GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL = "disabled";
         // when sha1 is provided build is scheduled right away instead of repo polling, so we do not check for trigger

--- a/src/test/java/hudson/plugins/git/GitStepTest.java
+++ b/src/test/java/hudson/plugins/git/GitStepTest.java
@@ -347,7 +347,7 @@ public class GitStepTest {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL = "disabled-for-polling";
         createJob();
-        /* sha1 is ignored because no access token is provided */
+        /* sha1 is ignored because invalid access token is provided */
         String sha1 = "4b714b66959463a98e9dfb1983db5a39a39fa6d6";
         String response = sampleRepo.notifyCommit(r, GitSampleRepoRule.INVALID_NOTIFY_COMMIT_TOKEN, sha1);
         assertThat(response, containsString("Invalid access token"));
@@ -359,7 +359,7 @@ public class GitStepTest {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL = "disabled-for-polling";
         createJob();
-        /* sha1 is ignored because invalid access token is provided */
+        /* sha1 is ignored because no access token is provided */
         String sha1 = "4b714b66959463a98e9dfb1983db5a39a39fa6d6";
         String response = sampleRepo.notifyCommit(r, null, sha1);
         assertThat(response, containsString("An access token is required when using the sha1 parameter"));

--- a/src/test/java/hudson/plugins/git/GitStepTest.java
+++ b/src/test/java/hudson/plugins/git/GitStepTest.java
@@ -349,8 +349,8 @@ public class GitStepTest {
         createJob();
         /* sha1 is ignored because no access token is provided */
         String sha1 = "4b714b66959463a98e9dfb1983db5a39a39fa6d6";
-        String response = sampleRepo.notifyCommit(r, null, sha1);
-        assertThat(response, containsString("An access token is required when using the sha1 parameter"));
+        String response = sampleRepo.notifyCommit(r, GitSampleRepoRule.INVALID_NOTIFY_COMMIT_TOKEN, sha1);
+        assertThat(response, containsString("Invalid access token"));
     }
 
     @Test
@@ -361,8 +361,8 @@ public class GitStepTest {
         createJob();
         /* sha1 is ignored because invalid access token is provided */
         String sha1 = "4b714b66959463a98e9dfb1983db5a39a39fa6d6";
-        String response = sampleRepo.notifyCommit(r, GitSampleRepoRule.INVALID_NOTIFY_COMMIT_TOKEN, sha1);
-        assertThat(response, containsString("Invalid access token"));
+        String response = sampleRepo.notifyCommit(r, null, sha1);
+        assertThat(response, containsString("An access token is required when using the sha1 parameter"));
     }
 
 }


### PR DESCRIPTION
## Remove mocked test replaced in earlier commit

* Remove mocked test replaced in earlier commit
* Match assertions to test names

When transforming the tests from mock objects to JenkinsRule, I mistakenly placed the notifyCommit calls and the assertions in the wrong methods.  Switch them so that the assertion being performed matches the name of the test.

### Testing done

Confirmed that automated tests pass.  Compared assertions from original code with assertions in replacement tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
