### PR TITLE
Restore compatibility for GitSampleRepoRule

### DIFF
--- a/src/test/java/hudson/plugins/git/GitStepTest.java
+++ b/src/test/java/hudson/plugins/git/GitStepTest.java
@@ -328,7 +328,7 @@ public class GitStepTest {
     public void testDoNotifyCommitWithInvalidApiToken() throws Exception {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         createJob();
-        String response = sampleRepo.notifyCommit(r, GitSampleRepoRule.INVALID_NOTIFY_COMMIT_TOKEN);
+        String response = sampleRepo.notifyCommitWithResults(r, GitSampleRepoRule.INVALID_NOTIFY_COMMIT_TOKEN);
         assertThat(response, containsString("Invalid access token"));
     }
 
@@ -337,7 +337,7 @@ public class GitStepTest {
     public void testDoNotifyCommitWithAllowModeRandomValue() throws Exception {
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         createJob();
-        String response = sampleRepo.notifyCommit(r, null);
+        String response = sampleRepo.notifyCommitWithResults(r, null);
         assertThat(response, containsString("An access token is required. Please refer to Git plugin documentation (https://plugins.jenkins.io/git/#plugin-content-push-notification-from-repository) for details."));
     }
 
@@ -349,7 +349,7 @@ public class GitStepTest {
         createJob();
         /* sha1 is ignored because invalid access token is provided */
         String sha1 = "4b714b66959463a98e9dfb1983db5a39a39fa6d6";
-        String response = sampleRepo.notifyCommit(r, GitSampleRepoRule.INVALID_NOTIFY_COMMIT_TOKEN, sha1);
+        String response = sampleRepo.notifyCommitWithResults(r, GitSampleRepoRule.INVALID_NOTIFY_COMMIT_TOKEN, sha1);
         assertThat(response, containsString("Invalid access token"));
     }
 
@@ -361,7 +361,7 @@ public class GitStepTest {
         createJob();
         /* sha1 is ignored because no access token is provided */
         String sha1 = "4b714b66959463a98e9dfb1983db5a39a39fa6d6";
-        String response = sampleRepo.notifyCommit(r, null, sha1);
+        String response = sampleRepo.notifyCommitWithResults(r, null, sha1);
         assertThat(response, containsString("An access token is required when using the sha1 parameter"));
     }
 

--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -102,17 +102,8 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
     }
 
     public void notifyCommit(JenkinsRule r) throws Exception {
-        synchronousPolling(r);
         String notifyCommitToken = ApiTokenPropertyConfiguration.get().generateApiToken("notifyCommit").getString("value");
-        WebResponse webResponse = r.createWebClient()
-                .goTo("git/notifyCommit?url=" + bareUrl() + "&token=" + notifyCommitToken, "text/plain").getWebResponse();
-        LOGGER.log(Level.FINE, webResponse.getContentAsString());
-        for (NameValuePair pair : webResponse.getResponseHeaders()) {
-            if (pair.getName().equals("Triggered")) {
-                LOGGER.log(Level.FINE, "Triggered: " + pair.getValue());
-            }
-        }
-        r.waitUntilNoActivity();
+        notifyCommitWithResults(r, notifyCommitToken, null);
     }
 
     public String notifyCommitWithResults(JenkinsRule r) throws Exception {

--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -101,13 +101,27 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         return new File(this.sampleRepo, rel).mkdirs();
     }
 
-    public String notifyCommit(JenkinsRule r) throws Exception {
+    public void notifyCommit(JenkinsRule r) throws Exception {
+        synchronousPolling(r);
         String notifyCommitToken = ApiTokenPropertyConfiguration.get().generateApiToken("notifyCommit").getString("value");
-        return notifyCommit(r, notifyCommitToken, null);
+        WebResponse webResponse = r.createWebClient()
+                .goTo("git/notifyCommit?url=" + bareUrl() + "&token=" + notifyCommitToken, "text/plain").getWebResponse();
+        LOGGER.log(Level.FINE, webResponse.getContentAsString());
+        for (NameValuePair pair : webResponse.getResponseHeaders()) {
+            if (pair.getName().equals("Triggered")) {
+                LOGGER.log(Level.FINE, "Triggered: " + pair.getValue());
+            }
+        }
+        r.waitUntilNoActivity();
     }
 
-    public String notifyCommit(JenkinsRule r, @CheckForNull String notifyCommitToken) throws Exception {
-        return notifyCommit(r, notifyCommitToken, null);
+    public String notifyCommitWithResults(JenkinsRule r) throws Exception {
+        String notifyCommitToken = ApiTokenPropertyConfiguration.get().generateApiToken("notifyCommit").getString("value");
+        return notifyCommitWithResults(r, notifyCommitToken, null);
+    }
+
+    public String notifyCommitWithResults(JenkinsRule r, @CheckForNull String notifyCommitToken) throws Exception {
+        return notifyCommitWithResults(r, notifyCommitToken, null);
     }
 
     /**
@@ -126,7 +140,7 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
      * @param notifyCommitToken token used for notifyCommit authentication
      * @param sha1 SHA-1 hash to included in notifyCommit
      **/
-    public String notifyCommit(JenkinsRule r, @CheckForNull String notifyCommitToken, @CheckForNull String sha1) throws Exception {
+    public String notifyCommitWithResults(JenkinsRule r, @CheckForNull String notifyCommitToken, @CheckForNull String sha1) throws Exception {
         boolean expectError = notifyCommitToken == null || notifyCommitToken.contains(INVALID_NOTIFY_COMMIT_TOKEN);
         synchronousPolling(r);
         JenkinsRule.WebClient webClient = r.createWebClient();


### PR DESCRIPTION
## Restore compatibility for GitSampleRepoRule

I forgot that there are other consumers of the Git plugin test suite.

Plugin BOM automated tests detected the problem.

### Testing done

`mvn clean verify` passes and the previous implementation is restored.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
