### PR TITLE
Downgrade matrix-project optional dependency for PCT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,9 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
       <optional>true</optional>
+      <!-- pipeline-model-definition plugins fail to start git plugin in PCT for 2.440.x and 2.452.x lines -->
+      <!-- TODO: Remove once this workaround dependency downgrade is no longer required for PCT -->
+      <version>822.824.v14451b_c0fd42</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Downgrade matrix-project optional dependency for PCT

An attempt to pass PCT with the pre-release of git plugin 5.3.0

The plugin BOM run to assess the master branch of the git plugin fails two BOM tests, one on the 2.440.x line and one on the 2.452.x line.  The failure can be duplicated locally with the command:

```
$ LINE=2.440.x PLUGINS=pipeline-model-definition  TEST=InjectedTest bash local-test.sh

[ERROR] org.jenkinsci.plugins.pipeline_model_definition.InjectedTest.testPluginActive -- Time elapsed: 0.001 s <<< FAILURE!
java.lang.AssertionError: While testing pipeline-model-definition, git failed to start
        at org.jvnet.hudson.test.PluginAutomaticTestBuilder$OtherTests.testPluginActive(PluginAutomaticTestBuilder.java:102)

Caused by: java.io.IOException: Failed to load: Git plugin (git 5.3.0-rc5283.29a_5456289b_2)
 - Update required: Matrix Project Plugin (matrix-project 822.824.v14451b_c0fd42) to be updated to 832.va_66e270d2946 or higher
        at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:988)

[ERROR] Failures:
[ERROR]   InjectedTest.testPluginActive While testing pipeline-model-definition, git failed to start

```

### Testing done

Automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
