### PR TITLE
Handle `GitException`

### DIFF
--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -153,7 +153,7 @@ public class GitPublisher extends Recorder implements Serializable {
             EnvVars environment,
             AbstractBuild<?, ?> build,
             UnsupportedCommand cmd)
-            throws IOException, InterruptedException {
+            throws GitException, IOException, InterruptedException {
         return gitSCM.createClient(listener, environment, build, build.getWorkspace(), cmd);
     }
     
@@ -190,7 +190,12 @@ public class GitPublisher extends Recorder implements Serializable {
 
             UnsupportedCommand cmd = new UnsupportedCommand();
             cmd.gitPublisher(true);
-            final GitClient git  = getGitClient(gitSCM, listener, environment, build, cmd);
+            final GitClient git;
+            try {
+                git = getGitClient(gitSCM, listener, environment, build, cmd);
+            } catch (GitException x) {
+                throw new IOException(x);
+            }
 
             URIish remoteURI;
 

--- a/src/main/java/hudson/plugins/git/RevisionParameterAction.java
+++ b/src/main/java/hudson/plugins/git/RevisionParameterAction.java
@@ -87,11 +87,11 @@ public class RevisionParameterAction extends InvisibleAction implements Serializ
     }   
 
     @Deprecated
-    public Revision toRevision(IGitAPI git) throws InterruptedException {
+    public Revision toRevision(IGitAPI git) throws GitException, InterruptedException {
         return toRevision((GitClient) git);
     }
 
-    public Revision toRevision(GitClient git) throws InterruptedException {
+    public Revision toRevision(GitClient git) throws GitException, InterruptedException {
     	if (revision != null) {
     		return revision;
     	}

--- a/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
@@ -54,7 +54,7 @@ public class PreBuildMerge extends GitSCMExtension {
     }
 
     @Override
-    public Revision decorateRevisionToBuild(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, Revision marked, Revision rev) throws IOException, InterruptedException {
+    public Revision decorateRevisionToBuild(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, Revision marked, Revision rev) throws GitException, IOException, InterruptedException {
         String remoteBranchRef = GitSCM.getParameterString(options.getRef(), build.getEnvironment(listener));
 
         // if the branch we are merging is already at the commit being built, the entire merge becomes no-op

--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -199,7 +199,7 @@ public class GitUtils implements Serializable {
      * @throws InterruptedException when interrupted
      */
     @WithBridgeMethods(Collection.class)
-    public List<Revision> filterTipBranches(final Collection<Revision> revisions) throws InterruptedException {
+    public List<Revision> filterTipBranches(final Collection<Revision> revisions) throws GitException, InterruptedException {
         // If we have 3 branches that we might want to build
         // ----A--.---.--- B
         //        \-----C

--- a/src/main/java/jenkins/plugins/git/GitHooksConfiguration.java
+++ b/src/main/java/jenkins/plugins/git/GitHooksConfiguration.java
@@ -28,6 +28,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Functions;
 import hudson.model.PersistentDescriptor;
+import hudson.plugins.git.GitException;
 import hudson.remoting.Channel;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
@@ -85,12 +86,12 @@ public class GitHooksConfiguration extends GlobalConfiguration implements Persis
         return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);
     }
 
-    public static void configure(GitClient client) throws IOException, InterruptedException {
+    public static void configure(GitClient client) throws GitException, IOException, InterruptedException {
         final GitHooksConfiguration configuration = GitHooksConfiguration.get();
         configure(client, configuration.isAllowedOnController(), configuration.isAllowedOnAgents());
     }
 
-    public static void configure(GitClient client, final boolean allowedOnController, final boolean allowedOnAgents) throws IOException, InterruptedException {
+    public static void configure(GitClient client, final boolean allowedOnController, final boolean allowedOnAgents) throws GitException, IOException, InterruptedException {
         if (Channel.current() == null) {
             //Running on controller
             try (Repository ignored = client.getRepository()){
@@ -106,7 +107,7 @@ public class GitHooksConfiguration extends GlobalConfiguration implements Persis
         }
     }
 
-    public static void configure(GitClient client, final boolean allowed) throws IOException, InterruptedException {
+    public static void configure(GitClient client, final boolean allowed) throws GitException, IOException, InterruptedException {
         if (!allowed) {
             client.withRepository((repo, channel) -> {
                 disable(repo);

--- a/src/main/java/jenkins/plugins/git/GitSCMBuilder.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMBuilder.java
@@ -30,6 +30,7 @@ import com.cloudbees.plugins.credentials.common.IdCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitTool;
 import hudson.plugins.git.UserRemoteConfig;
@@ -509,11 +510,16 @@ public class GitSCMBuilder<B extends GitSCMBuilder<B>> extends SCMBuilder<B, Git
             GitRefSCMHead gitHead = (GitRefSCMHead) scmHead;
             withRefSpec(gitHead.getRef());
         }
-        return new GitSCM(
-                asRemoteConfigs(),
-                Collections.singletonList(new BranchSpec(head().getName())),
-                browser(), gitTool(),
-                extensions);
+        try {
+            return new GitSCM(
+                    asRemoteConfigs(),
+                    Collections.singletonList(new BranchSpec(head().getName())),
+                    browser(), gitTool(),
+                    extensions);
+        } catch (GitException x) {
+            // TODO interface defines no checked exception
+            throw new IllegalStateException(x);
+        }
     }
 
     /**

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -183,6 +183,8 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 throw new IOException("Closed");
             }
             return client.withRepository((Repository repository, VirtualChannel virtualChannel) -> function.invoke(repository));
+        } catch (GitException x) {
+            throw new IOException(x);
         } finally {
             cacheLock.unlock();
         }
@@ -219,14 +221,14 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 changelog.to(out).max(GitSCM.MAX_CHANGELOG).execute();
                 executed = true;
                 return !commitId.equals(fromCommitId);
-            } catch (GitException ge) {
-                throw new IOException("Unable to retrieve changes", ge);
             } finally {
                 if (!executed) {
                     changelog.abort();
                 }
                 changeLogStream.close();
             }
+        } catch (GitException ge) {
+            throw new IOException("Unable to retrieve changes", ge);
         } finally {
             cacheLock.unlock();
         }
@@ -407,6 +409,8 @@ public class GitSCMFileSystem extends SCMFileSystem {
 
                 listener.getLogger().println("Done.");
                 return new GitSCMFileSystem(client, remote, Constants.R_REMOTES + remoteName + "/" + headNameResult.headName, (AbstractGitSCMSource.SCMRevisionImpl) rev);
+            } catch (GitException x) {
+                throw new IOException(x);
             } finally {
                 cacheLock.unlock();
             }
@@ -452,6 +456,8 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 listener.getLogger().println("Done.");
                 return new GitSCMFileSystem(client, gitSCMSource.getRemote(), Constants.R_REMOTES+remoteName+"/"+head.getName(),
                         (AbstractGitSCMSource.SCMRevisionImpl) rev);
+            } catch (GitException x) {
+                throw new IOException(x);
             } finally {
                 cacheLock.unlock();
             }

--- a/src/main/java/jenkins/plugins/git/GitStep.java
+++ b/src/main/java/jenkins/plugins/git/GitStep.java
@@ -29,6 +29,7 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.Item;
 import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.impl.LocalBranch;
@@ -82,7 +83,12 @@ public final class GitStep extends SCMStep {
 
     @Override
     public SCM createSCM() {
-        return new GitSCM(GitSCM.createRepoList(url, credentialsId), Collections.singletonList(new BranchSpec("*/" + branch)), null, null, Collections.singletonList(new LocalBranch(branch)));
+        try {
+            return new GitSCM(GitSCM.createRepoList(url, credentialsId), Collections.singletonList(new BranchSpec("*/" + branch)), null, null, Collections.singletonList(new LocalBranch(branch)));
+        } catch (GitException x) {
+            // TODO interface defines no checked exception
+            throw new IllegalStateException(x);
+        }
     }
 
     @Extension

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -7,6 +7,7 @@ import hudson.ExtensionPoint;
 import hudson.model.Item;
 import hudson.model.Node;
 import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitTool;
 import hudson.plugins.git.util.GitUtils;
 import jenkins.model.Jenkins;
@@ -102,7 +103,13 @@ public class GitToolChooser {
             if (cacheDir != null) {
                 Git git = Git.with(TaskListener.NULL, new EnvVars(EnvVars.masterEnvVars)).in(cacheDir).using("git");
                 GitClient client = git.getClient();
-                if (client.hasGitRepo(false)) {
+                boolean hasGitRepo;
+                try {
+                    hasGitRepo = client.hasGitRepo(false);
+                } catch (GitException x) {
+                    throw new IOException(x);
+                }
+                if (hasGitRepo) {
                     long clientRepoSize = FileUtils.sizeOfDirectory(cacheDir) / 1024; // Conversion from Bytes to Kilo Bytes
                     if (clientRepoSize > sizeOfRepo) {
                         if (sizeOfRepo > 0) {

--- a/src/test/java/hudson/plugins/git/CheckoutStepSnippetizerTest.java
+++ b/src/test/java/hudson/plugins/git/CheckoutStepSnippetizerTest.java
@@ -75,6 +75,8 @@ public class CheckoutStepSnippetizerTest {
     /* Tested values common to many tests */
     private final String remoteConfig = "userRemoteConfigs: [[url: '" + url + "']]";
 
+    public CheckoutStepSnippetizerTest() throws Exception {}
+
     @Test
     public void checkoutSimplest() throws Exception {
         tester.assertRoundTrip(checkoutStep, "checkout scmGit("

--- a/src/test/java/hudson/plugins/git/GitChangeSetPluginHistoryTest.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetPluginHistoryTest.java
@@ -65,7 +65,7 @@ public class GitChangeSetPluginHistoryTest {
         "edf066f3",
     };
 
-    public GitChangeSetPluginHistoryTest(GitClient git, boolean authorOrCommitter, String sha1String) throws IOException, InterruptedException {
+    public GitChangeSetPluginHistoryTest(GitClient git, boolean authorOrCommitter, String sha1String) throws Exception {
         this.sha1 = ObjectId.fromString(sha1String);
         StringWriter stringWriter = new StringWriter();
         git.changelog().includes(sha1).max(1).to(stringWriter).execute();
@@ -95,7 +95,7 @@ public class GitChangeSetPluginHistoryTest {
     }
 
     @Parameterized.Parameters(name = "{2}-{1}")
-    public static Collection<Object[]> generateData() throws IOException, InterruptedException {
+    public static Collection<Object[]> generateData() throws Exception {
         List<Object[]> args = new ArrayList<>();
         String[] implementations = new String[]{"git", "jgit"};
         boolean[] choices = {true, false};

--- a/src/test/java/hudson/plugins/git/GitChangeSetUtil.java
+++ b/src/test/java/hudson/plugins/git/GitChangeSetUtil.java
@@ -130,7 +130,7 @@ public class GitChangeSetUtil {
         }
     }
 
-    public static GitChangeSet genChangeSet(ObjectId sha1, String gitImplementation, boolean authorOrCommitter) throws IOException, InterruptedException {
+    public static GitChangeSet genChangeSet(ObjectId sha1, String gitImplementation, boolean authorOrCommitter) throws GitException, IOException, InterruptedException {
         EnvVars envVars = new EnvVars();
         TaskListener listener = StreamTaskListener.fromStdout();
         GitClient git = Git.with(listener, envVars).in(new FilePath(new File("."))).using(gitImplementation).getClient();

--- a/src/test/java/hudson/plugins/git/GitSCMBrowserTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMBrowserTest.java
@@ -126,7 +126,7 @@ public class GitSCMBrowserTest {
     }
 
     @Test
-    public void guessedBrowser() {
+    public void guessedBrowser() throws Exception {
         GitSCM gitSCM = new GitSCM(gitURI);
         GitRepositoryBrowser browser = (GitRepositoryBrowser) gitSCM.guessBrowser();
         if (expectedClass == null || expectedURI == null) {

--- a/src/test/java/hudson/plugins/git/GitSCMUnitTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMUnitTest.java
@@ -54,7 +54,7 @@ public class GitSCMUnitTest {
     private final GitSCM gitSCM = new GitSCM(gitDir);
     private final String repoURL = "https://github.com/jenkinsci/git-plugin";
 
-    public GitSCMUnitTest() {
+    public GitSCMUnitTest() throws Exception {
     }
 
     @Test
@@ -220,7 +220,7 @@ public class GitSCMUnitTest {
     }
 
     @Test
-    public void testRequiresWorkspaceForPollingSingleBranch() {
+    public void testRequiresWorkspaceForPollingSingleBranch() throws Exception {
         /* Force single-branch use case */
         GitSCM bigGitSCM = new GitSCM(createRepoList(repoURL, null),
                 Collections.singletonList(new BranchSpec("master")),
@@ -229,7 +229,7 @@ public class GitSCMUnitTest {
     }
 
     @Test
-    public void testRequiresWorkspaceForPollingSingleBranchWithRemoteName() {
+    public void testRequiresWorkspaceForPollingSingleBranchWithRemoteName() throws Exception {
         /* Force single-branch use case */
         GitSCM bigGitSCM = new GitSCM(createRepoList(repoURL, null),
                 Collections.singletonList(new BranchSpec("origin/master")),
@@ -238,7 +238,7 @@ public class GitSCMUnitTest {
     }
 
     @Test
-    public void testRequiresWorkspaceForPollingSingleBranchWithWildcardRemoteName() {
+    public void testRequiresWorkspaceForPollingSingleBranchWithWildcardRemoteName() throws Exception {
         /* Force single-branch use case */
         GitSCM bigGitSCM = new GitSCM(createRepoList(repoURL, null),
                 Collections.singletonList(new BranchSpec("*/master")),
@@ -247,7 +247,7 @@ public class GitSCMUnitTest {
     }
 
     @Test
-    public void testRequiresWorkspaceForPollingSingleBranchWithWildcardSuffix() {
+    public void testRequiresWorkspaceForPollingSingleBranchWithWildcardSuffix() throws Exception {
         /* Force single-branch use case */
         GitSCM bigGitSCM = new GitSCM(createRepoList(repoURL, null),
                 Collections.singletonList(new BranchSpec("master*")),
@@ -256,7 +256,7 @@ public class GitSCMUnitTest {
     }
 
     @Test
-    public void testRequiresWorkspaceForPollingMultiBranch() {
+    public void testRequiresWorkspaceForPollingMultiBranch() throws Exception {
         /* Multi-branch use case */
         List<BranchSpec> branches = new ArrayList<>();
         branches.add(new BranchSpec("master"));
@@ -268,7 +268,7 @@ public class GitSCMUnitTest {
     }
 
     @Test
-    public void testRequiresWorkspaceForPollingEmptyBranchName() {
+    public void testRequiresWorkspaceForPollingEmptyBranchName() throws Exception {
         /* Multi-branch use case */
         EnvVars env = new EnvVars();
         env.put("A", "");
@@ -291,7 +291,7 @@ public class GitSCMUnitTest {
 
     @Test
     @Deprecated
-    public void testIsDoGenerateSubmoduleConfigurationsTrue() {
+    public void testIsDoGenerateSubmoduleConfigurationsTrue() throws Exception {
         GitSCM bigGitSCM = new GitSCM(createRepoList(repoURL, null),
                 Collections.singletonList(new BranchSpec("master")),
                 null, null, Collections.emptyList());
@@ -343,7 +343,7 @@ public class GitSCMUnitTest {
 
     @Issue("JENKINS-68562")
     @Test
-    public void testAbortIfSourceIsLocal() {
+    public void testAbortIfSourceIsLocal() throws Exception {
         GitSCM gitSCM = new GitSCM(createRepoList(repoURL, null),
                 Collections.singletonList(new BranchSpec("master")),
                 null, null, Collections.emptyList());

--- a/src/test/java/hudson/plugins/git/GitTagActionTest.java
+++ b/src/test/java/hudson/plugins/git/GitTagActionTest.java
@@ -290,8 +290,12 @@ public class GitTagActionTest {
             @Override
             protected GitClient getGitClient(TaskListener listener, EnvVars environment, FilePath workspace) throws IOException, InterruptedException {
                 GitClient gitClient = super.getGitClient(listener, environment, workspace);
-                gitClient.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", "false");
-                gitClient.config(GitClient.ConfigLevel.LOCAL, "tag.gpgSign", "false");
+                try {
+                    gitClient.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", "false");
+                    gitClient.config(GitClient.ConfigLevel.LOCAL, "tag.gpgSign", "false");
+                } catch (GitException x) {
+                    throw new IOException(x);
+                }
                 return gitClient;
             }
         }

--- a/src/test/java/hudson/plugins/git/TestGitRepo.java
+++ b/src/test/java/hudson/plugins/git/TestGitRepo.java
@@ -32,7 +32,7 @@ public class TestGitRepo {
 	public final PersonIdent johnDoe = new PersonIdent("John Doe", "john@doe.com");
 	public final PersonIdent janeDoe = new PersonIdent("Jane Doe", "jane@doe.com");
     
-    public TestGitRepo(String name, File tmpDir, TaskListener listener) throws IOException, InterruptedException {
+    public TestGitRepo(String name, File tmpDir, TaskListener listener) throws Exception {
 		this.name = name;
 		this.listener = listener;
 		

--- a/src/test/java/hudson/plugins/git/browser/GitRepositoryBrowserTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GitRepositoryBrowserTest.java
@@ -4,6 +4,7 @@ import hudson.EnvVars;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSetUtil;
+import hudson.plugins.git.GitException;
 
 import org.eclipse.jgit.lib.ObjectId;
 
@@ -84,14 +85,14 @@ public class GitRepositoryBrowserTest {
         try {
             GitClient git = Git.with(TaskListener.NULL, new EnvVars()).getClient();
             headCommit = git.revParse("HEAD");
-        } catch (IOException | InterruptedException e) {
+        } catch (GitException | IOException | InterruptedException e) {
             headCommit = ObjectId.fromString("016407404eeda093385ba2ebe9557068b519b669"); // simple commit
         }
         return headCommit;
     }
 
     @Before
-    public void setUp() throws IOException, InterruptedException {
+    public void setUp() throws Exception {
         browser = new GitRepositoryBrowserImpl(null);
         changeSet = GitChangeSetUtil.genChangeSet(sha1, gitImplementation, useAuthorName);
         paths = changeSet.getPaths();

--- a/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+++ b/src/test/java/hudson/plugins/git/browser/GithubWebTest.java
@@ -136,7 +136,7 @@ public class GithubWebTest {
     }
 
     @Test
-    public void testGuessBrowser() {
+    public void testGuessBrowser() throws Exception {
         assertGuessURL("https://github.com/kohsuke/msv.git", "https://github.com/kohsuke/msv/");
         assertGuessURL("https://github.com/kohsuke/msv/", "https://github.com/kohsuke/msv/");
         assertGuessURL("https://github.com/kohsuke/msv", "https://github.com/kohsuke/msv/");
@@ -153,7 +153,7 @@ public class GithubWebTest {
         }
     }
 
-    private void assertGuessURL(String repo, String web) {
+    private void assertGuessURL(String repo, String web) throws Exception {
         RepositoryBrowser<?> guess = new GitSCM(repo).guessBrowser();
         String actual = guess instanceof GithubWeb ? ((GithubWeb) guess).getRepoUrl() : null;
         assertEquals("For repo '" + repo + "':", web, actual);

--- a/src/test/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowserTest.java
+++ b/src/test/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowserTest.java
@@ -24,7 +24,7 @@ public class TFS2013GitRepositoryBrowserTest {
     private static final GitChangeSetSample sample = new GitChangeSetSample(false);
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws Exception {
         GitSCM scm = new GitSCM(
                 Collections.singletonList(new UserRemoteConfig(repoUrl, null, null, null)),
                 new ArrayList<>(),

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionNoTagsTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionNoTagsTest.java
@@ -3,7 +3,6 @@ package hudson.plugins.git.extensions.impl;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.Set;
 
 import hudson.model.Result;
@@ -70,7 +69,7 @@ public class CloneOptionNoTagsTest extends GitSCMExtensionTest {
         assertTrue("there should no tags have been fetched from remote", allTagsInProjectWorkspace().isEmpty());
     }
 
-    private Set<String> allTagsInProjectWorkspace() throws IOException, InterruptedException {
+    private Set<String> allTagsInProjectWorkspace() throws Exception {
         GitClient git = Git.with(listener, null).in(project.getSomeWorkspace()).getClient();
         return git.getTagNames("*");
     }

--- a/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionShallowDefaultTagsTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/CloneOptionShallowDefaultTagsTest.java
@@ -8,7 +8,6 @@ import hudson.plugins.git.TestGitRepo;
 import hudson.plugins.git.extensions.GitSCMExtensionTest;
 import hudson.plugins.git.extensions.GitSCMExtension;
 
-import java.io.IOException;
 import java.util.Set;
 
 import org.jenkinsci.plugins.gitclient.Git;
@@ -51,7 +50,7 @@ public class CloneOptionShallowDefaultTagsTest extends GitSCMExtensionTest {
         assertEquals("tag " + tagName + " should have been cloned from remote", 1, tagsInProjectWorkspaceWithName(tagName).size());
     }
 
-    private Set<String> tagsInProjectWorkspaceWithName(String tagPattern) throws IOException, InterruptedException {
+    private Set<String> tagsInProjectWorkspaceWithName(String tagPattern) throws Exception {
         GitClient git = Git.with(listener, null).in(project.getSomeWorkspace()).getClient();
         return git.getTagNames(tagPattern);
     }

--- a/src/test/java/hudson/plugins/git/extensions/impl/SubmoduleOptionTest.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/SubmoduleOptionTest.java
@@ -260,7 +260,7 @@ public class SubmoduleOptionTest {
 
     @Test
     @Issue("JENKINS-64382")
-    public void testDetermineSupportForJGit() {
+    public void testDetermineSupportForJGit() throws Exception {
         /* JGit was incorrectly used when submodule option was added with no items checked. */
         GitSCM scm = new GitSCM("https://github.com/jenkinsci/git-plugin");
         scm.getExtensions().add(submoduleOption);
@@ -271,7 +271,7 @@ public class SubmoduleOptionTest {
 
     @Test
     @Issue("JENKINS-64382")
-    public void testDetermineSupportForJGitRecursiveSubmodules() {
+    public void testDetermineSupportForJGitRecursiveSubmodules() throws Exception {
         /* JGit was incorrectly used when submodule option was added with only recursive submodule checked. */
         GitSCM scm = new GitSCM("https://github.com/jenkinsci/git-plugin");
         submoduleOption = new SubmoduleOption(DISABLE_SUBMODULES_FALSE,
@@ -287,7 +287,7 @@ public class SubmoduleOptionTest {
     }
 
     @Test
-    public void testDetermineSupportForJGitThreads() {
+    public void testDetermineSupportForJGitThreads() throws Exception {
         GitSCM scm = new GitSCM("https://github.com/jenkinsci/git-plugin");
         Integer threads = randomSmallNonNegativeIntegerOrNull();
         submoduleOption.setThreads(threads);

--- a/src/test/java/hudson/plugins/git/util/AncestryBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/AncestryBuildChooserTest.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 
 import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.jenkinsci.plugins.gitclient.GitClient;
@@ -115,7 +114,7 @@ public class AncestryBuildChooserTest extends AbstractGitRepository {
     
     // Git Client implementation throws away committer date info so we have to do this manually..
     // Copied from JGitAPIImpl.commit(String message)
-    private void commit(String message, PersonIdent author, PersonIdent committer) {
+    private void commit(String message, PersonIdent author, PersonIdent committer) throws Exception {
         try (@SuppressWarnings("deprecation") // Local repository reference
              Repository repo = testGitClient.getRepository()) {
             CommitCommand cmd = Git.wrap(repo).commit().setMessage(message);
@@ -125,8 +124,6 @@ public class AncestryBuildChooserTest extends AbstractGitRepository {
                 // cmd.setCommitter(new PersonIdent(committer,new Date()));
                 cmd.setCommitter(committer);
             cmd.call();
-        } catch (GitAPIException e) {
-            throw new GitException(e);
         }
     }
     

--- a/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
+++ b/src/test/java/hudson/plugins/git/util/DefaultBuildChooserTest.java
@@ -157,7 +157,7 @@ public class DefaultBuildChooserTest extends AbstractGitRepository {
         assertThat(candidateRevisions, hasSize(1));
     }
 
-    private void createRefsWithPredefinedOrderInHashSet(String ref1, String ref2) throws InterruptedException {
+    private void createRefsWithPredefinedOrderInHashSet(String ref1, String ref2) throws Exception {
         ObjectId commit1 = testGitClient.revParse("HEAD");
         testGitClient.ref(ref1);
         testGitClient.commit("Commit");

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -25,6 +25,7 @@ import hudson.plugins.git.extensions.impl.BuildChooserSetting;
 import hudson.plugins.git.extensions.impl.LocalBranch;
 import hudson.util.StreamTaskListener;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1043,7 +1044,7 @@ public class AbstractGitSCMSourceTest {
 
         createRefLockEnvironment(listener, source);
 
-        final GitException e = assertThrows(GitException.class, () -> source.fetch("v1.2", listener, null));
+        final IOException e = assertThrows(IOException.class, () -> source.fetch("v1.2", listener, null));
         assertFalse(e.getMessage().contains("--prune"));
     }
 
@@ -1064,7 +1065,7 @@ public class AbstractGitSCMSourceTest {
 
         createRefLockEnvironment(listener, source);
 
-        final GitException e = assertThrows(GitException.class, () -> source.fetch("v1.2", listener, null));
+        final IOException e = assertThrows(IOException.class, () -> source.fetch("v1.2", listener, null));
         assertFalse(e.getMessage().contains("--prune"));
     }
 

--- a/src/test/java/jenkins/plugins/git/CliGitCommand.java
+++ b/src/test/java/jenkins/plugins/git/CliGitCommand.java
@@ -60,11 +60,11 @@ public class CliGitCommand {
     private String[] output;
     private ArgumentListBuilder args;
 
-    public CliGitCommand(GitClient client, String... arguments) {
+    public CliGitCommand(GitClient client, String... arguments) throws GitException {
         this(client, GitUtilsTest.getConfigNoSystemEnvsVars(), arguments);
     }
 
-    public CliGitCommand(GitClient client, EnvVars envVars, String... arguments) {
+    public CliGitCommand(GitClient client, EnvVars envVars, String... arguments) throws GitException {
         args = new ArgumentListBuilder("git");
         args.add(arguments);
         listener = StreamTaskListener.NULL;

--- a/src/test/java/jenkins/plugins/git/FIPSModeSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/FIPSModeSCMSourceTest.java
@@ -2,8 +2,8 @@ package jenkins.plugins.git;
 
 import hudson.logging.LogRecorder;
 import hudson.model.TaskListener;
-import hudson.plugins.git.GitException;
 import hudson.util.StreamTaskListener;
+import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.RealJenkinsRule;
@@ -29,7 +29,7 @@ public class FIPSModeSCMSourceTest {
         rule.then( r -> {
             GitSCMSource source = new GitSCMSource("http://insecure-repo");
             TaskListener listener = StreamTaskListener.fromStderr();
-            assertThrows("expected exception as repo doesn't exist", GitException.class, () -> source.fetch(listener));
+            assertThrows("expected exception as repo doesn't exist", IOException.class, () -> source.fetch(listener));
 
             LogRecorder logRecorder = new LogRecorder(AbstractGitSCMSource.class.getName());
             LogRecorder.Target target = new LogRecorder.Target(AbstractGitSCMSource.class.getName(), Level.SEVERE);

--- a/src/test/java/jenkins/plugins/git/GitHooksConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/git/GitHooksConfigurationTest.java
@@ -26,7 +26,6 @@ package jenkins.plugins.git;
 import hudson.EnvVars;
 import hudson.model.TaskListener;
 import java.io.File;
-import java.io.IOException;
 import java.util.Random;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.jenkinsci.plugins.gitclient.Git;
@@ -58,14 +57,14 @@ public class GitHooksConfigurationTest {
     }
 
     @Before
-    public void setUp() throws IOException, InterruptedException {
+    public void setUp() throws Exception {
         configuration = GitHooksConfiguration.get();
         Git git = Git.with(TaskListener.NULL, new EnvVars());
         client = git.getClient();
     }
 
     @After
-    public void resetHooksPath() throws IOException, InterruptedException {
+    public void resetHooksPath() throws Exception {
         client.withRepository((repo, channel) -> {
             final StoredConfig repoConfig = repo.getConfig();
             repoConfig.unset("core", null, "hooksPath");
@@ -118,7 +117,7 @@ public class GitHooksConfigurationTest {
         assertThat(GitHooksConfiguration.get().getCategory(), is(configuration.getCategory()));
     }
 
-    private void setCoreHooksPath(String hooksPath) throws IOException, InterruptedException {
+    private void setCoreHooksPath(String hooksPath) throws Exception {
         /* Configure a core.hook with path `hooksPath` */
         client.withRepository((repo, channel) -> {
             final StoredConfig repoConfig = repo.getConfig();
@@ -128,7 +127,7 @@ public class GitHooksConfigurationTest {
         });
     }
 
-    private String getCoreHooksPath() throws IOException, InterruptedException {
+    private String getCoreHooksPath() throws Exception {
         String hooksPath = client.withRepository((repo, channel) -> {
             final StoredConfig repoConfig = repo.getConfig();
             return repoConfig.getString("core", null, "hooksPath");

--- a/src/test/java/jenkins/plugins/git/GitSCMTelescopeTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMTelescopeTest.java
@@ -95,7 +95,7 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
     }
 
     @Test
-    public void testOf_GitSCM() {
+    public void testOf_GitSCM() throws Exception {
         /* Testing GitSCMTelescope.of() for non null return needs JenkinsRule */
         GitSCM multiBranchSource = new GitSCM(remote);
         GitSCMTelescope telescopeOfMultiBranchSource = GitSCMTelescope.of(multiBranchSource);
@@ -133,7 +133,7 @@ public class GitSCMTelescopeTest /* extends AbstractGitRepository */ {
      * @param repoUrl URL to the repository for the returned GitSCM
      * @return GitSCM with a single branch in its definition
      */
-    private GitSCM getSingleBranchSource(String repoUrl) {
+    private GitSCM getSingleBranchSource(String repoUrl) throws Exception {
         UserRemoteConfig remoteConfig = new UserRemoteConfig(
                 repoUrl,
                 "origin",

--- a/src/test/java/org/jenkinsci/plugins/gittagmessage/AbstractGitTagMessageExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gittagmessage/AbstractGitTagMessageExtensionTest.java
@@ -7,7 +7,6 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.util.BuildData;
 import hudson.plugins.git.util.GitUtilsTest;
 import jenkins.model.ParameterizedJobMixIn;
-import org.eclipse.jgit.errors.ConfigInvalidException;
 import org.eclipse.jgit.util.SystemReader;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
@@ -18,7 +17,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import java.io.IOException;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -47,7 +45,7 @@ public abstract class AbstractGitTagMessageExtensionTest<J extends Job<J, R> & P
     protected abstract void assertBuildEnvironment(R run, String expectedName, String expectedMessage) throws Exception;
 
     @Before
-    public void setUp() throws IOException, InterruptedException, ConfigInvalidException {
+    public void setUp() throws Exception {
         SystemReader.getInstance().getUserConfig().clear();
         // Set up a temporary git repository for each test case
         repo = Git.with(r.createTaskListener(), GitUtilsTest.getConfigNoSystemEnvsVars()).in(repoDir.getRoot()).getClient();


### PR DESCRIPTION
While playing with a CloudBees CI setup configured as code, I noticed to my alarm that when a sample Git repository was offline, Jenkins startup failed:

```
SEVERE	jenkins.InitReactorRunner$1#onTaskFailed: Failed ConfigurationAsCode.init
hudson.plugins.git.GitException: Command "git ls-remote -- …" returned status code 128:
stderr: fatal: unable to connect to …: errno=Connection refused
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2846)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:2185)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:2079)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:2070)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.CliGitAPIImpl.getRemoteReferences(CliGitAPIImpl.java:3799)
	at PluginClassLoader for git//jenkins.plugins.git.AbstractGitSCMSource.retrieve(AbstractGitSCMSource.java:863)
	at PluginClassLoader for scm-api//jenkins.scm.api.SCMSource.retrieve(SCMSource.java:655)
	at PluginClassLoader for scm-api//jenkins.scm.api.SCMSource.fetch(SCMSource.java:617)
	at PluginClassLoader for cloudbees-workflow-template//com.cloudbees.pipeline.governance.templates.TemplateCatalog.getLatestCatalogRevision(TemplateCatalog.java:806)
	at PluginClassLoader for cloudbees-workflow-template//com.cloudbees.pipeline.governance.templates.TemplateCatalog.getCatalogMetadata(TemplateCatalog.java:625)
	at PluginClassLoader for cloudbees-workflow-template//com.cloudbees.pipeline.governance.templates.TemplateCatalog.updateWithCatalogMetadata(TemplateCatalog.java:178)
	at PluginClassLoader for cloudbees-workflow-template//com.cloudbees.pipeline.governance.templates.GlobalTemplateCatalogConfigurator.configure(GlobalTemplateCatalogConfigurator.java:86)
	at PluginClassLoader for cloudbees-workflow-template//com.cloudbees.pipeline.governance.templates.GlobalTemplateCatalogConfigurator.configure(GlobalTemplateCatalogConfigurator.java:59)
	at PluginClassLoader for cloudbees-workflow-template//com.cloudbees.pipeline.governance.templates.GlobalTemplateCatalogConfigurator.configure(GlobalTemplateCatalogConfigurator.java:21)
	at PluginClassLoader for configuration-as-code//io.jenkins.plugins.casc.ConfigurationAsCode.lambda$configureWith$7(ConfigurationAsCode.java:823)
	at PluginClassLoader for configuration-as-code//io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:773)
	at PluginClassLoader for configuration-as-code//io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:823)
	at PluginClassLoader for configuration-as-code//io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:695)
	at PluginClassLoader for configuration-as-code//io.jenkins.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:352)
	at PluginClassLoader for configuration-as-code//io.jenkins.plugins.casc.ConfigurationAsCode.init(ConfigurationAsCode.java:341)
```

It turns out that there was nothing really wrong in the proprietary plugin: `GlobalTemplateCatalogConfigurator.configure` was catching an `IOException` thrown from `SCMSource.fetch` and proceeding. Unfortunately `AbstractGitSCMSource.retrieve` was passing along a `GitException` thrown from a `GitClient` method as is, without wrapping in a declared exception permitted by the interface in `scm-api`.

While I could have fixed merely this call site, once I started looking I found that the problem was fairly general in this plugin: in a number of places it is implementing APIs from core or `scm-api` which permit `IOException` but throwing this unchecked exception. So I decided to fix the general issue. If desired, this PR could be broken up and fixes to just those methods filed separately, though for legibility I find it helpful to be documenting where `GitException` is thrown.

Initially developed by manually looking up usages of `GitClient` methods throwing `GitException` and checking their call sites, but it proved much easier to use https://github.com/jenkinsci/git-client-plugin/pull/1166 with `GitException` checked and fix all compiler errors. My general principle is to just keeping adding `throws GitException` as needed until coming up to an interface defined in a dependency which does not allow it, and at that point wrapping it. Note that a number of places in the plugin already caught `GitException`, though generally printing an error to a `TaskListener` and then signaling some sort of failure separately rather than using it as a `cause`.
