### PR TITLE
Remove test conditionals for unsupported git versions

### DIFF
--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -524,16 +524,11 @@ public class AbstractGitSCMSourceTest {
                 break;
             }
         }
-        final boolean CLI_GIT_LESS_THAN_280 = !sampleRepo.gitVersionAtLeast(2, 8);
-        if (duplicatePrimary && CLI_GIT_LESS_THAN_280) {
-            assertThat(refAction, is(nullValue()));
-        } else {
-            assertThat(refAction, notNullValue());
-            assertThat(refAction.getName(), is("new-primary"));
-            when(owner.getAction(GitRemoteHeadRefAction.class)).thenReturn(refAction);
-            when(owner.getActions(GitRemoteHeadRefAction.class)).thenReturn(Collections.singletonList(refAction));
-            actions = source.fetchActions(headByName.get("new-primary"), null, listener);
-        }
+        assertThat(refAction, notNullValue());
+        assertThat(refAction.getName(), is("new-primary"));
+        when(owner.getAction(GitRemoteHeadRefAction.class)).thenReturn(refAction);
+        when(owner.getActions(GitRemoteHeadRefAction.class)).thenReturn(Collections.singletonList(refAction));
+        actions = source.fetchActions(headByName.get("new-primary"), null, listener);
 
         PrimaryInstanceMetadataAction primary = null;
         for (Action a: actions) {
@@ -542,11 +537,7 @@ public class AbstractGitSCMSourceTest {
                 break;
             }
         }
-        if (duplicatePrimary && CLI_GIT_LESS_THAN_280) {
-            assertThat(primary, is(nullValue()));
-        } else {
-            assertThat(primary, notNullValue());
-        }
+        assertThat(primary, notNullValue());
     }
 
     @Issue("JENKINS-31155")
@@ -1070,11 +1061,6 @@ public class AbstractGitSCMSourceTest {
 
     @Test
     public void refLockAvoidedIfPruneTraitPresentOnNotFoundRetrieval() throws Exception {
-        /* Older git versions have unexpected behaviors with prune */
-        if (!sampleRepo.gitVersionAtLeast(1, 9, 0)) {
-            /* Do not distract warnings system by using assumeThat to skip tests */
-            return;
-        }
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         TaskListener listener = StreamTaskListener.fromStderr();
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());
@@ -1089,11 +1075,6 @@ public class AbstractGitSCMSourceTest {
 
     @Test
     public void refLockAvoidedIfPruneTraitPresentOnTagRetrieval() throws Exception {
-        /* Older git versions have unexpected behaviors with prune */
-        if (!sampleRepo.gitVersionAtLeast(1, 9, 0)) {
-            /* Do not distract warnings system by using assumeThat to skip tests */
-            return;
-        }
         assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
         TaskListener listener = StreamTaskListener.fromStderr();
         GitSCMSource source = new GitSCMSource(sampleRepo.toString());

--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -81,12 +81,7 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         run(true, tmp.getRoot(), "git", "version");
         checkGlobalConfig();
         git("init", "--template="); // initialize without copying the installation defaults to ensure a vanilla repo that behaves the same everywhere
-	if (gitVersionAtLeast(2, 30)) {
-	    // Force branch name to master even if system default is not master
-	    // Fails on git 2.25, 2.20, and 2.17
-	    // Works on git 2.30 and later
-            git("branch", "-m", "master");
-	}
+        git("branch", "-m", "master");
         write("file", "");
         git("add", "file");
         git("config", "user.name", "Git SampleRepoRule");

--- a/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
+++ b/src/test/java/jenkins/plugins/git/GitUsernamePasswordBindingTest.java
@@ -213,7 +213,7 @@ public class GitUsernamePasswordBindingTest {
         if (isCliGitTool()) {
             if (isWindows()) {
                 assertThat(fileContents, containsString("GCM_INTERACTIVE=false"));
-            } else if (g.gitVersionAtLeast(2, 3, 0)) {
+            } else {
                 assertThat(fileContents, containsString("GIT_TERMINAL_PROMPT=false"));
             }
         }
@@ -262,7 +262,7 @@ public class GitUsernamePasswordBindingTest {
         if (isCliGitTool()) {
             if (isWindows()) {
                 assertThat(fileContents, containsString("GCM_INTERACTIVE=false"));
-            } else if (g.gitVersionAtLeast(2, 3, 0)) {
+            } else {
                 assertThat(fileContents, containsString("GIT_TERMINAL_PROMPT=false"));
             }
         }


### PR DESCRIPTION
## Remove test conditionals for unsupported git versions

Operating systems that provided versions of command line git older than 2.30 are no longer supported by their upstream providers and are thus no longer supported by the Jenkins project.  Remove the special cases in the tests for those unsupported operating systems.

### Testing done

Confirmed that automated tests pass with Java 21 on Linux.  Rely on ci.jenkins.io to test Windows and Java 17.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
