### PR TITLE
Restore test support for Ubuntu 20.04 with git 2.25

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -81,7 +81,12 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         run(true, tmp.getRoot(), "git", "version");
         checkGlobalConfig();
         git("init", "--template="); // initialize without copying the installation defaults to ensure a vanilla repo that behaves the same everywhere
-        git("branch", "-m", "master");
+        if (gitVersionAtLeast(2, 30)) {
+            // Force branch name to master even if system default is not master
+            // Fails on git 2.25 and earlier (Ubuntu 20.04, etc.)
+            // Works on git 2.30 and later
+            git("branch", "-m", "master");
+        }
         write("file", "");
         git("add", "file");
         git("config", "user.name", "Git SampleRepoRule");


### PR DESCRIPTION
## Restore test support for Ubuntu 20.04 with git 2.25

Ubuntu 20.04 is supported by Canonical until Apr 2025.  The plugin automated tests should continue to pass on Ubuntu 20.04 while it is still supported.

Fixes mistake made in 59f2bee4917eb6f7300c40d4cf1acb9322582596:

* #1629

Operating systems that provide versions of command line git older than 2.25 are no longer supported by their upstream providers and are thus no longer supported by the Jenkins project.  Restore a conditional for command line git 2.25 until at least May 2025 when Ubuntu 20.04 support will end.

### Testing done

Confirmed with git bisect on Ubuntu 20.04 that this change is what broke 189 tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
