### PR TITLE
Add sparseCheckout symbol for Pipeline

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -159,7 +159,7 @@ This removes remote tracking branches and tags from the local workspace if they 
 ----
 checkout scmGit(
     branches: [[name: 'master']],
-    extensions: [pruneStaleBranch(), pruneTags(true)],
+    extensions: [ pruneStaleBranch(), pruneTags(true) ],
     userRemoteConfigs: [[url: 'https://github.com/jenkinsci/ws-cleanup-plugin']])
 ----
 
@@ -1057,6 +1057,16 @@ Multiple sparse checkout path values can be added to a single job.
 Path::
 
   File or directory to be included in the checkout
+
+[source,groovy]
+----
+checkout scmGit(
+    branches: [[name: 'master']],
+    extensions: [
+        sparseCheckout(sparseCheckoutPaths: [[path: 'src'], [path: 'Makefile']])
+    ],
+    userRemoteConfigs: [[url: 'https://github.com/jenkinsci/git-plugin.git']])
+----
 
 [#git-lfs-pull-after-checkout]
 ==== Git LFS pull after checkout

--- a/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPaths.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPaths.java
@@ -13,6 +13,7 @@ import org.jenkinsci.plugins.gitclient.CloneCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.UnsupportedCommand;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -52,10 +53,11 @@ public class SparseCheckoutPaths extends GitSCMExtension {
     }
 
     @Extension
+    @Symbol("sparseCheckout")
     public static class DescriptorImpl extends GitSCMExtensionDescriptor {
         @Override
         public String getDisplayName() {
-            return "Sparse Checkout paths";
+            return "Sparse checkout paths";
         }
     }
 

--- a/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
@@ -163,6 +163,7 @@ public class CredentialsUserRemoteConfigTest {
             "pruneTags()",
             "pruneTags(false)",
             "pruneTags(true)",
+            "sparseCheckout(sparseCheckoutPaths: [[path: 'src'], [path: 'Makefile']])",
             "submodule(disableSubmodules: true)",
             "submodule(depth: 1, shallow: true)",
             "submodule(parentCredentials: true, recursiveSubmodules: true, threads: 13)",


### PR DESCRIPTION
## Add sparseCheckout symbol for Pipeline

Add the `sparseCheckout` symbol for Pipeline so that users do not need to use the old `$class` syntax.

Includes a test that confirms the sparseCheckout syntax works as expected.

### Testing done

Tested interactively to confirm that the new symbol behaves the same as the old syntax behaved.  Does not include detailed functional testing that the sparseCheckout symbol works as expected, since there are already tests of sparse checkout in other tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
