### PR TITLE
[JENKINS-43052] Warn in Pipeline build log if a deprecated extension is used

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -37,6 +37,29 @@ import org.jenkinsci.plugins.gitclient.*;
 public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExtension> {
 
     /**
+     * When extensions created for freestyle projects have a more
+     * general purpose replacement in Pipeline, the more general
+     * purpose Pipeline step is preferred.  This method allows the
+     * deprecated extension to suggest the preferred alternative.
+     *
+     * If the extension should not be used in Pipeline and there is an
+     * alternative syntax that should be used, return the alternative
+     * syntax suggestion.
+     *
+     * If the extension should not be used in Pipeline and there is no
+     * alternative syntax suggestion, return an empty string.
+     *
+     * If the extension should be used in Pipeline, return null.
+     *
+     * @return alternative syntax suggestion for Pipeline syntax to replace this extension.
+     *         Null indicates the extension is intended for use in Pipeline.
+     */
+    @CheckForNull
+    public String getDeprecationAlternative() {
+        return null;
+    }
+
+    /**
      * @return <code>true</code> when this extension has a requirement to get a workspace during polling,
      * typically as it has to check for incoming changes, not just remote HEAD.
      */
@@ -142,7 +165,7 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
             return rev;
         }
     }
-    
+
     @Deprecated
     public Revision decorateRevisionToBuild(GitSCM scm, AbstractBuild<?,?> build, GitClient git, BuildListener listener, Revision marked, Revision rev) throws IOException, InterruptedException, GitException {
         if (Util.isOverridden(GitSCMExtension.class, getClass(), "decorateRevisionToBuild", GitSCM.class, Run.class, GitClient.class, TaskListener.class, Revision.class, Revision.class)) {
@@ -165,6 +188,15 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
     public void beforeCheckout(GitSCM scm, Run<?,?> build, GitClient git, TaskListener listener) throws IOException, InterruptedException, GitException {
         if (build instanceof AbstractBuild && listener instanceof BuildListener) {
             beforeCheckout(scm, (AbstractBuild) build, git, (BuildListener) listener);
+        }
+        String message = "***DEPRECATED*** " + getDescriptor().getDisplayName() + " is deprecated in Pipeline.";
+        String alternative = getDeprecationAlternative();
+        if (alternative != null && !(build instanceof AbstractBuild)) {
+            if (alternative.isEmpty()) {
+                listener.getLogger().println(message);
+            } else {
+                listener.getLogger().println(message + " " + getDeprecationAlternative());
+            }
         }
     }
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/BuildChooserSetting.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/BuildChooserSetting.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git.extensions.impl;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.plugins.git.extensions.FakeGitSCMExtension;
@@ -28,6 +29,13 @@ public class BuildChooserSetting extends FakeGitSCMExtension {
         if (buildChooser==null)
             buildChooser = new DefaultBuildChooser();
         return buildChooser;
+    }
+
+    @Override
+    @CheckForNull
+    public String getDeprecationAlternative() {
+        // This extension is not intended to be used in Pipeline
+        return "Use separate Pipeline jobs for individual branches instead of switching between branches with the same job.";
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/extensions/impl/DisableRemotePoll.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/DisableRemotePoll.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git.extensions.impl;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
@@ -19,6 +20,13 @@ public class DisableRemotePoll extends GitSCMExtension {
     @Override
     public boolean requiresWorkspaceForPolling() {
         return true;
+    }
+
+    @Override
+    @CheckForNull
+    public String getDeprecationAlternative() {
+        // This extension is not intended to be used in Pipeline
+        return "Use poll: false instead.";
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/git/extensions/impl/IgnoreNotifyCommit.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/IgnoreNotifyCommit.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git.extensions.impl;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.plugins.git.extensions.FakeGitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
@@ -13,6 +14,14 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class IgnoreNotifyCommit extends FakeGitSCMExtension {
     @DataBoundConstructor
     public IgnoreNotifyCommit() {
+    }
+
+    @Override
+    @CheckForNull
+    public String getDeprecationAlternative() {
+        // This extension is not intended to be used in Pipeline
+        // No alternative is offered because notifyCommits should be ignored at a higher level in Pipeline
+        return "";
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/MessageExclusion.java
@@ -41,6 +41,13 @@ public class MessageExclusion extends GitSCMExtension {
 	public String getExcludedMessage() { return excludedMessage; }
 
 	@Override
+	@CheckForNull
+        public String getDeprecationAlternative() {
+		// This extension is not intended to be used in Pipeline
+		return "Use exclusion traits in multibranch Pipelines to exclude commit messages";
+	}
+
+	@Override
 	@SuppressFBWarnings(value="NP_BOOLEAN_RETURN_NULL", justification="null used to indicate other extensions should decide")
 	@CheckForNull
 	public Boolean isRevExcluded(GitSCM scm, GitClient git, GitChangeSet commit, TaskListener listener, BuildData buildData) throws IOException, InterruptedException, GitException {

--- a/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PathRestriction.java
@@ -37,6 +37,13 @@ public class PathRestriction extends GitSCMExtension {
         return true;
     }
 
+    @Override
+    @CheckForNull
+    public String getDeprecationAlternative() {
+        // This extension is not intended to be used in Pipeline
+        return "Use exclusion traits in multibranch Pipelines to exclude commit paths.";
+    }
+
     @DataBoundConstructor
     public PathRestriction(String includedRegions, String excludedRegions) {
         this.includedRegions = includedRegions;

--- a/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PreBuildMerge.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git.extensions.impl;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.plugins.git.GitException;
@@ -135,6 +136,13 @@ public class PreBuildMerge extends GitSCMExtension {
     @Override
     public GitClientType getRequiredClient() {
         return GitClientType.GITCLI;
+    }
+
+    @Override
+    @CheckForNull
+    public String getDeprecationAlternative() {
+        // This extension is not intended to be used in Pipeline
+        return "Use shell or bat or powershell steps to implement git merge.";
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/extensions/impl/RelativeTargetDirectory.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/RelativeTargetDirectory.java
@@ -1,15 +1,19 @@
 package hudson.plugins.git.extensions.impl;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.model.AbstractBuild;
 import hudson.model.Job;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Messages;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
@@ -31,6 +35,13 @@ public class RelativeTargetDirectory extends GitSCMExtension {
 
     public String getRelativeTargetDir() {
         return relativeTargetDir;
+    }
+
+    @Override
+    @CheckForNull
+    public String getDeprecationAlternative() {
+        // This extension is not intended to be used in Pipeline
+        return "Use 'dir()' or 'ws()' to checkout into a different Pipeline workspace directory.";
     }
 
     @Override

--- a/src/main/java/hudson/plugins/git/extensions/impl/ScmName.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/ScmName.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git.extensions.impl;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.FakeGitSCMExtension;
@@ -17,6 +18,16 @@ public class ScmName extends FakeGitSCMExtension {
     @DataBoundConstructor
     public ScmName(String name) {
         this.name = name;
+    }
+
+    @Override
+    @CheckForNull
+    public String getDeprecationAlternative() {
+        // This extension is not intended to be used in Pipeline
+        // Custom SCM name should be set directly by Pipeline
+        // arguments when performing multiple checkouts in a single
+        // Pipeline.
+        return "Use the custom scm name as the userRemoteConfigs value for 'name'";
     }
 
     public String getName() {

--- a/src/main/java/hudson/plugins/git/extensions/impl/WipeWorkspace.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/WipeWorkspace.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git.extensions.impl;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -28,6 +29,13 @@ public class WipeWorkspace extends GitSCMExtension {
     public void beforeCheckout(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener) throws IOException, InterruptedException, GitException {
         listener.getLogger().println("Wiping out workspace first.");
         git.getWorkTree().deleteContents();
+    }
+
+    @Override
+    @CheckForNull
+    public String getDeprecationAlternative() {
+        // This extension is not intended to be used in Pipeline
+        return "Use cleanWs() to empty the Pipeline workspace before checkout.";
     }
 
     /**


### PR DESCRIPTION
## [JENKINS-43052] Warn in Pipeline build log if a deprecated extension is used

When extensions created for freestyle projects have a more general purpose replacement in Pipeline, the more general purpose Pipeline step is preferred.  This method allows the deprecated extension to suggest the preferred alternative.

When one of those extensions is used in a Pipeline, write a ***DEPRECATED** warning message to the build log so that the user can eventually remove the use of the deprecated extension from their Pipeline.

The deprecated warning message in the build log does not alter any behavior, it only provides a message for the user.

Suggest alternatives for those cases where a reasonable alternative exists.

### Testing done

Tested by running a Pipeline job with one of the deprecated extensions and confirmed that the message was displayed as expected.

Tested by running a freestyle job with the same extension and confirmed that no message was written to the build log.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
