### PR TITLE
[JENKINS-73676] Allow users with Job/CONFIGURE permission to edit remote URL

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -444,7 +444,10 @@ public class GitSCMSource extends AbstractGitSCMSource {
         public FormValidation doCheckRemote(@AncestorInPath Item item,
                                          @QueryParameter String credentialsId,
                                          @QueryParameter String remote) throws IOException, InterruptedException {
-            Jenkins.get().checkPermission(Jenkins.MANAGE);
+            if (item == null && !Jenkins.get().hasPermission(Jenkins.MANAGE) ||
+                item != null && !item.hasPermission(Item.CONFIGURE)) {
+                return FormValidation.warning("Not allowed to modify remote");
+            }
             return isFIPSCompliantTLS(credentialsId, remote) ? FormValidation.ok() : FormValidation.error(hudson.plugins.git.Messages.git_fips_url_notsecured());
         }
 


### PR DESCRIPTION
## [JENKINS-73676] Allow users with Job/CONFIGURE permission to edit remote URL

Changes for FIPS mistakenly placed the requirement for administrator on the field when it previously allowed users with Job/CONFIGURE permission to modify the field.

### Testing done

Duplicated [JENKINS-73676](https://issues.jenkins.io/browse/JENKINS-73676) by installing Jenkins 2.473 with the role strategy plugin.  Configured three users:

* mwaite - Administrator
* a-developer - User with modify permission on jobs and credentials
* a-reader - User with only read permissions

Created a fine-grained personal access token for one of my private GitHub repositories and confirmed that the repository could be read with that credential and could not be read without that credential.

Created the 'Developer-role' and assigned 'a-developer' to the role.  Created the 'Reader-role' and assigned 'a-reader' to the role.

Confirmed that the 'mwaite' user could modify the URL of the remote repository before and after this change.

Confirmed that without this change, the 'a-developer' user is shown the job configuration form but sees a stack trace in the console and errors on the web page.

Confirmed that with this change, the 'a-developer' user is shown the job configuration form and is allowed to modify the URL of the remote repository.

Confirmed that the 'a-reader' user cannot see the editing form.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
