### PR TITLE
Fix acceptance tests by reverting capitalization change

### DIFF
--- a/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPaths.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPaths.java
@@ -57,7 +57,13 @@ public class SparseCheckoutPaths extends GitSCMExtension {
     public static class DescriptorImpl extends GitSCMExtensionDescriptor {
         @Override
         public String getDisplayName() {
-            return "Sparse checkout paths";
+            /* TODO Fix capitalization error here and in Jenkins acceptance test harness.
+             *
+             * https://github.com/jenkinsci/acceptance-test-harness/pull/1685#issuecomment-2310075738
+             * Acceptance test harness for Git SCM should find components by class instead of by
+             * display name. Otherwise changes to display name need to be made in ATH and the plugin.
+             */
+            return "Sparse Checkout paths";
         }
     }
 


### PR DESCRIPTION
## Fix acceptance tests by reverting capitalization change

The Jenkins acceptance test harness uses the display name to locate UI components and test them.  It locates those components by display name.

The tests in the acceptance test harness are especially valuable now while we are preparing for the Spring Security 6.x upgrade.  It is better to retain the previous capitalization and preserve Jenkins acceptance test harness results rather than need to spread the capitalization change into the acceptance test harness and related components.

Added TODO item to fix the capitalization in both the git plugin and the acceptance test harness in a future release.

### Testing done

Confirmed that automated tests pass on Java 21 Linux.  Confirmed by review of the acceptance test harness stack trace that the capitalization change is the source of the problem.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
