### PR TITLE
[JENKINS-73677] Decorate GitClient after adding credentials

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -912,9 +912,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         Git git = Git.with(listener, environment).in(ws).using(gitExe);
 
         GitClient c = git.getClient();
-        for (GitSCMExtension ext : extensions) {
-            c = ext.decorate(this,c);
-        }
 
         for (UserRemoteConfig uc : getUserRemoteConfigs()) {
             String ucCredentialsId = uc.getCredentialsId();
@@ -937,6 +934,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
         }
         // TODO add default credentials
+
+        for (GitSCMExtension ext : extensions) {
+            c = ext.decorate(this,c);
+        }
 
         return c;
     }

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -5,6 +5,7 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import org.htmlunit.html.HtmlPage;
@@ -2915,6 +2916,30 @@ public class GitSCMTest extends AbstractGitTestCase {
         r.waitForMessage("Commit message: \"test commit\"", run);
     }
 
+    @Issue("JENKINS-73677")
+    @Test
+    public void testExtensionsDecorateClientAfterSettingCredentials() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        FreeStyleProject project = setupSimpleProject("master");
+        StandardCredentials extensionCredentials = createCredential(CredentialsScope.GLOBAL, "github");
+        store.addCredentials(Domain.global(), extensionCredentials);
+        // setup global config
+        List<UserRemoteConfig> remoteConfigs = GitSCM.createRepoList("https://github.com/jenkinsci/git-plugin", null);
+        project.setScm(new GitSCM(
+            remoteConfigs,
+            Collections.singletonList(new BranchSpec("master")),
+            false,
+            null,
+            null,
+            null,
+            List.of(new TestSetCredentialsGitSCMExtension((StandardUsernameCredentials) extensionCredentials))));
+        sampleRepo.init();
+        sampleRepo.write("file", "v1");
+        sampleRepo.git("commit", "--all", "--message=test commit");
+        Run<?, ?> run = r.buildAndAssertSuccess(project);
+        r.waitForMessage("using GIT_ASKPASS to set credentials " + extensionCredentials.getDescription(), run);
+    }
+
     private void setupJGit(GitSCM git) {
         git.gitTool="jgit";
         r.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(new JGitTool(Collections.emptyList()));
@@ -2947,5 +2972,20 @@ public class GitSCMTest extends AbstractGitTestCase {
 
     private StandardCredentials createCredential(CredentialsScope scope, String id) {
         return new UsernamePasswordCredentialsImpl(scope, id, "desc: " + id, "username", "password");
+    }
+
+    public static class TestSetCredentialsGitSCMExtension extends GitSCMExtension {
+
+        private final StandardUsernameCredentials credentials;
+
+        public TestSetCredentialsGitSCMExtension(StandardUsernameCredentials credentials) {
+            this.credentials = credentials;
+        }
+
+        @Override
+        public GitClient decorate(GitSCM scm, GitClient git) throws GitException {
+            git.setCredentials(credentials);
+            return git;
+        }
     }
 }


### PR DESCRIPTION
[JENKINS-73677](https://issues.jenkins.io/browse/JENKINS-73677): Credentials are added to GitClient **after** the client is decorated by extensions.. A plugin cannot for example override the credentials passed in via a GitSCMExtension (Noticed as part of https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/867)

### Testing done

Tested simple scenario: configured Pipeline from SCM with GitSCM with provided Credentials.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
