### PR TITLE
Move hunks getting executed on agents to separate classes

### DIFF
--- a/src/main/java/jenkins/plugins/git/DisableHooks.java
+++ b/src/main/java/jenkins/plugins/git/DisableHooks.java
@@ -1,0 +1,25 @@
+package jenkins.plugins.git;
+
+import hudson.Functions;
+import hudson.remoting.VirtualChannel;
+import java.io.IOException;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.StoredConfig;
+import org.jenkinsci.plugins.gitclient.RepositoryCallback;
+
+/**
+ * Disables git hooks. This can get remotely executed on agents.
+ */
+class DisableHooks implements RepositoryCallback<Object> {
+    static final String DISABLED_WIN = "NUL:";
+    static final String DISABLED_NIX = "/dev/null";
+
+    @Override
+    public Object invoke(Repository repo, VirtualChannel channel) throws IOException, InterruptedException {
+        final String VAL = Functions.isWindows() ? DISABLED_WIN : DISABLED_NIX;
+        final StoredConfig repoConfig = repo.getConfig();
+        repoConfig.setString("core", null, "hooksPath", VAL);
+        repoConfig.save();
+        return null;
+    }
+}

--- a/src/main/java/jenkins/plugins/git/GitHooksConfiguration.java
+++ b/src/main/java/jenkins/plugins/git/GitHooksConfiguration.java
@@ -26,30 +26,22 @@ package jenkins.plugins.git;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.Functions;
 import hudson.model.PersistentDescriptor;
 import hudson.plugins.git.GitException;
 import hudson.remoting.Channel;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.lib.StoredConfig;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.IOException;
-import java.util.logging.Logger;
-
 
 
 @Extension @Symbol("gitHooks") @Restricted(NoExternalUse.class)
 public class GitHooksConfiguration extends GlobalConfiguration implements PersistentDescriptor {
-
-    public static final String DISABLED_WIN = "NUL:";
-    public static final String DISABLED_NIX = "/dev/null";
-    static final Logger LOGGER = Logger.getLogger(GitHooksConfiguration.class.getName());
 
     private boolean allowedOnController = false;
     private boolean allowedOnAgents = false;
@@ -109,33 +101,10 @@ public class GitHooksConfiguration extends GlobalConfiguration implements Persis
 
     public static void configure(GitClient client, final boolean allowed) throws GitException, IOException, InterruptedException {
         if (!allowed) {
-            client.withRepository((repo, channel) -> {
-                disable(repo);
-                return null;
-            });
+            client.withRepository(new DisableHooks());
         } else {
-            client.withRepository((repo, channel) -> {
-                unset(repo);
-                return null;
-            });
+            client.withRepository(new UnsetHooks());
         }
     }
 
-    private static void unset(final Repository repo) throws IOException {
-        final StoredConfig repoConfig = repo.getConfig();
-        final String val = repoConfig.getString("core", null, "hooksPath");
-        if (val != null && !val.isEmpty() && !DISABLED_NIX.equals(val) && !DISABLED_WIN.equals(val)) {
-            LOGGER.warning(() -> String.format("core.hooksPath explicitly set to %s and will be left intact on %s.", val, repo.getDirectory()));
-        } else {
-            repoConfig.unset("core", null, "hooksPath");
-            repoConfig.save();
-        }
-    }
-
-    private static void disable(final Repository repo) throws IOException {
-        final String VAL = Functions.isWindows() ? DISABLED_WIN : DISABLED_NIX;
-        final StoredConfig repoConfig = repo.getConfig();
-        repoConfig.setString("core", null, "hooksPath", VAL);
-        repoConfig.save();
-    }
 }

--- a/src/main/java/jenkins/plugins/git/UnsetHooks.java
+++ b/src/main/java/jenkins/plugins/git/UnsetHooks.java
@@ -1,0 +1,28 @@
+package jenkins.plugins.git;
+
+import hudson.remoting.VirtualChannel;
+import java.io.IOException;
+import java.util.logging.Logger;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.StoredConfig;
+import org.jenkinsci.plugins.gitclient.RepositoryCallback;
+
+/**
+ * Unsets git hooks. This can get remotely executed on agents.
+ */
+class UnsetHooks implements RepositoryCallback<Object> {
+    private static final Logger LOGGER = Logger.getLogger(UnsetHooks.class.getName());
+
+    @Override
+    public Object invoke(Repository repo, VirtualChannel channel) throws IOException, InterruptedException {
+        final StoredConfig repoConfig = repo.getConfig();
+        final String val = repoConfig.getString("core", null, "hooksPath");
+        if (val != null && !val.isEmpty() && !DisableHooks.DISABLED_NIX.equals(val) && !DisableHooks.DISABLED_WIN.equals(val)) {
+            LOGGER.warning(() -> String.format("core.hooksPath explicitly set to %s and will be left intact on %s.", val, repo.getDirectory()));
+        } else {
+            repoConfig.unset("core", null, "hooksPath");
+            repoConfig.save();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
I see `java.lang.NoClassDefFoundError: javax/servlet/ServletException` happening on agent side when loading these as lambdas. Happened on fresh agents (kubernetes agents) when running Jenkins through `hpi:run`, but also on permanent agent, as long as I clear `jarCache`.

Not sure where the class is being captured from, but moving these to standalone classes definitely fixes the issue I'm seeing.

```
AVERTISSEMENT: LinkageError while performing UserRequest:UserRPCRequest:org.jenkinsci.plugins.gitclient.GitClient.withRepository[org.jenkinsci.plugins.gitclient.RepositoryCallback](17)
java.lang.NoClassDefFoundError: javax/servlet/ServletException
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3402)
	at java.base/java.lang.Class.getDeclaredMethod(Class.java:2673)
	at java.base/java.lang.invoke.SerializedLambda$1.run(SerializedLambda.java:272)
	at java.base/java.lang.invoke.SerializedLambda$1.run(SerializedLambda.java:269)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:569)
	at java.base/java.lang.invoke.SerializedLambda.readResolve(SerializedLambda.java:269)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.io.ObjectStreamClass.invokeReadResolve(ObjectStreamClass.java:1190)
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2266)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
	at java.base/java.io.ObjectInputStream.readArray(ObjectInputStream.java:2157)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1721)
	at java.base/java.io.ObjectInputStream$FieldValues.<init>(ObjectInputStream.java:2606)
	at java.base/java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2457)
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2257)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
	at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:509)
	at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:467)
	at hudson.remoting.UserRequest.deserialize(UserRequest.java:289)
	at hudson.remoting.UserRequest.perform(UserRequest.java:189)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:377)
	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:140)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.ClassNotFoundException: javax.servlet.ServletException
	at hudson.remoting.RemoteClassLoader$ClassLoaderProxy.fetch(RemoteClassLoader.java:1029)
	at jdk.internal.reflect.GeneratedMethodAccessor89.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at hudson.remoting.RemoteInvocationHandler$RPCRequest.perform(RemoteInvocationHandler.java:924)
	at hudson.remoting.Request$2.run(Request.java:377)
	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
	at org.jenkinsci.remoting.CallableDecorator.call(CallableDecorator.java:18)
	at hudson.remoting.CallableDecoratorList.lambda$applyDecorator$0(CallableDecoratorList.java:19)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	... 1 more
	Suppressed: hudson.remoting.Channel$CallSiteStackTrace: Remote call to JNLP4-connect connection to localhost/127.0.0.1:8001
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1826)
		at hudson.remoting.Request.call(Request.java:199)
		at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:288)
		at jdk.proxy2/jdk.proxy2.$Proxy7.fetch(Unknown Source)
		at hudson.remoting.RemoteClassLoader.loadRemoteClass(RemoteClassLoader.java:315)
		at hudson.remoting.RemoteClassLoader.loadWithMultiClassLoader(RemoteClassLoader.java:284)
		at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:243)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:592)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
		at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
		at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3402)
		at java.base/java.lang.Class.getDeclaredMethod(Class.java:2673)
		at java.base/java.lang.invoke.SerializedLambda$1.run(SerializedLambda.java:272)
		at java.base/java.lang.invoke.SerializedLambda$1.run(SerializedLambda.java:269)
		at java.base/java.security.AccessController.doPrivileged(AccessController.java:569)
		at java.base/java.lang.invoke.SerializedLambda.readResolve(SerializedLambda.java:269)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:568)
		at java.base/java.io.ObjectStreamClass.invokeReadResolve(ObjectStreamClass.java:1190)
		at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2266)
		at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
		at java.base/java.io.ObjectInputStream.readArray(ObjectInputStream.java:2157)
		at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1721)
		at java.base/java.io.ObjectInputStream$FieldValues.<init>(ObjectInputStream.java:2606)
		at java.base/java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2457)
		at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2257)
		at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
		at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:509)
		at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:467)
		at hudson.remoting.UserRequest.deserialize(UserRequest.java:289)
		at hudson.remoting.UserRequest.perform(UserRequest.java:189)
		at hudson.remoting.UserRequest.perform(UserRequest.java:54)
		at hudson.remoting.Request$2.run(Request.java:377)
		at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
		at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:140)
		... 1 more
```

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
