### PR TITLE
Revert [JENKINS-73677] Decorate GitClient after adding credentials

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -912,6 +912,9 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         Git git = Git.with(listener, environment).in(ws).using(gitExe);
 
         GitClient c = git.getClient();
+        for (GitSCMExtension ext : extensions) {
+            c = ext.decorate(this,c);
+        }
 
         for (UserRemoteConfig uc : getUserRemoteConfigs()) {
             String ucCredentialsId = uc.getCredentialsId();
@@ -934,10 +937,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
         }
         // TODO add default credentials
-
-        for (GitSCMExtension ext : extensions) {
-            c = ext.decorate(this,c);
-        }
 
         return c;
     }


### PR DESCRIPTION
## Revert "[JENKINS-73677] Decorate GitClient after adding credentials

This reverts commit 843d48b3a124b93d2e5ef396e96776472179a147.

Tentative build to check for changes in host key verification.

### Testing done

None

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
