### PR TITLE
Temporarily depend on latest mina sshd plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <!-- TODO: Remove when 2.14.0-133.vcc091215a_358 or newer is in BOM -->
+        <!-- https://github.com/jenkinsci/mina-sshd-api-plugin/releases/tag/2.14.0-133.vcc091215a_358 -->
+        <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+        <artifactId>mina-sshd-api-common</artifactId>
+        <version>2.14.0-133.vcc091215a_358</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -95,13 +102,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <exclusions>
-        <!-- TODO: Remove the commons-io exclusion when no longer needed for upper bounds on mina dependency from git-client -->
-        <exclusion>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Temporarily depend on latest mina sshd plugin

[Mina SSHD API plugin 2.14.0-133.vcc091215a_358](https://github.com/jenkinsci/mina-sshd-api-plugin/releases/tag/2.14.0-133.vcc091215a_358) includes a bug fix to move fips-bundle-test to test scope and to not include commons-io in the dependencies of the plugin.  That release is not yet available in plugin BOM.  Once it is available in plugin BOM, this workaround can be removed.

The pull request that resolved the issue in mina sshd api plugin is 

* https://github.com/jenkinsci/mina-sshd-api-plugin/pull/119

### Testing done

Confirmed automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
