### PR TITLE
Depend on git client plugin 6.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,8 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
+      <!-- TODO: Remove when release is available in plugin BOM -->
+      <version>6.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Depend on git client plugin 6.1.0

Git client plugin 6.1.0 uses Jakarta EE 9 and requires Java 17.  Better to assure that users of git plugin 5.6.0 also have the matching version of git client plugin for Jakarta EE 9.  Reduces the version testing complications and lets me focus on single versions of each plugin in the 2.479 testing.

### Testing done

Rely on ci.jenkins.io test automation.  Interacive testing will follow before release.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
