### PR TITLE
Reproduce an issue with optional dependencies of detached plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.1</version>
+    <version>4.88</version>
     <relativePath />
   </parent>
 
@@ -66,10 +66,8 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <!-- TODO Replace with the standard jenkins.baseline references after LTS requires Java 17  -->
-    <!-- <jenkins.version>${jenkins.baseline}.1</jenkins.version> -->
-    <jenkins.version>${jenkins.baseline}</jenkins.version>
+    <jenkins.baseline>2.452</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <!-- Jenkins.MANAGE is still in Beta -->
     <useBeta>true</useBeta>
@@ -78,6 +76,7 @@
     <linkXRef>false</linkXRef>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
+    <test>InjectedTest</test>
   </properties>
 
   <dependencyManagement>
@@ -89,13 +88,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <!-- TODO: Remove when 2.14.0-133.vcc091215a_358 or newer is in BOM -->
-        <!-- https://github.com/jenkinsci/mina-sshd-api-plugin/releases/tag/2.14.0-133.vcc091215a_358 -->
-        <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
-        <artifactId>mina-sshd-api-common</artifactId>
-        <version>2.14.0-133.vcc091215a_358</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -106,8 +98,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
-      <!-- TODO: Remove when release is available in plugin BOM -->
-      <version>6.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -120,8 +110,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <!-- TODO: Remove when release is available in plugin BOM -->
-      <version>698.v8e3b_c788f0a_6</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -145,9 +133,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
       <optional>true</optional>
-      <!-- pipeline-model-definition plugins fail to start git plugin in PCT for 2.440.x and 2.452.x lines -->
-      <!-- TODO: Remove once this workaround dependency downgrade is no longer required for PCT -->
-      <version>822.824.v14451b_c0fd42</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/ApiTokenPropertyConfiguration.java
+++ b/src/main/java/hudson/plugins/git/ApiTokenPropertyConfiguration.java
@@ -14,7 +14,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import java.io.Serializable;
@@ -58,7 +58,7 @@ public class ApiTokenPropertyConfiguration extends GlobalConfiguration implement
     }
 
     @RequirePOST
-    public HttpResponse doGenerate(StaplerRequest2 req) {
+    public HttpResponse doGenerate(StaplerRequest req) {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         String apiTokenName = req.getParameter("apiTokenName");
@@ -102,7 +102,7 @@ public class ApiTokenPropertyConfiguration extends GlobalConfiguration implement
     }
 
     @RequirePOST
-    public HttpResponse doRevoke(StaplerRequest2 req) {
+    public HttpResponse doRevoke(StaplerRequest req) {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         String apiTokenUuid = req.getParameter("apiTokenUuid");

--- a/src/main/java/hudson/plugins/git/GitPublisher.java
+++ b/src/main/java/hudson/plugins/git/GitPublisher.java
@@ -28,7 +28,7 @@ import org.jenkinsci.plugins.gitclient.PushCommand;
 import org.jenkinsci.plugins.gitclient.UnsupportedCommand;
 import org.kohsuke.stapler.*;
 
-import jakarta.servlet.ServletException;
+import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -437,7 +437,7 @@ public class GitPublisher extends Recorder implements Serializable {
         }
         
         public FormValidation doCheckRemote(
-                @AncestorInPath AbstractProject project, StaplerRequest2 req)
+                @AncestorInPath AbstractProject project, StaplerRequest req)
                 throws IOException, ServletException {
             String remote = req.getParameter("value");
             boolean isMerge = req.getParameter("isMerge") != null;

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -66,10 +66,10 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 
-import jakarta.servlet.ServletException;
+import javax.servlet.ServletException;
 
 import java.io.File;
 import java.io.IOException;
@@ -1884,7 +1884,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             return mergeOptions;
         }
 
-        public FormValidation doGitRemoteNameCheck(StaplerRequest2 req)
+        public FormValidation doGitRemoteNameCheck(StaplerRequest req)
                 throws IOException, ServletException {
             String mergeRemoteName = req.getParameter("value");
             boolean isMerge = req.getParameter("isMerge") != null;
@@ -1905,7 +1905,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         @Override
-        public boolean configure(StaplerRequest2 req, JSONObject formData) throws FormException {
+        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
             req.bindJSON(this, formData);
             save();
             return true;

--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -19,10 +19,10 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import jakarta.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequest;
 
-import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.scm.api.SCMEvent;
@@ -180,7 +180,7 @@ public class GitStatus implements UnprotectedRootAction {
 
         return new HttpResponse() {
           @Override
-          public void generateResponse(StaplerRequest2 req, StaplerResponse2 rsp, Object node) throws IOException {
+          public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException {
             rsp.setStatus(SC_OK);
             rsp.setContentType("text/plain");
             for (int i = 0; i < contributors.size(); i++) {
@@ -232,7 +232,7 @@ public class GitStatus implements UnprotectedRootAction {
          * @param rsp the response.
          * @since 1.4.1
          */
-        public void addHeaders(StaplerRequest2 req, StaplerResponse2 rsp) {
+        public void addHeaders(StaplerRequest req, StaplerResponse rsp) {
         }
 
         /**
@@ -243,7 +243,7 @@ public class GitStatus implements UnprotectedRootAction {
          * @param w   the writer.
          * @since 1.4.1
          */
-        public void writeBody(StaplerRequest2 req, StaplerResponse2 rsp, PrintWriter w) {
+        public void writeBody(StaplerRequest req, StaplerResponse rsp, PrintWriter w) {
             writeBody(w);
         }
 
@@ -543,7 +543,7 @@ public class GitStatus implements UnprotectedRootAction {
              */
             @Override
             @SuppressWarnings("deprecation")
-            public void addHeaders(StaplerRequest2 req, StaplerResponse2 rsp) {
+            public void addHeaders(StaplerRequest req, StaplerResponse rsp) {
                 // Calls a deprecated getAbsoluteUrl() method because this is a remote API case
                 // as described in the Javadoc of the deprecated getAbsoluteUrl() method.
                 rsp.addHeader("Triggered", project.getAbsoluteUrl());
@@ -578,7 +578,7 @@ public class GitStatus implements UnprotectedRootAction {
              */
             @Override
             @SuppressWarnings("deprecation")
-            public void addHeaders(StaplerRequest2 req, StaplerResponse2 rsp) {
+            public void addHeaders(StaplerRequest req, StaplerResponse rsp) {
                 // Calls a deprecated getAbsoluteUrl() method because this is a remote API case
                 // as described in the Javadoc of the deprecated getAbsoluteUrl() method.
                 rsp.addHeader("Triggered", project.getAbsoluteUrl());

--- a/src/main/java/hudson/plugins/git/GitStatusCrumbExclusion.java
+++ b/src/main/java/hudson/plugins/git/GitStatusCrumbExclusion.java
@@ -3,10 +3,10 @@ package hudson.plugins.git;
 import hudson.Extension;
 import hudson.security.csrf.CrumbExclusion;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**

--- a/src/main/java/hudson/plugins/git/GitTagAction.java
+++ b/src/main/java/hudson/plugins/git/GitTagAction.java
@@ -11,13 +11,13 @@ import hudson.util.MultipartFormDataParser;
 import jenkins.model.*;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
-import org.kohsuke.stapler.StaplerRequest2;
-import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import jakarta.servlet.ServletException;
+import javax.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
@@ -149,7 +149,7 @@ public class GitTagAction extends AbstractScmTagAction implements Describable<Gi
      * @throws ServletException on servlet error
      */
     @RequirePOST
-    public synchronized void doSubmit(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
+    public synchronized void doSubmit(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         getACL().checkPermission(getPermission());
 
         try (MultipartFormDataParser parser = new MultipartFormDataParser(req)) {

--- a/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/AssemblaWeb.java
@@ -17,11 +17,11 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.servlet.ServletException;
+import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -98,7 +98,7 @@ public class AssemblaWeb extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public AssemblaWeb newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public AssemblaWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(AssemblaWeb.class, jsonObject);
         }
 

--- a/src/main/java/hudson/plugins/git/browser/BitbucketServer.java
+++ b/src/main/java/hudson/plugins/git/browser/BitbucketServer.java
@@ -8,7 +8,7 @@ import hudson.scm.RepositoryBrowser;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -81,7 +81,7 @@ public class BitbucketServer extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public BitbucketServer newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public BitbucketServer newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(BitbucketServer.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/BitbucketWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/BitbucketWeb.java
@@ -8,7 +8,7 @@ import hudson.scm.RepositoryBrowser;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -82,7 +82,7 @@ public class BitbucketWeb extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public BitbucketWeb newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public BitbucketWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(BitbucketWeb.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/CGit.java
+++ b/src/main/java/hudson/plugins/git/browser/CGit.java
@@ -10,7 +10,7 @@ import hudson.scm.browsers.QueryBuilder;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -92,7 +92,7 @@ public class CGit extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public CGit newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public CGit newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(CGit.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/FisheyeGitRepositoryBrowser.java
@@ -14,11 +14,11 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.servlet.ServletException;
+import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.URL;
 import java.util.regex.Pattern;
@@ -79,7 +79,7 @@ public class FisheyeGitRepositoryBrowser extends GitRepositoryBrowser {
 		@Override
                 @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                                     justification = "Inherited javadoc commits that req is non-null")
-		public FisheyeGitRepositoryBrowser newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+		public FisheyeGitRepositoryBrowser newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
 			return req.bindJSON(FisheyeGitRepositoryBrowser.class, jsonObject);
 		}
 

--- a/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitBlitRepositoryBrowser.java
@@ -17,11 +17,11 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.servlet.ServletException;
+import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -84,7 +84,7 @@ public class GitBlitRepositoryBrowser extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public GitBlitRepositoryBrowser newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public GitBlitRepositoryBrowser newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(GitBlitRepositoryBrowser.class, jsonObject);
         }
 

--- a/src/main/java/hudson/plugins/git/browser/GitLab.java
+++ b/src/main/java/hudson/plugins/git/browser/GitLab.java
@@ -12,14 +12,14 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.net.URL;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.servlet.ServletException;
+import javax.servlet.ServletException;
 
 import org.kohsuke.stapler.QueryParameter;
 
@@ -145,7 +145,7 @@ public class GitLab extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public GitLab newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public GitLab newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(GitLab.class, jsonObject);
         }
 

--- a/src/main/java/hudson/plugins/git/browser/GitList.java
+++ b/src/main/java/hudson/plugins/git/browser/GitList.java
@@ -10,7 +10,7 @@ import net.sf.json.JSONObject;
 
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -94,7 +94,7 @@ public class GitList extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public GitList newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public GitList newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(GitList.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -9,7 +9,7 @@ import hudson.plugins.git.GitChangeSet.Path;
 import hudson.scm.RepositoryBrowser;
 
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.net.IDN;
@@ -46,7 +46,7 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
 
     public final URL getUrl() throws IOException {
         String u = url;
-        StaplerRequest2 req = Stapler.getCurrentRequest2();
+        StaplerRequest req = Stapler.getCurrentRequest();
         if (req != null) {
             Job job = req.findAncestorObject(Job.class);
             if (job != null) {

--- a/src/main/java/hudson/plugins/git/browser/GitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GitWeb.java
@@ -10,7 +10,7 @@ import hudson.scm.browsers.QueryBuilder;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -94,7 +94,7 @@ public class GitWeb extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public GitWeb newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public GitWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(GitWeb.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/GithubWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GithubWeb.java
@@ -10,7 +10,7 @@ import net.sf.json.JSONObject;
 
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -100,7 +100,7 @@ public class GithubWeb extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-		public GithubWeb newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+		public GithubWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
 			return req.bindJSON(GithubWeb.class, jsonObject);
 		}
 	}

--- a/src/main/java/hudson/plugins/git/browser/Gitiles.java
+++ b/src/main/java/hudson/plugins/git/browser/Gitiles.java
@@ -17,7 +17,7 @@ import java.net.URL;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.servlet.ServletException;
+import javax.servlet.ServletException;
 
 import net.sf.json.JSONObject;
 
@@ -26,7 +26,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * @author Manolo Carrasco Moñino
@@ -72,7 +72,7 @@ public class Gitiles extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public Gitiles newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public Gitiles newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(Gitiles.class, jsonObject);
         }
 

--- a/src/main/java/hudson/plugins/git/browser/GitoriousWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GitoriousWeb.java
@@ -8,7 +8,7 @@ import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -76,7 +76,7 @@ public class GitoriousWeb extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public GitoriousWeb newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public GitoriousWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(GitoriousWeb.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/GogsGit.java
+++ b/src/main/java/hudson/plugins/git/browser/GogsGit.java
@@ -10,7 +10,7 @@ import net.sf.json.JSONObject;
 
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -102,7 +102,7 @@ public class GogsGit extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public GogsGit newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public GogsGit newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(GogsGit.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/KilnGit.java
+++ b/src/main/java/hudson/plugins/git/browser/KilnGit.java
@@ -11,7 +11,7 @@ import net.sf.json.JSONObject;
 
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -113,7 +113,7 @@ public class KilnGit extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public KilnGit newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public KilnGit newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(KilnGit.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/Phabricator.java
+++ b/src/main/java/hudson/plugins/git/browser/Phabricator.java
@@ -8,7 +8,7 @@ import hudson.scm.RepositoryBrowser;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -92,7 +92,7 @@ public class Phabricator extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public Phabricator newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public Phabricator newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(Phabricator.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/RedmineWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/RedmineWeb.java
@@ -9,7 +9,7 @@ import hudson.scm.RepositoryBrowser;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -95,7 +95,7 @@ public class RedmineWeb extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public RedmineWeb newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public RedmineWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(RedmineWeb.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/RhodeCode.java
+++ b/src/main/java/hudson/plugins/git/browser/RhodeCode.java
@@ -10,7 +10,7 @@ import hudson.scm.browsers.QueryBuilder;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -97,7 +97,7 @@ public class RhodeCode extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public RhodeCode newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public RhodeCode newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(RhodeCode.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/Stash.java
+++ b/src/main/java/hudson/plugins/git/browser/Stash.java
@@ -9,7 +9,7 @@ import hudson.scm.RepositoryBrowser;
 import hudson.scm.browsers.QueryBuilder;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -97,7 +97,7 @@ public class Stash extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public Stash newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public Stash newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(Stash.class, jsonObject);
         }
     }

--- a/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/TFS2013GitRepositoryBrowser.java
@@ -16,11 +16,11 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.servlet.ServletException;
+import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -95,7 +95,7 @@ public class TFS2013GitRepositoryBrowser extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public TFS2013GitRepositoryBrowser newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public TFS2013GitRepositoryBrowser newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             try {
                 req.getSubmittedForm();
             } catch (ServletException e) {

--- a/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/ViewGitWeb.java
@@ -18,11 +18,11 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.servlet.ServletException;
+import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -91,7 +91,7 @@ public class ViewGitWeb extends GitRepositoryBrowser {
         @Override
         @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
                             justification = "Inherited javadoc commits that req is non-null")
-        public ViewGitWeb newInstance(StaplerRequest2 req, @NonNull JSONObject jsonObject) throws FormException {
+        public ViewGitWeb newInstance(StaplerRequest req, @NonNull JSONObject jsonObject) throws FormException {
             return req.bindJSON(ViewGitWeb.class, jsonObject);
         }
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/PruneStaleTag.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/PruneStaleTag.java
@@ -47,7 +47,7 @@ import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Prune stale local tags that do not exist on any remote.
@@ -166,7 +166,7 @@ public class PruneStaleTag extends GitSCMExtension {
     public static class DescriptorImpl extends GitSCMExtensionDescriptor {
 
         @Override
-        public GitSCMExtension newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
+        public GitSCMExtension newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             return new PruneStaleTag(true);
         }
 

--- a/src/main/java/hudson/plugins/git/util/BuildData.java
+++ b/src/main/java/hudson/plugins/git/util/BuildData.java
@@ -21,7 +21,7 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -141,7 +141,7 @@ public class BuildData implements Action, Serializable, Cloneable {
     @Restricted(NoExternalUse.class) // only used from stapler/jelly
     @CheckForNull
     public Run<?,?> getOwningRun() {
-        StaplerRequest2 req = Stapler.getCurrentRequest2();
+        StaplerRequest req = Stapler.getCurrentRequest();
         if (req == null) {
             return null;
         }

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -107,8 +107,8 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest2;
-import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
@@ -671,7 +671,7 @@ public class GitSCMSource extends AbstractGitSCMSource {
                                     result.add(new GitStatus.ResponseContributor() {
                                         @Override
                                         @SuppressWarnings("deprecation")
-                                        public void addHeaders(StaplerRequest2 req, StaplerResponse2 rsp) {
+                                        public void addHeaders(StaplerRequest req, StaplerResponse rsp) {
                                             // Calls a deprecated getAbsoluteUrl() method because this is a remote API case
                                             // as described in the Javadoc of the deprecated getAbsoluteUrl() method.
                                             rsp.addHeader("Triggered", owner.getAbsoluteUrl());

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -33,10 +33,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
-import jakarta.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequest;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest2;
-import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 public class GitStatusTest extends AbstractGitProject {
 
@@ -536,8 +536,8 @@ public class GitStatusTest extends AbstractGitProject {
         HttpResponse rsp = this.gitStatus.doNotifyCommit(requestWithNoParameter, "a", "master", null, notifyCommitApiToken);
 
         // Up to 10 "Triggered" headers + 1 extra warning are returned.
-        StaplerRequest2 sReq = mock(StaplerRequest2.class);
-        StaplerResponse2 sRsp = mock(StaplerResponse2.class);
+        StaplerRequest sReq = mock(StaplerRequest.class);
+        StaplerResponse sRsp = mock(StaplerResponse.class);
         Mockito.when(sRsp.getWriter()).thenReturn(mock(PrintWriter.class));
         rsp.generateResponse(sReq, sRsp, null);
         Mockito.verify(sRsp, Mockito.times(11)).addHeader(Mockito.eq("Triggered"), Mockito.anyString());

--- a/src/test/java/hudson/plugins/git/GitStatusTheoriesTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTheoriesTest.java
@@ -21,7 +21,7 @@ import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 
-import jakarta.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequest;
 
 @RunWith(Theories.class)
 public class GitStatusTheoriesTest extends AbstractGitProject {

--- a/src/test/java/hudson/plugins/git/GitTagActionTest.java
+++ b/src/test/java/hudson/plugins/git/GitTagActionTest.java
@@ -48,7 +48,7 @@ import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 
-import jakarta.servlet.ServletException;
+import javax.servlet.ServletException;
 
 /**
  * Test git tag action. Low value test that was created as part of

--- a/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMSourceTest.java
@@ -49,7 +49,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import jakarta.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Collections;
 import org.jvnet.hudson.test.TestExtension;


### PR DESCRIPTION
Reproduced https://github.com/jenkinsci/git-plugin/pull/1627 in `bom` with

```xml
diff --git a/bom-2.452.x/pom.xml b/bom-2.452.x/pom.xml
index e5f613b9..28aa2f51 100644
--- a/bom-2.452.x/pom.xml
+++ b/bom-2.452.x/pom.xml
@@ -10,6 +10,8 @@
   <packaging>pom</packaging>
   <properties>
     <cloudbees-folder-plugin.version>6.928.v7c780211d66e</cloudbees-folder-plugin.version>
+    <!-- TODO https://github.com/jenkinsci/git-plugin/pull/1677 -->
+    <git-plugin.version>5.6.1-rc5339.d2579e568302</git-plugin.version>
     <plugin-util-api.version>4.1.0</plugin-util-api.version>
     <subversion-plugin.version>1269.v53185011cd9f</subversion-plugin.version>
     <workflow-job-plugin.version>1400.v7fd111b_ec82f</workflow-job-plugin.version>
@@ -66,6 +68,17 @@
         <artifactId>credentials</artifactId>
         <version>1380.va_435002fa_924</version>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>git</artifactId>
+        <version>${git-plugin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>git</artifactId>
+        <version>${git-plugin.version}</version>
+        <classifier>tests</classifier>
+      </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>job-dsl</artifactId>
```

and

```
LINE=2.452.x PLUGINS=pipeline-model-definition  TEST=InjectedTest bash local-test.sh
```