### PR TITLE
[JENKINS-73677] Decorate GitClient after adding credentials

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -913,9 +913,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         Git git = Git.with(listener, environment).in(ws).using(gitExe);
 
         GitClient c = git.getClient();
-        for (GitSCMExtension ext : extensions) {
-            c = ext.decorate(this,c);
-        }
 
         for (UserRemoteConfig uc : getUserRemoteConfigs()) {
             String ucCredentialsId = uc.getCredentialsId();
@@ -938,6 +935,10 @@ public class GitSCM extends GitSCMBackwardCompatibility {
             }
         }
         // TODO add default credentials
+
+        for (GitSCMExtension ext : extensions) {
+            c = ext.decorate(this,c);
+        }
 
         return c;
     }


### PR DESCRIPTION
(second attempt of https://github.com/jenkinsci/git-plugin/pull/1649)

[JENKINS-73677](https://issues.jenkins.io/browse/JENKINS-73677): Credentials are added to GitClient after the client is decorated by extensions.. A plugin cannot for example override the credentials passed in via a GitSCMExtension (Noticed as part of https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/867)

* Previous attempt to apply this caused problems [JENKINS-73797](https://issues.jenkins.io/browse/JENKINS-73797) for Bitbucket Branch Source user that use the SSH Credentials trait.
* The PR https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/899 has been merged in Bitbucket branch source to prevent this problem for happening again (~but unreleased at the moment~ released as [906.vedf430cb_4481](https://github.com/jenkinsci/bitbucket-branch-source-plugin/releases/tag/906.vedf430cb_4481)). 
* Now proposing to apply the change again in the Git plugin to be able to move forward.
* Will use the incrementals of this PR to rebase and test https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/867

### Testing done

Tested simple scenario: configured Pipeline from SCM with GitSCM with provided Credentials.
Tested other scenario: configured Multibranch SCM with Bitbucket Branch Source.
Tested other scenario: configured Multibranch SCM with Bitbucket Branch Source with SSH Credentials trait.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue