### PR TITLE
[JENKINS-75162] Fix links to plugins.jenkins.io content

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -294,7 +294,7 @@ Other credential types will not work with the ssh protocol.
 To minimize the delay between a push and a build, configure the remote repository to use a Webhook to notify Jenkins of changes to the repository.
 Refer to webhook documentation for your repository:
 
-* link:https://plugins.jenkins.io/github#GitHubPlugin-GitHubhooktriggerforGITScmpolling[GitHub]
+* link:https://plugins.jenkins.io/github/#plugin-content-github-hook-trigger-for-gitscm-polling[GitHub]
 * link:https://plugins.jenkins.io/bitbucket[Bitbucket]
 * link:https://plugins.jenkins.io/gitlab-branch-source[GitLab]
 * link:https://github.com/jenkinsci/gitea-plugin/blob/master/docs/README.md[Gitea]
@@ -364,7 +364,7 @@ hudson.plugins.git.GitStatus.NOTIFY_COMMIT_ACCESS_CONTROL='disabled-for-polling'
 [#enabling-jgit]
 === Enabling JGit
 
-See the link:https://plugins.jenkins.io/git-client/#enabling-jgit[git client plugin documentation] for instructions to enable JGit.
+See the link:https://plugins.jenkins.io/git-client/#plugin-content-enabling-jgit[git client plugin documentation] for instructions to enable JGit.
 JGit becomes available throughout Jenkins once it has been enabled.
 
 [#global-configuration]

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1165,7 +1165,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         buildData.saveBuild(revToBuild);
 
         if (buildData.getBuildsByBranchName().size() >= 100) {
-            log.println("JENKINS-19022: warning: possible memory leak due to Git plugin usage; see: https://plugins.jenkins.io/git/#remove-git-plugin-buildsbybranch-builddata-script");
+            log.println("JENKINS-19022: warning: possible memory leak due to Git plugin usage; see: https://plugins.jenkins.io/git/#plugin-content-remove-git-plugin-buildsbybranch-builddata-script");
         }
         boolean checkForMultipleRevisions = true;
         BuildSingleRevisionOnly ext = extensions.get(BuildSingleRevisionOnly.class);

--- a/src/main/resources/hudson/plugins/git/GitSCM/help.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help.html
@@ -41,7 +41,7 @@ checkout scmGit(userRemoteConfigs: [
     </p>
     <p>
     The <code>checkout</code> step can be used in many cases where the <code>git</code> step cannot be used.
-    Refer to the <a href="https://plugins.jenkins.io/git#extensions">git plugin documentation</a> for detailed descriptions of options available to the checkout step.
+    Refer to the <a href="https://plugins.jenkins.io/git/#plugin-content-extensions">git plugin documentation</a> for detailed descriptions of options available to the checkout step.
     For example, the <code>checkout</code> step supports:
     <ul>
       <li>SHA-1 checkout</li>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help.html
@@ -34,7 +34,7 @@ checkout scmGit(branches: [[name: 'main]],
     </p>
     <p>
     The <code>checkout</code> step can be used in many cases where the <code>git</code> step cannot be used.
-    Refer to the <a href="https://plugins.jenkins.io/git#extensions">git plugin documentation</a> for detailed descriptions of options available to the checkout step.
+    Refer to the <a href="https://plugins.jenkins.io/git/#plugin-content-extensions">git plugin documentation</a> for detailed descriptions of options available to the checkout step.
     For example, the <code>git</code> step does <strong>not</strong> support:
     <ul>
       <li>SHA-1 checkout</li>


### PR DESCRIPTION
## [JENKINS-75162] Fix links to plugins.jenkins.io content

The previous fragment identifiers in the documentation links no longer exist in the plugins.jenkins.io page content.  Readers that click those hyperlinks are taken to the top of the page instead of being taken to the specific content within the page.

Use fragment identifiers that exist so that a click of the link takes the reader to the correct location in the page content.

Partial fix of [JENKINS-75162](https://issues.jenkins.io/browse/JENKINS-75162).

### Testing done

Confirmed that each of the new hyperlinks opens to the correct location.  Checked all other https://plugins.jenkins.io references in the repository to confirm that they resolve to the expected locations.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
