### PR TITLE
Upgrade matrix-project test dependency based on plugin BOM results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,14 +193,6 @@
       <artifactId>git-tag-message</artifactId>
       <version>1.7.1</version>
       <scope>test</scope>
-      <exclusions>
-        <!-- this is introducing a dependency on an old version of git-plugin
-        and so a few of the usual suspects plugins eddsa, trilead which we don't really want -->
-        <exclusion>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>${project.artifactId}</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
@@ -213,12 +205,6 @@
       <artifactId>testcontainers-gitserver</artifactId>
       <version>0.11.0</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -102,9 +102,9 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
       <optional>true</optional>
-      <!-- pipeline-model-definition plugins fail to start git plugin in PCT for 2.452.x line -->
+      <!-- pipeline-model-definition plugins fail to start git plugin in PCT for 2.479.x and 2.492.x line -->
       <!-- TODO: Remove once this workaround dependency downgrade is no longer required for PCT -->
-      <version>845.vffd7fa_f27555</version>
+      <version>832.va_66e270d2946</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,13 +132,11 @@
       <version>3.18.1</version>
       <scope>test</scope>
     </dependency>
-    <!--Credential Binding Plugin-->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
     </dependency>
     <dependency>
-      <!-- we contribute AbstractBuildParameters for Git if it's available -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>parameterized-trigger</artifactId>
       <optional>true</optional>
@@ -222,7 +220,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- JCasC compatibility -->
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>


### PR DESCRIPTION
## Upgrade matrix-project test dependency based on plugin BOM results

The 2.452.x plugin bill of materials has reached end of life so this workaround can be upgraded to a newer version of matrix-project plugin.

Retain the workaround because the pipeline model definition plugin fails to start on the 2.479.x and 2.492.x lines if the workaround is removed.

Also remove some unnecessary exclusions and low value comments from the pom file.

Reverts and modifies pull request:

* #1710

### Testing done

Confirmed that the plugin BOM tests pass with a pre-release

```
export PLUGINS=pipeline-model-definition
export TEST=InjectedTest
LINE=2.462.x bash local-test.sh
LINE=2.479.x bash local-test.sh
LINE=2.492.x bash local-test.sh
LINE=weekly  bash local-test.sh
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
