### PR TITLE
Handle NullPointerException on desc which may prevent Jenkins from st…

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -2172,7 +2172,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         Jenkins jenkins = Jenkins.get();
         DescriptorImpl desc = jenkins.getDescriptorByType(DescriptorImpl.class);
 
-        if (desc.getOldGitExe() != null) {
+        if (desc != null && desc.getOldGitExe() != null) {
             String exe = desc.getOldGitExe();
             String defaultGit = GitTool.getDefaultInstallation().getGitExe();
             if (exe.equals(defaultGit)) {


### PR DESCRIPTION
…arting upon plugin upgrade

In src/main/java/hudson/plugins/git/GitSCM.java at line 2175 there is call to desc.getOldGitExe(), however the object "desc" could be null causing a NullPointerException that in turns prevents Jenkins from starting. We have experienced this issue in our environment when updating to plugin version 5.7.0. If "desc" is null, the code block can be safely skipped.

### Testing done

This change was tested locally in a vanilla instance of Jenkins 2.462.2. This is a minimal change. There are no relevant issues posted about this specific issue on GitHub/Jira.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
