### PR TITLE
[JENKINS-75311] Add closing quote in checkout scmGit branches example

### DIFF
--- a/src/main/resources/jenkins/plugins/git/GitStep/help.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help.html
@@ -19,7 +19,7 @@
     <p>
     The <code>git</code> step is a simplified shorthand for a subset of the more powerful <code>checkout</code> step:
 <pre>
-checkout scmGit(branches: [[name: 'main]],
+checkout scmGit(branches: [[name: 'main']],
     userRemoteConfigs: [[url: 'https://git-server/user/repository.git']])
 </pre>
     </p>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help_ja.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help_ja.html
@@ -5,7 +5,7 @@
     <p>
         このステップは、一般的なSCMのステップである
 <pre>
-checkout scmGit(branches: [[name: 'main]],
+checkout scmGit(branches: [[name: 'main']],
     userRemoteConfigs: [[url: 'https://git-server/user/repository.git']])
 </pre>
     　　の短縮形です。　


### PR DESCRIPTION
[[JENKINS-75311]](https://issues.jenkins.io/browse/JENKINS-75311) Fix missing closing quote in checkout scmGit branches argument

Fixed the incorrect checkout scmGit syntax, changing `branches: [[name: 'main]]` to `branches: [[name: 'main']]`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
