### PR TITLE
Remove incorrect annotation on GitSCM.getBrowser()

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -350,7 +350,6 @@ public class GitSCM extends GitSCMBackwardCompatibility {
     }
 
     @Override
-    @Whitelisted
     public GitRepositoryBrowser getBrowser() {
         return browser;
     }


### PR DESCRIPTION
## Remove incorrect annotation on GitSCM.getBrowser()

Jesse Glick notes in [JENKINS-75288](https://issues.jenkins.io/browse/JENKINS-75288):

> adding `@Whitelisted` to a method already marked `@Override` is clearly a mistake—this would never have any effect.

I didn't realize that was a mistake when I added the annotation.  Let's remove the annotation so that the code does not mislead someone to think that this can be used from a Pipeline without changes to hudson.scm.SCM.getBrowser().

In a multibranch Pipeline, the default checkout assigns current values to the scm object, including scm.browser.  That value can't be read unless the hudson.scm.SCM.getBrowser() method is approved through script security.

### Testing done

None.  Already confirmed that the annotation has no effect, as noted in [JENKINS-75288](https://issues.jenkins.io/browse/JENKINS-75288).  Removing the annotation will continue to have no effect.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
