### PR TITLE
Remove useless bridge method injector annotation

### DIFF
--- a/src/main/java/hudson/plugins/git/util/GitUtils.java
+++ b/src/main/java/hudson/plugins/git/util/GitUtils.java
@@ -1,6 +1,5 @@
 package hudson.plugins.git.util;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -197,7 +196,6 @@ public class GitUtils implements Serializable {
      * @return filtered tip branches
      * @throws InterruptedException when interrupted
      */
-    @WithBridgeMethods(Collection.class)
     public List<Revision> filterTipBranches(final Collection<Revision> revisions) throws GitException, InterruptedException {
         // If we have 3 branches that we might want to build
         // ----A--.---.--- B


### PR DESCRIPTION
#695 effectively removed the bridge method from the generated bytecode by removing `bridge-method-injector` from the build, but it did not remove the `@WithBridgeMethod` annotation, turning it into dead code. Since the intervening 6 years have clearly demonstrated that the bridge method is not actually needed, remove the useless annotation rather than adding `bridge-method-injector` back to the build.

###  Testing done

Dumped the bytecode of the class with `javap` before and after this change and verified it was the same (i.e., no bridge method both before and after, as expected).

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
