### PR TITLE
Ignore ssh subdomain to match loosely with azure Devops

### DIFF
--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -208,8 +208,20 @@ public class GitStatus implements UnprotectedRootAction {
      * @return true if left-hand side loosely matches right-hand side
      */
     public static boolean looselyMatches(URIish lhs, URIish rhs) {
-        return Objects.equals(lhs.getHost(),rhs.getHost())
+        return looselyMatchHost(lhs, rhs)
             && Objects.equals(normalizePath(lhs.getPath()), normalizePath(rhs.getPath()));
+    }
+
+    /**
+     * Match hosts removing any "ssh." at the start of the subdomain.
+     * Some cloud providers prepend "ssh." in the host for ssh urls - while only allowing to send the https url (without ssh.) to the notify commit endpoint.
+     *
+     * Ignoring the "ssh" subdomain allows keeping loosely matching the url.
+     */
+    private static boolean looselyMatchHost(URIish lhs, URIish rhs) {
+        String lhsHost = StringUtils.removeStart(lhs.getHost(), "ssh.");
+        String rhsHost = StringUtils.removeStart(rhs.getHost(), "ssh.");
+        return Objects.equals(lhsHost, rhsHost);
     }
 
     private static String normalizePath(String path) {

--- a/src/test/java/hudson/plugins/git/GitStatusTest.java
+++ b/src/test/java/hudson/plugins/git/GitStatusTest.java
@@ -1,42 +1,31 @@
 package hudson.plugins.git;
 
-import hudson.model.Action;
-import hudson.model.Cause;
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
-import hudson.model.ParameterValue;
-import hudson.model.ParametersAction;
-import hudson.model.ParametersDefinitionProperty;
-import hudson.model.Run;
-import hudson.model.StringParameterDefinition;
-import hudson.model.View;
+import hudson.model.*;
 import hudson.tasks.BatchFile;
 import hudson.tasks.CommandInterpreter;
 import hudson.tasks.Shell;
 import hudson.triggers.SCMTrigger;
 import hudson.util.RunList;
-import java.io.File;
-import java.io.PrintWriter;
-import java.net.URISyntaxException;
-import java.util.*;
-import org.eclipse.jgit.transport.URIish;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.kohsuke.stapler.HttpResponses;
-import org.mockito.Mockito;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import static org.junit.Assert.*;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
-
-import jakarta.servlet.http.HttpServletRequest;
 import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class GitStatusTest extends AbstractGitProject {
 
@@ -606,4 +595,20 @@ public class GitStatusTest extends AbstractGitProject {
         assertNotNull(lastBuild);
         assertEquals(lastBuild.getNumber(), 1);
     }
+
+    @Test
+    public void testDoNotifyCommitWithSshSubDomain() throws Exception { /* No parameters */
+        this.repoURL = "ssh://git@ssh.github.com/jenkinsci/git-plugin.git";
+        FreeStyleProject project = setupNotifyProject();
+        final String differingUrl = "https://github.com/jenkinsci/git-plugin.git";
+        this.gitStatus.doNotifyCommit(requestWithNoParameter, differingUrl, branch, sha1, notifyCommitApiToken);
+        assertEquals("URL: " + differingUrl
+                + " SHA1: " + sha1
+                + " Branches: " + branch, this.gitStatus.toString());
+
+        r.waitUntilNoActivity();
+        FreeStyleBuild lastBuild = project.getLastBuild();
+        assertNotNull(lastBuild);
+    }
+
 }


### PR DESCRIPTION
In case of azure devops a ssh. is added in front of the subdomain. Hence the loose match for the host fails.
This is especially painful since azure devops jenkins plugin does not allow to send the ssh based url in the commit hook, but always sends the https based one.

I have updated the looselyMatches in GitStatus to ignore the prepended ssh. subdomain in the host. 

### Testing done

Added a unit test to check matching works and project is triggered.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

