### PR TITLE
Clarify scmGit parameter for checkout Pipeline step

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ Prior release notes are recorded in the git plugin repository link:https://githu
 
 == Pipelines
 
-The link:https://www.jenkins.io/doc/pipeline/steps/params/scmgit/[scmGit parameter] of the git plugin is used with the Pipeline SCM link:https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/[`checkout` step] to checkout git repositories into Pipeline workspaces.
+The link:https://www.jenkins.io/doc/pipeline/steps/params/scmgit/[`scmGit` parameter] of the git plugin is used with the Pipeline SCM link:https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/[`checkout` step] to checkout git repositories into Pipeline workspaces.
 The link:https://www.jenkins.io/redirect/pipeline-snippet-generator[Pipeline Syntax Snippet Generator] guides the user to select checkout options.
 
 The link:https://youtu.be/ai1kf4ihZUo[90 second video clip] below introduces the Pipeline Syntax Snippet Generator and shows how it is used to generate steps for the Jenkins Pipeline.

--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ Prior release notes are recorded in the git plugin repository link:https://githu
 
 == Pipelines
 
-The git plugin provides an SCM implementation to be used with the Pipeline SCM link:https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/[`checkout` step].
+The link:https://www.jenkins.io/doc/pipeline/steps/params/scmgit/[scmGit parameter] of the git plugin is used with the Pipeline SCM link:https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/[`checkout` step] to checkout git repositories into Pipeline workspaces.
 The link:https://www.jenkins.io/redirect/pipeline-snippet-generator[Pipeline Syntax Snippet Generator] guides the user to select checkout options.
 
 The link:https://youtu.be/ai1kf4ihZUo[90 second video clip] below introduces the Pipeline Syntax Snippet Generator and shows how it is used to generate steps for the Jenkins Pipeline.

--- a/src/main/resources/hudson/plugins/git/GitSCM/help-extensions.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help-extensions.html
@@ -7,25 +7,25 @@
   Extensions include:
     <ul>
       <li>
-        <strong>Clone extensions</strong> modify the git operations that retrieve remote changes into the agent workspace.
+        <strong><a href="https://plugins.jenkins.io/git/#plugin-content-clone-extensions">Clone extensions</a></strong> modify the git operations that retrieve remote changes into the agent workspace.
         The extensions can adjust the amount of history retrieved, how long the retrieval is allowed to run, and other retrieval details.
       </li>
       <li>
-        <strong>Checkout extensions</strong> modify the git operations that place files in the workspace from the git repository on the agent.
+        <strong><a href="https://plugins.jenkins.io/git/#plugin-content-checkout-extensions">Checkout extensions</a></strong> modify the git operations that place files in the workspace from the git repository on the agent.
         The extensions can adjust the maximum duration of the checkout operation, the use and behavior of git submodules, the location of the workspace on the disc, and more.
       </li>
       <li>
-        <strong>Changelog extensions</strong> adapt the source code difference calculations for different cases.
+        <strong><a href="https://plugins.jenkins.io/git/#plugin-content-changelog-extensions">Changelog extensions</a></strong> adapt the source code difference calculations for different cases.
       </li>
       <li>
-        <strong>Tagging extensions</strong> allow the plugin to apply tags in the current workspace.
+        <strong><a href="https://plugins.jenkins.io/git/#plugin-content-tagging-extensions">Tagging extensions</a></strong> allow the plugin to apply tags in the current workspace.
       </li>
       <li>
-        <strong>Build initiation extensions</strong> control the conditions that start a build.
+        <strong><a href="https://plugins.jenkins.io/git/#plugin-content-build-initiation-extensions">Build initiation extensions</a></strong> control the conditions that start a build.
         They can ignore notifications of a change or force a deeper evaluation of the commits when polling.
       </li>
       <li>
-        <strong>Merge extensions</strong> can optionally merge changes from other branches into the current branch of the agent workspace.
+        <strong><a href="https://plugins.jenkins.io/git/#plugin-content-merge-extensions">Merge extensions</a></strong> can optionally merge changes from other branches into the current branch of the agent workspace.
         They control the source branch for the merge and the options applied to the merge.
       </li>
     </ul>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help.html
@@ -5,7 +5,7 @@
   </p>
 
   <p>
-  The <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/">scmGit parameter</a> of the git plugin is used with the Pipeline SCM <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/"><code>checkout<code> step</a> to checkout git repositories into Pipeline workspaces.
+  The <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>scmGit</code> parameter</a> of the git plugin is used with the Pipeline SCM <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/"><code>checkout<code> step</a> to checkout git repositories into Pipeline workspaces.
   The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator"><strong>Pipeline Syntax Snippet Generator</strong></a> guides the user to select git plugin checkout options and provides online help for each of the options.
   </p>
 
@@ -23,7 +23,7 @@
     </p>
 
     <p>
-    The <code>checkout</code> step provides access to all the Pipeline capabilities provided by the git plugin:
+    The <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>scmGit</code> parameter</a> of the <code>checkout</code> step provides access to all the Pipeline capabilities provided by the git plugin:
 <pre>
 checkout scmGit(userRemoteConfigs: [
                     [ url: 'https://github.com/jenkinsci/git-plugin' ]
@@ -34,13 +34,13 @@ checkout scmGit(userRemoteConfigs: [
     <hr>
 
     <p>
-    <strong>NOTE:</strong> The <code>checkout</code> step is the <strong>preferred SCM checkout method</strong>.
+    <strong>NOTE:</strong> The <code>checkout</code> step with the <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>scmGit</code> parameter</a> is the <strong>preferred SCM checkout method</strong>.
     For simpler cases that do not require all the capabilities of the git plugin, the <code>git</code> step can also be used.
     </p>
     <p>Use the <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Snippet Generator</a> to generate a sample pipeline script for the checkout step.
     </p>
     <p>
-    The <code>checkout</code> step can be used in many cases where the <code>git</code> step cannot be used.
+    The <code>checkout</code> step with the <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>scmGit</code> parameter</a> can be used in many cases where the <code>git</code> step cannot be used.
     Refer to the <a href="https://plugins.jenkins.io/git/#plugin-content-extensions">git plugin documentation</a> for detailed descriptions of options available to the checkout step.
     For example, the <code>checkout</code> step supports:
     <ul>

--- a/src/main/resources/hudson/plugins/git/GitSCM/help.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help.html
@@ -96,7 +96,7 @@ checkout changelog: false,
          scm: scmGit(userRemoteConfigs: [
                          [ credentialsId: 'my-private-key-credential-id',
                            url: 'git@github.com:jenkinsci/git-client-plugin.git' ]
-                         ])
+                     ])
 </pre>
     </p>
 
@@ -111,7 +111,7 @@ checkout changelog: false,
 checkout changelog: false,
          scm: scmGit(userRemoteConfigs: [
                          [ url: 'https://github.com/jenkinsci/credentials-plugin' ]
-                         ])
+                     ])
 </pre>
     </p>
 
@@ -126,7 +126,7 @@ checkout changelog: false,
 checkout poll: false,
          scm: scmGit(userRemoteConfigs: [
                          [ url: 'git://git.kernel.org/pub/scm/git/git.git' ]
-                         ])
+                     ])
 </pre>
     </p>
 

--- a/src/main/resources/hudson/plugins/git/GitSCM/help.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help.html
@@ -61,7 +61,7 @@ checkout scmGit(userRemoteConfigs: [
 
     <hr>
 
-    <strong><a id="checkout-step-with-defaults">Example: Checkout step with defaults</a></strong>
+    <strong id="checkout-step-with-defaults">Example: Checkout step with defaults</strong>
     <p>
     Checkout from the git plugin source repository using https protocol, no credentials, and the master branch.
     </p><p>The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Snippet Generator</a> generates this example:
@@ -72,7 +72,7 @@ checkout scmGit(userRemoteConfigs: [
 </pre>
     </p>
 
-    <strong><a id="checkout-step-with-https-and-branch">Example: Checkout step with https and a specific branch</a></strong>
+    <strong id="checkout-step-with-https-and-branch">Example: Checkout step with https and a specific branch</strong>
     <p>
     Checkout from the Jenkins source repository using https protocol, no credentials, and a specific branch (stable-2.289).
     </p>
@@ -85,7 +85,7 @@ checkout scmGit(branches: [[name: 'stable-2.289']],
 </pre>
     </p>
 
-    <strong><a id="checkout-step-with-ssh-and-credential">Example: Checkout step with ssh and a private key credential</a></strong>
+    <strong id="checkout-step-with-ssh-and-credential">Example: Checkout step with ssh and a private key credential</strong>
     <p>
     Checkout from the git client plugin source repository using ssh protocol, private key credentials, and the master branch.
     The credential must be a private key credential if the remote git repository is accessed with the ssh protocol.
@@ -100,7 +100,7 @@ checkout changelog: false,
 </pre>
     </p>
 
-    <strong><a id="checkout-step-with-https-and-changelog">Example: Checkout step with https and changelog disabled</a></strong>
+    <strong id="checkout-step-with-https-and-changelog">Example: Checkout step with https and changelog disabled</strong>
     <p>
     Checkout from the Jenkins source repository using https protocol, no credentials, the master branch, and changelog calculation disabled.
     If changelog is <code>false</code>, then the changelog will not be computed for this job.
@@ -115,7 +115,7 @@ checkout changelog: false,
 </pre>
     </p>
 
-    <strong><a id="checkout-step-with-git-and-polling">Example: Checkout step with git protocol and polling disabled</a></strong>
+    <strong id="checkout-step-with-git-and-polling">Example: Checkout step with git protocol and polling disabled</strong>
     <p>
     Checkout from the command line git repository using git protocol, no credentials, the master branch, and no polling for changes.
     If poll is <code>false</code>, then the remote repository will not be polled for changes.
@@ -132,7 +132,7 @@ checkout poll: false,
 
     <hr>
 
-    <strong><a id="argument-descriptions">Argument Descriptions</a></strong>
+    <strong id="argument-descriptions">Argument Descriptions</strong>
     <!-- Automatically generated argument docs inserted here -->
     <!-- See https://jenkins.io/doc/pipeline/steps/workflow-scm-step/ -->
     <!-- See also https://jenkins-url/pipeline-syntax/html#argument-descriptions -->

--- a/src/main/resources/hudson/plugins/git/GitSCM/help.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help.html
@@ -5,7 +5,7 @@
   </p>
 
   <p>
-  The git plugin provides an SCM implementation to be used with the Pipeline SCM <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step"><code>checkout</code></a> step.
+  The <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/">scmGit parameter</a> of the git plugin is used with the Pipeline SCM <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/"><code>checkout<code> step</a> to checkout git repositories into Pipeline workspaces.
   The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator"><strong>Pipeline Syntax Snippet Generator</strong></a> guides the user to select git plugin checkout options and provides online help for each of the options.
   </p>
 

--- a/src/main/resources/hudson/plugins/git/GitSCM/help.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help.html
@@ -109,9 +109,9 @@ checkout changelog: false,
     </p><p>The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
 checkout changelog: false,
-         scmGit(userRemoteConfigs: [
-                    [ url: 'https://github.com/jenkinsci/credentials-plugin' ]
-                ])
+         scm: scmGit(userRemoteConfigs: [
+                         [ url: 'https://github.com/jenkinsci/credentials-plugin' ]
+                         ])
 </pre>
     </p>
 
@@ -124,9 +124,9 @@ checkout changelog: false,
     </p><p>The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Snippet Generator</a> generates this example:
 <pre>
 checkout poll: false,
-         scmGit(userRemoteConfigs: [
-                    [ url: 'git://git.kernel.org/pub/scm/git/git.git' ]
-                ])
+         scm: scmGit(userRemoteConfigs: [
+                         [ url: 'git://git.kernel.org/pub/scm/git/git.git' ]
+                         ])
 </pre>
     </p>
 

--- a/src/main/resources/hudson/plugins/git/extensions/impl/GitLFSPull/help.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/GitLFSPull/help.html
@@ -1,4 +1,4 @@
 <div>
-	Enable <a href="https://git-lfs.github.com/">git large file support</a> for the workspace by pulling large files after the checkout completes.
+	Enable <a href="https://git-lfs.com/">git large file support</a> for the workspace by pulling large files after the checkout completes.
 	Requires that the controller and each agent performing an LFS checkout have installed `git lfs`.
 </div>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help-branch.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help-branch.html
@@ -8,6 +8,6 @@
     Remote branch names like 'origin/master' and 'origin/develop' are <strong>not supported</strong> as the branch argument.
     Tag names are <strong>not supported</strong> as the branch argument.
     SHA-1 hashes are <strong>not supported</strong> as the branch argument.
-    Remote branch names, tag names, and SHA-1 hashes are supported by the general purpose <code>checkout</code> step.
+    Remote branch names, tag names, and SHA-1 hashes are supported by the general purpose <code>checkout</code> step with the <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>scmGit</code> parameter</a>.
     </p>
 </div>

--- a/src/main/resources/jenkins/plugins/git/GitStep/help.html
+++ b/src/main/resources/jenkins/plugins/git/GitStep/help.html
@@ -4,7 +4,7 @@
     </p>
     <p>
     Use the <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Syntax Snippet Generator</a> to generate a sample pipeline script for the git step.
-    More advanced checkout operations require the <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>checkout</code> step</a> rather than the <code>git</code> step.
+    More advanced checkout operations require the <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>checkout</code> step with the <code>scmGit</code> parameter</a> rather than the <code>git</code> step.
     Examples of the <code>git</code> step include:
     <ul>
       <li><a href="#git-step-with-defaults">Git step with defaults</a></li>
@@ -17,7 +17,7 @@
     </p>
 
     <p>
-    The <code>git</code> step is a simplified shorthand for a subset of the more powerful <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>checkout</code> step</a>:
+    The <code>git</code> step is a simplified shorthand for a subset of the more powerful <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>checkout</code> step with the <code>scmGit</code> parameter</a>:
 <pre>
 checkout scmGit(branches: [[name: 'main']],
     userRemoteConfigs: [[url: 'https://git-server/user/repository.git']])
@@ -27,14 +27,14 @@ checkout scmGit(branches: [[name: 'main']],
     <hr>
 
     <p>
-    <strong>NOTE:</strong> The <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>checkout</code> step</a> is the <strong>preferred SCM checkout method</strong>.
+    <strong>NOTE:</strong> The <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>checkout</code> step with the scmGit parameter</a> is the <strong>preferred SCM checkout method</strong>.
     It provides significantly more functionality than the <code>git</code> step.
     </p>
     <p>Use the <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Syntax Snippet Generator</a> to generate a sample pipeline script for the checkout step.
     </p>
     <p>
-    The <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>checkout</code> step</a> can be used in many cases where the <code>git</code> step cannot be used.
-    Refer to the <a href="https://plugins.jenkins.io/git/#plugin-content-extensions">git plugin documentation</a> for detailed descriptions of options available to the <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>checkout</code> step</a>.
+    The <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>checkout</code> step with the scmGit parameter</a> can be used in many cases where the <code>git</code> step cannot be used.
+    Refer to the <a href="https://plugins.jenkins.io/git/#plugin-content-extensions">git plugin documentation</a> for detailed descriptions of options available to the <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>scmGit</code> parameter of the <code>checkout</code> step</a>.
     For example, the <code>git</code> step does <strong>not</strong> support:
     <ul>
       <li>SHA-1 checkout</li>
@@ -76,7 +76,7 @@ git 'https://github.com/jenkinsci/git-plugin.git'
       <li>Tag names are <strong>not supported</strong> as the branch argument</li>
     </ul>
     <p>
-    Remote branch names, SHA-1 hashes, and tag names <strong>are supported</strong> by the general purpose <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>checkout</code> step</a>.
+    Remote branch names, SHA-1 hashes, and tag names <strong>are supported</strong> by the general purpose <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>scmGit</code> parameter of the <code>checkout</code> step</a>.
     </p>
     <p>The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator">Pipeline Syntax Snippet Generator</a> generates this example:
 <pre>


### PR DESCRIPTION
## Clarify scmGit parameter for checkout Pipeline step

The documentation for the `scmGit` parameter to the `checkout` step is not as immediately accessible from the checkout page as I would like.  Readers have difficulty finding that documentation in the many other documentation links within the `checkout` step.

Add more links to the `scmGit` parameter documentation in hopes that readers will be more likely to find it.

Change also includes other minor documentation improvements like:

- Link from extensions help to plugins help page
- Use most recent Git LFS project link
- Place id on the strong tag instead of a separate a tag
- Fix syntax error in checkout example
- More consistent spacing in examples

### Testing done

Reviewed the formatting and content of the modified documentation pages from within a running Jenkins 2.511.

Confirmed that the newly added hyperlinks reach the correct location in the internal Pipeline steps reference page at /pipeline-syntax/html/

Confirmed that the Git LFS link works as expected.

Confirmed that the modified examples of the checkout step run as expected in Jenkins 2.511 with latest Pipeline plugins.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
