### PR TITLE
Include dev.azure.com in documentation and test data

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -560,7 +560,7 @@ Options include:
 URL or name::
 
   Root URL serving this Azure DevOps repository.
-  For example, `\https://example.visualstudio.com/_git/my-project.`
+  For example, `\https://dev.azure.com/example/_git/my-project`
 
 [bitbucketweb-repository-browser]
 ==== bitbucketweb

--- a/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
+++ b/src/test/java/hudson/plugins/git/CredentialsUserRemoteConfigTest.java
@@ -227,6 +227,7 @@ public class CredentialsUserRemoteConfigTest {
             "[$class: 'RhodeCode', repoUrl: 'https://code.rhodecode.com/rhodecode-enterprise-ce']",
             "[$class: 'Stash', repoUrl: 'https://markewaite@bitbucket.org/markewaite/git-plugin']",
             "[$class: 'TFS2013GitRepositoryBrowser', repoUrl: 'https://markwaite.visualstudio.com/DefaultCollection/git-plugin/_git/git-plugin']",
+            "[$class: 'TFS2013GitRepositoryBrowser', repoUrl: 'https://dev.azure.com/MarkEWaite/git-plugin/_git/git-plugin']",
             "[$class: 'ViewGitWeb', repoUrl: 'https://git.ti.com/gitweb', projectName: 'viewgitweb-project-name-value']",
             // Assembla now requires login to access their URLs
             // "assembla('https://app.assembla.com/spaces/git-plugin/git/source')",
@@ -242,6 +243,7 @@ public class CredentialsUserRemoteConfigTest {
             "gogs('https://try.gogs.io/MarkEWaite/git-plugin')", // Should this be gogsGit?
             "kiln('https://kiln.example.com/MarkEWaite/git-plugin')",
             "teamFoundation('https://markwaite.visualstudio.com/DefaultCollection/git-plugin/_git/git-plugin')",
+            "teamFoundation('https://dev.azure.com/MarkEWaite/git-plugin/_git/git-plugin')",
             "phabricator(repo: 'source/tool-spacemedia', repoUrl: 'https://phabricator.wikimedia.org/source/tool-spacemedia/')",
             "redmine('https://www.redmine.org/projects/redmine/repository')",
             "rhodeCode('https://code.rhodecode.com/rhodecode-enterprise-ce')",

--- a/src/test/java/jenkins/plugins/git/traits/MultibranchProjectTraitsTest.java
+++ b/src/test/java/jenkins/plugins/git/traits/MultibranchProjectTraitsTest.java
@@ -106,6 +106,7 @@ public class MultibranchProjectTraitsTest {
                 "    browser: gogs('https://try.gogs.io/MarkEWaite/git-plugin'),\n", // Should this be gogsGit?
                 "    browser: kiln('https://kiln.example.com/MarkEWaite/git-plugin'),\n",
                 "    browser: teamFoundation('https://markwaite.visualstudio.com/DefaultCollection/git-plugin/_git/git-plugin'),\n",
+                "    browser: teamFoundation('https://dev.azure.com/MarkEWaite/_git/git-plugin'),\n",
                 "    browser: phabricator(repo: 'source/tool-spacemedia', repoUrl: 'https://phabricator.wikimedia.org/source/tool-spacemedia/'),\n",
                 "    browser: redmine('https://www.redmine.org/projects/redmine/repository'),\n",
                 "    browser: rhodeCode('https://code.rhodecode.com/rhodecode-enterprise-ce'),\n",
@@ -136,6 +137,7 @@ public class MultibranchProjectTraitsTest {
                 "    browser: [$class: 'RedmineWeb', repoUrl: 'https://www.redmine.org/projects/redmine/repository'],\n",
                 "    browser: [$class: 'Stash', repoUrl: 'https://markewaite@bitbucket.org/markewaite/git-plugin'],\n",
                 "    browser: [$class: 'TFS2013GitRepositoryBrowser', repoUrl: 'https://markwaite.visualstudio.com/DefaultCollection/git-plugin/_git/git-plugin'],\n",
+                "    browser: [$class: 'TFS2013GitRepositoryBrowser', repoUrl: 'https://dev.azure.com/MarkEWaite/_git/git-plugin'],\n",
                 "    browser: [$class: 'RhodeCode', repoUrl: 'https://code.rhodecode.com/rhodecode-enterprise-ce'],\n",
                 "    browser: [$class: 'ViewGitWeb', repoUrl: 'https://git.ti.com/gitweb', projectName: 'viewgitweb-project-name-value'],\n", // Not likely a viewgit site, but reasonable approximation
         };


### PR DESCRIPTION
## Include dev.azure.com in documentation and test data

Microsoft Azure DevOps has transitioned its base URLs from visualstudio.com to dev.azure.com.  The transition is performed by organization administrators from their organization settings.  The plugin needs to test samples with the old base URL and the new base URL.

Added configuration test cases for dev.azure.com based on my transition of the MarkEWaite organization from visualstudio.com to dev.azure.com.

### Testing done

* Confirmed that azure.dev.com was being used in the randomly selected configuration changes in the tests.  Ran modified tests 36 times and saw that dev.azure.com appeared in 7 of 36 runs.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
