### PR TITLE
[JENKINS-75854] Do not fetch tags in multibranch Pipeline if "Discover tags" is not enabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.17</version>
+    <version>5.18</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4948.vcf1d17350668</version>
+        <version>4969.v6ffa_18d90c9f</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.21.2</version>
+      <version>1.21.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4924.v6b_eb_a_79a_d9d0</version>
+        <version>4948.vcf1d17350668</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.21.1</version>
+      <version>1.21.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>4.0.2</version>
+      <version>4.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -400,6 +400,9 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             client.setRemoteUrl(remoteName, getRemote());
             listener.getLogger().println((prune ? "Fetching & pruning " : "Fetching ") + remoteName + "...");
             FetchCommand fetch = client.fetch_();
+            if (!context.wantTags()) {
+                fetch.tags(false);
+            }
             fetch = fetch.prune(prune);
 
             URIish remoteURI = null;

--- a/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/AbstractGitSCMSource.java
@@ -400,9 +400,7 @@ public abstract class AbstractGitSCMSource extends SCMSource {
             client.setRemoteUrl(remoteName, getRemote());
             listener.getLogger().println((prune ? "Fetching & pruning " : "Fetching ") + remoteName + "...");
             FetchCommand fetch = client.fetch_();
-            if (!context.wantTags()) {
-                fetch.tags(false);
-            }
+            fetch.tags(context.wantTags());
             fetch = fetch.prune(prune);
 
             URIish remoteURI = null;

--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -129,6 +129,24 @@ public class GitSCMSource extends AbstractGitSCMSource {
     private String credentialsId;
 
     static final String IGNORE_TAG_DISCOVERY_TRAIT_PROPERTY = GitSCMSource.class.getName() + ".IGNORE_TAG_DISCOVERY_TRAIT";
+
+    /**
+     * Ignore the tag discovery trait when fetching multibranch Pipelines.
+     *
+     * Git plugin versions 5.7.0 and earlier will always fetch tags
+     * when scanning a multibranch Pipeline, whether or not the tag
+     * discovery trait had been added. Releases after git plugin 5.7.0
+     * honor the tag discovery trait when scanning a multibranch
+     * Pipeline. If the tag discovery trait has been added, then tags
+     * are fetched. If the tag discovery trait has not been added,
+     * then tags are not fetched.
+     *
+     * If honoring the tag discovery trait causes problems for a user,
+     * a Java property can be set during Jenkins startup to restore
+     * the previous (buggy) behavior.
+     *
+     * Refer to the plugin documentation for more details.
+     */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL")
     public static /* not final */ boolean IGNORE_TAG_DISCOVERY_TRAIT =
             SystemProperties.getBoolean(IGNORE_TAG_DISCOVERY_TRAIT_PROPERTY);
@@ -300,7 +318,6 @@ public class GitSCMSource extends AbstractGitSCMSource {
     public boolean isIgnoreOnPushNotifications() {
         return SCMTrait.find(traits, IgnoreOnPushNotificationTrait.class) != null;
     }
-
 
     // For Stapler only
     @Restricted(DoNotUse.class)

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -454,13 +454,6 @@ public class AbstractGitSCMSourceTest {
         rev = source.fetch(v2Hash.substring(0, 10), listener, null);
         assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
         assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(v2Hash));
-
-        String v2Tag = "refs/tags/v2";
-        listener.getLogger().printf("%n=== fetch('%s') ===%n%n", v2Tag);
-        rev = source.fetch(v2Tag, listener, null);
-        assertThat(rev, instanceOf(AbstractGitSCMSource.SCMRevisionImpl.class));
-        assertThat(((AbstractGitSCMSource.SCMRevisionImpl) rev).getHash(), is(v2Hash));
-
     }
 
     public static abstract class ActionableSCMSourceOwner extends Actionable implements SCMSourceOwner {

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -1147,13 +1147,17 @@ public class AbstractGitSCMSourceTest {
         sampleRepo.write("file", "modified3");
         sampleRepo.git("commit", "--all", "--message=dev3");
         System.setProperty(Git.class.getName() + ".mockClient", MockGitClientForTags.class.getName());
-        GitSCMSource source = new GitSCMSource(sampleRepo.toString());
-        TaskListener listener = StreamTaskListener.fromStderr();
-        source.fetch(listener);
-        assertFalse(tagsFetched);
-        source.setTraits(Collections.singletonList(new TagDiscoveryTrait()));
-        source.fetch(listener);
-        assertTrue(tagsFetched);
+        try {
+            GitSCMSource source = new GitSCMSource(sampleRepo.toString());
+            TaskListener listener = StreamTaskListener.fromStderr();
+            source.fetch(listener);
+            assertFalse(tagsFetched);
+            source.setTraits(Collections.singletonList(new TagDiscoveryTrait()));
+            source.fetch(listener);
+            assertTrue(tagsFetched);
+        } finally {
+            System.clearProperty(Git.class.getName() + ".mockClient");
+        }
     }
 
     static boolean tagsFetched;

--- a/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
+++ b/src/test/java/jenkins/plugins/git/AbstractGitSCMSourceTest.java
@@ -81,6 +81,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -1138,6 +1139,97 @@ public class AbstractGitSCMSourceTest {
             sharedSampleRepo = null;
         }
     }
+
+    @Test
+    public void indexingDoNotFetchTagsWithoutTagDiscoveryTrait() throws Exception {
+        assumeTrue("Test class max time " + MAX_SECONDS_FOR_THESE_TESTS + " exceeded", isTimeAvailable());
+        sampleRepo.init();
+        sampleRepo.git("checkout", "-b", "dev");
+        sampleRepo.write("file", "modified");
+        sampleRepo.git("commit", "--all", "--message=dev");
+        sampleRepo.git("tag", "lightweight");
+        sampleRepo.write("file", "modified2");
+        sampleRepo.git("commit", "--all", "--message=dev2");
+        sampleRepo.git("tag", "-a", "annotated", "-m", "annotated");
+        sampleRepo.write("file", "modified3");
+        sampleRepo.git("commit", "--all", "--message=dev3");
+        System.setProperty(Git.class.getName() + ".mockClient", MockGitClientForTags.class.getName());
+        GitSCMSource source = new GitSCMSource(sampleRepo.toString());
+        TaskListener listener = StreamTaskListener.fromStderr();
+        source.fetch(listener);
+        assertFalse(tagsFetched);
+        source.setTraits(Collections.singletonList(new TagDiscoveryTrait()));
+        source.fetch(listener);
+        assertTrue(tagsFetched);
+    }
+
+    static boolean tagsFetched;
+
+    public static class MockGitClientForTags extends TestJGitAPIImpl {
+
+        public MockGitClientForTags(String exe, EnvVars env, File workspace, TaskListener listener) {
+            super(workspace, listener);
+        }
+
+        @Override
+        public FetchCommand fetch_() {
+            // resetting to default behaviour, which is tags are fetched
+            tagsFetched = true;
+            final FetchCommand fetchCommand = super.fetch_();
+            return new FetchCommand() {
+                @Override
+                public FetchCommand from(URIish urIish, List<RefSpec> list) {
+                    fetchCommand.from(urIish, list);
+                    return this;
+                }
+
+                @Override
+                @Deprecated
+                public FetchCommand prune() {
+                    fetchCommand.prune(true);
+                    return this;
+                }
+
+                @Override
+                public FetchCommand prune(boolean b) {
+                    fetchCommand.prune(b);
+                    return this;
+                }
+
+                @Override
+                public FetchCommand shallow(boolean b) {
+                    fetchCommand.shallow(b);
+                    return this;
+                }
+
+                @Override
+                public FetchCommand timeout(Integer integer) {
+                    fetchCommand.timeout(integer);
+                    return this;
+                }
+
+                @Override
+                public FetchCommand tags(boolean b) {
+                    fetchCommand.tags(b);
+                    // record the value being set for assertions later
+                    tagsFetched = b;
+                    return this;
+                }
+
+                @Override
+                public FetchCommand depth(Integer integer) {
+                    fetchCommand.depth(integer);
+                    return this;
+                }
+
+                @Override
+                public void execute() throws GitException, InterruptedException {
+                    fetchCommand.execute();
+                }
+            };
+        }
+    }
+
     //Ugly but MockGitClient needs to be static and no good way to pass it on
     static GitSampleRepoRule sharedSampleRepo;
 


### PR DESCRIPTION
See [JENKINS-75854](https://issues.jenkins.io/browse/JENKINS-75854)

If the "Discover Tags" trait is not set, there is no need to fetch tags on branch indexing.

<!-- Please describe your pull request here. -->

### Testing done

* Create a multibranch job using the Git branch source
* Make sure the "Discover Tags" trait is not added
* Check that the git command that runs on branch indexing does **not includes** the `--tags` modifier
* Now add the "Discover Tags" trait and trigger branch indexing
* Check that the git command that runs on branch indexing **includes** the `--tags` modifier

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
