### PR TITLE
Contextualize credentials used by `GitSCMFileSystem` when possible

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -381,6 +381,9 @@ public class GitSCMFileSystem extends SCMFileSystem {
                                 GitClient.CREDENTIALS_MATCHER
                             )
                         );
+                    if (_build != null && credential != null && credential.forRun(_build) instanceof StandardCredentials standardCredential) {
+                        credential = standardCredential;
+                    }
                     client.addDefaultCredentials(credential);
                     CredentialsProvider.track(owner, credential);
                 }


### PR DESCRIPTION
After https://github.com/jenkinsci/github-branch-source-plugin/pull/822, credential lookups for `GitHubAppCredentials` configured to use an inference-based repository access strategy fail when using `GitSCMFileSystem`. Normally `GitHubSCMFileSystem` is used instead of  `GitSCMFileSystem`, and that works fine, but `GitSCMFileSystem` gets used in cases where you have to configure a `GitSCM` directly, since there is no GitHub-specific SCM implementation.

For example, you can run into this problem if you use "Pipeline script from SCM" to configure a Pipeline, enable lightweight checkout, and use `GitHubAppCredentials` for the `GitSCM` credentials.

For more context, credential lookups for `GitHubAppCredentials` were expected to fall into one of two cases:
1. Credentials used by Jenkins or a plugin to contact GitHub in a way that the secrets will not be exposed directly to Jenkins users are expected to use [`Connector.lookupScanCredentials`](https://github.com/jenkinsci/github-branch-source-plugin/blob/42f74f7f450068521e3416e73c369098f9fc2918/src/main/java/org/jenkinsci/plugins/github_branch_source/Connector.java#L293). This ensures proper owner inference and bypasses repository inference because the credential usage context is trusted. Plugins that need to do this kind of lookup may require changes like https://github.com/jenkinsci/github-checks-plugin/pull/398 (but others were already using `Connector.lookupScanCredentials`).
2. Credentials whose secrets may be exposed directly to Jenkins users via things like the `withCredentials` step. Plugins that need to do this kind of lookup need to use `CredentialsProvider.findCredentialById` and pass an appropriate `Run` context for proper owner and repository inference, like is already done in this plugin in `GitSCM.lookupScanCredentials`.

`GitSCMFileSystem` is a bit of an awkward spot. Conceptually, it falls under case 1 and should use `Connector.lookupScanCredentials` to contextualize `GitHubAppCredentials` for a trusted context, but we can't add a `github-branch-source` dependency here or else we'll have circular dependencies. This leaves us with two options:
* Some kind of API change upstream:
    * Perhaps a method in  in `credentials` that is comparable to `Credentials.forRun` that allows contextualization of generic credential lookups, and avoids the need to use `Connector.lookupScanCredentials` directly when working with `GitHubAppCredentials`
    * Some way to (optionally?) use `GitHubSCMFileSystem` with `GitSCM`, or a GitHub-specific SCM implementation or similar that bypasses `GitSCMFileSystem` in this case
 * Something like the change in this PR,  where run-based contextualization is used to allow _some_ owner inference strategies to work with `GitSCMFileSystem`, although repository inference strategies would still not be supported

CC @jeromepochat 

### Testing done

See new automated test.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
