### PR TITLE
Remove upper bounds from `gitVersionAtLeast`

### DIFF
--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -193,13 +193,13 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         final int gitMajor = Integer.parseInt(fields[0]);
         final int gitMinor = Integer.parseInt(fields[1]);
         final int gitPatch = Integer.parseInt(fields[2]);
-        if (gitMajor < 1 || gitMajor > 3) {
+        if (gitMajor < 1) {
             LOGGER.log(Level.WARNING, "Unexpected git major version " + gitMajor + " parsed from '" + versionOutput + "', field:'" + fields[0] + "'");
         }
-        if (gitMinor < 0 || gitMinor > 50) {
+        if (gitMinor < 0) {
             LOGGER.log(Level.WARNING, "Unexpected git minor version " + gitMinor + " parsed from '" + versionOutput + "', field:'" + fields[1] + "'");
         }
-        if (gitPatch < 0 || gitPatch > 20) {
+        if (gitPatch < 0) {
             LOGGER.log(Level.WARNING, "Unexpected git patch version " + gitPatch + " parsed from '" + versionOutput + "', field:'" + fields[2] + "'");
         }
 


### PR DESCRIPTION
While testing https://github.com/jenkinsci/workflow-cps-plugin/pull/1080 with Git 2.51.0 (built from sources locally) I noticed a warning also seen in CI

```
$ git --version
   3.520 [id=57]	WARNING	j.plugins.git.GitSampleRepoRule#gitVersionAtLeast: Unexpected git minor version 51 parsed from 'git version 2.51.0', field:'51'
```

This seems senseless. What is OK about 49 but not OK about 51?

Originally introduced in 71fe2d70e62203dcd4a2242dacbd6624308245a6 and then relaxed somewhat in dff8d142f0ff650a19d19de028fc758c90eabf57 (#690).
