### PR TITLE
Better symbol for `GitSCMSource`

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMSource.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMSource.java
@@ -435,7 +435,7 @@ public class GitSCMSource extends AbstractGitSCMSource {
         return traits;
     }
 
-    @Symbol("git")
+    @Symbol({"gitSource", "git"})
     @Extension
     public static class DescriptorImpl extends SCMSourceDescriptor {
 


### PR DESCRIPTION
d1ee85b1f5996bf38165898ddc818d478bd27d7f introduced a symbol but it is unusable from Pipeline script, as noted in a similar case in #1373.