### PR TITLE
Fix formatting of scmGit Pipeline help

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitSCM/help.html
+++ b/src/main/resources/hudson/plugins/git/GitSCM/help.html
@@ -5,7 +5,7 @@
   </p>
 
   <p>
-  The <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>scmGit</code> parameter</a> of the git plugin is used with the Pipeline SCM <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/"><code>checkout<code> step</a> to checkout git repositories into Pipeline workspaces.
+  The <a href="https://www.jenkins.io/doc/pipeline/steps/params/scmgit/"><code>scmGit</code> parameter</a> of the git plugin is used with the Pipeline SCM <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/"><code>checkout</code> step</a> to checkout git repositories into Pipeline workspaces.
   The <a href="https://www.jenkins.io/redirect/pipeline-snippet-generator"><strong>Pipeline Syntax Snippet Generator</strong></a> guides the user to select git plugin checkout options and provides online help for each of the options.
   </p>
 


### PR DESCRIPTION
## Fix formatting of scmGit Pipeline help

Was displaying red text for most of the page at

https://www.jenkins.io/doc/pipeline/steps/params/scmgit/

The `<code>` tag that opened on the checkout keyword was not closed.  Close that tag so that the page renders correctly in the [Pipeline steps reference](https://www.jenkins.io/doc/pipeline/steps/params/scmgit/) on the Jenkins documentation site.

The Pipeline steps reference inside the running Jenkins controller was not affected.  It seems to ignore the `<code>` tags.

### Testing done

Code review confirms that the closing and opening tags are matched.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
