### PR TITLE
Test with Java 25 and Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,6 @@ buildPlugin(
   // we use Docker for containerized tests
   useContainerAgent: false,
   configurations: [
-    [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 25],
+    [platform: 'windows', jdk: 21],
 ])


### PR DESCRIPTION
## Test with Java 25 and Java 21

Java 25 released in September 2025 and the Jenkins project wants to support it soon after its release.  This pull request updates the plugin to compile and test with Java 25 and Java 21.  The Java byte code continues to be Java 17 byte code from both those compilers due to the configuration of the plugin pom.  That is intentional because we continue to support Java 17 but we don't need to compile and test with Java 17.  We've seen no issues that were specific to Java 17.  

### Testing done

* Confirmed that tests are successful with Java 25

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
