### PR TITLE
Fix BuildData cleanup script in documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1661,7 +1661,7 @@ for (job in allItems) {
         hudson.plugins.git.Revision r = action.getLastBuiltRevision();
         if (r != null) {
           for (branch in r.getBranches()) {
-            action.buildsByBranchName.put(fixNull(branch.getName()), action.lastBuild)
+            action.buildsByBranchName.put(fixNull((String) branch.getName()), action.lastBuild)
           }
         }
         build.actions.remove(action)
@@ -1680,7 +1680,7 @@ for (job in allItems) {
             hudson.plugins.git.Revision r = action.getLastBuiltRevision();
             if (r != null) {
               for (branch in r.getBranches()) {
-                action.buildsByBranchName.put(fixNull(branch.getName()), action.lastBuild)
+                action.buildsByBranchName.put(fixNull((String) branch.getName()), action.lastBuild)
               }
             }
             run.actions.remove(action)


### PR DESCRIPTION
The BuildData cleanup script might create `null` keys. This was fixed in the [plugin itself](https://github.com/jenkinsci/git-plugin/commit/494e5b8f353fb2012211b8939d7582b0f2c61e25), but the cleanup script might re-introduce `null` keys.