### PR TITLE
JENKINS-75316: Make Git build summary clickable links #3874

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -2007,13 +2007,16 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         BuildData base = getBuildData(build);
         ScmName sn = getExtensions().get(ScmName.class);
         String scmName = sn == null ? null : sn.getName();
-        if (base==null)
-            return new BuildData(scmName, getUserRemoteConfigs());
-        else {
-           BuildData buildData = base.clone();
+        BuildData buildData;
+        if (base==null) {
+            buildData = new BuildData(scmName, getUserRemoteConfigs());
+        } else {
+           buildData = base.clone();
            buildData.setScmName(scmName);
            return buildData;
         }
+        buildData.setBrowser(getBrowser());
+        return buildData;
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/git/browser/GitRepositoryBrowser.java
@@ -45,7 +45,7 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
         return url;
     }
 
-    public final URL getUrl() throws IOException {
+    public URL getUrl() throws IOException {
         String u = url;
         StaplerRequest2 req = Stapler.getCurrentRequest2();
         if (req != null) {
@@ -104,6 +104,17 @@ public abstract class GitRepositoryBrowser extends RepositoryBrowser<GitChangeSe
         if (commitId != null && !commitId.isBlank()) {
             return getChangeSetLink(new CommitChangeSet(commitId));
         }
+        return null;
+    }
+
+    /**
+     * Determines the link to the given ref.
+     *
+     * @param ref The specific ref to link to
+     * @return null if the browser doesn't have any meaningful URL for a ref
+     */
+    @CheckForNull
+    public URL getRefLink(String ref) throws IOException {
         return null;
     }
 

--- a/src/main/java/hudson/plugins/git/browser/GithubWeb.java
+++ b/src/main/java/hudson/plugins/git/browser/GithubWeb.java
@@ -37,6 +37,17 @@ public class GithubWeb extends GitRepositoryBrowser {
     }
 
     /**
+     * Determines the link to the given ref.
+     * @param ref The specific ref to link to
+     * @return null if the browser doesn't have any meaningful URL for a ref
+     */
+    @Override
+    public URL getRefLink(String ref) throws IOException {
+        URL url = getUrl();
+        return new URL(url, url.getPath() + "tree/" + ref);
+    }
+
+    /**
      * Creates a link to the file diff.
      * http://[GitHib URL]/commit/573670a3bb1f3b939e87f1dee3e99b6bfe281fcb#diff-N
      *

--- a/src/main/resources/hudson/plugins/git/util/BuildData/summary.jelly
+++ b/src/main/resources/hudson/plugins/git/util/BuildData/summary.jelly
@@ -4,26 +4,48 @@
 	xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 	<t:summary icon="symbol-git-logo plugin-git">
 
-	<strong>${%Revision}</strong>: ${it.lastBuiltRevision.sha1.name()}
+    <j:set var="browser" value="${it.browser}"/>
+    <j:set var="revisionLink" value="${it.getCommitUrl(it.lastBuiltRevision.sha1.name())}"/>
+    <j:choose>
+        <j:when test="${revisionLink!=null}">
+            <strong>${%Revision}</strong>: <a href="${revisionLink}">${it.lastBuiltRevision.sha1.name()}</a>
+        </j:when>
+        <j:otherwise>
+            <strong>${%Revision}</strong>: ${it.lastBuiltRevision.sha1.name()}
+        </j:otherwise>
+    </j:choose>
+
 	<j:if test="${!empty(it.scmName)}"><br/><strong>${%SCM}</strong>: ${it.scmName}</j:if>
 	<j:if test="${!empty(it.remoteUrls)}">
 		<j:forEach var="remoteUrl" items="${it.remoteUrls}">
-			<j:if test="${remoteUrl.startsWith('http')}">
-				<br/><strong>${%Repository}</strong>: <a href="${remoteUrl}">${remoteUrl}</a>
-			</j:if>
-			<j:if test="${!remoteUrl.startsWith('http')}">
-				<br/><strong>${%Repository}</strong>: ${remoteUrl}
-			</j:if>
+            <j:set var="repoLink" value="${it.repositoryUrl}"/>
+            <j:choose>
+                <j:when test="${repoLink!=null}">
+                    <br/><strong>${%Repository}</strong>: <a href="${repoLink}">${remoteUrl}</a>
+                </j:when>
+                <j:when test="${remoteUrl.startsWith('http')}">
+                    <br/><strong>${%Repository}</strong>: <a href="${remoteUrl}">${remoteUrl}</a>
+                </j:when>
+                <j:otherwise>
+                    <br/><strong>${%Repository}</strong>: ${remoteUrl}
+                </j:otherwise>
+            </j:choose>
 		</j:forEach>
 	</j:if>
         <ul>
         <j:forEach var="branch" items="${it.lastBuiltRevision.branches}">
           <j:if test="${branch!=''}">
-            <li>${branch.name}</li>
+            <j:set var="branchLink" value="${it.getRefUrl(branch.name)}"/>
+                <j:choose>
+                    <j:when test="${branchLink!=null}">
+                        <li><a href="${branchLink}">${branch.name}</a></li>
+                    </j:when>
+                    <j:otherwise>
+                        <li>${branch.name}</li>
+                    </j:otherwise>
+                </j:choose>
           </j:if>
         </j:forEach>
         </ul>
-
-
 	</t:summary>
 </j:jelly>

--- a/src/test/java/hudson/plugins/git/util/BuildDataBrowserTest.java
+++ b/src/test/java/hudson/plugins/git/util/BuildDataBrowserTest.java
@@ -1,0 +1,18 @@
+package hudson.plugins.git.util;
+
+import hudson.plugins.git.browser.GithubWeb;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BuildDataBrowserTest {
+
+    @Test
+    public void testBrowserPersistence() {
+        BuildData data = new BuildData();
+        assertNull(data.getBrowser());
+
+        GithubWeb browser = new GithubWeb("https://github.com/jenkinsci/git-plugin");
+        data.setBrowser(browser);
+        assertEquals(browser, data.getBrowser());
+    }
+}


### PR DESCRIPTION
Description

This pull request improves the Git Build Data summary by adding clickable hyperlinks for the revision, repository, and branch references. This allows users to directly navigate to diffs, repository pages, and branch views from the Jenkins build summary UI. The implementation supports both HTTP and SSH repository configurations and only renders links when a Git repository browser is configured.

Fixes issue #3874
Jira: https://issues.jenkins.io/browse/JENKINS-75285

Changes:
1.GitSCM.java:
* Updated copyBuildData to explicitly persist the configured GitRepositoryBrowser into the BuildData object.
* Why: Previously, the browser configuration was not saved with the build data, making it impossible to generate browser-specific links (like GitHub or GitWeb) during the view rendering.

2.BuildData.java:
* Added helper methods: getCommitUrl(String), getRefUrl(String), and getRepositoryUrl().
* Why: To encapsulate the link generation logic. 
 These methods:
   *Safely handle IOException from the browser.•Sanitize URLs by stripping .git suffixes to ensure 
compatibility with web interfaces (e.g., GitHub).
   *Normalize branch names (stripping refs/remotes/origin/ or refs/heads/) so links point to the correct branch view.
    *Handle the conversion of SSH remote URLs to HTTP browser URLs via the configured browser.

3.summary.jelly:
* Updated the Jelly template to use the new BuildData helper methods.
* Why: To render <a> tags for the Revision, Repository, and Branches instead of plain text, providing a better user experience.

4.BuildDataTest.java:
* Added unit tests (testSshRepositoryLink, testCommitUrlSanitization, testRefUrlNormalization).
* Why: To verify that SSH URLs are correctly converted to HTTP links, that .git suffixes are removed, and that internal ref paths are normalized to human-readable branch names.

### Testing done

Executed unit tests locally.
Added new automated tests to cover browser link generation logic.
Verified clickable links render correctly in Jenkins build summary UI.
<img width="1813" height="750" alt="image" src="https://github.com/user-attachments/assets/c6c559e4-863f-43fb-945c-410ffc0d279d" />
<img width="1916" height="903" alt="image" src="https://github.com/user-attachments/assets/ff6846f8-7bca-4d43-a6e2-6b831c0281dd" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- #3874
- https://issues.jenkins.io/browse/JENKINS-75316
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

