### PR TITLE
Deprecate getOldGitExe() method

### DIFF
--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -1810,6 +1810,17 @@ public class GitSCM extends GitSCMBackwardCompatibility {
 
         public void setAddGitTagAction(boolean addGitTagAction) { this.addGitTagAction = addGitTagAction; }
 
+        /**
+         * Old configuration of git executable, unused since 2023.
+         * Returns null in all cases.
+         * @deprecated use GitTool
+         * @return null
+         */
+        @Deprecated(since = "5.11.0")
+        public String getOldGitExe() {
+            return null;
+        }
+
         public static List<RemoteConfig> createRepositoryConfigurations(String[] urls,
                 String[] repoNames,
                 String[] refs) throws GitException, IOException {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Remove dead code: `DescriptorImpl.getOldGitExe()` always returns `null`, so the `if (desc.getOldGitExe() != null)` block in `onLoaded()` never runs. This removes that block, the unused `getOldGitExe()` method (and its Javadoc), and the now-unused `desc` variable so `onLoaded()` is an empty initializer.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Refactor/cleanup only: no behavior change. The removed code was unreachable because `getOldGitExe()` always returns `null`. Ran the existing test suite (e.g. `mvn test`) to confirm nothing regresses. No new tests added for removal of dead code.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->