### PR TITLE
Remove redundant test assertion

### DIFF
--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -262,7 +262,6 @@ class GitSCMTest extends AbstractGitTestCase {
 
         JenkinsRule.WebClient wc = r.createWebClient();
         HtmlPage page = wc.goTo("credentials/store/system/domain/_/credentials/" + credential.getId());
-        assertThat("Have usage tracking reported", page.getElementById("usage"), notNullValue());
         assertThat("No fingerprint created until first use", page.getElementById("usage-missing"), notNullValue());
         assertThat("No fingerprint created until first use", page.getElementById("usage-present"), nullValue());
 


### PR DESCRIPTION
## Remove redundant test assertion

Existing assertions already check that the credential usage tracking is correct.  This assertion adds no real value to the test.

Addresses part of issue:

* https://github.com/jenkinsci/credentials-plugin/issues/1032

Discoverd in plugin BOM pull request:

* https://github.com/jenkinsci/bom/pull/6504

### Testing done

* Confirmed that tests pass with older credentials plugin and with latest credentials plugin.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
