### PR TITLE
feat: Respect user-defined Git author identity in merges

### DIFF
--- a/src/main/java/jenkins/plugins/git/MergeWithGitSCMExtension.java
+++ b/src/main/java/jenkins/plugins/git/MergeWithGitSCMExtension.java
@@ -32,6 +32,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.impl.PreBuildMerge;
+import hudson.plugins.git.extensions.impl.UserIdentity;
 import hudson.plugins.git.util.MergeRecord;
 import java.io.IOException;
 import jenkins.scm.api.SCMSource;
@@ -109,9 +110,16 @@ public class MergeWithGitSCMExtension extends GitSCMExtension {
         );
         checkout(scm, build, git, listener, rev);
         try {
-            /* could parse out of JenkinsLocationConfiguration.get().getAdminAddress() but seems overkill */
-            git.setAuthor("Jenkins", "nobody@nowhere");
-            git.setCommitter("Jenkins", "nobody@nowhere");
+            UserIdentity userIdentity = scm.getExtensions().get(UserIdentity.class);
+            if (userIdentity != null) {
+                userIdentity.decorate(scm, git);
+            } else {
+                GitSCM.DescriptorImpl d = scm.getDescriptor();
+                String authorName  = d.getGlobalConfigName()  != null ? d.getGlobalConfigName()  : "Jenkins";
+                String authorEmail = d.getGlobalConfigEmail() != null ? d.getGlobalConfigEmail() : "nobody@nowhere";
+                git.setAuthor(authorName, authorEmail);
+                git.setCommitter(authorName, authorEmail);
+            }
             MergeCommand cmd = git.merge().setRevisionToMerge(baseObjectId);
             for (GitSCMExtension ext : scm.getExtensions()) {
                 // By default we do a regular merge, allowing it to fast-forward.

--- a/src/test/java/jenkins/plugins/git/MergeWithGitSCMExtensionTest.java
+++ b/src/test/java/jenkins/plugins/git/MergeWithGitSCMExtensionTest.java
@@ -1,20 +1,29 @@
 package jenkins.plugins.git;
 
+import hudson.FilePath;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
+import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.TestGitRepo;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionTest;
+import hudson.plugins.git.extensions.impl.UserIdentity;
 import hudson.plugins.git.util.BuildData;
-import org.junit.jupiter.api.Test;
-
 import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -82,6 +91,87 @@ class MergeWithGitSCMExtensionTest extends GitSCMExtensionTest {
         assertEquals(firstBuild.getNumber(), gitSCM.getBuildData(firstBuild).lastBuild.getBuildNumber());
         assertEquals(firstMarked, gitSCM.getBuildData(firstBuild).lastBuild.getMarked());
         assertEquals(firstRevision, gitSCM.getBuildData(firstBuild).lastBuild.getRevision());
+    }
+
+    @Test
+    void testMergeCommitUsesDefaultIdentity() throws Exception {
+        String integrationHash = makeDivergingBranches();
+        FreeStyleProject p = createMergeProject(integrationHash);
+
+        FreeStyleBuild build = build(p, Result.SUCCESS);
+
+        PersonIdent author = headCommitAuthor(build.getWorkspace());
+        assertEquals("Jenkins", author.getName());
+        assertEquals("nobody@nowhere", author.getEmailAddress());
+    }
+
+    @Test
+    void testMergeCommitUsesGlobalConfigIdentity() throws Exception {
+        GitSCM.DescriptorImpl descriptor = (GitSCM.DescriptorImpl) r.jenkins.getDescriptorByType(GitSCM.DescriptorImpl.class);
+        descriptor.setGlobalConfigName("CI Bot");
+        descriptor.setGlobalConfigEmail("ci@example.com");
+
+        String integrationHash = makeDivergingBranches();
+        FreeStyleProject p = createMergeProject(integrationHash);
+
+        FreeStyleBuild build = build(p, Result.SUCCESS);
+
+        PersonIdent author = headCommitAuthor(build.getWorkspace());
+        assertEquals("CI Bot", author.getName());
+        assertEquals("ci@example.com", author.getEmailAddress());
+    }
+
+    @Test
+    void testMergeCommitUsesUserIdentityExtension() throws Exception {
+        String integrationHash = makeDivergingBranches();
+        FreeStyleProject p = createMergeProject(integrationHash);
+        ((GitSCM) p.getScm()).getExtensions().add(new UserIdentity("Bot User", "bot@example.com"));
+
+        FreeStyleBuild build = build(p, Result.SUCCESS);
+
+        PersonIdent author = headCommitAuthor(build.getWorkspace());
+        assertEquals("Bot User", author.getName());
+        assertEquals("bot@example.com", author.getEmailAddress());
+    }
+
+    /**
+     * Commits a file on integration and a different file on master so the two branches diverge,
+     * enabling a true merge commit (not a fast-forward) when they are later merged.
+     *
+     * @return SHA of the new integration HEAD
+     */
+    private String makeDivergingBranches() throws Exception {
+        repo.git.checkoutBranch("integration", "master");
+        repo.commit("integration-only-file", repo.janeDoe, "Integration branch commit");
+        String integrationHash = repo.git.revParse(Constants.HEAD).name();
+        repo.git.checkout().ref("master").execute();
+        repo.commit("master-only-file", repo.johnDoe, "Master diverging commit");
+        return integrationHash;
+    }
+
+    /**
+     * Creates a project that builds master and merges the integration branch at the given hash.
+     */
+    private FreeStyleProject createMergeProject(String mergeBaseHash) throws Exception {
+        FreeStyleProject p = r.createFreeStyleProject();
+        GitSCM scm = new GitSCM(
+                repo.remoteConfigs(),
+                Collections.singletonList(new BranchSpec("master")),
+                null, null,
+                Collections.emptyList());
+        scm.getExtensions().add(new MergeWithGitSCMExtension("integration", mergeBaseHash));
+        p.setScm(scm);
+        p.getBuildersList().add(new CaptureEnvironmentBuilder());
+        return p;
+    }
+
+    private PersonIdent headCommitAuthor(FilePath workspace) throws Exception {
+        File workspaceDir = new File(workspace.getRemote());
+        try (Repository gitRepo = new FileRepositoryBuilder().setWorkTree(workspaceDir).build();
+             RevWalk revWalk = new RevWalk(gitRepo)) {
+            RevCommit headCommit = revWalk.parseCommit(gitRepo.resolve(Constants.HEAD));
+            return headCommit.getAuthorIdent();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description

Previously, `MergeWithGitSCMExtension` always used hardcoded values `"Jenkins" / "nobody@nowhere"` as the author and committer of the merge commit, ignoring any user-configured identity.

The `decorateRevisionToBuild` method now resolves the identity in the following order:

1. **If a `UserIdentity` extension** is configured in the `GitSCM`, it is applied via `userIdentity.decorate(scm, git)`.
2. **Otherwise**, it falls back to the global descriptor configuration (`getGlobalConfigName()` / `getGlobalConfigEmail()`), and only uses `"Jenkins" / "nobody@nowhere"` when those values are `null`.

### Testing done

Three automated tests were added to `MergeWithGitSCMExtensionTest`:

- `testMergeCommitUsesDefaultIdentity` — verifies that when no identity is configured, the merge commit is authored by `Jenkins / nobody@nowhere`.
- `testMergeCommitUsesGlobalConfigIdentity` — sets `globalConfigName` / `globalConfigEmail` on the `GitSCM` descriptor and verifies the merge commit reflects those values.
- `testMergeCommitUsesUserIdentityExtension` — adds a `UserIdentity` extension to the SCM and verifies it takes precedence over the global config.

All three tests build a real Jenkins freestyle project with a diverging branch scenario and inspect the HEAD commit's `PersonIdent` via JGit's `RevWalk`.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests