### PR TITLE
Only configure the gpgsigning if the repository exists

### DIFF
--- a/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
@@ -251,11 +251,11 @@ public abstract class AbstractGitTestCase {
 
     protected FreeStyleBuild build(final FreeStyleProject project, final Result expectedResult, final String...expectedNewlyCommittedFiles) throws Exception {
         final FreeStyleBuild build = project.scheduleBuild2(0).get();
-        for(final String expectedNewlyCommittedFile : expectedNewlyCommittedFiles) {
-            assertTrue(build.getWorkspace().child(expectedNewlyCommittedFile).exists(), expectedNewlyCommittedFile + " file not found in workspace");
-        }
         if(expectedResult != null) {
             r.assertBuildStatus(expectedResult, build);
+        }
+        for(final String expectedNewlyCommittedFile : expectedNewlyCommittedFiles) {
+            assertTrue(build.getWorkspace().child(expectedNewlyCommittedFile).exists(), expectedNewlyCommittedFile + " file not found in workspace");
         }
         return build;
     }

--- a/src/test/java/hudson/plugins/git/GitSCMSlowTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMSlowTest.java
@@ -334,8 +334,11 @@ class GitSCMSlowTest extends AbstractGitTestCase {
         @Override
         public GitClient decorate(GitSCM scm, GitClient git) throws IOException, InterruptedException, GitException {
             GitClient gitClient = super.decorate(scm, git);
-            gitClient.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", "false");
-            gitClient.config(GitClient.ConfigLevel.LOCAL, "tag.gpgSign", "false");
+            if (gitClient.hasGitRepo()) {
+                // Do not attempt to disable GPG signing unless we're in a repository
+                gitClient.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", "false");
+                gitClient.config(GitClient.ConfigLevel.LOCAL, "tag.gpgSign", "false");
+            }
             return gitClient;
         }
     }


### PR DESCRIPTION
## Only configure the gpgsigning if the repository exists

Some test configurations in my lab environment fail merge tests because the repository does not yet exist when the decorator is run.

### Testing done

Confirmed that testMerge fails on my test environment without this pull request and passes with it

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
