### PR TITLE
Declare precise node to run node-specific tests

### DIFF
--- a/src/test/java/hudson/plugins/git/Security2478Test.java
+++ b/src/test/java/hudson/plugins/git/Security2478Test.java
@@ -41,13 +41,13 @@ class Security2478Test {
     @Test
     void checkoutShouldNotAbortWhenLocalSourceAndRunningOnAgent() throws Exception {
         assertFalse(GitSCM.ALLOW_LOCAL_CHECKOUT, "Non Remote checkout should be disallowed");
-        r.createOnlineSlave();
+        var agent = r.createOnlineSlave();
         sampleRepo.init();
         sampleRepo.write("file", "v1");
         sampleRepo.git("commit", "--all", "--message=test commit");
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "pipeline");
 
-        String script = "node {\n" +
+        String script = "node('" + agent.getNodeName() + "') {\n" +
                 "   checkout([$class: 'GitSCM', branches: [[name: '*/master']], extensions: [], userRemoteConfigs: [[url: '" + sampleRepo.fileUrl() + "', credentialsId: '']]])\n" +
                 "}";
         p.setDefinition(new CpsFlowDefinition(script, true));
@@ -65,7 +65,7 @@ class Security2478Test {
 
         String path = "file://" + workspaceDir + File.separator + "jobName@script" + File.separator + "anyhmachash";
         String escapedPath = path.replace("\\", "\\\\"); // for windows
-        String script = "node {\n" +
+        String script = "node('built-in') {\n" +
                 "   checkout([$class: 'GitSCM', branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[" +
                 "url: '" + escapedPath + "'," +
                 " credentialsId: '']]])\n" +

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -242,7 +242,7 @@ class GitSCMFileSystemTest {
         SCMRevision revision = source.fetch(new GitBranchSCMHead("dev"), null);
         sampleRepo.write("file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
-        long fileSystemAllowedOffset = 1500;
+        long fileSystemAllowedOffset = 2500; // Sometimes a busy file system is offset more than 1500 ms
         if ("OpenBSD".equals(System.getProperty("os.name"))) {
             fileSystemAllowedOffset = 2 * fileSystemAllowedOffset;
         }


### PR DESCRIPTION
## Declare precise node to run node-specific tests

Tests may have been passing by accident or luck, since the precise node was not specified and the tests depend on a precise node.

Also extends allowed file system offset in test

Busy file systems can be even slower than estimated.  I needed an additional 1 second offset when Jenkins core tests were running on the same Linux computer that was testing the git plugin.

### Testing done

Confirmed tests pass consistently on my Linux development computer.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
