### PR TITLE
feat: Add support for gerrit changes for download Jenkins file and support custom refspec in lightweight checkout

### DIFF
--- a/src/main/java/hudson/plugins/git/BranchSpec.java
+++ b/src/main/java/hudson/plugins/git/BranchSpec.java
@@ -159,6 +159,9 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
             String regexSubstring = expandedName.substring(1, expandedName.length());
             return Pattern.compile(regexSubstring);
         }
+        if (expandedName.startsWith("refs/changes/")) {
+            return Pattern.compile(Pattern.quote(expandedName));
+        }
         if (repositoryName != null) {
             // remove the "refs/.../" stuff from the branch-spec if necessary
             String pattern = cutRefs(expandedName)

--- a/src/main/java/hudson/plugins/git/BranchSpec.java
+++ b/src/main/java/hudson/plugins/git/BranchSpec.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -84,7 +86,7 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
      * @return true if ref matches configured pattern
      */
     public boolean matches(String ref, EnvVars env) {
-        return getPattern(env).matcher(ref).matches();
+        return asPredicate(atom -> refPredicate(env, atom)).test(ref);
     }
 
     /**
@@ -97,9 +99,45 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
         if (branchName == null) {
             return false;
         }
-        Pattern pattern = getPattern(new EnvVars(), repositoryName);
         String branchWithoutRefs = cutRefs(branchName);
-        return pattern.matcher(branchWithoutRefs).matches() || pattern.matcher(join(repositoryName, branchWithoutRefs)).matches();
+        String joined = join(repositoryName, branchWithoutRefs);
+        return asPredicate(atom -> repositoryBranchPredicate(repositoryName, atom, branchWithoutRefs, joined))
+                .test(branchName);
+    }
+
+    /**
+     * Combines the individual branch specs of this spec's name into a single predicate, evaluating
+     * a logical expression with {@code ||} (OR) and {@code &&} (AND). {@code &&} binds tighter than
+     * {@code ||}. The supplied function compiles a single spec (atom) into a predicate.
+     */
+    private <T> Predicate<T> asPredicate(Function<String, Predicate<T>> atomPredicate) {
+        Predicate<T> expression = t -> false;
+        for (String orTerm : name.split("\\|\\|")) {
+            if (orTerm.trim().isEmpty()) {
+                continue;
+            }
+            Predicate<T> conjunction = t -> true;
+            for (String atom : orTerm.split("&&")) {
+                String trimmedAtom = atom.trim();
+                if (trimmedAtom.isEmpty()) {
+                    continue;
+                }
+                conjunction = conjunction.and(atomPredicate.apply(trimmedAtom));
+            }
+            expression = expression.or(conjunction);
+        }
+        return expression;
+    }
+
+    private Predicate<String> refPredicate(EnvVars env, String atom) {
+        Pattern pattern = getPattern(env, null, atom);
+        return ref -> pattern.matcher(ref).matches();
+    }
+
+    private Predicate<String> repositoryBranchPredicate(String repositoryName, String atom,
+                                                        String branchWithoutRefs, String joined) {
+        Pattern pattern = getPattern(new EnvVars(), repositoryName, atom);
+        return ref -> pattern.matcher(branchWithoutRefs).matches() || pattern.matcher(joined).matches();
     }
 
     /**
@@ -140,20 +178,19 @@ public class BranchSpec extends AbstractDescribableImpl<BranchSpec> implements S
         return items;
     }
 
-    private String getExpandedName(EnvVars env) {
-        String expandedName = env.expand(name);
-        if (expandedName.length() == 0) {
-            return "**";
-        }
-        return expandedName;
-    }
-
     private Pattern getPattern(EnvVars env) {
-        return getPattern(env, null);
+        return getPattern(env, null, name);
     }
 
     private Pattern getPattern(EnvVars env, String repositoryName) {
-        String expandedName = getExpandedName(env);
+        return getPattern(env, repositoryName, name);
+    }
+
+    private Pattern getPattern(EnvVars env, String repositoryName, String specName) {
+        String expandedName = env.expand(specName);
+        if (expandedName.length() == 0) {
+            expandedName = "**";
+        }
         // use regex syntax directly if name starts with colon
         if (expandedName.startsWith(":") && expandedName.length() > 1) {
             String regexSubstring = expandedName.substring(1, expandedName.length());

--- a/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
+++ b/src/main/java/hudson/plugins/git/util/DefaultBuildChooser.java
@@ -284,7 +284,8 @@ public class DefaultBuildChooser extends BuildChooser {
      * @return true if branchSpec requires advanced matching
      */
     boolean isAdvancedSpec(String branchSpec) {
-        // null or wildcards or regexp
-        return (branchSpec == null || branchSpec.contains("*") || branchSpec.startsWith(":"));
+        // null or wildcards or regexp or logical expression
+        return (branchSpec == null || branchSpec.contains("*") || branchSpec.startsWith(":")
+                || branchSpec.contains("||") || branchSpec.contains("&&"));
     }
 }

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -361,7 +361,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 }
 
                 String remoteHead = headName;
-                if (prefix.equals(Constants.R_HEADS) || prefix.equals(Constants.R_TAGS)) {
+                if (prefix != null && (prefix.equals(Constants.R_HEADS) || prefix.equals(Constants.R_TAGS))) {
                     remoteHead = Constants.R_REMOTES + remoteName + "/" + headName;
                 }
 

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -59,6 +59,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
@@ -403,15 +406,36 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 }
 
                 HeadNameResult headNameResult = HeadNameResult.calculate(branchSpec, rev, env);
+                String head = Constants.R_REMOTES + remoteName + "/" + headNameResult.headName;
 
-                client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(
-                        "+" + headNameResult.prefix + headNameResult.headName + ":" + Constants.R_REMOTES + remoteName + "/"
-                                + headNameResult.headName))).execute();
+                if (branchSpec.getName().equals("FETCH_HEAD")) {
+                    head = "FETCH_HEAD";
+                } else {
+                    // check for a commit hash in branchSpec
+                    final String regex = "^[a-fA-F0-9]{40}$";
+                    final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+                    final Matcher matcher = pattern.matcher(branchSpec.getName());
+
+                    if (matcher.find()) {
+                        head = branchSpec.getName();
+                        rev = new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead(headNameResult.headName), head);
+                    }
+                }
+
+                String refspec = config.getRefspec();
+                if (refspec != null) {
+                    if (env != null) {
+                        refspec = env.expand(refspec);
+                    }
+                } else {
+                    refspec = "+" + headNameResult.prefix + headNameResult.headName + ":" + Constants.R_REMOTES + remoteName + "/"
+                            + headNameResult.headName;
+                }
+
+                client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(refspec))).execute();
 
                 listener.getLogger().println("Done.");
-                return new GitSCMFileSystem(client, remote, Constants.R_REMOTES + remoteName + "/" + headNameResult.headName, (AbstractGitSCMSource.SCMRevisionImpl) rev);
-            } catch (GitException x) {
-                throw new IOException(x);
+                return new GitSCMFileSystem(client, remote, head, (AbstractGitSCMSource.SCMRevisionImpl) rev);
             } finally {
                 cacheLock.unlock();
             }

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -329,7 +329,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     prefix = "refs/changes/";
                 } else {
                     // check for FETCH_HEAD
-                    if (branchSpecExpandedName.equals("FETCH_HEAD") && !refspecExpandedName.equals("")) {
+                    if (branchSpecExpandedName.equals(Constants.FETCH_HEAD) && !refspecExpandedName.equals("")) {
                         prefix = null;
                     } else {
                         // check for commit-id

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -345,27 +345,27 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     }
                 }
 
-                String headName = branchSpecExpandedName;
+                String calculatedHeadName = branchSpecExpandedName;
                 if (rev != null && env != null) {
-                    headName = env.expand(rev.getHead().getName());
+                    calculatedHeadName = env.expand(rev.getHead().getName());
                 } else {
                     if (prefix != null && branchSpecExpandedName.startsWith(prefix)) {
-                        headName = branchSpecExpandedName.substring(prefix.length());
+                        calculatedHeadName = branchSpecExpandedName.substring(prefix.length());
                     } else if (branchSpecExpandedName.startsWith("*/")) {
-                        headName = branchSpecExpandedName.substring(2);
+                        calculatedHeadName = branchSpecExpandedName.substring(2);
                     }
                 }
 
                 if (refspecExpandedName == null || refspecExpandedName.equals("")) {
-                    refspecExpandedName = "+" + prefix + headName + ":" + Constants.R_REMOTES + remoteName + "/" + headName;
+                    refspecExpandedName = "+" + prefix + calculatedHeadName + ":" + Constants.R_REMOTES + remoteName + "/" + calculatedHeadName;
                 }
 
-                String remoteHead = headName;
+                String remoteHead = calculatedHeadName;
                 if (prefix != null && (prefix.equals(Constants.R_HEADS) || prefix.equals(Constants.R_TAGS))) {
-                    remoteHead = Constants.R_REMOTES + remoteName + "/" + headName;
+                    remoteHead = Constants.R_REMOTES + remoteName + "/" + calculatedHeadName;
                 }
 
-                return new HeadNameResult(headName, remoteHead, refspecExpandedName, rev);
+                return new HeadNameResult(calculatedHeadName, remoteHead, refspecExpandedName, rev);
             }
         }
 

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -294,41 +294,78 @@ public class GitSCMFileSystem extends SCMFileSystem {
 
         static class HeadNameResult {
             final String headName;
-            final String prefix;
+            final String remoteHeadName;
+            final String refspec;
+            final SCMRevision rev;
 
-            private HeadNameResult(String headName, String prefix) {
+            private HeadNameResult(String headName, String remoteHeadName, String refspec, SCMRevision rev) {
                 this.headName = headName;
-                this.prefix = prefix;
+                this.remoteHeadName = remoteHeadName;
+                this.refspec = refspec;
+                this.rev = rev;
             }
 
             static HeadNameResult calculate(@NonNull BranchSpec branchSpec,
                                             @CheckForNull SCMRevision rev,
-                                            @CheckForNull EnvVars env) {
+                                            @NonNull String refSpec,
+                                            @CheckForNull EnvVars env,
+                                            @CheckForNull String remoteName) {
+
                 String branchSpecExpandedName = branchSpec.getName();
                 if (env != null) {
                     branchSpecExpandedName = env.expand(branchSpecExpandedName);
                 }
+                String refspecExpandedName = refSpec;
+                if (env != null) {
+                    refspecExpandedName = env.expand(refspecExpandedName);
+                }
 
+                // default to a branch (refs/heads)
                 String prefix = Constants.R_HEADS;
+                // check for a tag
                 if (branchSpecExpandedName.startsWith(Constants.R_TAGS)) {
                     prefix = Constants.R_TAGS;
                 } else if (branchSpecExpandedName.startsWith("refs/changes")) {
                     prefix = "refs/changes/";
+                } else {
+                    // check for FETCH_HEAD
+                    if (branchSpecExpandedName.equals("FETCH_HEAD") && !refspecExpandedName.equals("")) {
+                        prefix = null;
+                    } else {
+                        // check for commit-id
+                        final String regex = "^[a-fA-F0-9]{40}$";
+                        final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+                        final Matcher matcher = pattern.matcher(branchSpecExpandedName);
+
+                        if (matcher.find()) {
+                            // commit-id
+                            prefix = null;
+                            rev = new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead(branchSpecExpandedName), branchSpecExpandedName);
+                        }
+                    }
                 }
 
-                String headName;
+                String headName = branchSpecExpandedName;
                 if (rev != null && env != null) {
                     headName = env.expand(rev.getHead().getName());
                 } else {
-                    if (branchSpecExpandedName.startsWith(prefix)) {
+                    if (prefix != null && branchSpecExpandedName.startsWith(prefix)) {
                         headName = branchSpecExpandedName.substring(prefix.length());
                     } else if (branchSpecExpandedName.startsWith("*/")) {
                         headName = branchSpecExpandedName.substring(2);
-                    } else {
-                        headName = branchSpecExpandedName;
                     }
                 }
-                return new HeadNameResult(headName, prefix);
+
+                if (refspecExpandedName == null || refspecExpandedName.equals("")) {
+                    refspecExpandedName = "+" + prefix + headName + ":" + Constants.R_REMOTES + remoteName + "/" + headName;
+                }
+
+                String remoteHead = headName;
+                if (prefix == Constants.R_HEADS || prefix == Constants.R_TAGS) {
+                    remoteHead = Constants.R_REMOTES + remoteName + "/" + headName;
+                }
+
+                return new HeadNameResult(headName, remoteHead, refspecExpandedName, rev);
             }
         }
 
@@ -405,37 +442,11 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     listener.getLogger().println("URI syntax exception for '" + remoteName + "' " + ex);
                 }
 
-                HeadNameResult headNameResult = HeadNameResult.calculate(branchSpec, rev, env);
-                String head = Constants.R_REMOTES + remoteName + "/" + headNameResult.headName;
-
-                if (branchSpec.getName().equals("FETCH_HEAD")) {
-                    head = "FETCH_HEAD";
-                } else {
-                    // check for a commit hash in branchSpec
-                    final String regex = "^[a-fA-F0-9]{40}$";
-                    final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
-                    final Matcher matcher = pattern.matcher(branchSpec.getName());
-
-                    if (matcher.find()) {
-                        head = branchSpec.getName();
-                        rev = new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead(headNameResult.headName), head);
-                    }
-                }
-
-                String refspec = config.getRefspec();
-                if (refspec != null) {
-                    if (env != null) {
-                        refspec = env.expand(refspec);
-                    }
-                } else {
-                    refspec = "+" + headNameResult.prefix + headNameResult.headName + ":" + Constants.R_REMOTES + remoteName + "/"
-                            + headNameResult.headName;
-                }
-
-                client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(refspec))).execute();
+                HeadNameResult headNameResult = HeadNameResult.calculate(branchSpec, rev, config.getRefspec(), env, remoteName);
+                client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(headNameResult.refspec))).execute();
 
                 listener.getLogger().println("Done.");
-                return new GitSCMFileSystem(client, remote, head, (AbstractGitSCMSource.SCMRevisionImpl) rev);
+                return new GitSCMFileSystem(client, remote, headNameResult.remoteHeadName, (AbstractGitSCMSource.SCMRevisionImpl) headNameResult.rev);
             } finally {
                 cacheLock.unlock();
             }

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -307,7 +307,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
 
             static HeadNameResult calculate(@NonNull BranchSpec branchSpec,
                                             @CheckForNull SCMRevision rev,
-                                            @NonNull String refSpec,
+                                            @CheckForNull String refSpec,
                                             @CheckForNull EnvVars env,
                                             @CheckForNull String remoteName) {
 

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -361,7 +361,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 }
 
                 String remoteHead = headName;
-                if (prefix == Constants.R_HEADS || prefix == Constants.R_TAGS) {
+                if (prefix.equals(Constants.R_HEADS) || prefix.equals(Constants.R_TAGS)) {
                     remoteHead = Constants.R_REMOTES + remoteName + "/" + headName;
                 }
 

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -267,6 +267,9 @@ public class GitSCMFileSystem extends SCMFileSystem {
                         || gscm.getBranches().get(0).getName().matches(
                             "^((\\Q" + Constants.R_TAGS + "\\E.*)|([^/]+)|(\\*/[^/*]+(/[^/*]+)*))$"
                         )
+                        || gscm.getBranches().get(0).getName().matches(
+                            "^((\\Qrefs/changes/\\E.*)|([^/]+)|(\\*/[^/*]+(/[^/*]+)*))$"
+                        )
                     );
             // we only support where the branch spec is obvious and not a wildcard
         }
@@ -306,6 +309,8 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 String prefix = Constants.R_HEADS;
                 if (branchSpecExpandedName.startsWith(Constants.R_TAGS)) {
                     prefix = Constants.R_TAGS;
+                } else if (branchSpecExpandedName.startsWith("refs/changes")) {
+                    prefix = "refs/changes/";
                 }
 
                 String headName;

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -316,7 +316,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     branchSpecExpandedName = env.expand(branchSpecExpandedName);
                 }
                 String refspecExpandedName = refSpec;
-                if (env != null) {
+                if (env != null && refspecExpandedName != null) {
                     refspecExpandedName = env.expand(refspecExpandedName);
                 }
 
@@ -329,7 +329,8 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     prefix = "refs/changes/";
                 } else {
                     // check for FETCH_HEAD
-                    if (branchSpecExpandedName.equals(Constants.FETCH_HEAD) && !refspecExpandedName.equals("")) {
+                    if (branchSpecExpandedName.equals(Constants.FETCH_HEAD) && refspecExpandedName != null &&
+                            !refspecExpandedName.equals("")) {
                         prefix = null;
                     } else {
                         // check for commit-id
@@ -357,11 +358,15 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 }
 
                 if (refspecExpandedName == null || refspecExpandedName.equals("")) {
-                    refspecExpandedName = "+" + prefix + calculatedHeadName + ":" + Constants.R_REMOTES + remoteName + "/" + calculatedHeadName;
+                    if (prefix.equals(Constants.R_TAGS)) {
+                        refspecExpandedName = "+" + prefix + calculatedHeadName + ":"  + prefix + calculatedHeadName;
+                    } else {
+                        refspecExpandedName = "+" + prefix + calculatedHeadName + ":" + Constants.R_REMOTES + remoteName + "/" + calculatedHeadName;
+                    }
                 }
 
                 String remoteHead = calculatedHeadName;
-                if (prefix != null && (prefix.equals(Constants.R_HEADS) || prefix.equals(Constants.R_TAGS))) {
+                if (prefix != null && prefix.equals(Constants.R_HEADS)) {
                     remoteHead = Constants.R_REMOTES + remoteName + "/" + calculatedHeadName;
                 }
 

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -445,7 +445,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 HeadNameResult headNameResult = HeadNameResult.calculate(branchSpec, rev, config.getRefspec(), env, remoteName);
                 client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(headNameResult.refspec))).execute();
 
-                listener.getLogger().println("Done.");
+                listener.getLogger().println("Done with " + remoteName + " using " + headNameResult.headName + ".");
                 return new GitSCMFileSystem(client, remote, headNameResult.remoteHeadName, (AbstractGitSCMSource.SCMRevisionImpl) headNameResult.rev);
             } finally {
                 cacheLock.unlock();

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -293,13 +293,11 @@ public class GitSCMFileSystem extends SCMFileSystem {
         }
 
         static class HeadNameResult {
-            final String headName;
             final String remoteHeadName;
             final String refspec;
             final SCMRevision rev;
 
-            private HeadNameResult(String headName, String remoteHeadName, String refspec, SCMRevision rev) {
-                this.headName = headName;
+            private HeadNameResult(String remoteHeadName, String refspec, SCMRevision rev) {
                 this.remoteHeadName = remoteHeadName;
                 this.refspec = refspec;
                 this.rev = rev;
@@ -370,7 +368,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     remoteHead = Constants.R_REMOTES + remoteName + "/" + calculatedHeadName;
                 }
 
-                return new HeadNameResult(calculatedHeadName, remoteHead, refspecExpandedName, rev);
+                return new HeadNameResult(remoteHead, refspecExpandedName, rev);
             }
         }
 
@@ -450,7 +448,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 HeadNameResult headNameResult = HeadNameResult.calculate(branchSpec, rev, config.getRefspec(), env, remoteName);
                 client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(headNameResult.refspec))).execute();
 
-                listener.getLogger().println("Done with " + remoteName + " using " + headNameResult.headName + ".");
+                listener.getLogger().println("Done with " + remoteName + " using " + headNameResult.remoteHeadName + ".");
                 return new GitSCMFileSystem(client, remote, headNameResult.remoteHeadName, (AbstractGitSCMSource.SCMRevisionImpl) headNameResult.rev);
             } finally {
                 cacheLock.unlock();

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -312,7 +312,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
 
             static HeadNameResult calculate(@NonNull BranchSpec branchSpec,
                                             @CheckForNull SCMRevision rev,
-                                            @NonNull String refSpec,
+                                            @CheckForNull String refSpec,
                                             @CheckForNull EnvVars env,
                                             @CheckForNull String remoteName) {
 

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -264,18 +264,40 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     && gscm.getUserRemoteConfigs().size() == 1
                     && gscm.getBranches().size() == 1
                     && !gscm.getBranches().get(0).getName().equals("*") // JENKINS-57587
-                    && (
-                        gscm.getBranches().get(0).getName().matches(
-                            "^((\\Q" + Constants.R_HEADS + "\\E.*)|([^/]+)|(\\*/[^/*]+(/[^/*]+)*))$"
-                        )
-                        || gscm.getBranches().get(0).getName().matches(
-                            "^((\\Q" + Constants.R_TAGS + "\\E.*)|([^/]+)|(\\*/[^/*]+(/[^/*]+)*))$"
-                        )
-                        || gscm.getBranches().get(0).getName().matches(
-                            "^((\\Qrefs/changes/\\E.*)|([^/]+)|(\\*/[^/*]+(/[^/*]+)*))$"
-                        )
-                    );
+                    && isSupportedBranchSpec(gscm.getBranches().get(0).getName());
             // we only support where the branch spec is obvious and not a wildcard
+        }
+
+        /**
+         * Tests whether a branch spec can be handled by the lightweight checkout. A logical OR
+         * chain of obvious single refs is supported (used as an ordered fallback); a logical AND
+         * is not, because it selects a set of refs rather than the single ref to fetch.
+         */
+        static boolean isSupportedBranchSpec(@NonNull String branchSpecName) {
+            if (branchSpecName.contains("&&")) {
+                return false;
+            }
+            for (String operand : branchSpecName.split("\\|\\|")) {
+                if (operand.trim().isEmpty()) {
+                    continue;
+                }
+                if (!isSupportedSingleRefSpec(operand.trim())) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static boolean isSupportedSingleRefSpec(@NonNull String name) {
+            if (name.equals("*") || name.equals("**")) {
+                // wildcard selecting every branch, not a single ref
+                return false;
+            }
+            return name.matches("^(\\Q" + Constants.R_HEADS + "\\E.*)$")
+                    || name.matches("^(\\Q" + Constants.R_TAGS + "\\E.*)$")
+                    || name.matches("^(\\Qrefs/changes/\\E.*)$")
+                    || name.matches("^[^/]+$")
+                    || name.matches("^\\*/[^/*]+(/[^/*]+)*$");
         }
 
         @Override
@@ -450,14 +472,63 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     listener.getLogger().println("URI syntax exception for '" + remoteName + "' " + ex);
                 }
 
-                HeadNameResult headNameResult = HeadNameResult.calculate(branchSpec, rev, config.getRefspec(), env, remoteName);
-                client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(headNameResult.refspec))).execute();
+                HeadNameResult headNameResult = null;
+                String resolvedHead = null;
+                GitException lastFailure = null;
+                for (String operand : branchSpec.getName().split("\\|\\|")) {
+                    if (operand.trim().isEmpty()) {
+                        continue;
+                    }
+                    HeadNameResult candidate = HeadNameResult.calculate(new BranchSpec(operand.trim()), rev, config.getRefspec(), env, remoteName);
+                    try {
+                        client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(candidate.refspec))).execute();
+                    } catch (GitException x) {
+                        lastFailure = x;
+                        listener.getLogger().println("Fetch of '" + operand.trim() + "' failed, trying next alternative");
+                        continue;
+                    }
+                    boolean ready = candidate.rev != null;
+                    String candidateHead;
+                    if (candidate.rev != null) {
+                        candidateHead = ((AbstractGitSCMSource.SCMRevisionImpl) candidate.rev).getHash();
+                    } else {
+                        candidateHead = refspecDestination(candidate.refspec);
+                        ready = refExists(client, candidateHead);
+                    }
+                    if (ready) {
+                        headNameResult = candidate;
+                        resolvedHead = candidateHead;
+                        break;
+                    }
+                    listener.getLogger().println("Ref '" + candidateHead + "' not found for '" + operand.trim() + "', trying next alternative");
+                }
 
-                listener.getLogger().println("Done with " + remoteName + " using " + headNameResult.remoteHeadName + ".");
-                return new GitSCMFileSystem(client, remote, headNameResult.remoteHeadName, (AbstractGitSCMSource.SCMRevisionImpl) headNameResult.rev);
+                if (headNameResult == null) {
+                    throw new IOException("Unable to fetch any of the branch specifications: " + branchSpec.getName(), lastFailure);
+                }
+
+                listener.getLogger().println("Done with " + remoteName + " using " + resolvedHead + ".");
+                return new GitSCMFileSystem(client, remote, resolvedHead, (AbstractGitSCMSource.SCMRevisionImpl) headNameResult.rev);
             } finally {
                 cacheLock.unlock();
             }
+        }
+
+        /**
+         * Resolves the local destination ref written by a fetch refspec. For a refspec without an
+         * explicit destination (e.g. {@code refs/changes/1/2/3}) the fetch writes to FETCH_HEAD.
+         */
+        private static String refspecDestination(@NonNull String refspec) {
+            String spec = refspec;
+            if (spec.startsWith("+")) {
+                spec = spec.substring(1);
+            }
+            int colon = spec.lastIndexOf(':');
+            return colon >= 0 ? spec.substring(colon + 1) : Constants.FETCH_HEAD;
+        }
+
+        private static boolean refExists(GitClient client, String ref) throws IOException, InterruptedException {
+            return client.withRepository((repository, channel) -> repository.findRef(ref) != null);
         }
 
         @Override

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -334,7 +334,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     prefix = "refs/changes/";
                 } else {
                     // check for FETCH_HEAD
-                    if (branchSpecExpandedName.equals("FETCH_HEAD") && !refspecExpandedName.equals("")) {
+                    if (branchSpecExpandedName.equals(Constants.FETCH_HEAD) && !refspecExpandedName.equals("")) {
                         prefix = null;
                     } else {
                         // check for commit-id

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -366,7 +366,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 }
 
                 String remoteHead = headName;
-                if (prefix == Constants.R_HEADS || prefix == Constants.R_TAGS) {
+                if (prefix.equals(Constants.R_HEADS) || prefix.equals(Constants.R_TAGS)) {
                     remoteHead = Constants.R_REMOTES + remoteName + "/" + headName;
                 }
 

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -450,7 +450,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 HeadNameResult headNameResult = HeadNameResult.calculate(branchSpec, rev, config.getRefspec(), env, remoteName);
                 client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(headNameResult.refspec))).execute();
 
-                listener.getLogger().println("Done.");
+                listener.getLogger().println("Done with " + remoteName + " using " + headNameResult.headName + ".");
                 return new GitSCMFileSystem(client, remote, headNameResult.remoteHeadName, (AbstractGitSCMSource.SCMRevisionImpl) headNameResult.rev);
             } finally {
                 cacheLock.unlock();

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -299,41 +299,78 @@ public class GitSCMFileSystem extends SCMFileSystem {
 
         static class HeadNameResult {
             final String headName;
-            final String prefix;
+            final String remoteHeadName;
+            final String refspec;
+            final SCMRevision rev;
 
-            private HeadNameResult(String headName, String prefix) {
+            private HeadNameResult(String headName, String remoteHeadName, String refspec, SCMRevision rev) {
                 this.headName = headName;
-                this.prefix = prefix;
+                this.remoteHeadName = remoteHeadName;
+                this.refspec = refspec;
+                this.rev = rev;
             }
 
             static HeadNameResult calculate(@NonNull BranchSpec branchSpec,
                                             @CheckForNull SCMRevision rev,
-                                            @CheckForNull EnvVars env) {
+                                            @NonNull String refSpec,
+                                            @CheckForNull EnvVars env,
+                                            @CheckForNull String remoteName) {
+
                 String branchSpecExpandedName = branchSpec.getName();
                 if (env != null) {
                     branchSpecExpandedName = env.expand(branchSpecExpandedName);
                 }
+                String refspecExpandedName = refSpec;
+                if (env != null) {
+                    refspecExpandedName = env.expand(refspecExpandedName);
+                }
 
+                // default to a branch (refs/heads)
                 String prefix = Constants.R_HEADS;
+                // check for a tag
                 if (branchSpecExpandedName.startsWith(Constants.R_TAGS)) {
                     prefix = Constants.R_TAGS;
                 } else if (branchSpecExpandedName.startsWith("refs/changes")) {
                     prefix = "refs/changes/";
+                } else {
+                    // check for FETCH_HEAD
+                    if (branchSpecExpandedName.equals("FETCH_HEAD") && !refspecExpandedName.equals("")) {
+                        prefix = null;
+                    } else {
+                        // check for commit-id
+                        final String regex = "^[a-fA-F0-9]{40}$";
+                        final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+                        final Matcher matcher = pattern.matcher(branchSpecExpandedName);
+
+                        if (matcher.find()) {
+                            // commit-id
+                            prefix = null;
+                            rev = new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead(branchSpecExpandedName), branchSpecExpandedName);
+                        }
+                    }
                 }
 
-                String headName;
+                String headName = branchSpecExpandedName;
                 if (rev != null && env != null) {
                     headName = env.expand(rev.getHead().getName());
                 } else {
-                    if (branchSpecExpandedName.startsWith(prefix)) {
+                    if (prefix != null && branchSpecExpandedName.startsWith(prefix)) {
                         headName = branchSpecExpandedName.substring(prefix.length());
                     } else if (branchSpecExpandedName.startsWith("*/")) {
                         headName = branchSpecExpandedName.substring(2);
-                    } else {
-                        headName = branchSpecExpandedName;
                     }
                 }
-                return new HeadNameResult(headName, prefix);
+
+                if (refspecExpandedName == null || refspecExpandedName.equals("")) {
+                    refspecExpandedName = "+" + prefix + headName + ":" + Constants.R_REMOTES + remoteName + "/" + headName;
+                }
+
+                String remoteHead = headName;
+                if (prefix == Constants.R_HEADS || prefix == Constants.R_TAGS) {
+                    remoteHead = Constants.R_REMOTES + remoteName + "/" + headName;
+                }
+
+                return new HeadNameResult(headName, remoteHead, refspecExpandedName, rev);
             }
         }
 
@@ -410,37 +447,11 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     listener.getLogger().println("URI syntax exception for '" + remoteName + "' " + ex);
                 }
 
-                HeadNameResult headNameResult = HeadNameResult.calculate(branchSpec, rev, env);
-                String head = Constants.R_REMOTES + remoteName + "/" + headNameResult.headName;
-
-                if (branchSpec.getName().equals("FETCH_HEAD")) {
-                    head = "FETCH_HEAD";
-                } else {
-                    // check for a commit hash in branchSpec
-                    final String regex = "^[a-fA-F0-9]{40}$";
-                    final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
-                    final Matcher matcher = pattern.matcher(branchSpec.getName());
-
-                    if (matcher.find()) {
-                        head = branchSpec.getName();
-                        rev = new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead(headNameResult.headName), head);
-                    }
-                }
-
-                String refspec = config.getRefspec();
-                if (refspec != null) {
-                    if (env != null) {
-                        refspec = env.expand(refspec);
-                    }
-                } else {
-                    refspec = "+" + headNameResult.prefix + headNameResult.headName + ":" + Constants.R_REMOTES + remoteName + "/"
-                            + headNameResult.headName;
-                }
-
-                client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(refspec))).execute();
+                HeadNameResult headNameResult = HeadNameResult.calculate(branchSpec, rev, config.getRefspec(), env, remoteName);
+                client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(headNameResult.refspec))).execute();
 
                 listener.getLogger().println("Done.");
-                return new GitSCMFileSystem(client, remote, head, (AbstractGitSCMSource.SCMRevisionImpl) rev);
+                return new GitSCMFileSystem(client, remote, headNameResult.remoteHeadName, (AbstractGitSCMSource.SCMRevisionImpl) headNameResult.rev);
             } finally {
                 cacheLock.unlock();
             }

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -321,7 +321,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     branchSpecExpandedName = env.expand(branchSpecExpandedName);
                 }
                 String refspecExpandedName = refSpec;
-                if (env != null) {
+                if (env != null && refspecExpandedName != null) {
                     refspecExpandedName = env.expand(refspecExpandedName);
                 }
 
@@ -334,7 +334,8 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     prefix = "refs/changes/";
                 } else {
                     // check for FETCH_HEAD
-                    if (branchSpecExpandedName.equals(Constants.FETCH_HEAD) && !refspecExpandedName.equals("")) {
+                    if (branchSpecExpandedName.equals(Constants.FETCH_HEAD) && refspecExpandedName != null &&
+                            !refspecExpandedName.equals("")) {
                         prefix = null;
                     } else {
                         // check for commit-id
@@ -362,11 +363,15 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 }
 
                 if (refspecExpandedName == null || refspecExpandedName.equals("")) {
-                    refspecExpandedName = "+" + prefix + calculatedHeadName + ":" + Constants.R_REMOTES + remoteName + "/" + calculatedHeadName;
+                    if (prefix.equals(Constants.R_TAGS)) {
+                        refspecExpandedName = "+" + prefix + calculatedHeadName + ":"  + prefix + calculatedHeadName;
+                    } else {
+                        refspecExpandedName = "+" + prefix + calculatedHeadName + ":" + Constants.R_REMOTES + remoteName + "/" + calculatedHeadName;
+                    }
                 }
 
                 String remoteHead = calculatedHeadName;
-                if (prefix != null && (prefix.equals(Constants.R_HEADS) || prefix.equals(Constants.R_TAGS))) {
+                if (prefix != null && prefix.equals(Constants.R_HEADS)) {
                     remoteHead = Constants.R_REMOTES + remoteName + "/" + calculatedHeadName;
                 }
 

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -60,6 +60,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
@@ -408,15 +411,36 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 }
 
                 HeadNameResult headNameResult = HeadNameResult.calculate(branchSpec, rev, env);
+                String head = Constants.R_REMOTES + remoteName + "/" + headNameResult.headName;
 
-                client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(
-                        "+" + headNameResult.prefix + headNameResult.headName + ":" + Constants.R_REMOTES + remoteName + "/"
-                                + headNameResult.headName))).execute();
+                if (branchSpec.getName().equals("FETCH_HEAD")) {
+                    head = "FETCH_HEAD";
+                } else {
+                    // check for a commit hash in branchSpec
+                    final String regex = "^[a-fA-F0-9]{40}$";
+                    final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+                    final Matcher matcher = pattern.matcher(branchSpec.getName());
+
+                    if (matcher.find()) {
+                        head = branchSpec.getName();
+                        rev = new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead(headNameResult.headName), head);
+                    }
+                }
+
+                String refspec = config.getRefspec();
+                if (refspec != null) {
+                    if (env != null) {
+                        refspec = env.expand(refspec);
+                    }
+                } else {
+                    refspec = "+" + headNameResult.prefix + headNameResult.headName + ":" + Constants.R_REMOTES + remoteName + "/"
+                            + headNameResult.headName;
+                }
+
+                client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(refspec))).execute();
 
                 listener.getLogger().println("Done.");
-                return new GitSCMFileSystem(client, remote, Constants.R_REMOTES + remoteName + "/" + headNameResult.headName, (AbstractGitSCMSource.SCMRevisionImpl) rev);
-            } catch (GitException x) {
-                throw new IOException(x);
+                return new GitSCMFileSystem(client, remote, head, (AbstractGitSCMSource.SCMRevisionImpl) rev);
             } finally {
                 cacheLock.unlock();
             }

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -268,6 +268,9 @@ public class GitSCMFileSystem extends SCMFileSystem {
                         || gscm.getBranches().get(0).getName().matches(
                             "^((\\Q" + Constants.R_TAGS + "\\E.*)|([^/]+)|(\\*/[^/*]+(/[^/*]+)*))$"
                         )
+                        || gscm.getBranches().get(0).getName().matches(
+                            "^((\\Qrefs/changes/\\E.*)|([^/]+)|(\\*/[^/*]+(/[^/*]+)*))$"
+                        )
                     );
             // we only support where the branch spec is obvious and not a wildcard
         }
@@ -311,6 +314,8 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 String prefix = Constants.R_HEADS;
                 if (branchSpecExpandedName.startsWith(Constants.R_TAGS)) {
                     prefix = Constants.R_TAGS;
+                } else if (branchSpecExpandedName.startsWith("refs/changes")) {
+                    prefix = "refs/changes/";
                 }
 
                 String headName;

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -366,7 +366,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 }
 
                 String remoteHead = headName;
-                if (prefix.equals(Constants.R_HEADS) || prefix.equals(Constants.R_TAGS)) {
+                if (prefix != null && (prefix.equals(Constants.R_HEADS) || prefix.equals(Constants.R_TAGS))) {
                     remoteHead = Constants.R_REMOTES + remoteName + "/" + headName;
                 }
 

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -350,27 +350,27 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     }
                 }
 
-                String headName = branchSpecExpandedName;
+                String calculatedHeadName = branchSpecExpandedName;
                 if (rev != null && env != null) {
-                    headName = env.expand(rev.getHead().getName());
+                    calculatedHeadName = env.expand(rev.getHead().getName());
                 } else {
                     if (prefix != null && branchSpecExpandedName.startsWith(prefix)) {
-                        headName = branchSpecExpandedName.substring(prefix.length());
+                        calculatedHeadName = branchSpecExpandedName.substring(prefix.length());
                     } else if (branchSpecExpandedName.startsWith("*/")) {
-                        headName = branchSpecExpandedName.substring(2);
+                        calculatedHeadName = branchSpecExpandedName.substring(2);
                     }
                 }
 
                 if (refspecExpandedName == null || refspecExpandedName.equals("")) {
-                    refspecExpandedName = "+" + prefix + headName + ":" + Constants.R_REMOTES + remoteName + "/" + headName;
+                    refspecExpandedName = "+" + prefix + calculatedHeadName + ":" + Constants.R_REMOTES + remoteName + "/" + calculatedHeadName;
                 }
 
-                String remoteHead = headName;
+                String remoteHead = calculatedHeadName;
                 if (prefix != null && (prefix.equals(Constants.R_HEADS) || prefix.equals(Constants.R_TAGS))) {
-                    remoteHead = Constants.R_REMOTES + remoteName + "/" + headName;
+                    remoteHead = Constants.R_REMOTES + remoteName + "/" + calculatedHeadName;
                 }
 
-                return new HeadNameResult(headName, remoteHead, refspecExpandedName, rev);
+                return new HeadNameResult(calculatedHeadName, remoteHead, refspecExpandedName, rev);
             }
         }
 

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -298,13 +298,11 @@ public class GitSCMFileSystem extends SCMFileSystem {
         }
 
         static class HeadNameResult {
-            final String headName;
             final String remoteHeadName;
             final String refspec;
             final SCMRevision rev;
 
-            private HeadNameResult(String headName, String remoteHeadName, String refspec, SCMRevision rev) {
-                this.headName = headName;
+            private HeadNameResult(String remoteHeadName, String refspec, SCMRevision rev) {
                 this.remoteHeadName = remoteHeadName;
                 this.refspec = refspec;
                 this.rev = rev;
@@ -375,7 +373,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                     remoteHead = Constants.R_REMOTES + remoteName + "/" + calculatedHeadName;
                 }
 
-                return new HeadNameResult(calculatedHeadName, remoteHead, refspecExpandedName, rev);
+                return new HeadNameResult(remoteHead, refspecExpandedName, rev);
             }
         }
 
@@ -455,7 +453,7 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 HeadNameResult headNameResult = HeadNameResult.calculate(branchSpec, rev, config.getRefspec(), env, remoteName);
                 client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(headNameResult.refspec))).execute();
 
-                listener.getLogger().println("Done with " + remoteName + " using " + headNameResult.headName + ".");
+                listener.getLogger().println("Done with " + remoteName + " using " + headNameResult.remoteHeadName + ".");
                 return new GitSCMFileSystem(client, remote, headNameResult.remoteHeadName, (AbstractGitSCMSource.SCMRevisionImpl) headNameResult.rev);
             } finally {
                 cacheLock.unlock();

--- a/src/main/resources/hudson/plugins/git/BranchSpec/help-name.html
+++ b/src/main/resources/hudson/plugins/git/BranchSpec/help-name.html
@@ -47,6 +47,10 @@
            Tracks/checks out the specified tag.<br/>
            E.g. <code>refs/tags/git-2.3.0</code>
       </li>
+      <li> <strong><code>refs/changes/&lt;gerritChange&gt;</code></strong><br/>
+           Tracks/checks out the specified gerrit change.<br/>
+           E.g. <code>refs/changes/91/45391/1</code>
+      </li>
       <li> <strong><code>&lt;commitId&gt;</code></strong><br/>
            Checks out the specified commit.<br/>
            E.g. <code>5062ac843f2b947733e6a3b105977056821bd352</code>, <code>5062ac84</code>, ...

--- a/src/main/resources/hudson/plugins/git/BranchSpec/help-name.html
+++ b/src/main/resources/hudson/plugins/git/BranchSpec/help-name.html
@@ -67,8 +67,13 @@
            fetched is used, so it acts as a fallback.<br/>
            <code>&amp;&amp;</code> means <em>and</em>: the branch must match both specifications.
            <code>&amp;&amp;</code> binds tighter than <code>||</code>.<br/>
-           E.g. <code>${GERRIT_REF_SPEC} || */master</code> (use the Gerrit change if present, otherwise
-           <code>master</code>), or <code>origin/* &amp;&amp; :^(?!origin/wip).*</code>.
+           Examples:<br/>
+           <ul>
+             <li><code>${GERRIT_REF_SPEC} || */master</code> — use the Gerrit change when its ref is present,
+                 otherwise fall back to <code>master</code>.</li>
+             <li><code>origin/* &amp;&amp; :^(?!origin/wip).*</code> — all <code>origin</code> branches except
+                 <code>origin/wip</code>.</li>
+           </ul>
       </li>
       <li> <strong><code>&lt;Wildcards&gt;</code></strong><br/>
            The syntax is of the form: <code>REPOSITORYNAME/BRANCH</code>.

--- a/src/main/resources/hudson/plugins/git/BranchSpec/help-name.html
+++ b/src/main/resources/hudson/plugins/git/BranchSpec/help-name.html
@@ -60,6 +60,16 @@
            result is used as described above.<br/>
            E.g. <code>${TREEISH}</code>, <code>refs/tags/${TAGNAME}</code>, ...
       </li>
+      <li> <strong><code>&lt;specA&gt; || &lt;specB&gt;</code> / <code>&lt;specA&gt; &amp;&amp; &lt;specB&gt;</code></strong><br/>
+           Branch specifications can be combined into a logical expression.<br/>
+           <code>||</code> means <em>or</em>: the branch matches either specification. In a lightweight checkout
+           (e.g. loading a Jenkinsfile) the specifications are tried left-to-right and the first one that can be
+           fetched is used, so it acts as a fallback.<br/>
+           <code>&amp;&amp;</code> means <em>and</em>: the branch must match both specifications.
+           <code>&amp;&amp;</code> binds tighter than <code>||</code>.<br/>
+           E.g. <code>${GERRIT_REF_SPEC} || */master</code> (use the Gerrit change if present, otherwise
+           <code>master</code>), or <code>origin/* &amp;&amp; :^(?!origin/wip).*</code>.
+      </li>
       <li> <strong><code>&lt;Wildcards&gt;</code></strong><br/>
            The syntax is of the form: <code>REPOSITORYNAME/BRANCH</code>.
            In addition, <code>BRANCH</code> is recognized as a shorthand of <code>*/BRANCH</code>, '*' is recognized as a wildcard,

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -74,9 +74,4 @@
     <Class name="hudson.plugins.git.extensions.impl.PathRestriction" />
     <Method name="normalize" />
   </Match>
-  <Match>
-    <Bug pattern="URF_UNREAD_FIELD" />
-    <Class name="jenkins.plugins.git.GitSCMFileSystem$BuilderImpl$HeadNameResult" />
-    <Field name="headName" />
-  </Match>
 </FindBugsFilter>

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -74,4 +74,9 @@
     <Class name="hudson.plugins.git.extensions.impl.PathRestriction" />
     <Method name="normalize" />
   </Match>
+  <Match>
+    <Bug pattern="URF_UNREAD_FIELD" />
+    <Class name="jenkins.plugins.git.GitSCMFileSystem$BuilderImpl$HeadNameResult" />
+    <Field name="headName" />
+  </Match>
 </FindBugsFilter>

--- a/src/test/java/hudson/plugins/git/BranchSpecTest.java
+++ b/src/test/java/hudson/plugins/git/BranchSpecTest.java
@@ -150,6 +150,14 @@ class BranchSpecTest {
     }
 
     @Test
+    public void testMatchesGerritChangeRef() {
+        BranchSpec spec = new BranchSpec("refs/changes/91/45391/1");
+
+        assertTrue(spec.matches("refs/changes/91/45391/1"));
+        assertFalse(spec.matches("refs/heads/refs/changes/91/45391/1"));
+    }
+
+    @Test
     void testUsesJavaPatternDirectlyIfPrefixedWithColon() {
     	BranchSpec m = new BranchSpec(":^(?!(origin/prefix)).*");
     	assertTrue(m.matches("origin"));

--- a/src/test/java/hudson/plugins/git/BranchSpecTest.java
+++ b/src/test/java/hudson/plugins/git/BranchSpecTest.java
@@ -158,6 +158,42 @@ class BranchSpecTest {
     }
 
     @Test
+    void testMatchesLogicalOr() {
+        BranchSpec spec = new BranchSpec("master || develop");
+
+        assertTrue(spec.matches("refs/heads/master"));
+        assertTrue(spec.matches("refs/heads/develop"));
+        assertFalse(spec.matches("refs/heads/feature"));
+    }
+
+    @Test
+    void testMatchesLogicalAnd() {
+        BranchSpec spec = new BranchSpec("origin/* && :^(?!origin/wip).*");
+
+        assertTrue(spec.matches("origin/feature"));
+        assertFalse(spec.matches("origin/wip"));
+    }
+
+    @Test
+    void testMatchesLogicalPrecedence() {
+        // `&&` binds tighter than `||`: `master || develop && master` is `master || (develop && master)`
+        BranchSpec spec = new BranchSpec("master || develop && master");
+
+        assertTrue(spec.matches("refs/heads/master"));
+        assertFalse(spec.matches("refs/heads/develop"));
+    }
+
+    @Test
+    void testMatchesLogicalWithEnv() {
+        BranchSpec spec = new BranchSpec("${BRANCH} || master");
+        EnvVars env = createEnvMap("BRANCH", "develop");
+
+        assertTrue(spec.matches("refs/heads/develop", env));
+        assertTrue(spec.matches("refs/heads/master", env));
+        assertFalse(spec.matches("refs/heads/feature", env));
+    }
+
+    @Test
     void testUsesJavaPatternDirectlyIfPrefixedWithColon() {
     	BranchSpec m = new BranchSpec(":^(?!(origin/prefix)).*");
     	assertTrue(m.matches("origin"));

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -478,7 +478,7 @@ class GitSCMFileSystemTest {
         sampleRepo.git("mv", "file", "dir/subdir/file");
         sampleRepo.write("dir/subdir/file", "modified");
         sampleRepo.git("commit", "--all", "--message=dev");
-        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(), new GitSCM(createRepoListWithRefspec(sampleRepo.toString(), "dev"), Collections.singletonList(new BranchSpec("FETCH_HEAD")), null, null, Collections.emptyList()));
+        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(), new GitSCM(createRepoListWithRefspec(sampleRepo.toString(), "dev"), Collections.singletonList(new BranchSpec(Constants.FETCH_HEAD)), null, null, Collections.emptyList()));
         assertEquals("modified", getFileContent(fs, "dir/subdir/file", "modified"));
     }
 
@@ -586,15 +586,15 @@ class GitSCMFileSystemTest {
     @Test
     public void calculate_head_name_with_refspec_FETCH_HEAD() throws Exception {
         String remote = "origin";
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("FETCH_HEAD"), null, "refs/changes/1/2/3", null, remote);
-        assertEquals("FETCH_HEAD", result1.headName);
-        assertEquals("FETCH_HEAD", result1.remoteHeadName);
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec(Constants.FETCH_HEAD), null, "refs/changes/1/2/3", null, remote);
+        assertEquals(Constants.FETCH_HEAD, result1.headName);
+        assertEquals(Constants.FETCH_HEAD, result1.remoteHeadName);
         assertEquals("refs/changes/1/2/3", result1.refspec);
 
         GitSCMFileSystem.BuilderImpl.HeadNameResult result2 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, "${REFSPEC}",
-                new EnvVars("BRANCH", "FETCH_HEAD", "REFSPEC", "refs/changes/1/2/3"), remote);
-        assertEquals("FETCH_HEAD", result2.headName);
-        assertEquals("FETCH_HEAD", result2.remoteHeadName);
+                new EnvVars("BRANCH", Constants.FETCH_HEAD, "REFSPEC", "refs/changes/1/2/3"), remote);
+        assertEquals(Constants.FETCH_HEAD, result2.headName);
+        assertEquals(Constants.FETCH_HEAD, result2.remoteHeadName);
         assertEquals("refs/changes/1/2/3", result2.refspec);
     }
 

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -541,17 +541,17 @@ class GitSCMFileSystemTest {
     @Test
     public void calculate_head_name() throws Exception {
         String remote = "origin";
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("branch"), null, null, null, remote);
+        HeadNameResult result1 = HeadNameResult.calculate(new BranchSpec("branch"), null, null, null, remote);
         assertEquals("branch", result1.headName);
         assertEquals("refs/remotes/origin/branch", result1.remoteHeadName);
         assertEquals("+refs/heads/branch:refs/remotes/origin/branch", result1.refspec);
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result2 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("refs/heads/branch"), null, null, null, remote);
+        HeadNameResult result2 = HeadNameResult.calculate(new BranchSpec("refs/heads/branch"), null, null, null, remote);
         assertEquals("branch", result2.headName);
         assertEquals("refs/remotes/origin/branch", result2.remoteHeadName);
         assertEquals("+refs/heads/branch:refs/remotes/origin/branch", result2.refspec);
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result3 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("refs/tags/my-tag"), null, null, null, remote);
+        HeadNameResult result3 = HeadNameResult.calculate(new BranchSpec("refs/tags/my-tag"), null, null, null, remote);
         assertEquals("my-tag", result3.headName);
         assertEquals("refs/remotes/origin/my-tag", result3.remoteHeadName);
         assertEquals("+refs/tags/my-tag:refs/remotes/origin/my-tag", result3.refspec);
@@ -562,12 +562,12 @@ class GitSCMFileSystemTest {
         String remote = "origin";
         String commit = "0123456789" + "0123456789" + "0123456789" + "0123456789";
         String branch = "branch";
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec(commit), null, branch, null, remote);
+        HeadNameResult result1 = HeadNameResult.calculate(new BranchSpec(commit), null, branch, null, remote);
         assertEquals(commit, result1.headName);
         assertEquals(commit, result1.remoteHeadName);
         assertEquals(branch, result1.refspec);
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result2 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, "${REFSPEC}",
+        HeadNameResult result2 = HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, "${REFSPEC}",
                 new EnvVars("BRANCH", commit, "REFSPEC", branch), remote);
         assertEquals(commit, result2.headName);
         assertEquals(commit, result2.remoteHeadName);
@@ -577,12 +577,12 @@ class GitSCMFileSystemTest {
     @Test
     public void calculate_head_name_with_refspec_FETCH_HEAD() throws Exception {
         String remote = "origin";
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec(Constants.FETCH_HEAD), null, "refs/changes/1/2/3", null, remote);
+        HeadNameResult result1 = HeadNameResult.calculate(new BranchSpec(Constants.FETCH_HEAD), null, "refs/changes/1/2/3", null, remote);
         assertEquals(Constants.FETCH_HEAD, result1.headName);
         assertEquals(Constants.FETCH_HEAD, result1.remoteHeadName);
         assertEquals("refs/changes/1/2/3", result1.refspec);
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result2 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, "${REFSPEC}",
+        HeadNameResult result2 = HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, "${REFSPEC}",
                 new EnvVars("BRANCH", Constants.FETCH_HEAD, "REFSPEC", "refs/changes/1/2/3"), remote);
         assertEquals(Constants.FETCH_HEAD, result2.headName);
         assertEquals(Constants.FETCH_HEAD, result2.remoteHeadName);
@@ -599,7 +599,7 @@ class GitSCMFileSystemTest {
         ObjectId git260 = client.revParse(GIT_2_6_0_TAG);
         AbstractGitSCMSource.SCMRevisionImpl rev260 =
                 new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git260.getName());
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("master-f"), rev260, null, null, "origin");
+        HeadNameResult result1 = HeadNameResult.calculate(new BranchSpec("master-f"), rev260, null, null, "origin");
         assertEquals("master-f", result1.headName);
         assertTrue(result1.refspec.startsWith("+" + Constants.R_HEADS));
     }

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -417,41 +417,36 @@ class GitSCMFileSystemTest {
         assertEquals("modified", getFileContent(fs, "dir/subdir/file", "modified"));
     }
 
+    public String getFileContent(SCMFileSystem fs, String path, String expectedContent) throws IOException, InterruptedException {
+        assertThat(fs, notNullValue());
+        assertThat(fs.getRoot(), notNullValue());
+        Iterable<SCMFile> children = fs.getRoot().children();
+        Iterator<SCMFile> iterator = children.iterator();
+        assertThat(iterator.hasNext(), is(true));
+        SCMFile dir = iterator.next();
+        assertThat(iterator.hasNext(), is(false));
+        assertThat(dir.getName(), is("dir"));
+        assertThat(dir.getType(), is(SCMFile.Type.DIRECTORY));
+        children = dir.children();
+        iterator = children.iterator();
+        assertThat(iterator.hasNext(), is(true));
+        SCMFile subdir = iterator.next();
+        assertThat(iterator.hasNext(), is(false));
+        assertThat(subdir.getName(), is("subdir"));
+        assertThat(subdir.getType(), is(SCMFile.Type.DIRECTORY));
+        children = subdir.children();
+        iterator = children.iterator();
+        assertThat(iterator.hasNext(), is(true));
+        SCMFile file = iterator.next();
+        assertThat(iterator.hasNext(), is(false));
+        assertThat(file.getName(), is("file"));
+        return file.contentAsString();
+    }
+
     public static List<UserRemoteConfig> createRepoListWithRefspec(String url, String refspec) {
         List<UserRemoteConfig> repoList = new ArrayList<>();
         repoList.add(new UserRemoteConfig(url, null, refspec, null));
         return repoList;
-    }
-
-    public String getFileContent(SCMFileSystem fs, String path, String expectedContent) throws IOException, InterruptedException {
-        assertThat(fs, notNullValue());
-        assertThat(fs.getRoot(), notNullValue());
-        String[] segments = path.split("/");
-
-        SCMFile parent = fs.getRoot();
-        SCMFile file = null;
-        for (String segment: segments) {
-            Iterable<SCMFile> children = parent.children();
-            Iterator<SCMFile> iterator = children.iterator();
-            if (segment == segments[segments.length - 1]) {
-                // file
-                assertThat(iterator.hasNext(), is(true));
-                SCMFile t = iterator.next();
-                assertThat(iterator.hasNext(), is(false));
-                assertThat(t.getName(), is(segment));
-                assertThat(t.getType(), is(SCMFile.Type.REGULAR_FILE));
-                file = t;
-            } else {
-                // dir
-                assertThat(iterator.hasNext(), is(true));
-                SCMFile dir = iterator.next();
-                assertThat(iterator.hasNext(), is(false));
-                assertThat(dir.getName(), is(segment));
-                assertThat(dir.getType(), is(SCMFile.Type.DIRECTORY));
-                parent = dir;
-            }
-        }
-        return file.contentAsString();
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -435,6 +435,29 @@ class GitSCMFileSystemTest {
         assertThat(file.contentAsString(), is("modified"));
     }
 
+    @Test
+    public void testSupportsGerritChangeRef() throws Exception {
+        // Create a dummy GitSCM configured with a Gerrit change refspec
+        GitSCM scm = new GitSCM(
+                GitSCM.createRepoList("https://example.com/repo.git", null),
+                Collections.singletonList(new BranchSpec("refs/changes/91/45391/1")),
+                null, null, Collections.emptyList());
+
+        GitSCMFileSystem.BuilderImpl builder = new GitSCMFileSystem.BuilderImpl();
+        assertTrue(builder.supports(scm), "Builder should support refs/changes/ branch specs");
+    }
+
+    @Test
+    public void testHeadNameResultCalculateGerritChange() {
+        BranchSpec spec = new BranchSpec("refs/changes/91/45391/1");
+
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result =
+                GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(spec, null, null);
+
+        assertEquals("refs/changes/", result.prefix);
+        assertEquals("91/45391/1", result.headName);
+    }
+
     @Issue("JENKINS-52964")
     @Test
     void filesystem_supports_descriptor() throws Exception {

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -514,27 +514,27 @@ class GitSCMFileSystemTest {
     public void calculate_head_name_with_env() throws Exception {
         String remote = "origin";
         HeadNameResult result1 = HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, null, new EnvVars("BRANCH", "master-a"), remote);
-        assertEquals("master-a", result1.headName);
+        assertEquals("refs/remotes/origin/master-a", result1.remoteHeadName);
         assertTrue(result1.refspec.startsWith("+" + Constants.R_HEADS));
 
         HeadNameResult result2 = HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, null, new EnvVars("BRANCH", "refs/heads/master-b"), remote);
-        assertEquals("master-b", result2.headName);
+        assertEquals("refs/remotes/origin/master-b", result2.remoteHeadName);
         assertTrue(result2.refspec.startsWith("+" + Constants.R_HEADS));
 
         HeadNameResult result3 = HeadNameResult.calculate(new BranchSpec("refs/heads/${BRANCH}"), null, null, new EnvVars("BRANCH", "master-c"), remote);
-        assertEquals("master-c", result3.headName);
+        assertEquals("refs/remotes/origin/master-c", result3.remoteHeadName);
         assertTrue(result3.refspec.startsWith("+" + Constants.R_HEADS));
 
         HeadNameResult result4 = HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, null, null, remote);
-        assertEquals("${BRANCH}", result4.headName);
+        assertEquals("refs/remotes/origin/${BRANCH}", result4.remoteHeadName);
         assertTrue(result4.refspec.startsWith("+" + Constants.R_HEADS));
 
         HeadNameResult result5 = HeadNameResult.calculate(new BranchSpec("*/${BRANCH}"), null, null, new EnvVars("BRANCH", "master-d"), remote);
-        assertEquals("master-d", result5.headName);
+        assertEquals("refs/remotes/origin/master-d", result5.remoteHeadName);
         assertTrue(result5.refspec.startsWith("+" + Constants.R_HEADS));
 
         HeadNameResult result6 = HeadNameResult.calculate(new BranchSpec("*/master-e"), null, null, new EnvVars("BRANCH", "dummy"), remote);
-        assertEquals("master-e", result6.headName);
+        assertEquals("refs/remotes/origin/master-e", result6.remoteHeadName);
         assertTrue(result6.refspec.startsWith("+" + Constants.R_HEADS));
     }
 
@@ -542,17 +542,14 @@ class GitSCMFileSystemTest {
     public void calculate_head_name() throws Exception {
         String remote = "origin";
         HeadNameResult result1 = HeadNameResult.calculate(new BranchSpec("branch"), null, null, null, remote);
-        assertEquals("branch", result1.headName);
         assertEquals("refs/remotes/origin/branch", result1.remoteHeadName);
         assertEquals("+refs/heads/branch:refs/remotes/origin/branch", result1.refspec);
 
         HeadNameResult result2 = HeadNameResult.calculate(new BranchSpec("refs/heads/branch"), null, null, null, remote);
-        assertEquals("branch", result2.headName);
         assertEquals("refs/remotes/origin/branch", result2.remoteHeadName);
         assertEquals("+refs/heads/branch:refs/remotes/origin/branch", result2.refspec);
 
         HeadNameResult result3 = HeadNameResult.calculate(new BranchSpec("refs/tags/my-tag"), null, null, null, remote);
-        assertEquals("my-tag", result3.headName);
         assertEquals("my-tag", result3.remoteHeadName);
         assertEquals("+refs/tags/my-tag:refs/tags/my-tag", result3.refspec);
     }
@@ -563,13 +560,11 @@ class GitSCMFileSystemTest {
         String commit = "0123456789" + "0123456789" + "0123456789" + "0123456789";
         String branch = "branch";
         HeadNameResult result1 = HeadNameResult.calculate(new BranchSpec(commit), null, branch, null, remote);
-        assertEquals(commit, result1.headName);
         assertEquals(commit, result1.remoteHeadName);
         assertEquals(branch, result1.refspec);
 
         HeadNameResult result2 = HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, "${REFSPEC}",
                 new EnvVars("BRANCH", commit, "REFSPEC", branch), remote);
-        assertEquals(commit, result2.headName);
         assertEquals(commit, result2.remoteHeadName);
         assertEquals(branch, result2.refspec);
     }
@@ -578,13 +573,11 @@ class GitSCMFileSystemTest {
     public void calculate_head_name_with_refspec_FETCH_HEAD() throws Exception {
         String remote = "origin";
         HeadNameResult result1 = HeadNameResult.calculate(new BranchSpec(Constants.FETCH_HEAD), null, "refs/changes/1/2/3", null, remote);
-        assertEquals(Constants.FETCH_HEAD, result1.headName);
         assertEquals(Constants.FETCH_HEAD, result1.remoteHeadName);
         assertEquals("refs/changes/1/2/3", result1.refspec);
 
         HeadNameResult result2 = HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, "${REFSPEC}",
                 new EnvVars("BRANCH", Constants.FETCH_HEAD, "REFSPEC", "refs/changes/1/2/3"), remote);
-        assertEquals(Constants.FETCH_HEAD, result2.headName);
         assertEquals(Constants.FETCH_HEAD, result2.remoteHeadName);
         assertEquals("refs/changes/1/2/3", result2.refspec);
     }
@@ -600,7 +593,7 @@ class GitSCMFileSystemTest {
         AbstractGitSCMSource.SCMRevisionImpl rev260 =
                 new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git260.getName());
         HeadNameResult result1 = HeadNameResult.calculate(new BranchSpec("master-f"), rev260, null, null, "origin");
-        assertEquals("master-f", result1.headName);
+        assertEquals("refs/remotes/origin/master-f", result1.remoteHeadName);
         assertTrue(result1.refspec.startsWith("+" + Constants.R_HEADS));
     }
 }

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -553,8 +553,8 @@ class GitSCMFileSystemTest {
 
         HeadNameResult result3 = HeadNameResult.calculate(new BranchSpec("refs/tags/my-tag"), null, null, null, remote);
         assertEquals("my-tag", result3.headName);
-        assertEquals("refs/remotes/origin/my-tag", result3.remoteHeadName);
-        assertEquals("+refs/tags/my-tag:refs/remotes/origin/my-tag", result3.refspec);
+        assertEquals("my-tag", result3.remoteHeadName);
+        assertEquals("+refs/tags/my-tag:refs/tags/my-tag", result3.refspec);
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -32,11 +32,15 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitException;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import hudson.plugins.git.UserRemoteConfig;
 import jenkins.plugins.git.junit.jupiter.WithGitSampleRepo;
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMFileSystem;
@@ -410,29 +414,72 @@ class GitSCMFileSystemTest {
         sampleRepo.git("commit", "--all", "--message=dev");
         sampleRepo.git("tag", "v1.0");
         SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(), new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null), Collections.singletonList(new BranchSpec("refs/tags/v1.0")), null, null, Collections.emptyList()));
+        assertEquals("modified", getFileContent(fs, "dir/subdir/file", "modified"));
+    }
+
+    public static List<UserRemoteConfig> createRepoListWithRefspec(String url, String refspec) {
+        List<UserRemoteConfig> repoList = new ArrayList<>();
+        repoList.add(new UserRemoteConfig(url, null, refspec, null));
+        return repoList;
+    }
+
+    public String getFileContent(SCMFileSystem fs, String path, String expectedContent) throws IOException, InterruptedException {
         assertThat(fs, notNullValue());
         assertThat(fs.getRoot(), notNullValue());
-        Iterable<SCMFile> children = fs.getRoot().children();
-        Iterator<SCMFile> iterator = children.iterator();
-        assertThat(iterator.hasNext(), is(true));
-        SCMFile dir = iterator.next();
-        assertThat(iterator.hasNext(), is(false));
-        assertThat(dir.getName(), is("dir"));
-        assertThat(dir.getType(), is(SCMFile.Type.DIRECTORY));
-        children = dir.children();
-        iterator = children.iterator();
-        assertThat(iterator.hasNext(), is(true));
-        SCMFile subdir = iterator.next();
-        assertThat(iterator.hasNext(), is(false));
-        assertThat(subdir.getName(), is("subdir"));
-        assertThat(subdir.getType(), is(SCMFile.Type.DIRECTORY));
-        children = subdir.children();
-        iterator = children.iterator();
-        assertThat(iterator.hasNext(), is(true));
-        SCMFile file = iterator.next();
-        assertThat(iterator.hasNext(), is(false));
-        assertThat(file.getName(), is("file"));
-        assertThat(file.contentAsString(), is("modified"));
+        String[] segments = path.split("/");
+
+        SCMFile parent = fs.getRoot();
+        SCMFile file = null;
+        for (String segment: segments) {
+            Iterable<SCMFile> children = parent.children();
+            Iterator<SCMFile> iterator = children.iterator();
+            if (segment == segments[segments.length - 1]) {
+                // file
+                assertThat(iterator.hasNext(), is(true));
+                SCMFile t = iterator.next();
+                assertThat(iterator.hasNext(), is(false));
+                assertThat(t.getName(), is(segment));
+                assertThat(t.getType(), is(SCMFile.Type.REGULAR_FILE));
+                file = t;
+            } else {
+                // dir
+                assertThat(iterator.hasNext(), is(true));
+                SCMFile dir = iterator.next();
+                assertThat(iterator.hasNext(), is(false));
+                assertThat(dir.getName(), is(segment));
+                assertThat(dir.getType(), is(SCMFile.Type.DIRECTORY));
+                parent = dir;
+            }
+        }
+        return file.contentAsString();
+    }
+
+    @Test
+    public void create_SCMFileSystem_from_commit() throws Exception {
+        sampleRepo.init();
+        sampleRepo.git("checkout", "-b", "dev");
+        sampleRepo.mkdirs("dir/subdir");
+        sampleRepo.git("mv", "file", "dir/subdir/file");
+        sampleRepo.write("dir/subdir/file", "modified");
+        sampleRepo.git("commit", "--all", "--message=dev");
+        String modifiedCommit = sampleRepo.head();
+        sampleRepo.write("dir/subdir/file", "modified again");
+        sampleRepo.git("commit", "--all", "--message=dev");
+        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(), new GitSCM(createRepoListWithRefspec(sampleRepo.toString(), "dev"), Collections.singletonList(new BranchSpec(modifiedCommit)), null, null, Collections.emptyList()));
+        assertEquals(modifiedCommit, fs.getRevision().toString());
+        assertEquals("modified", getFileContent(fs, "dir/subdir/file", "modified"));
+    }
+
+    @Test
+    public void create_SCMFileSystem_from_FETCH_HEAD() throws Exception {
+        sampleRepo.init();
+        sampleRepo.git("checkout", "-b", "dev");
+        sampleRepo.mkdirs("dir/subdir");
+        sampleRepo.git("mv", "file", "dir/subdir/file");
+        sampleRepo.write("dir/subdir/file", "modified");
+        sampleRepo.git("commit", "--all", "--message=dev");
+        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(), new GitSCM(createRepoListWithRefspec(sampleRepo.toString(), "dev"), Collections.singletonList(new BranchSpec("FETCH_HEAD")), null, null, Collections.emptyList()));
+        assertEquals("modified", getFileContent(fs, "dir/subdir/file", "modified"));
     }
 
     @Test
@@ -467,36 +514,88 @@ class GitSCMFileSystemTest {
 
     @Issue("JENKINS-42971")
     @Test
-    void calculate_head_name_with_env() throws Exception {
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null,
-                new EnvVars("BRANCH", "master-a"));
+    public void calculate_head_name_with_env() throws Exception {
+        String remote = "origin";
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, null,
+                new EnvVars("BRANCH", "master-a"), remote);
         assertEquals("master-a", result1.headName);
-        assertEquals(Constants.R_HEADS, result1.prefix);
+        assertTrue(result1.refspec.startsWith("+" + Constants.R_HEADS));
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result2 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null,
-                new EnvVars("BRANCH", "refs/heads/master-b"));
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result2 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, null,
+                new EnvVars("BRANCH", "refs/heads/master-b"), remote);
         assertEquals("master-b", result2.headName);
-        assertEquals(Constants.R_HEADS, result2.prefix);
+        assertTrue(result2.refspec.startsWith("+" + Constants.R_HEADS));
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result3 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("refs/heads/${BRANCH}"), null,
-                new EnvVars("BRANCH", "master-c"));
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result3 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("refs/heads/${BRANCH}"), null,null,
+                new EnvVars("BRANCH", "master-c"), remote);
         assertEquals("master-c", result3.headName);
-        assertEquals(Constants.R_HEADS, result3.prefix);
+        assertTrue(result3.refspec.startsWith("+" + Constants.R_HEADS));
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result4 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null,
-                null);
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result4 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, null,
+                null, remote);
         assertEquals("${BRANCH}", result4.headName);
-        assertEquals(Constants.R_HEADS, result4.prefix);
+        assertTrue(result4.refspec.startsWith("+" + Constants.R_HEADS));
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result5 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("*/${BRANCH}"), null,
-                new EnvVars("BRANCH", "master-d"));
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result5 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("*/${BRANCH}"), null, null,
+                new EnvVars("BRANCH", "master-d"), remote);
         assertEquals("master-d", result5.headName);
-        assertEquals(Constants.R_HEADS, result5.prefix);
+        assertTrue(result5.refspec.startsWith("+" + Constants.R_HEADS));
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result6 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("*/master-e"), null,
-                new EnvVars("BRANCH", "dummy"));
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result6 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("*/master-e"), null, null,
+                new EnvVars("BRANCH", "dummy"), remote);
         assertEquals("master-e", result6.headName);
-        assertEquals(Constants.R_HEADS, result6.prefix);
+        assertTrue(result6.refspec.startsWith("+" + Constants.R_HEADS));
+    }
+
+    @Test
+    public void calculate_head_name() throws Exception {
+        String remote = "origin";
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("branch"), null, null, null, remote);
+        assertEquals("branch", result1.headName);
+        assertEquals("refs/remotes/origin/branch", result1.remoteHeadName);
+        assertEquals("+refs/heads/branch:refs/remotes/origin/branch", result1.refspec);
+
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result2 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("refs/heads/branch"), null, null, null, remote);
+        assertEquals("branch", result2.headName);
+        assertEquals("refs/remotes/origin/branch", result2.remoteHeadName);
+        assertEquals("+refs/heads/branch:refs/remotes/origin/branch", result2.refspec);
+
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result3 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("refs/tags/my-tag"), null, null, null, remote);
+        assertEquals("my-tag", result3.headName);
+        assertEquals("refs/remotes/origin/my-tag", result3.remoteHeadName);
+        assertEquals("+refs/tags/my-tag:refs/remotes/origin/my-tag", result3.refspec);
+    }
+
+    @Test
+    public void calculate_head_name_with_refspec_commit() throws Exception {
+        String remote = "origin";
+        String commit = "0123456789" + "0123456789" + "0123456789" + "0123456789";
+        String branch = "branch";
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec(commit), null, branch, null, remote);
+        assertEquals(commit, result1.headName);
+        assertEquals(commit, result1.remoteHeadName);
+        assertEquals(branch, result1.refspec);
+
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result2 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, "${REFSPEC}",
+                new EnvVars("BRANCH", commit, "REFSPEC", branch), remote);
+        assertEquals(commit, result2.headName);
+        assertEquals(commit, result2.remoteHeadName);
+        assertEquals(branch, result2.refspec);
+    }
+
+    @Test
+    public void calculate_head_name_with_refspec_FETCH_HEAD() throws Exception {
+        String remote = "origin";
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("FETCH_HEAD"), null, "refs/changes/1/2/3", null, remote);
+        assertEquals("FETCH_HEAD", result1.headName);
+        assertEquals("FETCH_HEAD", result1.remoteHeadName);
+        assertEquals("refs/changes/1/2/3", result1.refspec);
+
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result2 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, "${REFSPEC}",
+                new EnvVars("BRANCH", "FETCH_HEAD", "REFSPEC", "refs/changes/1/2/3"), remote);
+        assertEquals("FETCH_HEAD", result2.headName);
+        assertEquals("FETCH_HEAD", result2.remoteHeadName);
+        assertEquals("refs/changes/1/2/3", result2.refspec);
     }
 
     /* GitSCMFileSystem in git plugin 4.14.0 reported a null pointer
@@ -509,8 +608,8 @@ class GitSCMFileSystemTest {
         ObjectId git260 = client.revParse(GIT_2_6_0_TAG);
         AbstractGitSCMSource.SCMRevisionImpl rev260 =
                 new AbstractGitSCMSource.SCMRevisionImpl(new SCMHead("origin"), git260.getName());
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("master-f"), rev260, null);
+        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("master-f"), rev260, null, null, "origin");
         assertEquals("master-f", result1.headName);
-        assertEquals(Constants.R_HEADS, result1.prefix);
+        assertTrue(result1.refspec.startsWith("+" + Constants.R_HEADS));
     }
 }

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -495,11 +495,11 @@ class GitSCMFileSystemTest {
     public void testHeadNameResultCalculateGerritChange() {
         BranchSpec spec = new BranchSpec("refs/changes/91/45391/1");
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result =
-                GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(spec, null, null);
+        HeadNameResult result =
+                HeadNameResult.calculate(spec, null, null, null, "origin");
 
-        assertEquals("refs/changes/", result.prefix);
-        assertEquals("91/45391/1", result.headName);
+        assertEquals("91/45391/1", result.remoteHeadName);
+        assertTrue(result.refspec.startsWith("+refs/changes/"));
     }
 
     @Issue("JENKINS-52964")

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -72,6 +72,8 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import jenkins.plugins.git.GitSCMFileSystem.BuilderImpl.HeadNameResult;
+
 /**
  * Tests for {@link AbstractGitSCMSource}
  */
@@ -511,33 +513,27 @@ class GitSCMFileSystemTest {
     @Test
     public void calculate_head_name_with_env() throws Exception {
         String remote = "origin";
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, null,
-                new EnvVars("BRANCH", "master-a"), remote);
+        HeadNameResult result1 = HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, null, new EnvVars("BRANCH", "master-a"), remote);
         assertEquals("master-a", result1.headName);
         assertTrue(result1.refspec.startsWith("+" + Constants.R_HEADS));
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result2 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, null,
-                new EnvVars("BRANCH", "refs/heads/master-b"), remote);
+        HeadNameResult result2 = HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, null, new EnvVars("BRANCH", "refs/heads/master-b"), remote);
         assertEquals("master-b", result2.headName);
         assertTrue(result2.refspec.startsWith("+" + Constants.R_HEADS));
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result3 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("refs/heads/${BRANCH}"), null,null,
-                new EnvVars("BRANCH", "master-c"), remote);
+        HeadNameResult result3 = HeadNameResult.calculate(new BranchSpec("refs/heads/${BRANCH}"), null, null, new EnvVars("BRANCH", "master-c"), remote);
         assertEquals("master-c", result3.headName);
         assertTrue(result3.refspec.startsWith("+" + Constants.R_HEADS));
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result4 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, null,
-                null, remote);
+        HeadNameResult result4 = HeadNameResult.calculate(new BranchSpec("${BRANCH}"), null, null, null, remote);
         assertEquals("${BRANCH}", result4.headName);
         assertTrue(result4.refspec.startsWith("+" + Constants.R_HEADS));
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result5 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("*/${BRANCH}"), null, null,
-                new EnvVars("BRANCH", "master-d"), remote);
+        HeadNameResult result5 = HeadNameResult.calculate(new BranchSpec("*/${BRANCH}"), null, null, new EnvVars("BRANCH", "master-d"), remote);
         assertEquals("master-d", result5.headName);
         assertTrue(result5.refspec.startsWith("+" + Constants.R_HEADS));
 
-        GitSCMFileSystem.BuilderImpl.HeadNameResult result6 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("*/master-e"), null, null,
-                new EnvVars("BRANCH", "dummy"), remote);
+        HeadNameResult result6 = HeadNameResult.calculate(new BranchSpec("*/master-e"), null, null, new EnvVars("BRANCH", "dummy"), remote);
         assertEquals("master-e", result6.headName);
         assertTrue(result6.refspec.startsWith("+" + Constants.R_HEADS));
     }

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -502,6 +502,84 @@ class GitSCMFileSystemTest {
         assertTrue(result.refspec.startsWith("+refs/changes/"));
     }
 
+    @Test
+    public void testSupportsLogicalOr() {
+        GitSCM scm = new GitSCM(
+                GitSCM.createRepoList("https://example.com/repo.git", null),
+                Collections.singletonList(new BranchSpec("refs/changes/91/45391/1 || */master")),
+                null, null, Collections.emptyList());
+
+        GitSCMFileSystem.BuilderImpl builder = new GitSCMFileSystem.BuilderImpl();
+        assertTrue(builder.supports(scm), "Builder should support logical OR branch specs");
+    }
+
+    @Test
+    public void testSupportsLogicalAndRejected() {
+        GitSCM scm = new GitSCM(
+                GitSCM.createRepoList("https://example.com/repo.git", null),
+                Collections.singletonList(new BranchSpec("*/master && */dev")),
+                null, null, Collections.emptyList());
+
+        GitSCMFileSystem.BuilderImpl builder = new GitSCMFileSystem.BuilderImpl();
+        assertFalse(builder.supports(scm), "Builder should not support logical AND branch specs");
+    }
+
+    @Test
+    public void testSupportsWildcardOperandRejected() {
+        GitSCM scm = new GitSCM(
+                GitSCM.createRepoList("https://example.com/repo.git", null),
+                Collections.singletonList(new BranchSpec("* || */master")),
+                null, null, Collections.emptyList());
+
+        GitSCMFileSystem.BuilderImpl builder = new GitSCMFileSystem.BuilderImpl();
+        assertFalse(builder.supports(scm), "Builder should not support a bare wildcard operand");
+    }
+
+    @Test
+    public void create_SCMFileSystem_with_fallback() throws Exception {
+        sampleRepo.init();
+        sampleRepo.git("checkout", "-b", "dev");
+        sampleRepo.write("file", "dev-content");
+        sampleRepo.git("commit", "--all", "--message=dev");
+        sampleRepo.git("checkout", "-b", "feature");
+        sampleRepo.write("file", "feature-content");
+        sampleRepo.git("commit", "--all", "--message=feature");
+
+        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(),
+                new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null),
+                        Collections.singletonList(new BranchSpec("refs/changes/nonexistent/1/1 || */dev")),
+                        null, null, Collections.emptyList()));
+        assertThat(fs, notNullValue());
+        assertEquals("dev-content", getRootFileContent(fs));
+    }
+
+    @Test
+    public void create_SCMFileSystem_with_fallback_first_wins() throws Exception {
+        sampleRepo.init();
+        sampleRepo.git("checkout", "-b", "dev");
+        sampleRepo.write("file", "dev-content");
+        sampleRepo.git("commit", "--all", "--message=dev");
+        sampleRepo.git("checkout", "-b", "feature");
+        sampleRepo.write("file", "feature-content");
+        sampleRepo.git("commit", "--all", "--message=feature");
+
+        SCMFileSystem fs = SCMFileSystem.of(r.createFreeStyleProject(),
+                new GitSCM(GitSCM.createRepoList(sampleRepo.toString(), null),
+                        Collections.singletonList(new BranchSpec("*/feature || */dev")),
+                        null, null, Collections.emptyList()));
+        assertThat(fs, notNullValue());
+        assertEquals("feature-content", getRootFileContent(fs));
+    }
+
+    private String getRootFileContent(SCMFileSystem fs) throws IOException, InterruptedException {
+        for (SCMFile child : fs.getRoot().children()) {
+            if (child.getName().equals("file")) {
+                return child.contentAsString();
+            }
+        }
+        return null;
+    }
+
     @Issue("JENKINS-52964")
     @Test
     void filesystem_supports_descriptor() throws Exception {


### PR DESCRIPTION
## [JENKINS-71506] Support custom refspec in lightweight checkout

Let user specify a custom refspec to fetch.
Add support for branch names FETCH_HEAD or a commit hash.

This allows to use lightweight checkout for:

* Fetch the pipeline from a Gerrit change (refspec:
  refs/changes/*/change/patchset and branch: FETCH_HEAD).

* Fetch the pipeline from a fixed commit of a branch, instead of head (refspec: branch and branch: commit hash).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [x] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
