### PR TITLE
Document shallow clone depth's effect on changesets

### DIFF
--- a/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-depth.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/CloneOption/help-depth.html
@@ -1,4 +1,6 @@
 <div>
   Set shallow clone depth, so that git will only download recent history of the project,
   saving time and disk space when you just want to access the latest commits of a repository.
+  Note that this has an effect on the changesets listed by Jenkins. Setting this to 1 causes
+  all files in the repository to be listed in every change.
 </div>

--- a/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/help-depth.html
+++ b/src/main/resources/hudson/plugins/git/extensions/impl/SubmoduleOption/help-depth.html
@@ -1,4 +1,6 @@
 <div>
   Set shallow clone depth, so that git will only download recent history of the project,
   saving time and disk space when you just want to access the latest commits of a repository.
+  Note that this has an effect on the changesets listed by Jenkins. Setting this to 1 causes
+  all files in the repository to be listed in every change.
 </div>


### PR DESCRIPTION
I stumbled across an issue concerning the files shown in changesets. Since some date the changesets would list all files of the repository instead of only the changed ones. I tried looking for a recent change within the Jenkins codebase that might cause this issue and came across this [comment](https://github.com/jenkinsci/git-plugin/pull/3923#issuecomment-3868419021). I realized I had made the same configuration change to reduce load. 
This PR adds a note in the help text of the configuration parameter (I first started to write an issue, but since this is only a small change in the documentation, I followed the hint to just create a PR instead).

### Testing done

I did not build the plugin to test this. As it is a minor documentation change, I am quite confident it works as expected. I am, however, not a native English speaker, so if the wording seems off, feel free to let me know. 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
