### PR TITLE
Fix documentation error in RhodeCode URL

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -762,7 +762,7 @@ URL::
 
 image:images/git-repository-browser-rhodecode.png[RhodeCode Repository Browser]
 
-Repository browser for git repositories hosted by link:https://thodecode.com/[RhodeCode].
+Repository browser for git repositories hosted by link:https://rhodecode.com/[RhodeCode].
 Options include:
 
 [[rhodecode-url]]


### PR DESCRIPTION
### Description

Fixes a typo in `README.adoc` where the RhodeCode website URL was misspelled as `thodecode.com` instead of the correct `rhodecode.com`.

**File:** `README.adoc`  
**Section:** `==== rhodecode` (Repository Browser section)

**Before:**
`link:https://thodecode.com/[RhodeCode]`

**After:**
`link:https://rhodecode.com/[RhodeCode]`

### Testing done

This is a documentation-only change (URL typo fix).

- Verified that `https://rhodecode.com/` is the correct RhodeCode website URL
- Confirmed no other occurrences of "thodecode" exist in the repository
- No code changes - no automated tests applicable for a URL typo fix

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed