### PR TITLE
fix deprecated git protocol url

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -175,7 +175,6 @@ public class GitToolChooser {
     }
 
     /* Protocol patterns to extract hostname and path from typical repository URLs */
-    private static Pattern gitProtocolPattern = Pattern.compile("^git://([^/]+)/(.+?)/*$");
     private static Pattern httpProtocolPattern = Pattern.compile("^https?://([^/]+)/(.+?)/*$");
     private static Pattern sshAltProtocolPattern = Pattern.compile("^[\\w]+@(.+):(.+?)/*$");
     private static Pattern sshProtocolPattern = Pattern.compile("^ssh://[\\w]+@([^/]+)/(.+?)/*$");
@@ -193,7 +192,7 @@ public class GitToolChooser {
         Pattern [] protocolPatterns = {
                 sshAltProtocolPattern,
                 sshProtocolPattern,
-                gitProtocolPattern,
+                httpProtocolPattern,
         };
 
         String matcherReplacement = "https://$1/$2";
@@ -237,14 +236,12 @@ public class GitToolChooser {
         }
 
         Pattern [] protocolPatterns = {
-                gitProtocolPattern,
                 httpProtocolPattern,
                 sshAltProtocolPattern,
                 sshProtocolPattern,
         };
 
         String[] matcherReplacements = {
-                "git://$1/$2",     // git protocol
                 "git@$1:$2",       // ssh protocol alternate URL
                 "https://$1/$2",   // https protocol
                 "ssh://git@$1/$2", // ssh protocol


### PR DESCRIPTION
Removes mention of deprecated git protocol i.e git:// from loggers

### Testing done

Ran all Test Cases

### Submitter checklist
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

fix issue #3975 
