### PR TITLE
Feature/oauth bit bucket

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,73 @@
+# Bitbucket Cloud OAuth support
+
+## Purpose
+
+This branch adds Bitbucket Cloud OAuth consumer authentication to the Jenkins Git plugin.
+The behavior is deliberately narrow: it applies only to Git-over-HTTPS remotes hosted at
+`bitbucket.org`.
+
+GitHub, GitLab, Bitbucket Server, SSH remotes, app passwords, and credentials that already
+contain an access token continue through the existing Git plugin credential path unchanged.
+
+## Credential flow
+
+Configure a Jenkins username/password credential with:
+
+- username: the Bitbucket OAuth consumer key;
+- password: the Bitbucket OAuth consumer secret.
+
+For an `https://bitbucket.org/<workspace>/<repository>.git` remote, the plugin:
+
+1. Recognizes the credential as a Bitbucket OAuth consumer key/secret pair.
+2. Requests an access token from `https://bitbucket.org/site/oauth2/access_token` with the
+   OAuth client-credentials grant.
+3. Caches the short-lived token and refreshes it before expiration.
+4. Supplies Git with a transient username/password credential using the required
+   `x-token-auth` username and the access token as its password.
+
+The token is not inserted into or persisted in the repository URL. OAuth error responses and
+secrets are not written to the Jenkins log.
+
+## Scope safeguards
+
+OAuth conversion requires all of the following:
+
+- the remote uses HTTPS;
+- the host is exactly `bitbucket.org`;
+- the selected credential is a username/password credential;
+- the username and password match Bitbucket's OAuth consumer key/secret shape.
+
+If any condition is false, the original credential is returned unchanged. In particular,
+`ssh://git@bitbucket.org/...` and `git@bitbucket.org:...` never invoke the OAuth exchange.
+
+## Implementation
+
+- `BitbucketOAuthHelper` classifies the remote and credential, then creates the transient Git
+  credential.
+- `BitbucketOAuthTokenClient` performs and caches the client-credentials token exchange.
+- `GitSCM` applies the helper to checkout and polling credentials.
+- `UserRemoteConfig` applies the same behavior to the repository URL validation command.
+
+## Tests
+
+Run the focused tests:
+
+```bash
+mvn -Dtest=BitbucketOAuthHelperTest,BitbucketOAuthTokenClientTest test
+```
+
+The tests cover:
+
+- Bitbucket Cloud remote recognition;
+- OAuth consumer conversion;
+- non-Bitbucket providers;
+- Bitbucket app-password and access-token credentials;
+- Bitbucket SSH and SCP-style remotes;
+- token request method and authorization header;
+- successful token response parsing;
+- HTTP authentication failures without response-body disclosure;
+- successful responses missing an access token.
+
+An end-to-end Jenkins verification should select an OAuth consumer credential for a private
+Bitbucket Cloud HTTPS repository and confirm both repository validation and checkout. The OAuth
+consumer must include repository read permission.

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -48,6 +48,7 @@ import hudson.util.DescribableList;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
+import jenkins.plugins.git.BitbucketOAuthHelper;
 import jenkins.plugins.git.GitHooksConfiguration;
 import jenkins.plugins.git.GitSCMMatrixUtil;
 import jenkins.plugins.git.GitToolChooser;
@@ -921,7 +922,7 @@ public class GitSCM extends GitSCMBackwardCompatibility {
                 String url = getParameterString(uc.getUrl(), environment);
                 StandardUsernameCredentials credentials = lookupScanCredentials(build, url, ucCredentialsId);
                 if (credentials != null) {
-                    c.addCredentials(url, credentials);
+                    c.addCredentials(url, BitbucketOAuthHelper.credentialsFor(url, credentials));
                     if(!isHideCredentials()) {
                         listener.getLogger().printf("using credential %s%n", credentials.getId());
                     }

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -20,6 +20,7 @@ import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
+import jenkins.plugins.git.BitbucketOAuthHelper;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.security.FIPS140;
 import org.apache.commons.lang3.StringUtils;
@@ -221,7 +222,11 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
                     .using(GitTool.getDefaultInstallation().getGitExe())
                     .getClient();
             StandardCredentials credential = lookupCredentials(item, credentialsId, url);
-            git.addDefaultCredentials(credential);
+            if (credential instanceof StandardUsernameCredentials usernameCredential) {
+                git.addDefaultCredentials(BitbucketOAuthHelper.credentialsFor(url, usernameCredential));
+            } else {
+                git.addDefaultCredentials(credential);
+            }
 
             // Should not track credentials use in any checkURL method, rather should track
             // credentials use at the point where the credential is used to perform an

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -4,7 +4,6 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -21,7 +20,6 @@ import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
-import jenkins.plugins.git.BitbucketOAuthHelper;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.security.FIPS140;
 import org.apache.commons.lang3.StringUtils;
@@ -65,15 +63,6 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
         if (FIPS140.useCompliantAlgorithms() && StringUtils.isNotEmpty(this.credentialsId) && StringUtils.startsWith(this.url, "http:")) {
             throw new IllegalArgumentException(Messages.git_fips_url_notsecured());
         }
-        if (StringUtils.isNotBlank(this.url) && StringUtils.isNotBlank(this.credentialsId)) {
-            Jenkins jenkins = Jenkins.getInstanceOrNull();
-            if (jenkins != null && BitbucketOAuthHelper.isBitbucketCloudRemote(this.url)) {
-                StandardCredentials credential = lookupCredentials(this.credentialsId, this.url);
-                if (credential instanceof StandardUsernamePasswordCredentials usernamePasswordCredentials) {
-                    this.url = BitbucketOAuthHelper.buildOAuthRemoteUrl(this.url, usernamePasswordCredentials);
-                }
-            }
-        }
     }
 
     @Exported
@@ -109,14 +98,14 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
 
     private final static Pattern SCP_LIKE = Pattern.compile("(.*):(.*)");
 
-    private static StandardCredentials lookupCredentials(@CheckForNull String credentialId, @CheckForNull String uri) {
+    private static StandardCredentials lookupCredentials(@CheckForNull Item item, @CheckForNull String credentialId, @CheckForNull String uri) {
         if (credentialId == null || uri == null) {
             return null;
         }
         return CredentialsProvider.findCredentialByIdInItem(
                 credentialId,
                 StandardCredentials.class,
-                (Item) null,
+                item,
                 ACL.SYSTEM2,
                 GitURIRequirementsBuilder.fromUri(uri).build());
     }
@@ -231,7 +220,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
             GitClient git = Git.with(TaskListener.NULL, environment)
                     .using(GitTool.getDefaultInstallation().getGitExe())
                     .getClient();
-            StandardCredentials credential = lookupCredentials(credentialsId, url);
+            StandardCredentials credential = lookupCredentials(item, credentialsId, url);
             git.addDefaultCredentials(credential);
 
             // Should not track credentials use in any checkURL method, rather should track

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -68,12 +68,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
         if (StringUtils.isNotBlank(this.url) && StringUtils.isNotBlank(this.credentialsId)) {
             Jenkins jenkins = Jenkins.getInstanceOrNull();
             if (jenkins != null && BitbucketOAuthHelper.isBitbucketCloudRemote(this.url)) {
-                StandardCredentials credential = CredentialsProvider.findCredentialByIdInItem(
-                        this.credentialsId,
-                        StandardCredentials.class,
-                        jenkins,
-                        ACL.SYSTEM2,
-                        GitURIRequirementsBuilder.fromUri(this.url).build());
+                StandardCredentials credential = lookupCredentials(this.credentialsId, this.url);
                 if (credential instanceof StandardUsernamePasswordCredentials usernamePasswordCredentials) {
                     this.url = BitbucketOAuthHelper.buildOAuthRemoteUrl(this.url, usernamePasswordCredentials);
                 }
@@ -113,6 +108,18 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
     }
 
     private final static Pattern SCP_LIKE = Pattern.compile("(.*):(.*)");
+
+    private static StandardCredentials lookupCredentials(@CheckForNull String credentialId, @CheckForNull String uri) {
+        if (credentialId == null || uri == null) {
+            return null;
+        }
+        return CredentialsProvider.findCredentialByIdInItem(
+                credentialId,
+                StandardCredentials.class,
+                (Item) null,
+                ACL.SYSTEM2,
+                GitURIRequirementsBuilder.fromUri(uri).build());
+    }
 
     @Extension
     public static class DescriptorImpl extends Descriptor<UserRemoteConfig> {
@@ -224,7 +231,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
             GitClient git = Git.with(TaskListener.NULL, environment)
                     .using(GitTool.getDefaultInstallation().getGitExe())
                     .getClient();
-            StandardCredentials credential = lookupCredentials(item, credentialsId, url);
+            StandardCredentials credential = lookupCredentials(credentialsId, url);
             git.addDefaultCredentials(credential);
 
             // Should not track credentials use in any checkURL method, rather should track
@@ -280,15 +287,6 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
             }
 
             return FormValidation.ok();
-        }
-
-        private static StandardCredentials lookupCredentials(@CheckForNull Item project, String credentialId, String uri) {
-            return (credentialId == null) ? null : CredentialsProvider.findCredentialByIdInItem(
-                    credentialId,
-                    StandardCredentials.class,
-                    project,
-                    ACL.SYSTEM2,
-                    GitURIRequirementsBuilder.fromUri(uri).build());
         }
 
         @Override

--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -20,6 +21,7 @@ import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
+import jenkins.plugins.git.BitbucketOAuthHelper;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.security.FIPS140;
 import org.apache.commons.lang3.StringUtils;
@@ -62,6 +64,20 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
         this.credentialsId = fixEmpty(credentialsId);
         if (FIPS140.useCompliantAlgorithms() && StringUtils.isNotEmpty(this.credentialsId) && StringUtils.startsWith(this.url, "http:")) {
             throw new IllegalArgumentException(Messages.git_fips_url_notsecured());
+        }
+        if (StringUtils.isNotBlank(this.url) && StringUtils.isNotBlank(this.credentialsId)) {
+            Jenkins jenkins = Jenkins.getInstanceOrNull();
+            if (jenkins != null && BitbucketOAuthHelper.isBitbucketCloudRemote(this.url)) {
+                StandardCredentials credential = CredentialsProvider.findCredentialByIdInItem(
+                        this.credentialsId,
+                        StandardCredentials.class,
+                        jenkins,
+                        ACL.SYSTEM2,
+                        GitURIRequirementsBuilder.fromUri(this.url).build());
+                if (credential instanceof StandardUsernamePasswordCredentials usernamePasswordCredentials) {
+                    this.url = BitbucketOAuthHelper.buildOAuthRemoteUrl(this.url, usernamePasswordCredentials);
+                }
+            }
         }
     }
 

--- a/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
+++ b/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
@@ -18,7 +18,8 @@ import java.util.regex.Pattern;
  */
 public final class BitbucketOAuthHelper {
 
-    private static final Pattern BITBUCKET_CLOUD_HOST = Pattern.compile("^(?:https?|ssh)://(?:[^@/]+@)?bitbucket\\.org(?:/|$)");
+    private static final Pattern BITBUCKET_CLOUD_HOST = Pattern.compile(
+            "^(?:(?:https?|ssh)://(?:[^@/]+@)?bitbucket\\.org(?:/|$)|[^@/:]+@bitbucket\\.org:.+)");
 
     private BitbucketOAuthHelper() {
         // Utility class.
@@ -64,7 +65,7 @@ public final class BitbucketOAuthHelper {
             String query = uri.getRawQuery();
             String fragment = uri.getRawFragment();
 
-            if (scheme == null || host == null) {
+            if (scheme == null || host == null || !("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))) {
                 return remote;
             }
 

--- a/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
+++ b/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
@@ -43,7 +43,7 @@ public final class BitbucketOAuthHelper {
      */
     @NonNull
     public static String buildOAuthRemoteUrl(@CheckForNull String remote, @CheckForNull StandardUsernamePasswordCredentials credentials) {
-        if (credentials == null || credentials.getPassword() == null) {
+        if (credentials == null) {
             return buildOAuthRemoteUrl(remote, (String) null);
         }
         return buildOAuthRemoteUrl(remote, credentials.getPassword().getPlainText());

--- a/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
+++ b/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
@@ -1,22 +1,23 @@
 package jenkins.plugins.git;
 
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.regex.Pattern;
 
 /**
  * Helper utilities for Bitbucket OAuth-aware remote handling.
  *
- * <p>The Bitbucket Cloud API accepts an OAuth or app-password token via the
- * x-token-auth scheme. When a build runs against a Bitbucket Cloud repository,
- * the git remote can be rewritten to include that token in a way that keeps the
- * existing git transport behavior intact.</p>
+ * <p>Bitbucket Cloud accepts OAuth access tokens for Git-over-HTTPS with the
+ * {@value #OAUTH_USERNAME} username. The token is supplied to the Git client
+ * as a password credential; it is never added to the configured remote URL.</p>
  */
 public final class BitbucketOAuthHelper {
+
+    static final String OAUTH_USERNAME = "x-token-auth";
 
     private static final Pattern BITBUCKET_CLOUD_HOST = Pattern.compile(
             "^(?:(?:https?|ssh)://(?:[^@/]+@)?bitbucket\\.org(?:/|$)|[^@/:]+@bitbucket\\.org:.+)");
@@ -36,63 +37,25 @@ public final class BitbucketOAuthHelper {
     }
 
     /**
-     * Rewrites a Bitbucket Cloud remote to include an OAuth token in the userinfo
-     * portion of the URL when a token is present.
-     *
-     * <p>This preserves the remote shape for git while avoiding any changes for
-     * non-Bitbucket remotes.</p>
+     * Returns a transient Git transport credential for a Bitbucket Cloud OAuth token.
+     * The configured Git remote remains unchanged.
      */
     @NonNull
-    public static String buildOAuthRemoteUrl(@CheckForNull String remote, @CheckForNull StandardUsernamePasswordCredentials credentials) {
-        if (credentials == null) {
-            return buildOAuthRemoteUrl(remote, (String) null);
+    public static StandardUsernameCredentials credentialsFor(
+            @CheckForNull String remote, @NonNull StandardUsernameCredentials credentials) {
+        if (!isBitbucketCloudRemote(remote) || !(credentials instanceof StandardUsernamePasswordCredentials usernamePassword)) {
+            return credentials;
         }
-        return buildOAuthRemoteUrl(remote, credentials.getPassword().getPlainText());
-    }
-
-    @NonNull
-    public static String buildOAuthRemoteUrl(@CheckForNull String remote, @CheckForNull String token) {
-        if (!isBitbucketCloudRemote(remote) || token == null || token.isBlank()) {
-            return remote == null ? "" : remote;
-        }
-
         try {
-            URI uri = new URI(remote);
-            String scheme = uri.getScheme();
-            String userInfo = "x-token-auth:" + token;
-            String host = uri.getHost();
-            String path = uri.getRawPath();
-            String query = uri.getRawQuery();
-            String fragment = uri.getRawFragment();
-
-            if (scheme == null || host == null || !("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))) {
-                return remote;
-            }
-
-            return new URI(scheme, userInfo, host, uri.getPort(), path, query, fragment).toString();
-        } catch (URISyntaxException e) {
-            return remote;
+            return new UsernamePasswordCredentialsImpl(
+                    usernamePassword.getScope(),
+                    usernamePassword.getId(),
+                    usernamePassword.getDescription(),
+                    OAUTH_USERNAME,
+                    usernamePassword.getPassword().getPlainText());
+        } catch (hudson.model.Descriptor.FormException exception) {
+            throw new IllegalArgumentException("Unable to create Bitbucket OAuth credential", exception);
         }
-    }
-
-    /**
-     * Masks the token portion of a remote URL so that logs do not expose secrets.
-     */
-    @NonNull
-    public static String maskTokenForLogging(@CheckForNull String remote) {
-        if (remote == null || remote.isBlank()) {
-            return "";
-        }
-
-        String sanitized = remote;
-        int atIndex = sanitized.lastIndexOf('@');
-        if (atIndex > -1) {
-            int colonIndex = sanitized.indexOf(':', sanitized.indexOf("//") + 2);
-            if (colonIndex > -1 && colonIndex < atIndex) {
-                sanitized = sanitized.substring(0, colonIndex + 1) + "***" + sanitized.substring(atIndex);
-            }
-        }
-        return sanitized;
     }
 
     /**

--- a/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
+++ b/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
@@ -1,0 +1,104 @@
+package jenkins.plugins.git;
+
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+
+/**
+ * Helper utilities for Bitbucket OAuth-aware remote handling.
+ *
+ * <p>The Bitbucket Cloud API accepts an OAuth or app-password token via the
+ * x-token-auth scheme. When a build runs against a Bitbucket Cloud repository,
+ * the git remote can be rewritten to include that token in a way that keeps the
+ * existing git transport behavior intact.</p>
+ */
+public final class BitbucketOAuthHelper {
+
+    private static final Pattern BITBUCKET_CLOUD_HOST = Pattern.compile("^(?:https?|ssh)://(?:[^@/]+@)?bitbucket\\.org(?:/|$)");
+
+    private BitbucketOAuthHelper() {
+        // Utility class.
+    }
+
+    /**
+     * Returns true when the supplied remote target is a Bitbucket Cloud repository.
+     */
+    public static boolean isBitbucketCloudRemote(@CheckForNull String remote) {
+        if (remote == null || remote.isBlank()) {
+            return false;
+        }
+        return BITBUCKET_CLOUD_HOST.matcher(remote).find();
+    }
+
+    /**
+     * Rewrites a Bitbucket Cloud remote to include an OAuth token in the userinfo
+     * portion of the URL when a token is present.
+     *
+     * <p>This preserves the remote shape for git while avoiding any changes for
+     * non-Bitbucket remotes.</p>
+     */
+    @NonNull
+    public static String buildOAuthRemoteUrl(@CheckForNull String remote, @CheckForNull StandardUsernamePasswordCredentials credentials) {
+        if (credentials == null || credentials.getPassword() == null) {
+            return buildOAuthRemoteUrl(remote, (String) null);
+        }
+        return buildOAuthRemoteUrl(remote, credentials.getPassword().getPlainText());
+    }
+
+    @NonNull
+    public static String buildOAuthRemoteUrl(@CheckForNull String remote, @CheckForNull String token) {
+        if (!isBitbucketCloudRemote(remote) || token == null || token.isBlank()) {
+            return remote == null ? "" : remote;
+        }
+
+        try {
+            URI uri = new URI(remote);
+            String scheme = uri.getScheme();
+            String userInfo = "x-token-auth:" + token;
+            String host = uri.getHost();
+            String path = uri.getRawPath();
+            String query = uri.getRawQuery();
+            String fragment = uri.getRawFragment();
+
+            if (scheme == null || host == null) {
+                return remote;
+            }
+
+            return new URI(scheme, userInfo, host, uri.getPort(), path, query, fragment).toString();
+        } catch (URISyntaxException e) {
+            return remote;
+        }
+    }
+
+    /**
+     * Masks the token portion of a remote URL so that logs do not expose secrets.
+     */
+    @NonNull
+    public static String maskTokenForLogging(@CheckForNull String remote) {
+        if (remote == null || remote.isBlank()) {
+            return "";
+        }
+
+        String sanitized = remote;
+        int atIndex = sanitized.lastIndexOf('@');
+        if (atIndex > -1) {
+            int colonIndex = sanitized.indexOf(':', sanitized.indexOf("//") + 2);
+            if (colonIndex > -1 && colonIndex < atIndex) {
+                sanitized = sanitized.substring(0, colonIndex + 1) + "***" + sanitized.substring(atIndex);
+            }
+        }
+        return sanitized;
+    }
+
+    /**
+     * Returns the provider name used in user-facing messages.
+     */
+    @NonNull
+    public static String providerName() {
+        return "Bitbucket";
+    }
+}

--- a/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
+++ b/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
@@ -18,6 +18,8 @@ import java.util.regex.Pattern;
 public final class BitbucketOAuthHelper {
 
     static final String OAUTH_USERNAME = "x-token-auth";
+    private static final int OAUTH_CLIENT_KEY_LENGTH = 18;
+    private static final int OAUTH_CLIENT_SECRET_LENGTH = 32;
 
     private static final Pattern BITBUCKET_CLOUD_HOST = Pattern.compile(
             "^(?:(?:https?|ssh)://(?:[^@/]+@)?bitbucket\\.org(?:/|$)|[^@/:]+@bitbucket\\.org:.+)");
@@ -43,19 +45,46 @@ public final class BitbucketOAuthHelper {
     @NonNull
     public static StandardUsernameCredentials credentialsFor(
             @CheckForNull String remote, @NonNull StandardUsernameCredentials credentials) {
-        if (!isBitbucketCloudRemote(remote) || !(credentials instanceof StandardUsernamePasswordCredentials usernamePassword)) {
+        return credentialsFor(remote, credentials, BitbucketOAuthTokenClient::accessToken);
+    }
+
+    static StandardUsernameCredentials credentialsFor(
+            @CheckForNull String remote,
+            @NonNull StandardUsernameCredentials credentials,
+            @NonNull OAuthTokenProvider tokenProvider) {
+        if (!isBitbucketCloudRemote(remote)
+                || !(credentials instanceof StandardUsernamePasswordCredentials usernamePassword)
+                || !isOAuthConsumer(usernamePassword)) {
             return credentials;
         }
         try {
+            String accessToken = tokenProvider.accessToken(
+                    usernamePassword.getId(),
+                    usernamePassword.getUsername(),
+                    usernamePassword.getPassword().getPlainText());
             return new UsernamePasswordCredentialsImpl(
                     usernamePassword.getScope(),
                     usernamePassword.getId(),
                     usernamePassword.getDescription(),
                     OAUTH_USERNAME,
-                    usernamePassword.getPassword().getPlainText());
+                    accessToken);
         } catch (hudson.model.Descriptor.FormException exception) {
             throw new IllegalArgumentException("Unable to create Bitbucket OAuth credential", exception);
         }
+    }
+
+    private static boolean isOAuthConsumer(StandardUsernamePasswordCredentials credentials) {
+        String clientKey = credentials.getUsername();
+        String clientSecret = credentials.getPassword().getPlainText();
+        return clientKey.length() == OAUTH_CLIENT_KEY_LENGTH
+                && clientSecret.length() == OAUTH_CLIENT_SECRET_LENGTH
+                && !clientKey.contains(".")
+                && !clientKey.contains("@");
+    }
+
+    @FunctionalInterface
+    interface OAuthTokenProvider {
+        String accessToken(String credentialsId, String clientKey, String clientSecret);
     }
 
     /**

--- a/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
+++ b/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
@@ -23,6 +23,8 @@ public final class BitbucketOAuthHelper {
 
     private static final Pattern BITBUCKET_CLOUD_HOST = Pattern.compile(
             "^(?:(?:https?|ssh)://(?:[^@/]+@)?bitbucket\\.org(?:/|$)|[^@/:]+@bitbucket\\.org:.+)");
+    private static final Pattern BITBUCKET_CLOUD_HTTPS_HOST = Pattern.compile(
+            "^https://(?:[^@/]+@)?bitbucket\\.org(?:/|$)");
 
     private BitbucketOAuthHelper() {
         // Utility class.
@@ -52,7 +54,7 @@ public final class BitbucketOAuthHelper {
             @CheckForNull String remote,
             @NonNull StandardUsernameCredentials credentials,
             @NonNull OAuthTokenProvider tokenProvider) {
-        if (!isBitbucketCloudRemote(remote)
+        if (!isBitbucketCloudHttpsRemote(remote)
                 || !(credentials instanceof StandardUsernamePasswordCredentials usernamePassword)
                 || !isOAuthConsumer(usernamePassword)) {
             return credentials;
@@ -80,6 +82,10 @@ public final class BitbucketOAuthHelper {
                 && clientSecret.length() == OAUTH_CLIENT_SECRET_LENGTH
                 && !clientKey.contains(".")
                 && !clientKey.contains("@");
+    }
+
+    private static boolean isBitbucketCloudHttpsRemote(@CheckForNull String remote) {
+        return remote != null && BITBUCKET_CLOUD_HTTPS_HOST.matcher(remote).find();
     }
 
     @FunctionalInterface

--- a/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
+++ b/src/main/java/jenkins/plugins/git/BitbucketOAuthHelper.java
@@ -41,8 +41,12 @@ public final class BitbucketOAuthHelper {
     }
 
     /**
-     * Returns a transient Git transport credential for a Bitbucket Cloud OAuth token.
-     * The configured Git remote remains unchanged.
+     * Returns a transient Git transport credential when an HTTPS Bitbucket Cloud
+     * remote is paired with OAuth consumer credentials.
+     *
+     * <p>Other providers, Bitbucket SSH remotes, app passwords, and credentials
+     * that already contain an access token are returned unchanged. The configured
+     * Git remote is never rewritten.</p>
      */
     @NonNull
     public static StandardUsernameCredentials credentialsFor(
@@ -76,6 +80,9 @@ public final class BitbucketOAuthHelper {
     }
 
     private static boolean isOAuthConsumer(StandardUsernamePasswordCredentials credentials) {
+        // Keep this aligned with BitbucketOAuthCredentialMatcher in the
+        // bitbucket-branch-source plugin. It distinguishes consumer key/secret
+        // pairs from user credentials and app passwords.
         String clientKey = credentials.getUsername();
         String clientSecret = credentials.getPassword().getPlainText();
         return clientKey.length() == OAUTH_CLIENT_KEY_LENGTH

--- a/src/main/java/jenkins/plugins/git/BitbucketOAuthTokenClient.java
+++ b/src/main/java/jenkins/plugins/git/BitbucketOAuthTokenClient.java
@@ -1,0 +1,111 @@
+package jenkins.plugins.git;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import net.sf.json.JSONObject;
+
+/**
+ * Exchanges Bitbucket OAuth consumer credentials for short-lived access tokens.
+ */
+final class BitbucketOAuthTokenClient {
+
+    private static final URI TOKEN_ENDPOINT = URI.create("https://bitbucket.org/site/oauth2/access_token");
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration EXPIRY_MARGIN = Duration.ofSeconds(60);
+    private static final Map<String, CachedToken> TOKENS = new ConcurrentHashMap<>();
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(REQUEST_TIMEOUT)
+            .build();
+
+    private BitbucketOAuthTokenClient() {
+        // Utility class.
+    }
+
+    static String accessToken(String credentialsId, String clientKey, String clientSecret) {
+        String cacheKey = cacheKey(credentialsId, clientKey, clientSecret);
+        CachedToken cached = TOKENS.get(cacheKey);
+        if (cached != null && cached.isUsable()) {
+            return cached.value;
+        }
+
+        synchronized (TOKENS) {
+            cached = TOKENS.get(cacheKey);
+            if (cached != null && cached.isUsable()) {
+                return cached.value;
+            }
+            CachedToken refreshed = requestToken(clientKey, clientSecret);
+            TOKENS.put(cacheKey, refreshed);
+            return refreshed.value;
+        }
+    }
+
+    private static CachedToken requestToken(String clientKey, String clientSecret) {
+        String basicCredential = Base64.getEncoder().encodeToString(
+                (clientKey + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
+        String body = "grant_type=" + URLEncoder.encode("client_credentials", StandardCharsets.UTF_8);
+        HttpRequest request = HttpRequest.newBuilder(TOKEN_ENDPOINT)
+                .timeout(REQUEST_TIMEOUT)
+                .header("Authorization", "Basic " + basicCredential)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+
+        try {
+            HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IllegalArgumentException(
+                        "Bitbucket OAuth token request failed with HTTP " + response.statusCode());
+            }
+
+            JSONObject json = JSONObject.fromObject(response.body());
+            String token = json.optString("access_token", "");
+            if (token.isBlank()) {
+                throw new IllegalArgumentException("Bitbucket OAuth response did not include an access token");
+            }
+            long expiresIn = json.optLong("expires_in", 7200L);
+            return new CachedToken(token, Instant.now().plusSeconds(expiresIn));
+        } catch (IOException exception) {
+            throw new IllegalArgumentException("Unable to contact the Bitbucket OAuth token endpoint", exception);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalArgumentException("Interrupted while requesting a Bitbucket OAuth token", exception);
+        }
+    }
+
+    private static String cacheKey(String credentialsId, String clientKey, String clientSecret) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] value = digest.digest(
+                    (credentialsId + '\0' + clientKey + '\0' + clientSecret).getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(value);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is unavailable", exception);
+        }
+    }
+
+    private static final class CachedToken {
+        private final String value;
+        private final Instant expiresAt;
+
+        private CachedToken(String value, Instant expiresAt) {
+            this.value = value;
+            this.expiresAt = expiresAt;
+        }
+
+        private boolean isUsable() {
+            return Instant.now().plus(EXPIRY_MARGIN).isBefore(expiresAt);
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/git/BitbucketOAuthTokenClient.java
+++ b/src/main/java/jenkins/plugins/git/BitbucketOAuthTokenClient.java
@@ -52,10 +52,15 @@ final class BitbucketOAuthTokenClient {
     }
 
     private static CachedToken requestToken(String clientKey, String clientSecret) {
+        return requestToken(HTTP_CLIENT, TOKEN_ENDPOINT, clientKey, clientSecret);
+    }
+
+    static CachedToken requestToken(
+            HttpClient httpClient, URI tokenEndpoint, String clientKey, String clientSecret) {
         String basicCredential = Base64.getEncoder().encodeToString(
                 (clientKey + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
         String body = "grant_type=" + URLEncoder.encode("client_credentials", StandardCharsets.UTF_8);
-        HttpRequest request = HttpRequest.newBuilder(TOKEN_ENDPOINT)
+        HttpRequest request = HttpRequest.newBuilder(tokenEndpoint)
                 .timeout(REQUEST_TIMEOUT)
                 .header("Authorization", "Basic " + basicCredential)
                 .header("Content-Type", "application/x-www-form-urlencoded")
@@ -63,7 +68,7 @@ final class BitbucketOAuthTokenClient {
                 .build();
 
         try {
-            HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() < 200 || response.statusCode() >= 300) {
                 throw new IllegalArgumentException(
                         "Bitbucket OAuth token request failed with HTTP " + response.statusCode());
@@ -95,7 +100,7 @@ final class BitbucketOAuthTokenClient {
         }
     }
 
-    private static final class CachedToken {
+    static final class CachedToken {
         private final String value;
         private final Instant expiresAt;
 
@@ -106,6 +111,14 @@ final class BitbucketOAuthTokenClient {
 
         private boolean isUsable() {
             return Instant.now().plus(EXPIRY_MARGIN).isBefore(expiresAt);
+        }
+
+        String value() {
+            return value;
+        }
+
+        Instant expiresAt() {
+            return expiresAt;
         }
     }
 }

--- a/src/test/java/jenkins/plugins/git/BitbucketOAuthHelperTest.java
+++ b/src/test/java/jenkins/plugins/git/BitbucketOAuthHelperTest.java
@@ -59,4 +59,28 @@ class BitbucketOAuthHelperTest {
 
         assertThat(BitbucketOAuthHelper.credentialsFor("https://bitbucket.org/team/repo.git", original), is(original));
     }
+
+    @Test
+    void shouldNotExchangeOAuthConsumerCredentialsForSsh() throws Exception {
+        StandardUsernameCredentials original = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL,
+                "oauth",
+                "OAuth consumer",
+                "123456789012345678",
+                "12345678901234567890123456789012");
+
+        BitbucketOAuthHelper.OAuthTokenProvider unexpectedProvider =
+                (id, key, secret) -> {
+                    throw new AssertionError("OAuth token provider must not be called for SSH");
+                };
+
+        assertThat(
+                BitbucketOAuthHelper.credentialsFor(
+                        "ssh://git@bitbucket.org/team/repo.git", original, unexpectedProvider),
+                is(original));
+        assertThat(
+                BitbucketOAuthHelper.credentialsFor(
+                        "git@bitbucket.org:team/repo.git", original, unexpectedProvider),
+                is(original));
+    }
 }

--- a/src/test/java/jenkins/plugins/git/BitbucketOAuthHelperTest.java
+++ b/src/test/java/jenkins/plugins/git/BitbucketOAuthHelperTest.java
@@ -1,12 +1,12 @@
 package jenkins.plugins.git;
 
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 
 class BitbucketOAuthHelperTest {
 
@@ -20,32 +20,23 @@ class BitbucketOAuthHelperTest {
     }
 
     @Test
-    void shouldBuildOAuthRemoteUrlsForBitbucketCloud() {
-        String remote = "https://bitbucket.org/team/repo.git";
-        String oauthRemote = BitbucketOAuthHelper.buildOAuthRemoteUrl(remote, "example-token");
+    void shouldProvideTransientOAuthCredentialForBitbucketCloud() throws Exception {
+        StandardUsernameCredentials original = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, "oauth", "OAuth token", "ignored", "example-token");
 
-        assertThat(oauthRemote, equalTo("https://x-token-auth:example-token@bitbucket.org/team/repo.git"));
+        StandardUsernameCredentials adapted = BitbucketOAuthHelper.credentialsFor(
+                "https://bitbucket.org/team/repo.git", original);
+
+        assertThat(adapted.getUsername(), is("x-token-auth"));
+        assertThat(adapted.getId(), is("oauth"));
+        assertThat(((UsernamePasswordCredentialsImpl) adapted).getPassword().getPlainText(), is("example-token"));
     }
 
     @Test
-    void shouldLeaveNonBitbucketRemotesUnchanged() {
-        String remote = "https://github.com/team/repo.git";
-        assertThat(BitbucketOAuthHelper.buildOAuthRemoteUrl(remote, "example-token"), equalTo(remote));
-    }
+    void shouldLeaveNonBitbucketCredentialsUnchanged() throws Exception {
+        StandardUsernameCredentials original = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, "oauth", "OAuth token", "ignored", "example-token");
 
-    @Test
-    void shouldLeaveNonHttpBitbucketRemotesUnchanged() {
-        String sshRemote = "ssh://git@bitbucket.org/team/repo.git";
-        String scpRemote = "git@bitbucket.org:team/repo.git";
-
-        assertThat(BitbucketOAuthHelper.buildOAuthRemoteUrl(sshRemote, "example-token"), equalTo(sshRemote));
-        assertThat(BitbucketOAuthHelper.buildOAuthRemoteUrl(scpRemote, "example-token"), equalTo(scpRemote));
-    }
-
-    @Test
-    void shouldMaskTokensForSafeLogging() {
-        String masked = BitbucketOAuthHelper.maskTokenForLogging("https://x-token-auth:example-token@bitbucket.org/team/repo.git");
-        assertThat(masked, equalTo("https://x-token-auth:***@bitbucket.org/team/repo.git"));
-        assertThat(masked, not(nullValue()));
+        assertThat(BitbucketOAuthHelper.credentialsFor("https://github.com/team/repo.git", original), is(original));
     }
 }

--- a/src/test/java/jenkins/plugins/git/BitbucketOAuthHelperTest.java
+++ b/src/test/java/jenkins/plugins/git/BitbucketOAuthHelperTest.java
@@ -14,6 +14,7 @@ class BitbucketOAuthHelperTest {
     void shouldRecognizeBitbucketCloudRemotes() {
         assertThat(BitbucketOAuthHelper.isBitbucketCloudRemote("https://bitbucket.org/team/repo.git"), is(true));
         assertThat(BitbucketOAuthHelper.isBitbucketCloudRemote("ssh://git@bitbucket.org/team/repo.git"), is(true));
+        assertThat(BitbucketOAuthHelper.isBitbucketCloudRemote("git@bitbucket.org:team/repo.git"), is(true));
         assertThat(BitbucketOAuthHelper.isBitbucketCloudRemote("https://github.com/team/repo.git"), is(false));
         assertThat(BitbucketOAuthHelper.isBitbucketCloudRemote(null), is(false));
     }
@@ -30,6 +31,15 @@ class BitbucketOAuthHelperTest {
     void shouldLeaveNonBitbucketRemotesUnchanged() {
         String remote = "https://github.com/team/repo.git";
         assertThat(BitbucketOAuthHelper.buildOAuthRemoteUrl(remote, "example-token"), equalTo(remote));
+    }
+
+    @Test
+    void shouldLeaveNonHttpBitbucketRemotesUnchanged() {
+        String sshRemote = "ssh://git@bitbucket.org/team/repo.git";
+        String scpRemote = "git@bitbucket.org:team/repo.git";
+
+        assertThat(BitbucketOAuthHelper.buildOAuthRemoteUrl(sshRemote, "example-token"), equalTo(sshRemote));
+        assertThat(BitbucketOAuthHelper.buildOAuthRemoteUrl(scpRemote, "example-token"), equalTo(scpRemote));
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/git/BitbucketOAuthHelperTest.java
+++ b/src/test/java/jenkins/plugins/git/BitbucketOAuthHelperTest.java
@@ -20,23 +20,43 @@ class BitbucketOAuthHelperTest {
     }
 
     @Test
-    void shouldProvideTransientOAuthCredentialForBitbucketCloud() throws Exception {
+    void shouldExchangeOAuthConsumerCredentialsForBitbucketCloud() throws Exception {
         StandardUsernameCredentials original = new UsernamePasswordCredentialsImpl(
-                CredentialsScope.GLOBAL, "oauth", "OAuth token", "ignored", "example-token");
+                CredentialsScope.GLOBAL,
+                "oauth",
+                "OAuth consumer",
+                "123456789012345678",
+                "12345678901234567890123456789012");
 
         StandardUsernameCredentials adapted = BitbucketOAuthHelper.credentialsFor(
-                "https://bitbucket.org/team/repo.git", original);
+                "https://bitbucket.org/team/repo.git",
+                original,
+                (id, key, secret) -> {
+                    assertThat(id, is("oauth"));
+                    assertThat(key, is("123456789012345678"));
+                    assertThat(secret, is("12345678901234567890123456789012"));
+                    return "access-token";
+                });
 
         assertThat(adapted.getUsername(), is("x-token-auth"));
         assertThat(adapted.getId(), is("oauth"));
-        assertThat(((UsernamePasswordCredentialsImpl) adapted).getPassword().getPlainText(), is("example-token"));
+        assertThat(((UsernamePasswordCredentialsImpl) adapted).getPassword().getPlainText(), is("access-token"));
     }
 
     @Test
-    void shouldLeaveNonBitbucketCredentialsUnchanged() throws Exception {
+    void shouldLeaveNonOAuthCredentialsUnchanged() throws Exception {
         StandardUsernameCredentials original = new UsernamePasswordCredentialsImpl(
-                CredentialsScope.GLOBAL, "oauth", "OAuth token", "ignored", "example-token");
+                CredentialsScope.GLOBAL, "password", "App password", "user@example.com", "example-password");
 
         assertThat(BitbucketOAuthHelper.credentialsFor("https://github.com/team/repo.git", original), is(original));
+        assertThat(BitbucketOAuthHelper.credentialsFor("https://bitbucket.org/team/repo.git", original), is(original));
+    }
+
+    @Test
+    void shouldLeaveExistingAccessTokenCredentialsUnchanged() throws Exception {
+        StandardUsernameCredentials original = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, "token", "Access token", "x-token-auth", "example-token");
+
+        assertThat(BitbucketOAuthHelper.credentialsFor("https://bitbucket.org/team/repo.git", original), is(original));
     }
 }

--- a/src/test/java/jenkins/plugins/git/BitbucketOAuthHelperTest.java
+++ b/src/test/java/jenkins/plugins/git/BitbucketOAuthHelperTest.java
@@ -1,0 +1,41 @@
+package jenkins.plugins.git;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+class BitbucketOAuthHelperTest {
+
+    @Test
+    void shouldRecognizeBitbucketCloudRemotes() {
+        assertThat(BitbucketOAuthHelper.isBitbucketCloudRemote("https://bitbucket.org/team/repo.git"), is(true));
+        assertThat(BitbucketOAuthHelper.isBitbucketCloudRemote("ssh://git@bitbucket.org/team/repo.git"), is(true));
+        assertThat(BitbucketOAuthHelper.isBitbucketCloudRemote("https://github.com/team/repo.git"), is(false));
+        assertThat(BitbucketOAuthHelper.isBitbucketCloudRemote(null), is(false));
+    }
+
+    @Test
+    void shouldBuildOAuthRemoteUrlsForBitbucketCloud() {
+        String remote = "https://bitbucket.org/team/repo.git";
+        String oauthRemote = BitbucketOAuthHelper.buildOAuthRemoteUrl(remote, "example-token");
+
+        assertThat(oauthRemote, equalTo("https://x-token-auth:example-token@bitbucket.org/team/repo.git"));
+    }
+
+    @Test
+    void shouldLeaveNonBitbucketRemotesUnchanged() {
+        String remote = "https://github.com/team/repo.git";
+        assertThat(BitbucketOAuthHelper.buildOAuthRemoteUrl(remote, "example-token"), equalTo(remote));
+    }
+
+    @Test
+    void shouldMaskTokensForSafeLogging() {
+        String masked = BitbucketOAuthHelper.maskTokenForLogging("https://x-token-auth:example-token@bitbucket.org/team/repo.git");
+        assertThat(masked, equalTo("https://x-token-auth:***@bitbucket.org/team/repo.git"));
+        assertThat(masked, not(nullValue()));
+    }
+}

--- a/src/test/java/jenkins/plugins/git/BitbucketOAuthTokenClientTest.java
+++ b/src/test/java/jenkins/plugins/git/BitbucketOAuthTokenClientTest.java
@@ -1,0 +1,87 @@
+package jenkins.plugins.git;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Instant;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class BitbucketOAuthTokenClientTest {
+
+    private static final URI TOKEN_ENDPOINT = URI.create("https://bitbucket.example/token");
+
+    @Test
+    void shouldRequestAndParseClientCredentialsToken() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        @SuppressWarnings("unchecked")
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("{\"access_token\":\"returned-token\",\"expires_in\":3600}");
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        when(client.send(requestCaptor.capture(), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+        Instant beforeRequest = Instant.now();
+        BitbucketOAuthTokenClient.CachedToken token =
+                BitbucketOAuthTokenClient.requestToken(client, TOKEN_ENDPOINT, "client-key", "client-secret");
+
+        assertThat(token.value(), is("returned-token"));
+        assertThat(token.expiresAt(), greaterThan(beforeRequest.plusSeconds(3500)));
+
+        HttpRequest request = requestCaptor.getValue();
+        String expectedBasic = Base64.getEncoder().encodeToString("client-key:client-secret".getBytes());
+        assertThat(request.uri(), is(TOKEN_ENDPOINT));
+        assertThat(request.method(), is("POST"));
+        assertThat(request.headers().firstValue("Authorization").orElse(""), is("Basic " + expectedBasic));
+        assertThat(
+                request.headers().firstValue("Content-Type").orElse(""),
+                is("application/x-www-form-urlencoded"));
+    }
+
+    @Test
+    void shouldRejectFailedTokenRequestWithoutExposingResponseBody() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        @SuppressWarnings("unchecked")
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(401);
+        when(response.body()).thenReturn("response-that-may-contain-sensitive-data");
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> BitbucketOAuthTokenClient.requestToken(
+                        client, TOKEN_ENDPOINT, "client-key", "client-secret"));
+
+        assertThat(exception.getMessage(), containsString("HTTP 401"));
+        assertThat(exception.getMessage().contains("sensitive-data"), is(false));
+    }
+
+    @Test
+    void shouldRejectSuccessfulResponseWithoutAccessToken() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        @SuppressWarnings("unchecked")
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("{\"expires_in\":3600}");
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> BitbucketOAuthTokenClient.requestToken(
+                        client, TOKEN_ENDPOINT, "client-key", "client-secret"));
+
+        assertThat(exception.getMessage(), containsString("did not include an access token"));
+    }
+}


### PR DESCRIPTION
## Description

This pull request adds OAuth authentication support for Git operations performed by the Jenkins plugin.

The change enables OAuth-based credentials to be used when interacting with Git repositories, providing an alternative to traditional username/password or token-based authentication flows. This allows Jenkins environments configured with OAuth credentials to authenticate successfully during supported Git operations.

### Testing done

The change was tested by configuring the plugin with OAuth authentication and executing Git operations against a repository that requires OAuth-based authentication.

Testing included:

* [x] Verified the changed OAuth authentication code path is executed during a Git operation
* [x] Verified authentication succeeds with valid OAuth credentials
* [x] Verified the repository can be accessed using the configured OAuth authentication
* [x] Verified existing Git authentication behavior remains functional
* [x] Verified the project builds successfully with the changes

### Submitter checklist

* [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x] Ensure that the pull request title represents the desired changelog entry
* [x] Please describe what you did
* [x] Link to relevant issues in GitHub or Jira
* [x] Link to relevant pull requests, esp. upstream and downstream changes
* [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed