### PR TITLE
Troubles with local shallow clone as an origin repository

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -55,6 +55,7 @@ import java.io.Writer;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -106,10 +107,12 @@ public class GitSCMFileSystem extends SCMFileSystem {
      * @param head   identifier for the head commit to be referenced
      * @param rev    the revision.
      * @throws IOException on I/O error
+     * @throws GitRefNotFoundException (extends IOException) if the "head" reference is not found
      * @throws InterruptedException on thread interruption
      */
-    protected GitSCMFileSystem(GitClient client, String remote, final String head, @CheckForNull
-            AbstractGitSCMSource.SCMRevisionImpl rev) throws IOException, InterruptedException {
+    protected GitSCMFileSystem(
+            GitClient client, String remote, final String head, @CheckForNull AbstractGitSCMSource.SCMRevisionImpl rev)
+            throws IOException, InterruptedException {
         super(rev);
         this.remote = remote;
         this.head = head;
@@ -120,12 +123,39 @@ public class GitSCMFileSystem extends SCMFileSystem {
             commitId = invoke((Repository repository) -> {
                 Ref ref = repository.findRef(head);
                 if (ref == null) {
-                    throw new IOException("Expected ref " + head + " was not created by preceding git fetch");
+                    throw new GitRefNotFoundException(head);
                 }
-                return repository.findRef(head).getObjectId();
+                return ref.getObjectId();
             });
         } else {
             commitId = ObjectId.fromString(rev.getHash());
+        }
+    }
+
+    /**
+     * Thrown when the local git cache does not contain the ref expected to
+     * be checked out, even though the preceding {@code git fetch} reported
+     * success. This happens when the remote named ref (branch or tag) is
+     * itself a shallow clone: git tooling receives the requested objects
+     * but silently refuses to create or update the local ref, because doing
+     * so would record a new shallow root (so it logs "shallow roots are not
+     * allowed to be updated").
+     */
+    public static class GitRefNotFoundException extends IOException {
+        private final String ref;
+
+        GitRefNotFoundException(String ref) {
+            super("Expected ref " + ref + " was not created by preceding git fetch");
+            this.ref = ref;
+        }
+
+        /**
+         * The ref that was expected but missing from the local cache.
+         *
+         * @return the ref name
+         */
+        public String getRef() {
+            return ref;
         }
     }
 
@@ -415,12 +445,20 @@ public class GitSCMFileSystem extends SCMFileSystem {
 
                 HeadNameResult headNameResult = HeadNameResult.calculate(branchSpec, rev, env);
 
-                client.fetch_().prune(true).from(remoteURI, Collections.singletonList(new RefSpec(
-                        "+" + headNameResult.prefix + headNameResult.headName + ":" + Constants.R_REMOTES + remoteName + "/"
-                                + headNameResult.headName))).execute();
+                List<RefSpec> refSpecs =
+                        Collections.singletonList(new RefSpec("+" + headNameResult.prefix + headNameResult.headName
+                                + ":" + Constants.R_REMOTES + remoteName + "/" + headNameResult.headName));
+                client.fetch_().prune(true).from(remoteURI, refSpecs).execute();
 
                 listener.getLogger().println("Done.");
-                return new GitSCMFileSystem(client, remote, Constants.R_REMOTES + remoteName + "/" + headNameResult.headName, (AbstractGitSCMSource.SCMRevisionImpl) rev);
+                return buildFileSystem(
+                        client,
+                        remote,
+                        Constants.R_REMOTES + remoteName + "/" + headNameResult.headName,
+                        (AbstractGitSCMSource.SCMRevisionImpl) rev,
+                        remoteURI,
+                        refSpecs,
+                        listener);
             } catch (GitException x) {
                 throw new IOException(x);
             } finally {
@@ -464,14 +502,95 @@ public class GitSCMFileSystem extends SCMFileSystem {
                 } catch (URISyntaxException ex) {
                     listener.getLogger().println("URI syntax exception for '" + remoteName + "' " + ex);
                 }
-                client.fetch_().prune(true).from(remoteURI, builder.asRefSpecs()).execute();
+                List<RefSpec> refSpecs = builder.asRefSpecs();
+                client.fetch_().prune(true).from(remoteURI, refSpecs).execute();
                 listener.getLogger().println("Done.");
-                return new GitSCMFileSystem(client, gitSCMSource.getRemote(), Constants.R_REMOTES+remoteName+"/"+head.getName(),
-                        (AbstractGitSCMSource.SCMRevisionImpl) rev);
+                return buildFileSystem(
+                        client,
+                        gitSCMSource.getRemote(),
+                        Constants.R_REMOTES + remoteName + "/" + head.getName(),
+                        (AbstractGitSCMSource.SCMRevisionImpl) rev,
+                        remoteURI,
+                        refSpecs,
+                        listener);
             } catch (GitException x) {
                 throw new IOException(x);
             } finally {
                 cacheLock.unlock();
+            }
+        }
+
+        /**
+         * Builds a {@link GitSCMFileSystem}, retrying once through JGit's
+         * own fetch implementation if the expected ref is missing from the
+         * cache after the initial command line git fetch.<br/>
+         *
+         * Command line git refuses to create or update a ref when doing
+         * so would require recording a new shallow root, which can happen
+         * when the configured remote is itself a shallow clone (for example,
+         * a minimized offline repository snapshot). The fetch itself reports
+         * success, and the objects are transferred into the new repository
+         * index, but the symbolic ref is left missing and
+         * {@link GitSCMFileSystem}'s constructor throws a
+         * {@link GitRefNotFoundException}.<br/>
+         *
+         * JGit's own fetch implementation does not apply that restriction,
+         * so retrying the same fetch directly through JGit against the cache
+         * repository recovers the missing ref without needing any additional
+         * configuration from the user.<br/>
+         *
+         * TOTHINK: We *might* implement this with `git fetch --update-shallow`
+         * using the CLI tool as well, but that would need extending the
+         * FetchCommand interface and implementations. It may also depend on
+         * the abilities of the particular git tool version installed on a node.
+         * In this plugin we have jGit anyway, and its abilities seem to
+         * suffice for this task, so there is little need to pile complexity
+         * in favor of pedantism. This stance can be revised if needed.<br/>
+         *
+         * @param client the client
+         * @param remote the remote GIT URL
+         * @param ref the ref expected to be checked out, e.g. {@code refs/remotes/origin/master}
+         * @param rev the revision, or {@code null} to resolve {@code ref} from the cache
+         * @param remoteURI the URI passed to the preceding fetch, may be {@code null}
+         * @param refSpecs the ref specs passed to the preceding fetch
+         * @param listener where to log the retry attempt
+         * @return the resulting {@link GitSCMFileSystem}
+         * @throws IOException on I/O error, including when the ref is still missing after the retry
+         * @throws InterruptedException on thread interruption
+         */
+        private static GitSCMFileSystem buildFileSystem(
+                GitClient client,
+                String remote,
+                String ref,
+                @CheckForNull AbstractGitSCMSource.SCMRevisionImpl rev,
+                @CheckForNull URIish remoteURI,
+                List<RefSpec> refSpecs,
+                TaskListener listener)
+                throws IOException, InterruptedException {
+            try {
+                return new GitSCMFileSystem(client, remote, ref, rev);
+            } catch (GitRefNotFoundException refNotFoundException) {
+                listener.getLogger()
+                        .println("Ref " + ref + " missing after fetch, retrying through JGit in case "
+                                + "the remote is a shallow clone or snapshot");
+                try {
+                    client.<Void>withRepository((Repository repository, VirtualChannel channel) -> {
+                        try {
+                            org.eclipse.jgit.api.Git.wrap(repository)
+                                    .fetch()
+                                    .setRemote(remoteURI != null ? remoteURI.toString() : remote)
+                                    .setRefSpecs(refSpecs)
+                                    .call();
+                        } catch (org.eclipse.jgit.api.errors.GitAPIException e) {
+                            throw new IOException(e);
+                        }
+                        return null;
+                    });
+                } catch (IOException fallbackFailure) {
+                    refNotFoundException.addSuppressed(fallbackFailure);
+                    throw refNotFoundException;
+                }
+                return new GitSCMFileSystem(client, remote, ref, rev);
             }
         }
     }

--- a/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java
@@ -69,6 +69,7 @@ import jenkins.scm.api.SCMSourceDescriptor;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
@@ -115,7 +116,17 @@ public class GitSCMFileSystem extends SCMFileSystem {
         cacheEntry = AbstractGitSCMSource.getCacheEntry(remote);
         listener = new LogTaskListener(LOGGER, Level.FINER);
         this.client = client;
-        commitId = rev == null ? invoke((Repository repository) -> repository.findRef(head).getObjectId()) : ObjectId.fromString(rev.getHash());
+        if (rev == null) {
+            commitId = invoke((Repository repository) -> {
+                Ref ref = repository.findRef(head);
+                if (ref == null) {
+                    throw new IOException("Expected ref " + head + " was not created by preceding git fetch");
+                }
+                return repository.findRef(head).getObjectId();
+            });
+        } else {
+            commitId = ObjectId.fromString(rev.getHash());
+        }
     }
 
     @Override

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -684,26 +684,21 @@ class GitSCMFileSystemTest {
 
                 // This is the code path used by Pipeline lightweight checkout
                 // with the bare repo used as origin git source for the pipeline.
-                // This is actually the point where the test fails with broken
-                // plugin versions:
+                // This is actually the point where the test failed when the
+                // research for https://github.com/jenkinsci/git-plugin/pull/3988
+                // was started, with broken plugin versions (5.10.1 and older):
                 //   java.lang.NullPointerException: Cannot invoke
                 //       "org.eclipse.jgit.lib.Ref.getObjectId()" because the return
                 //       value of "org.eclipse.jgit.lib.Repository.findRef(String)" is null
-                // Or after the initial fix, we should get a meaningful message:
+                // An intermediate fix reported a meaningful message instead:
                 //   java.io.IOException: Expected ref refs/remotes/origin/shallow/master
                 //       was not created by preceding git fetch
-                try {
-                    SCMFileSystem fs = SCMFileSystem.of(
-                            r.jenkins.getItemByFullName("pipeline-from-git-shallow"),
-                            scmFromOrigin,
-                            null
-                    );
-                    assertNotNull(fs);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    assertTrue(e.toString().contains("was not created by preceding git fetch"));
-                    assertTrue(!(e.toString().contains("NullPointerException")));
-                }
+                // The fix applied here retries the fetch through JGit (which does not
+                // refuse to update refs that would introduce a new shallow root), so
+                // this should now succeed and return a usable filesystem.
+                SCMFileSystem fs =
+                        SCMFileSystem.of(r.jenkins.getItemByFullName("pipeline-from-git-shallow"), scmFromOrigin, null);
+                assertNotNull(fs);
 
                 // This may produce an NPE that we are looking for
                 // (to confirm the problem with initial code and the

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -662,12 +662,21 @@ class GitSCMFileSystemTest {
                 //   java.lang.NullPointerException: Cannot invoke
                 //       "org.eclipse.jgit.lib.Ref.getObjectId()" because the return
                 //       value of "org.eclipse.jgit.lib.Repository.findRef(String)" is null
-                SCMFileSystem fs = SCMFileSystem.of(
-                        r.jenkins.getItemByFullName("pipeline-from-git-shallow"),
-                        scmFromOrigin,
-                        null
-                );
-                assertNotNull(fs);
+                // Or after the initial fix, we should get a meaningful message:
+                //   java.io.IOException: Expected ref refs/remotes/origin/shallow/master
+                //       was not created by preceding git fetch
+                try {
+                    SCMFileSystem fs = SCMFileSystem.of(
+                            r.jenkins.getItemByFullName("pipeline-from-git-shallow"),
+                            scmFromOrigin,
+                            null
+                    );
+                    assertNotNull(fs);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    assertTrue(e.toString().contains("was not created by preceding git fetch"));
+                    assertTrue(!(e.toString().contains("NullPointerException")));
+                }
 
                 // This may produce an NPE that we are looking for
                 // (to confirm the problem with initial code and the
@@ -691,9 +700,23 @@ class GitSCMFileSystemTest {
 
                 r.assertLogContains("Cloning repository", b);
                 r.assertLogContains("Fetching upstream changes from", b);
-                r.assertLogContains("Checking out Revision", b);
-                r.assertLogContains("Start of Pipeline", b);
-                r.assertLogContains("End of Pipeline", b);
+
+                // We probably fail at this one until shallow checkout is fixed.
+                try {
+                    r.assertLogContains("Checking out Revision", b);
+                    r.assertLogContains("Start of Pipeline", b);
+                    r.assertLogContains("End of Pipeline", b);
+                } catch (Throwable t) {
+                    // Troubles are expected at the moment, this test confirms them
+                    t.printStackTrace();
+
+                    // NOTE: The plugin fix applied so far is to throw
+                    //  a meaningful message instead of the unhelpful
+                    //  NPE (when lightweight code path is used).
+                    //  There is no checkout still.
+                    //  Here we pass the actual git checkout path.
+                    r.assertLogContains("Couldn't find any revision to build. Verify the repository and branch configuration for this job", b);
+                }
             }
         } finally {
             cloneRepo.after();

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -28,6 +28,7 @@ package jenkins.plugins.git;
 import hudson.EnvVars;
 import hudson.model.Result;
 import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitException;
@@ -513,13 +514,39 @@ class GitSCMFileSystemTest {
          * containers, tailored for a purpose like offline automation.
          */
         File gitDir = new File(".");
-        //GitClient client = Git.with(TaskListener.NULL, new EnvVars()).in(gitDir).using("git").getClient();
+        GitClient client = Git.with(TaskListener.NULL, new EnvVars()).in(gitDir).using("git").getClient();
 
         sampleRepo.initBare();
-        sampleRepo.git("fetch", "--depth=1", gitDir.getAbsolutePath(), "master");
 
-        // NOTE: Code below is repeatable if multiple branches should be
-        // provided via shallow replicas:
+        // Here we parameterize branchNameOriginal more due to the fact
+        // that in e.g. automated Jenkins CI builds a PR source branch
+        // of git-plugin might be the only named ref checked out in the
+        // build workspace, and so the run-time would not necessarily
+        // know about a "master" to fetch. We can still name the branch
+        // made from a FETCH_HEAD in the sampleRepo replica whatever we
+        // like (e.g. branchName="master" as expected by test cases).
+        String branchNameOriginal = null;
+        try {
+            // Pick any, actually
+            for (Branch b : client.getBranches()) {
+                branchNameOriginal = b.getName();
+                break;
+            }
+        } catch (Exception ignored) {
+            // no-op, fall back to master below
+            ignored.printStackTrace();
+        }
+
+        if (branchNameOriginal == null) {
+            branchNameOriginal = "master";
+        }
+
+        sampleRepo.git("fetch", "--depth=1", gitDir.getAbsolutePath(), branchNameOriginal);
+
+        // NOTE: Code below (after the initial "fetch") is repeatable
+        // if multiple branches should be provided via shallow replicas.
+        // Our tests expect to see a "master" so we name whatever we
+        // did fetch like that.
         String branchName = "master";
 
         // The fetch (if successful) updated the local repository index,

--- a/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMFileSystemTest.java
@@ -26,6 +26,7 @@
 package jenkins.plugins.git;
 
 import hudson.EnvVars;
+import hudson.model.Result;
 import hudson.model.TaskListener;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
@@ -34,9 +35,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import hudson.plugins.git.UserRemoteConfig;
 import jenkins.plugins.git.junit.jupiter.WithGitSampleRepo;
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMFileSystem;
@@ -49,6 +52,10 @@ import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -489,5 +496,327 @@ class GitSCMFileSystemTest {
         GitSCMFileSystem.BuilderImpl.HeadNameResult result1 = GitSCMFileSystem.BuilderImpl.HeadNameResult.calculate(new BranchSpec("master-f"), rev260, null);
         assertEquals("master-f", result1.headName);
         assertEquals(Constants.R_HEADS, result1.prefix);
+    }
+
+    /** Helper for test(s) below. Populates {@link #sampleRepo} with
+     *  a bare git repository which has a "shallow/master" branch
+     *  and a forged "master" branch, both with a git snapshot history
+     *  one commit deep. They differ in metadata (one is shallow,
+     *  another is complete as far as the git index is concerned).
+     *  No remote repository is registered as an "origin" of this one.
+     */
+    void prepare_bare_shallow_origin() throws Exception {
+        /* Populate a bare repository into sampleRepo with a shallow
+         * fetch from an existing repo. Unlike `git clone --depth...`
+         * this routine can be repeated to provide a snapshot of
+         * multiple git branches or tags into e.g. generated Jenkins
+         * containers, tailored for a purpose like offline automation.
+         */
+        File gitDir = new File(".");
+        //GitClient client = Git.with(TaskListener.NULL, new EnvVars()).in(gitDir).using("git").getClient();
+
+        sampleRepo.initBare();
+        sampleRepo.git("fetch", "--depth=1", gitDir.getAbsolutePath(), "master");
+
+        // NOTE: Code below is repeatable if multiple branches should be
+        // provided via shallow replicas:
+        String branchName = "master";
+
+        // The fetch (if successful) updated the local repository index,
+        // but did not record any symbolic references like branch names.
+        // Stash that commit as a branch on the side, and forge another
+        // branch with the original name (but necessarily different hash)
+        // which is completely responsible for its own history per metadata.
+        sampleRepo.git("branch", "shallow/" + branchName, "FETCH_HEAD");
+
+        // Original hash (refers to shallow metadata):
+        String hashOriginal = sampleRepo.gitOutput(false,
+                "rev-parse", "shallow/" + branchName);
+        if (hashOriginal != null)
+            hashOriginal = hashOriginal.lines().toList().get(0);
+        assertNotNull(hashOriginal);
+        assertNotEquals("", hashOriginal);
+
+        // Same content as if it is the one and only commit to know about
+        // in the git data tree:
+        String hashTreeContent = sampleRepo.gitOutput(false,
+                "rev-parse", "shallow/" + branchName + "^{tree}");
+        if (hashTreeContent != null)
+            hashTreeContent = hashTreeContent.lines().toList().get(0);
+        assertNotNull(hashTreeContent);
+        assertNotEquals("", hashTreeContent);
+
+        // Use that tree content to create a new commit:
+        String hashNewTip = sampleRepo.gitOutput(false,
+                "commit-tree", hashTreeContent,
+                "-m", "Shallow snapshot of " + branchName + " at " + hashOriginal);
+        if (hashNewTip != null)
+            hashNewTip = hashNewTip.lines().toList().get(0);
+        assertNotNull(hashNewTip);
+        assertNotEquals("", hashNewTip);
+
+        // Now there is a symbolic name for "master" pointing to
+        // a commit in the index. Note that by construct of the
+        // offline source repo, there is no "origin" and so no
+        // symbolic "refs/heads/origin/master", for example.
+        // This is to not be confused with clones in Jenkins git
+        // cache or in ultimate jobs, which could refer to this
+        // bare repo as their "origin".
+        sampleRepo.git("update-ref", "refs/heads/" + branchName, hashNewTip);
+    }
+
+    /** By default, git has a problem cloning from a shallow repository
+     *  as it does not know how to handle the history responsibly.
+     *  There are flags to let it trust the shallow origin "as is",
+     *  but the plugin currently does not seem to use that feature.<br/>
+     *
+     *  As a result, repos cloned from this bare repo will be
+     *  semi-instantiated with present index files but absent
+     *  symbolic references.<br/>
+     *
+     *  The test is to verify that the plugin can handle such repos
+     *  with a reasonable error rather than an NPE somewhere in its
+     *  call stack (bug present in git-5.10.1).<br/>
+     */
+    @Test
+    void handle_bare_shallow_local_origin() throws Throwable {
+        GitSampleRepoRule cloneRepo = new GitSampleRepoRule();
+        cloneRepo.before();
+
+        try {
+            prepare_bare_shallow_origin();
+
+            // See if we can clone the incomplete history
+            cloneRepo.git("clone",
+                    "-b", "shallow/master",
+                    sampleRepo.getRoot().toString(),
+                    cloneRepo.getRoot().toString());
+
+            cloneRepo.git("remote", "-v");
+            cloneRepo.git("branch", "-a");
+
+            String gitLog = cloneRepo.gitOutput(false, "log", "--oneline");
+            assertNotNull(gitLog);
+            assertNotEquals(0, gitLog.length());
+            assertEquals(1, gitLog.lines().toList().size());
+
+            // Do something like what "Pipeline from SCM" does;
+            // with git-5.10.1 this already fails (because git
+            // did not create symbolic ref for the branch name):
+            GitSCM scmFromOrigin = new GitSCM(
+                    List.of(new UserRemoteConfig(
+                            sampleRepo.getRoot().toString(),
+                            null,
+                            null,
+                            null
+                    )),
+                    List.of(new BranchSpec("refs/heads/shallow/master")),
+                    false,
+                    Collections.emptyList(),
+                    null,
+                    null,
+                    Collections.emptyList()
+            );
+            assertNotNull(scmFromOrigin);
+
+            List<BranchSpec> branches = scmFromOrigin.getBranches();
+            assertNotNull(branches);
+            assertNotEquals(0, branches.size());
+            branches.forEach(b -> {
+                assertNotNull(b.getName());
+            });
+
+            GitSCM scmFromClone = new GitSCM(
+                    List.of(new UserRemoteConfig(
+                            cloneRepo.getRoot().toString(),
+                            null,
+                            null,
+                            null
+                    )),
+                    List.of(new BranchSpec("refs/heads/shallow/master")),
+                    false,
+                    Collections.emptyList(),
+                    null,
+                    null,
+                    Collections.emptyList()
+            );
+            assertNotNull(scmFromClone);
+
+            branches = scmFromClone.getBranches();
+            assertNotNull(branches);
+            assertNotEquals(0, branches.size());
+            branches.forEach(b -> {
+                assertNotNull(b.getName());
+            });
+
+            if (r != null) {
+                WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "pipeline-from-git-shallow");
+                // This repo is used as test subject and has *some* Jenkinsfile;
+                // we don't plan to fully run that job, but it must pass git checkout
+                p.setDefinition(new CpsScmFlowDefinition(scmFromOrigin, "Jenkinsfile"));
+
+                // This is the code path used by Pipeline lightweight checkout
+                // with the bare repo used as origin git source for the pipeline.
+                // This is actually the point where the test fails with broken
+                // plugin versions:
+                //   java.lang.NullPointerException: Cannot invoke
+                //       "org.eclipse.jgit.lib.Ref.getObjectId()" because the return
+                //       value of "org.eclipse.jgit.lib.Repository.findRef(String)" is null
+                SCMFileSystem fs = SCMFileSystem.of(
+                        r.jenkins.getItemByFullName("pipeline-from-git-shallow"),
+                        scmFromOrigin,
+                        null
+                );
+                assertNotNull(fs);
+
+                // This may produce an NPE that we are looking for
+                // (to confirm the problem with initial code and the
+                // lack of one after the fix) in the job context,
+                // assuming we have miraculously survived till now.
+                WorkflowRun b = null;
+                Result res = null;
+                try {
+                    b = p.scheduleBuild2(0).waitForStart();
+                    r.waitForCompletion(b);
+                    res = b.getResult();
+                } catch (Throwable t) {
+                    // We do not care at this point that the job failed,
+                    // as it may be due to the shallow clone or lack of
+                    // the buildPlugin() step defined by Jenkins CI farm.
+                    t.printStackTrace();
+                }
+
+                assertNotNull(res);
+                r.assertLogNotContains("java.lang.NullPointerException: ", b);
+
+                r.assertLogContains("Cloning repository", b);
+                r.assertLogContains("Fetching upstream changes from", b);
+                r.assertLogContains("Checking out Revision", b);
+                r.assertLogContains("Start of Pipeline", b);
+                r.assertLogContains("End of Pipeline", b);
+            }
+        } finally {
+            cloneRepo.after();
+        }
+    }
+
+    /** This test is to verify that unlike the setup crafted in
+     *  {@link #handle_bare_shallow_local_origin}, the equivalent
+     *  branch name with a complete history (albeit also a single
+     *  commit deep) just works as far as git tooling and this
+     *  plugin are concerned.
+     */
+    @Test
+    void handle_bare_complete_local_origin() throws Throwable {
+        GitSampleRepoRule cloneRepo = new GitSampleRepoRule();
+        cloneRepo.before();
+
+        try {
+            prepare_bare_shallow_origin();
+
+            // Make sure we can clone the complete history
+            cloneRepo.git("clone",
+                    "-b", "master",
+                    sampleRepo.getRoot().toString(),
+                    cloneRepo.getRoot().toString());
+
+            cloneRepo.git("remote", "-v");
+            cloneRepo.git("branch", "-a");
+
+            String gitLog = cloneRepo.gitOutput(false, "log", "--oneline");
+            assertNotNull(gitLog);
+            assertNotEquals(0, gitLog.length());
+            assertEquals(1, gitLog.lines().toList().size());
+
+            // Do something like what "Pipeline from SCM" does;
+            // with git-5.10.1 this already fails (because git
+            // did not create symbolic ref for the branch name):
+            GitSCM scmFromOrigin = new GitSCM(
+                    List.of(new UserRemoteConfig(
+                            sampleRepo.getRoot().toString(),
+                            null,
+                            null,
+                            null
+                    )),
+                    List.of(new BranchSpec("refs/heads/master")),
+                    false,
+                    Collections.emptyList(),
+                    null,
+                    null,
+                    Collections.emptyList()
+            );
+            assertNotNull(scmFromOrigin);
+
+            List<BranchSpec> branches = scmFromOrigin.getBranches();
+            assertNotNull(branches);
+            assertNotEquals(0, branches.size());
+            branches.forEach(b -> {
+                assertNotNull(b.getName());
+            });
+
+            GitSCM scmFromClone = new GitSCM(
+                    List.of(new UserRemoteConfig(
+                            cloneRepo.getRoot().toString(),
+                            null,
+                            null,
+                            null
+                    )),
+                    List.of(new BranchSpec("refs/heads/master")),
+                    false,
+                    Collections.emptyList(),
+                    null,
+                    null,
+                    Collections.emptyList()
+            );
+            assertNotNull(scmFromClone);
+
+            branches = scmFromClone.getBranches();
+            assertNotNull(branches);
+            assertNotEquals(0, branches.size());
+            branches.forEach(b -> {
+                assertNotNull(b.getName());
+            });
+
+            if (r != null) {
+                WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "pipeline-from-git-complete");
+                // This repo is used as test subject and has *some* Jenkinsfile;
+                // we don't plan to fully run that job, but it must pass git checkout
+                p.setDefinition(new CpsScmFlowDefinition(scmFromOrigin, "Jenkinsfile"));
+
+                // This is the code path used by Pipeline lightweight checkout
+                // with the bare repo used as origin git source for the pipeline
+                SCMFileSystem fs = SCMFileSystem.of(
+                        r.jenkins.getItemByFullName("pipeline-from-git-complete"),
+                        scmFromOrigin,
+                        null
+                );
+                assertNotNull(fs);
+
+                // We do not anticipate grave problems with this build
+                WorkflowRun b = null;
+                Result res = null;
+                try {
+                    b = p.scheduleBuild2(0).waitForStart();
+                    r.waitForCompletion(b);
+                    res = b.getResult();
+                } catch (Throwable t) {
+                    // We do not care at this point that the job failed,
+                    // as it may be due to lack of the buildPlugin() step
+                    // defined by Jenkins CI farm.
+                    t.printStackTrace();
+                }
+
+                assertNotNull(res);
+                r.assertLogNotContains("java.lang.NullPointerException: ", b);
+
+                r.assertLogContains("Cloning repository", b);
+                r.assertLogContains("Fetching upstream changes from", b);
+                r.assertLogContains("Checking out Revision", b);
+                r.assertLogContains("Start of Pipeline", b);
+                r.assertLogContains("End of Pipeline", b);
+            }
+        } finally {
+            cloneRepo.after();
+        }
     }
 }

--- a/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/GitSampleRepoRule.java
@@ -35,12 +35,21 @@ import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.scm.impl.mock.AbstractSampleDVCSRepoRule;
+import jenkins.scm.impl.mock.AbstractSampleRepoRule;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.RepositoryBuilder;
+import org.junit.jupiter.api.Assumptions;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Manages a sample Git repository.
@@ -69,6 +78,60 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         run("git", cmds);
     }
 
+    /** The commonly used {@link #git} command calls {@link #run} which
+     *  "returns" {@code void}.<br/>
+     *
+     *  Here we pick up code from {@link AbstractSampleDVCSRepoRule#run}
+     *  and further {@link AbstractSampleRepoRule#run} (both from SCM plugin)
+     *  to return the {@code stdout} of this git command. This output is not
+     *  chomped in any way, so you may want to split it into an array of lines,
+     *  using {@code String.split("\\R")} or {@code output.lines().toList()}
+     *  for example (including a removal of {@code \n} ending the single line).<br/>
+     *
+     *  Based on the {@code probing} argument, we "assume" or "assert" that
+     *  the command did succeed (returned exit code 0).<br/>
+     */
+    public String gitOutput(boolean probing, String... cmds) throws Exception {
+        List<String> args = new ArrayList<>();
+        args.add("git");
+        args.addAll(Arrays.asList(cmds));
+
+        try {
+            // Collect tool output into our BAOS object;
+            // use it to retrieve the output of the command for
+            // calling code as well as print into the original log.
+            ByteArrayOutputStream baosStdout = new ByteArrayOutputStream();
+
+            // Run-time log goes here:
+            TaskListener listenerStdout = StreamTaskListener.fromStdout();
+
+            int r = new Launcher.LocalLauncher(listenerStdout).launch()
+                    .cmds(args.toArray(new String[0]))
+                    .pwd(sampleRepo)
+                    .stdout(baosStdout)
+                    .join();
+
+            // Report a copy of the resulting output:
+            listenerStdout.getLogger().println(baosStdout.toString(StandardCharsets.UTF_8));
+
+            String message = Arrays.toString(cmds) + " failed with error code";
+            if (probing) {
+                Assumptions.assumeTrue(r == 0, message);
+            } else {
+                assertThat(message, r, is(0));
+            }
+
+            return baosStdout.toString(StandardCharsets.UTF_8);
+        } catch (Exception x) {
+            if (probing) {
+                Assumptions.abort(Arrays.toString(cmds) + " failed with exception (required tooling not installed?)\n" + x);
+                return null;
+            } else {
+                throw x;
+            }
+        }
+    }
+
     private static void checkGlobalConfig() throws Exception {
         if (initialized) return;
         initialized = true;
@@ -95,6 +158,27 @@ public final class GitSampleRepoRule extends AbstractSampleDVCSRepoRule {
         git("config", "commit.gpgsign", "false");
         git("config", "tag.gpgSign", "false");
         git("commit", "--message=init");
+    }
+
+    /** Similar to {@link #init}, but prepares a bare git repository
+     *  without any commits or branches, just marks that the default
+     *  branch (if/when one appears) would be "master".
+     */
+    public void initBare() throws Exception {
+        run(true, tmp.getRoot(), "git", "version");
+        checkGlobalConfig();
+        git("init", "--bare", "-b", "master", "--template=", "."); // initialize without copying the installation defaults to ensure a vanilla repo that behaves the same everywhere
+        if (gitVersionAtLeast(2, 30)) {
+            // Force branch name to master even if system default is not master
+            // Fails on git 2.25 and earlier (Ubuntu 20.04, etc.)
+            // Works on git 2.30 and later
+            git("branch", "-m", "master");
+        }
+        git("config", "user.name", "Git SampleRepoRule");
+        git("config", "user.email", "gits@mplereporule");
+        git("config", "init.defaultbranch", "master");
+        git("config", "commit.gpgsign", "false");
+        git("config", "tag.gpgSign", "false");
     }
 
     public final boolean mkdirs(String rel) throws IOException {


### PR DESCRIPTION
For context, I am preparing Jenkins images for a project where pre-built pre-configured containers would act as automation servers with logging and UI for a specific business purpose, embedded on offline devices. To make the implementation similar to our other (CI) workflows, we want to use the Jenkins Shared Libraries and Pipeline job definitions from Git. However to keep the footprint small (and remove potential leaks that could have been in git histories), the prepared images use shallow clones of our CI development repositories, as of some specific commit (branch tip, tag). The run-time deployments are offline and would not see any real "git remote" systems.

So the containers with Jenkins include a location with sub-directories, where each one is a bare git repository with one or more symbolically named git references (we may deliver several branches to shuffle production/troubleshooting code variants etc.) for histories just a single commit long, and no persistently defined remotes. Initially truly shallow commits were used (with git metadata saying that we should trust that invisible histories do exist somewhere, just not here), but this proved troublesome (throwing NPE from a constructor) as explored in this ticket. A workaround is possible, however the unexplained NPE is not nice so subsequent commits will try to address it.

During this effort I started with something I use for ages for JSL development: using a local filesystem repository (my active git workspace) as the Git source for configured Global Libraries. This works cleanly with paths and `file://` URI schema alike, and (may be a separate bug or not) does not stumble upon `hudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT` property protection, at least not when configuring and checking branch names in `$JENKINS_URL/configure` UI (Jenkins did complain in subsequent `@Library` loads when instantiating jobs). It also did not seem to mind using shallow commits in the source repository for branch-based references to `@Library` loads.

Expanding this experience to "Pipeline from SCM" failed for me with (default) Lightweight checkouts, with job run attempts instantly logging the NPE:
```
Started by user admin
java.lang.NullPointerException: Cannot invoke "org.eclipse.jgit.lib.Ref.getObjectId()" because the return value of "org.eclipse.jgit.lib.Repository.findRef(String)" is null
	at PluginClassLoader for git//jenkins.plugins.git.GitSCMFileSystem.lambda$new$0(GitSCMFileSystem.java:117)
	at PluginClassLoader for git//jenkins.plugins.git.GitSCMFileSystem.lambda$invoke$e8567d7e$1(GitSCMFileSystem.java:184)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.AbstractGitAPIImpl.withRepository(AbstractGitAPIImpl.java:28)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.CliGitAPIImpl.withRepository(CliGitAPIImpl.java:83)
	at PluginClassLoader for git//jenkins.plugins.git.GitSCMFileSystem.invoke(GitSCMFileSystem.java:184)
	at PluginClassLoader for git//jenkins.plugins.git.GitSCMFileSystem.<init>(GitSCMFileSystem.java:117)
	at PluginClassLoader for git//jenkins.plugins.git.GitSCMFileSystem$BuilderImpl.build(GitSCMFileSystem.java:407)
	at PluginClassLoader for scm-api//jenkins.scm.api.SCMFileSystem.of(SCMFileSystem.java:219)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition.create(CpsScmFlowDefinition.java:123)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition.create(CpsScmFlowDefinition.java:70)
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:320)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:456)
Finished: FAILURE
```

Disabling Lightweight checkouts did not crash instantly, but stumbled on that protective property (not a show-stopper, just a point for comparison):
```
Started by user admin
Checking out git /var/jenkins_home/.git-seed/ci into
  /var/jenkins_home/workspace/Manage-LNexus@script/8c760ac94efe469c7e0e79342dd71dbee760c441188cadda57210bbf73f3c51e
  to read Jenkinsfile-lnexus-deliver
ERROR: Checkout of Git remote '/var/jenkins_home/.git-seed/ci' aborted because it
  references a local directory, which may be insecure. You can allow local checkouts
  anyway by setting the system property 'hudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT' to true.
ERROR: Maximum checkout retry attempts reached, aborting
ERROR: Checkout of Git remote '/var/jenkins_home/.git-seed/ci' aborted because it
  references a local directory, which may be insecure. You can allow local checkouts
  anyway by setting the system property 'hudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT' to true.
ERROR: Maximum checkout retry attempts reached, aborting
Finished: FAILURE
```

After some drilling in the filesystem with consultations from ChatGPT, the root cause seems to have been constrained to the use of shallow branch as the desired source: at least in `$JENKINS_HOME/caches/git-$HASH/` directories made as part of further checkout by default (probably not needed for *this* setup, but whatever), the git index and sample hook files were instantiated, but the `refs` directory remained empty. With manual reproduction, git actively refused the shallow source (see last line):
```
jenkins@jenkins-b7bc9cbc-95n6j:~/caches/git-1f1cb224ce6ef770a77794222e6f2a6e$ git fetch -v origin \
   +refs/heads/staging:refs/remotes/origin/staging
remote: Enumerating objects: 148, done.
remote: Counting objects: 100% (148/148), done.
remote: Compressing objects: 100% (98/98), done.
remote: Total 148 (delta 47), reused 148 (delta 47), pack-reused 0 (from 0)
Receiving objects: 100% (148/148), 603.41 KiB | 27.43 MiB/s, done.
Resolving deltas: 100% (47/47), done.
warning: rejected refs/remotes/origin/staging because shallow roots are not allowed to be updated

$ git fsck --no-reflogs --unreachable
Checking object directories: 100% (256/256), done.
Checking objects: 100% (148/148), done.
notice: HEAD points to an unborn branch (master)
notice: No default references
dangling commit 4969235855bb3867de3f31c9c794addd3b1a839d
```

As the result, when the plugin makes a lookup for `refs/heads/staging` or `refs/heads/origin/staging` in the cloned repository, it finds nothing and the constructor ends up with `findRef(head) == null` in https://github.com/jenkinsci/git-plugin/blob/git-5.10.1/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java#L117:
```
commitId = rev == null ? invoke((Repository repository) -> repository.findRef(head).getObjectId()) : ObjectId.fromString(rev.getHash());
```
called from https://github.com/jenkinsci/git-plugin/blob/git-5.10.1/src/main/java/jenkins/plugins/git/GitSCMFileSystem.java#L407:
```
return new GitSCMFileSystem(client, remote, Constants.R_REMOTES + remoteName + "/" + headNameResult.headName, (AbstractGitSCMSource.SCMRevisionImpl) rev);
```
(note that default `remoteName=="origin"` is valid for the cloned repo, just not for the original local one).

For our local remediation, I used `git commit-tree` (as replicated in the PR'ed test case) to forge a complete single-commit git history in the expected branch name, as the starting and only commit of the branch.

ChatGPT suggested that we could also
> make Jenkins fetch with `--no-shallow` but the Git plugin does not expose this cleanly for this path. You would need to patch/configure the Git client behavior, and it is fighting the intended model.

Maybe this suggestion should be explored too. For now I plan to implement a meaningful message instead of unhelpful NPE via something like:
```
Ref ref = repository.findRef(head);
if (ref == null) {
    throw new IOException("Expected ref " + head + " was not created by fetch");
}
```

### Testing done

Problem detected during setup.

Minimized and reproduced with help of AI (ChatGPT).

Experience used to make a reproducer in the test cases added and posted here; they should hopefully confirm fixes later on. UPDATE: fixes also made and posted. This part was also augmented by AI (kudos to Claude).

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
