### PR TITLE
[JENKINS-70303] Trim leading/trailing whitespace from refspecs

### DIFF
--- a/src/main/java/hudson/plugins/git/UserRemoteConfig.java
+++ b/src/main/java/hudson/plugins/git/UserRemoteConfig.java
@@ -58,7 +58,7 @@ public class UserRemoteConfig extends AbstractDescribableImpl<UserRemoteConfig> 
     public UserRemoteConfig(String url, String name, String refspec, @CheckForNull String credentialsId) {
         this.url = fixEmptyAndTrim(url);
         this.name = fixEmpty(name);
-        this.refspec = fixEmpty(refspec);
+        this.refspec = fixEmptyAndTrim(refspec);
         this.credentialsId = fixEmpty(credentialsId);
         if (FIPS140.useCompliantAlgorithms() && StringUtils.isNotEmpty(this.credentialsId) && StringUtils.startsWith(this.url, "http:")) {
             throw new IllegalArgumentException(Messages.git_fips_url_notsecured());

--- a/src/main/java/jenkins/plugins/git/GitSCMBuilder.java
+++ b/src/main/java/jenkins/plugins/git/GitSCMBuilder.java
@@ -439,7 +439,7 @@ public class GitSCMBuilder<B extends GitSCMBuilder<B>> extends SCMBuilder<B, Git
         }
         List<RefSpec> result = new ArrayList<>(refSpecs.size());
         for (String refSpec : refSpecs) {
-            result.add(new RefSpec(refSpec));
+            result.add(new RefSpec(refSpec.trim()));
         }
         return result;
     }

--- a/src/test/java/hudson/plugins/git/UserRemoteConfigRefSpecTest.java
+++ b/src/test/java/hudson/plugins/git/UserRemoteConfigRefSpecTest.java
@@ -12,6 +12,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class UserRemoteConfigRefSpecTest {
 
+    @Issue("JENKINS-70303")
+    @Test
+    void constructorTrimsLeadingAndTrailingWhitespaceFromRefspec() {
+        UserRemoteConfig config = new UserRemoteConfig(
+                "git://git.example.com/repository-that-does-not-exist",
+                "origin",
+                " +refs/heads/master:refs/remotes/origin/master ",
+                null);
+        assertEquals("+refs/heads/master:refs/remotes/origin/master", config.getRefspec());
+    }
+
     @Issue("JENKINS-57660")
     @Test
     void testdoCheckRefspecSuccessWithoutWildcards(){

--- a/src/test/java/jenkins/plugins/git/GitSCMBuilderTest.java
+++ b/src/test/java/jenkins/plugins/git/GitSCMBuilderTest.java
@@ -399,6 +399,19 @@ class GitSCMBuilderTest {
     }
 
     @Test
+    void withRefSpecLeadingAndTrailingWhitespace() throws Exception {
+        instance.withRefSpec(" +refs/heads/master:refs/remotes/@{remote}/master ");
+        GitSCM scm = instance.build();
+        assertThat(scm.getUserRemoteConfigs(), contains(allOf(
+                instanceOf(UserRemoteConfig.class),
+                hasProperty("url", is("http://git.test/repo.git")),
+                hasProperty("name", is("origin")),
+                hasProperty("refspec", is("+refs/heads/master:refs/remotes/origin/master")),
+                hasProperty("credentialsId", is(nullValue())))
+        ));
+    }
+
+    @Test
     void withRefSpecs() throws Exception {
         instance.withRefSpecs(Collections.singletonList("+refs/heads/master:refs/remotes/@{remote}/master"));
         assertThat(instance.refSpecs(), contains("+refs/heads/master:refs/remotes/@{remote}/master"));


### PR DESCRIPTION
# [JENKINS-70303] Trim leading/trailing whitespace from refspecs

## Problem

When a user-supplied refspec has a leading space (e.g. `" +refs/heads/master:refs/remotes/origin/master"`), JGit's `RefSpec` parser fails to recognize the `+` force-update marker because the space hides it, and the checkout fails with "Remote does not have available for fetch." Command-line git tolerates this kind of extra whitespace; JGit does not.

Reported in [JENKINS-70303](https://issues.jenkins.io/browse/JENKINS-70303) against Jenkins 2.375.1 / git plugin 4.14.3 / git client plugin 3.13.1 and https://github.com/jenkinsci/git-client-plugin/issues/1663

## Related prior work

Both prior attempts targeted **git-client-plugin** (the lower-level git client abstraction), not git-plugin:

- [git-client-plugin#1095](https://github.com/jenkinsci/git-client-plugin/pull/1095) — a small patch to `JGitAPIImpl.java` only. Closed for inactivity after review feedback asking for: a link to the issue, an automated test, and fixing a new spotbugs warning it introduced. None of that was addressed before it went stale.
- [git-client-plugin#1096](https://github.com/jenkinsci/git-client-plugin/pull/1096) — a much more thorough attempt, trimming refspecs across `GitAPI.java`, `CliGitAPIImpl.java`, `JGitAPIImpl.java`, `LegacyCompatibleGitAPIImpl.java` and `RemoteGitImpl.java`, with tests, and with maintainer (Mark Waite) commits directly on the branch. Still **open** as of this writing, opened January 2024, no activity since March 2024 — stalled despite being close to mergeable.

This PR takes a different, narrower approach: instead of patching the git-client abstraction (CLI and/or JGit implementations), it trims the refspec at the two points in **git-plugin** where a user-supplied refspec string is first turned into a `RefSpec`/config value, before it ever reaches git-client:

- `UserRemoteConfig` constructor (classic Freestyle `GitSCM` / data-bound form submission)
- `GitSCMBuilder.asRefSpecs()` (multibranch `GitSCMSource`)

This covers both entry points with a much smaller diff, doesn't touch the JGit/CLI client layer at all (so it doesn't depend on #1096 landing), and avoids the spotbugs issue that sank #1095.

## Changes

- `UserRemoteConfig.java`: use `fixEmptyAndTrim(refspec)` instead of `fixEmpty(refspec)` in the constructor.
- `GitSCMBuilder.java`: call `refSpec.trim()` before constructing each `RefSpec` in `asRefSpecs()`.

## Testing

- **New unit tests** covering both fixed entry points:
  - `UserRemoteConfigRefSpecTest.constructorTrimsLeadingAndTrailingWhitespaceFromRefspec`
  - `GitSCMBuilderTest.withRefSpecLeadingAndTrailingWhitespace`
- Targeted test run (`UserRemoteConfigRefSpecTest`, `GitSCMBuilderTest`): green.
- Full `mvn compile test-compile`: clean, no errors.
- Coverage (`mvn -P enable-jacoco test jacoco:report`): both modified lines are fully exercised (0 missed instructions) — `UserRemoteConfig.java:60` and `GitSCMBuilder.java:442`. File-level: `GitSCMBuilder.java` 96.4% instruction / 96.5% line coverage; `UserRemoteConfig.java` 26.0% instruction / 27.1% line coverage (this class has many unrelated getters/validators not exercised by this slice of the suite).

- **Manual verification** on a local `mvn hpi:run` Jenkins instance: configured a Freestyle job against a local repo with a refspec containing leading/trailing spaces. Confirmed in the saved `config.xml` that the stored refspec is trimmed (`+refs/heads/feature-branch:refs/remotes/origin/feature-branch`, no surrounding whitespace), and the checkout completed successfully.

## Checklist (per CONTRIBUTING.adoc)

- [x] Read CONTRIBUTING.adoc
- [x] Referenced the Jira issue in commit messages
- [x] Added tests that verify the change
- [x] Unit tests pass locally
- [x] Interactively tested the change
