### PR TITLE
Exclude git://github.com from cache alternate URLs

### DIFF
--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -269,8 +269,15 @@ public class GitToolChooser {
             addSuffixVariants(remoteURL, alternatives);
         }
 
+        alternatives.removeIf(GitToolChooser::isObsoleteGitHubGitProtocol);
+
         LOGGER.log(Level.FINE, "Cache repo alternative URLs: {0}", alternatives);
         return alternatives;
+    }
+
+    /** GitHub disabled unauthenticated git://; other providers may still use it. */
+    private static boolean isObsoleteGitHubGitProtocol(@NonNull String url) {
+        return url.startsWith("git://github.com/");
     }
 
     /** Cache the estimated repository size for variants of repository URL */

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -277,7 +277,15 @@ public class GitToolChooser {
 
     /** GitHub disabled unauthenticated git://; other providers may still use it. */
     private static boolean isObsoleteGitHubGitProtocol(@NonNull String url) {
-        return url.startsWith("git://github.com/");
+        if (!url.startsWith("git://")) {
+            return false;
+        }
+        try {
+            java.net.URI uri = java.net.URI.create(url);
+            return "github.com".equalsIgnoreCase(uri.getHost());
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     /** Cache the estimated repository size for variants of repository URL */

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -333,7 +333,7 @@ class GitToolChooserTest {
         String githubRemote = "https://github.com/MarkEWaite/simple-java-maven-app.git";
         GitToolChooser sizeEstimator = new GitToolChooser(githubRemote, null, null, tool, null, TaskListener.NULL, true);
         Set<String> alternatives = sizeEstimator.remoteAlternatives(githubRemote);
-assertThat("Remote: " + githubRemote, alternatives, everyItem(not(anyOf(startsWith("git://github.com/"), startsWith("git://github.com:")))));
+        assertThat("Remote: " + githubRemote, alternatives, everyItem(not(anyOf(startsWith("git://github.com/"), startsWith("git://github.com:")))));
     }
 
     /* Test conversion of any remote alternative of git repo URLs to a standard URL */

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -333,7 +333,7 @@ class GitToolChooserTest {
         String githubRemote = "https://github.com/MarkEWaite/simple-java-maven-app.git";
         GitToolChooser sizeEstimator = new GitToolChooser(githubRemote, null, null, tool, null, TaskListener.NULL, true);
         Set<String> alternatives = sizeEstimator.remoteAlternatives(githubRemote);
-        assertThat("Remote: " + githubRemote, alternatives, everyItem(not(startsWith("git://github.com/"))));
+assertThat("Remote: " + githubRemote, alternatives, everyItem(not(anyOf(startsWith("git://github.com/"), startsWith("git://github.com:")))));
     }
 
     /* Test conversion of any remote alternative of git repo URLs to a standard URL */

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -328,6 +328,12 @@ class GitToolChooserTest {
             Set<String> alternatives = sizeEstimator.remoteAlternatives(remote);
             assertThat("Remote+'/': " + remote, alternatives, containsInAnyOrder(remoteAlternatives));
         }
+
+        /* GitHub no longer supports git:// - check those URLs are not included */
+        String githubRemote = "https://github.com/MarkEWaite/simple-java-maven-app.git";
+        GitToolChooser sizeEstimator = new GitToolChooser(githubRemote, null, null, tool, null, TaskListener.NULL, true);
+        Set<String> alternatives = sizeEstimator.remoteAlternatives(githubRemote);
+        assertThat("Remote: " + githubRemote, alternatives, everyItem(not(startsWith("git://github.com/"))));
     }
 
     /* Test conversion of any remote alternative of git repo URLs to a standard URL */


### PR DESCRIPTION
## Summary
GitHub stopped supporting unauthenticated `git://` a while back, but `GitToolChooser.remoteAlternatives()` was still adding `git://github.com/...` URLs to the cache alternate list.

This change filters those out for `github.com` only. Other hosts still get `git://` variants.

Fixes #3975 

## Changes
- `GitToolChooser.java` — remove obsolete `git://github.com/` from alternate URLs
- `GitToolChooserTest.java` — assert GitHub remotes don't include `git://github.com/`

## Test plan
-  `GitToolChooserTest#testRemoteAlternatives` passed locally